### PR TITLE
build: Add watchDebug and devDebug

### DIFF
--- a/packages/api/api-git/package.json
+++ b/packages/api/api-git/package.json
@@ -9,9 +9,9 @@
   ],
   "scripts": {
     "prepublish": "npm run build",
-    "watch": "cms-scripts watch",
+    "watch": "cms-scripts watchDebug",
     "build": "cms-scripts build",
-    "dev": "cms-scripts dev",
+    "dev": "cms-scripts devDebug",
     "test": "jest --passWithNoTests"
   },
   "dependencies": {

--- a/packages/core/scripts/bin/cms-scripts.js
+++ b/packages/core/scripts/bin/cms-scripts.js
@@ -33,9 +33,15 @@ const COMMANDS = {
     build(createBuildOptions({ uglify: { debug: false } }))
   },
   dev() {
+    build(createBuildOptions())
+  },
+  devDebug() {
     build(createBuildOptions({ uglify: { debug: true } }))
   },
   watch() {
+    watch(createBuildOptions())
+  },
+  watchDebug() {
     watch(createBuildOptions({ uglify: { debug: true } }))
   },
 }


### PR DESCRIPTION
closes #152 

@tinacms/api-git uses those commands, which always compress the output.
Other packages use watch and dev which do not.