### PR TITLE
feat: theme override

### DIFF
--- a/packages/tinacms/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/tinacms/src/components/Tina.tsx
@@ -4,16 +4,22 @@ import { ModalProvider } from './modals/ModalProvider'
 import { SidebarContext } from './sidebar/SidebarProvider'
 import { cms } from '../index'
 import styled, { ThemeProvider } from 'styled-components'
-import { TinaReset, theme } from '@tinacms/styles'
+import { TinaReset, Theme, theme as DEFAULT_THEME } from '@tinacms/styles'
 import { Sidebar } from './sidebar/Sidebar'
 import { SIDEBAR_WIDTH } from '../Globals'
 
 interface TinaProps {
   position: 'fixed' | 'float'
   hidden?: boolean
+  theme?: Theme
 }
 
-export const Tina: React.FC<TinaProps> = ({ children, position, hidden }) => {
+export const Tina: React.FC<TinaProps> = ({
+  children,
+  position,
+  hidden,
+  theme = DEFAULT_THEME,
+}) => {
   const [isOpen, setIsOpen] = React.useState(false)
 
   const props = {


### PR DESCRIPTION
It's now possible to override the default theme

e.g.
```jsx
import { theme as DEFAULT_THEME } from "@tinacms/styles"
import { Tina } from "@tinacms/tinacms"

let theme = DEFAULT_THEME

theme.color.primary = "pink"

<Tina theme={theme} />
```