### PR TITLE
style: add fade in animation to empty state

### DIFF
--- a/packages/tinacms/src/components/FormView.tsx
+++ b/packages/tinacms/src/components/FormView.tsx
@@ -147,6 +147,15 @@ const Emoji = styled.span`
   display: inline-block;
 `
 
+const EmptyStateAnimation = keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`
+
 const EmptyState = styled.div`
   position: relative;
   display: flex;
@@ -158,6 +167,12 @@ const EmptyState = styled.div`
   width: 100%;
   height: 100%;
   overflow-y: auto;
+  animation-name: ${EmptyStateAnimation};
+  animation-delay: 300ms;
+  animation-timing-function: ease-out;
+  animation-iteration-count: 1;
+  animation-fill-mode: both;
+  animation-duration: 150ms;
   > *:first-child {
     margin: 0 0 ${padding()} 0;
   }


### PR DESCRIPTION
While forms load the empty state is sometimes displayed. This adds an animation with a delay so that in the time it takes a form to load the empty state isn't visible. 

Closes #291