### PR TITLE
build: fix updating demo deps when bumping versions

### DIFF
--- a/packages/demo-cra/package.json
+++ b/packages/demo-cra/package.json
@@ -1,5 +1,6 @@
 {
   "name": "demo-cra",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "react-tinacms": "0.4.0",

--- a/packages/demo-gatsby/package.json
+++ b/packages/demo-gatsby/package.json
@@ -1,5 +1,6 @@
 {
   "name": "demo-gatsby",
+  "version": "1.0.0",
   "private": true,
   "description": "A starter for a blog powered by Gatsby and Markdown",
   "author": "Kyle Mathews <mathews.kyle@gmail.com>",

--- a/packages/demo-next/package.json
+++ b/packages/demo-next/package.json
@@ -1,5 +1,6 @@
 {
   "name": "demo-next",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "develop": "next dev",


### PR DESCRIPTION
`lerna version` doesn't update the dependencies of packages without
a version