### PR TITLE
Add missing step & fix path in Readme "To get started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ To get started:
 ```bash
 git clone git@github.com:tinacms/tinacms.git
 cd tinacms
-npm run bootstrap
+npm install && npm run bootstrap
 
 # Start the Gatsby demo
-cd packages/demo/demo-gatsby
-npm run start
+cd packages/demo-gatsby
+npm install && npm run start
 ```
 
 ### Commands


### PR DESCRIPTION
* Fix an error when setting up for the first time and running `npm run bootstrap` without first running `npm install`. 

> lerna ERR! ENOLERNA `lerna.json` does not exist, have you run `lerna init`?

* Correct path into demo folder
* Fix similar missing package error when running demo without first running npm install:

> Error: Unable to find plugin "gatsby-tinacms-json". Perhaps you need to install its package?