### PR TITLE
Date format fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ npm run start
 
 ### Commands
 
-| Commands                           | Descriptiton                                  |
+| Commands                           | Description                                  |
 | ---------------------------------- | --------------------------------------------- |
 | npm run bootstrap                  | Install dependencies and link local packages. |
 | npm run build                      | Build all packages                            |

--- a/packages/@tinacms/core/src/cms-forms/form.ts
+++ b/packages/@tinacms/core/src/cms-forms/form.ts
@@ -169,8 +169,8 @@ export interface Field {
   label?: string
   description?: string
   component: React.FC<any> | string | null
-  parse?: (value: string, name: string) => any
-  format?: (value: string, name: string) => any
+  parse?: (value: any, name: string, field: Field) => any
+  format?: (value: any, name: string, field: Field) => any
   defaultValue?: any
   fields?: Field[]
 }

--- a/packages/@tinacms/form-builder/src/field-plugin.tsx
+++ b/packages/@tinacms/form-builder/src/field-plugin.tsx
@@ -29,6 +29,7 @@ export interface FieldPlugin {
     meta: any,
     field: Field
   ): string | object | undefined
-  parse?: (value: string, name: string) => any
+  parse?: (value: any, name: string, field: Field) => any
+  format?: (value: any, name: string, field: Field) => any
   defaultValue?: any
 }

--- a/packages/@tinacms/form-builder/src/final-form-builder.tsx
+++ b/packages/@tinacms/form-builder/src/final-form-builder.tsx
@@ -86,6 +86,12 @@ export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
           parse = plugin.parse
         }
 
+        let format = field.format
+
+        if (!format && plugin && plugin.format) {
+          format = plugin.format
+        }
+
         let defaultValue = field.defaultValue
 
         if (!parse && plugin && plugin.defaultValue) {
@@ -97,8 +103,16 @@ export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
             name={field.name}
             key={field.name}
             type={type}
-            parse={parse}
-            format={field.format}
+            parse={
+              parse
+                ? (value: any, name: string) => parse!(value, name, field)
+                : undefined
+            }
+            format={
+              format
+                ? (value: any, name: string) => format!(value, name, field)
+                : undefined
+            }
             defaultValue={defaultValue}
             validate={(value, values, meta) => {
               if (plugin && plugin.validate) {

--- a/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
@@ -26,8 +26,7 @@ import { useEffect, useState, useRef } from 'react'
 import { useFrameContext } from '../../components/SyledFrame'
 import styled from 'styled-components'
 import { InputCss } from '@tinacms/fields'
-import * as _moment from 'moment'
-const moment = _moment //https://github.com/jvandemo/generator-angular2-library/issues/221#issuecomment-355945207
+import { format, parse } from './dateFormat'
 
 export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
   ({ input, field }) => {
@@ -74,31 +73,9 @@ const DatetimeContainer = styled.div`
   }
 `
 
-const DEFAULT_DATE_DISPLAY_FORMAT = 'MMM DD, YYYY'
 export default {
   name: 'date',
   Component: DateField,
-  format(
-    val: _moment.Moment | string,
-    _name: string,
-    field: DatetimepickerProps
-  ) {
-    const dateFormat =
-      typeof field.dateFormat === 'string'
-        ? field.dateFormat
-        : DEFAULT_DATE_DISPLAY_FORMAT
-
-    if (typeof val === 'string') {
-      var date = moment(val)
-      return date.isValid() ? date.format(dateFormat) : val
-    }
-    return moment(val).format(dateFormat)
-  },
-  parse(val: _moment.Moment | string): any {
-    if (typeof val === 'string') {
-      var date = moment(val)
-      return date.isValid() ? date.toDate() : val
-    }
-    return val.toDate()
-  },
+  format,
+  parse,
 }

--- a/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
@@ -26,6 +26,8 @@ import { useEffect, useState, useRef } from 'react'
 import { useFrameContext } from '../../components/SyledFrame'
 import styled from 'styled-components'
 import { InputCss } from '@tinacms/fields'
+import * as _moment from 'moment'
+const moment = _moment //https://github.com/jvandemo/generator-angular2-library/issues/221#issuecomment-355945207
 
 export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
   ({ input, field }) => {
@@ -57,6 +59,7 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
             onFocus={input.onFocus}
             onChange={input.onChange}
             open={isOpen}
+            timeFormat={false}
             {...field}
           />
         </ReactDateTimeContainer>
@@ -71,11 +74,31 @@ const DatetimeContainer = styled.div`
   }
 `
 
+const DEFAULT_DATE_DISPLAY_FORMAT = 'MMM DD, YYYY'
 export default {
   name: 'date',
   Component: DateField,
-  parse(date: any) {
-    if (typeof date === 'string') return date
-    return date.toDate()
+  format(
+    val: _moment.Moment | string,
+    _name: string,
+    field: DatetimepickerProps
+  ) {
+    const dateFormat =
+      typeof field.dateFormat === 'string'
+        ? field.dateFormat
+        : DEFAULT_DATE_DISPLAY_FORMAT
+
+    if (typeof val === 'string') {
+      var date = moment(val)
+      return date.isValid() ? date.format(dateFormat) : val
+    }
+    return moment(val).format(dateFormat)
+  },
+  parse(val: _moment.Moment | string): any {
+    if (typeof val === 'string') {
+      var date = moment(val)
+      return date.isValid() ? date.toDate() : val
+    }
+    return val.toDate()
   },
 }

--- a/packages/tinacms/src/plugins/fields/dateFormat.test.ts
+++ b/packages/tinacms/src/plugins/fields/dateFormat.test.ts
@@ -1,0 +1,70 @@
+import { format, parse } from './dateFormat'
+
+import * as _moment from 'moment'
+const moment = _moment //https://github.com/jvandemo/generator-angular2-library/issues/221#issuecomment-355945207
+
+describe('date format', () => {
+  describe('format', () => {
+    const dateString = '03 02 1972'
+    const dateFormat = 'MM DD YYYY'
+
+    describe('with moment input', () => {
+      it('returns properly formatted string', () => {
+        const date = moment(dateString, dateFormat)
+        const result = format(date, 'date', { dateFormat: 'MM YYYY' })
+        expect(result).toEqual('03 1972')
+      })
+    })
+
+    describe('with date string input', () => {
+      it('returns properly formatted string', () => {
+        const dateString = '03 02 1972'
+        const dateFormat = 'MM DD YYYY'
+        const result = format(dateString, 'date', { dateFormat: 'MM YYYY' })
+        expect(result).toEqual('03 1972')
+      })
+    })
+
+    describe('with non-date string input', () => {
+      it('returns input string', () => {
+        const result = format('hello!', 'date', { dateFormat: 'MM YYYY' })
+        expect(result).toEqual('hello!')
+      })
+    })
+  })
+
+  describe('parse', () => {
+    const dateString = '07 02 1972'
+    const dateFormat = 'MM DD YYYY'
+
+    describe('with moment input', () => {
+      it('returns correct date', () => {
+        const date = moment(dateString, dateFormat)
+        const result = parse(date, 'date', { dateFormat: 'MM YYYY' }) as Date
+
+        console.log('mmm ' + result)
+        console.log('month: ' + result.getMonth())
+        expect(result.getMonth()).toEqual(6)
+        expect(result.getFullYear()).toEqual(1972)
+      })
+    })
+
+    describe('with date string input', () => {
+      it('returns correct date', () => {
+        const result = parse('07/02/1992', 'date', {
+          dateFormat: 'MM/DD/YYYY', // should match date
+        }) as Date
+
+        expect(result.getMonth()).toEqual(6)
+        expect(result.getFullYear()).toEqual(1992)
+      })
+    })
+
+    describe('with non-date string input', () => {
+      it('returns input string', () => {
+        const result = parse('hello!', 'date', { dateFormat: 'MM YYYY' })
+        expect(result).toEqual('hello!')
+      })
+    })
+  })
+})

--- a/packages/tinacms/src/plugins/fields/dateFormat.ts
+++ b/packages/tinacms/src/plugins/fields/dateFormat.ts
@@ -1,0 +1,40 @@
+import * as _moment from 'moment'
+import { DatetimepickerProps } from 'react-datetime'
+const moment = _moment //https://github.com/jvandemo/generator-angular2-library/issues/221#issuecomment-355945207
+
+const DEFAULT_DATE_DISPLAY_FORMAT = 'MMM DD, YYYY'
+
+// Format date for display
+export const format = (
+  val: _moment.Moment | string,
+  _name: string,
+  field: DatetimepickerProps
+): string => {
+  const dateFormat =
+    typeof field.dateFormat === 'string'
+      ? field.dateFormat
+      : DEFAULT_DATE_DISPLAY_FORMAT
+
+  if (typeof val === 'string') {
+    const date = moment(val) // TODO Take in export date here once it's configurable
+    return date.isValid() ? date.format(dateFormat) : val
+  }
+  return moment(val).format(dateFormat)
+}
+
+// Format datepicker value for export
+export const parse = (
+  val: _moment.Moment | string,
+  _name: string,
+  field: DatetimepickerProps
+) => {
+  const dateFormat =
+    typeof field.dateFormat === 'string'
+      ? field.dateFormat
+      : DEFAULT_DATE_DISPLAY_FORMAT
+  if (typeof val === 'string') {
+    const date = moment(val, dateFormat)
+    return date.isValid() ? date.toDate() : val
+  }
+  return val.toDate()
+}


### PR DESCRIPTION
Fix for: https://github.com/tinacms/tinacms/issues/307 
Also:
- Uses 'format' from plugin if not set on field
- Adds "field" as a param for 'parse' & 'format'.
- Hides TimeFormat by default (because it's currently buggy, and will require more attention)
- Changes default date display to: MMM DD, YYYY