### PR TITLE
Markdownremark alias

### DIFF
--- a/packages/react-tinacms-remark/src/errors.ts
+++ b/packages/react-tinacms-remark/src/errors.ts
@@ -63,3 +63,31 @@ export const pageQuery = graphql\`
  }
 \`
   `
+
+export const ERROR_INVALID_QUERY_NAME = (queryName: string) =>
+  `useRemarkForm(markdownRemark) '${queryName}' was not found on the top node of the graphql query` +
+  `
+
+1. Check if the '${queryName}' attribute is included in the GraphQL query. For example:
+
+export const pageQuery = graphql\`
+  query BlogPostBySlug($slug: String!) {
+    markdownRemark(fields: { slug: { eq: $slug } }) {
+      rawMarkdownBody
+      // etc...
+    }
+ }
+
+2. If you are using an alias, For example:
+
+ export const pageQuery = graphql\`
+   query BlogPostBySlug($slug: String!) {
+     myContent: markdownRemark(fields: { slug: { eq: $slug } }) {
+       rawMarkdownBody
+       // etc...
+     }
+  }
+ 
+  ...then you can optionally use the 'queryName' option to specify a new property in place of ${queryName}
+\`
+  `

--- a/packages/react-tinacms-remark/src/remarkFormHoc.tsx
+++ b/packages/react-tinacms-remark/src/remarkFormHoc.tsx
@@ -20,20 +20,16 @@ import * as React from 'react'
 import { FormOptions, Form } from '@tinacms/core'
 import { TinaForm } from '@tinacms/form-builder'
 import { useRemarkForm } from './useRemarkForm'
+import { ERROR_INVALID_QUERY_NAME } from './errors'
 
 interface RemarkFormProps extends Partial<FormOptions<any>> {
   queryName?: string // Configure where we are pulling the initial form data from.
 }
 
-export function remarkForm(
-  Component: any,
-  options: RemarkFormProps = {
-    queryName: 'markdownRemark',
-  }
-) {
+export function remarkForm(Component: any, options: RemarkFormProps = {}) {
   return function RemarkForm(props: any) {
     const [markdownRemark] = useRemarkForm(
-      props.data[options.queryName || 'markdownRemark'],
+      getMarkdownRemark(props.data, options.queryName),
       options
     )
 
@@ -44,7 +40,7 @@ export function remarkForm(
 export function liveRemarkForm(Component: any, options: RemarkFormProps = {}) {
   return function RemarkForm(props: any) {
     const [markdownRemark, form] = useRemarkForm(
-      props.data[options.queryName || 'markdownRemark'],
+      getMarkdownRemark(props.data, options.queryName),
       options
     )
 
@@ -62,4 +58,12 @@ export function liveRemarkForm(Component: any, options: RemarkFormProps = {}) {
       </TinaForm>
     )
   }
+}
+
+const getMarkdownRemark = (data: any, queryName: string = 'markdownRemark') => {
+  const markdownRemark = data[queryName]
+  if (!markdownRemark) {
+    throw ERROR_INVALID_QUERY_NAME(queryName)
+  }
+  return markdownRemark
 }


### PR DESCRIPTION
allow 'markdownRemark' queryName to be configurable. Also describe in the error message that 'queryName' can be used for aliases