### PR TITLE
Set debug var in dev mode

### DIFF
--- a/packages/core/scripts/bin/cms-scripts.js
+++ b/packages/core/scripts/bin/cms-scripts.js
@@ -33,10 +33,10 @@ const COMMANDS = {
     build(createBuildOptions({ uglify: { debug: false } }))
   },
   dev() {
-    build(createBuildOptions())
+    build(createBuildOptions({ uglify: { debug: true } }))
   },
   watch() {
-    watch(createBuildOptions())
+    watch(createBuildOptions({ uglify: { debug: true } }))
   },
 }
 


### PR DESCRIPTION
Fix for `ReferenceError: DEBUG is not defined` when in dev mode