### PR TITLE
fix: clicking wysiwyg does not provoke blur

### DIFF
--- a/packages/@tinacms/fields/src/Wysiwyg/state/plugins/Menu/Menu.tsx
+++ b/packages/@tinacms/fields/src/Wysiwyg/state/plugins/Menu/Menu.tsx
@@ -141,7 +141,6 @@ const commandContrl = (
           onClick={this.onClick}
           bottom={this.props.bottom}
           disabled={!this.canDo()}
-          onMouseDown={(e: any) => e.preventDefault()}
         >
           <Icon />
         </MenuButton>


### PR DESCRIPTION
closes #261 

Does not fix _editing_ links, but you can toggle the link-mark on some text