### PR TITLE
improvement: Use utc as default for datepicker

### DIFF
--- a/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
@@ -57,7 +57,7 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
             onFocus={input.onFocus}
             onChange={input.onChange}
             open={isOpen}
-            utc
+            utc // https://github.com/tinacms/tinacms/pull/326#issuecomment-543836469
             {...field}
           />
         </ReactDateTimeContainer>

--- a/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/DateFieldPlugin.tsx
@@ -57,6 +57,7 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
             onFocus={input.onFocus}
             onChange={input.onChange}
             open={isOpen}
+            utc
             {...field}
           />
         </ReactDateTimeContainer>


### PR DESCRIPTION
Displaying in the users timezone causes issues with the datepicker: https://github.com/tinacms/tinacms/issues/256

E.g When a user chooses Jan 26, it might then display Jan 25, or Jan 27 depending on the current time of day, and the browser's timezone setting. 

If a user wants to configure the display setting to use the user's timezone they can, but this will fix issues for the majority of users.