### PR TITLE
Clearable Images

### DIFF
--- a/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
@@ -20,9 +20,11 @@ import * as React from 'react'
 import { useDropzone } from 'react-dropzone'
 import styled from 'styled-components'
 import { radius, color, font, timing } from '@tinacms/styles'
+import { TrashIcon } from '@tinacms/icons'
 
 interface ImageUploadProps {
   onDrop: (acceptedFiles: any[]) => void
+  onClear: () => void
   value?: string
   previewSrc?: string
 }
@@ -64,6 +66,13 @@ const ImgPlaceholder = styled.div`
   }
 `
 
+const ImageActions = styled.div`
+  top: 0;
+  right: 0;
+  position: absolute;
+  display: none;
+`
+
 const StyledImage = styled.img`
   max-width: 100%;
   border-radius: ${radius('small')};
@@ -71,10 +80,25 @@ const StyledImage = styled.img`
   ${DropArea}:hover & {
     opacity: 0.6;
   }
+
+  ${ImageActions} {
+    display: block;
+  }
+`
+
+const StyledImageContainer = styled.div`
+  position: relative;
+
+  &:hover {
+    ${ImageActions} {
+      display: block;
+    }
+  }
 `
 
 export const ImageUpload = ({
   onDrop,
+  onClear,
   value,
   previewSrc,
 }: ImageUploadProps) => {
@@ -90,7 +114,19 @@ export const ImageUpload = ({
     <DropArea {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
       <input {...getInputProps()} />
       {value ? (
-        <StyledImage src={previewSrc} />
+        <StyledImageContainer>
+          <StyledImage src={previewSrc} />
+          <ImageActions>
+            <DeleteButton
+              onClick={e => {
+                e.stopPropagation()
+                onClear()
+              }}
+            >
+              <TrashIcon />
+            </DeleteButton>
+          </ImageActions>
+        </StyledImageContainer>
       ) : (
         <ImgPlaceholder>
           Drag 'n' drop some files here,
@@ -101,3 +137,20 @@ export const ImageUpload = ({
     </DropArea>
   )
 }
+
+const DeleteButton = styled.button`
+  text-align: center;
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  padding: 0.75rem 0.5rem;
+  margin: 0;
+  transition: all 85ms ease-out;
+  svg {
+    transition: all 85ms ease-out;
+  }
+  &:hover {
+    background-color: #f6f6f9;
+  }
+`

--- a/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
@@ -24,7 +24,7 @@ import { TrashIcon } from '@tinacms/icons'
 
 interface ImageUploadProps {
   onDrop: (acceptedFiles: any[]) => void
-  onClear: () => void
+  onClear?: () => void
   value?: string
   previewSrc?: string
 }
@@ -118,14 +118,16 @@ export const ImageUpload = ({
       {value ? (
         <StyledImageContainer>
           <StyledImage src={previewSrc} />
-          <DeleteButton
-            onClick={e => {
-              e.stopPropagation()
-              onClear()
-            }}
-          >
-            <TrashIcon />
-          </DeleteButton>
+          {onClear && (
+            <DeleteButton
+              onClick={e => {
+                e.stopPropagation()
+                onClear()
+              }}
+            >
+              <TrashIcon />
+            </DeleteButton>
+          )}
         </StyledImageContainer>
       ) : (
         <ImgPlaceholder>

--- a/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
@@ -19,7 +19,7 @@ limitations under the License.
 import * as React from 'react'
 import { useDropzone } from 'react-dropzone'
 import styled from 'styled-components'
-import { radius, color, font, timing } from '@tinacms/styles'
+import { radius, color, font, timing, IconButton } from '@tinacms/styles'
 import { TrashIcon } from '@tinacms/icons'
 
 interface ImageUploadProps {
@@ -66,32 +66,34 @@ const ImgPlaceholder = styled.div`
   }
 `
 
-const ImageActions = styled.div`
-  top: 0;
-  right: 0;
-  position: absolute;
-  display: none;
-`
-
 const StyledImage = styled.img`
   max-width: 100%;
   border-radius: ${radius('small')};
   transition: opacity ${timing('short')} ease-out;
-  ${DropArea}:hover & {
-    opacity: 0.6;
-  }
+  margin: 0;
+  display: block;
+`
 
-  ${ImageActions} {
-    display: block;
+const DeleteButton = styled(IconButton)`
+  top: 0.5rem;
+  right: 0.5rem;
+  position: absolute;
+  &:not(:hover) {
+    fill: ${color.grey()};
+    background-color: transparent;
+    border-color: transparent;
   }
 `
 
 const StyledImageContainer = styled.div`
+  background-color: ${color.grey(4)};
   position: relative;
-
+  border-radius: ${radius('small')};
+  overflow: hidden;
+  background-color: ${color.grey(8)};
   &:hover {
-    ${ImageActions} {
-      display: block;
+    ${StyledImage} {
+      opacity: 0.6;
     }
   }
 `
@@ -116,16 +118,14 @@ export const ImageUpload = ({
       {value ? (
         <StyledImageContainer>
           <StyledImage src={previewSrc} />
-          <ImageActions>
-            <DeleteButton
-              onClick={e => {
-                e.stopPropagation()
-                onClear()
-              }}
-            >
-              <TrashIcon />
-            </DeleteButton>
-          </ImageActions>
+          <DeleteButton
+            onClick={e => {
+              e.stopPropagation()
+              onClear()
+            }}
+          >
+            <TrashIcon />
+          </DeleteButton>
         </StyledImageContainer>
       ) : (
         <ImgPlaceholder>
@@ -137,20 +137,3 @@ export const ImageUpload = ({
     </DropArea>
   )
 }
-
-const DeleteButton = styled.button`
-  text-align: center;
-  flex: 0 0 auto;
-  border: 0;
-  background: transparent;
-  cursor: pointer;
-  padding: 0.75rem 0.5rem;
-  margin: 0;
-  transition: all 85ms ease-out;
-  svg {
-    transition: all 85ms ease-out;
-  }
-  &:hover {
-    background-color: #f6f6f9;
-  }
-`

--- a/packages/@tinacms/styles/src/Button.tsx
+++ b/packages/@tinacms/styles/src/Button.tsx
@@ -101,7 +101,6 @@ export const IconButton = styled(Button)`
   height: 2rem;
   margin: 0;
   position: relative;
-  border: 1px solid ${color.primary()};
   transform-origin: 50% 50%;
   transition: all 150ms ease-out;
   padding: 0;

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -296,7 +296,7 @@ const BlogPostForm = {
       label: "Thumbnail",
       component: "image",
       // Generate the frontmatter value based on the filename
-      parse: filename => `./${filename}`,
+      parse: filename => (filename ? `./${filename}` : null),
 
       // Decide the file upload directory for the post
       uploadDir: blogPost => {

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -306,7 +306,7 @@ const BlogPostForm = {
           .splice(0, postPathParts.length - 1)
           .join("/")
 
-        return postDirectory
+        return "packages/demo-gatsby" + postDirectory
       },
 
       // Generate the src attribute for the preview image.

--- a/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
@@ -37,13 +37,15 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
       previewSrc={props.field.previewSrc(props.form.getState().values, props)}
       onDrop={(acceptedFiles: any[]) => {
         acceptedFiles.forEach(async (file: any) => {
-          // @ts-ignore
           await cms.api.git!.onUploadMedia!({
             directory: props.field.uploadDir(props.form.getState().values),
             content: file,
           })
           props.input.onChange(file.name)
         })
+      }}
+      onClear={() => {
+        props.input.onChange('')
       }}
     />
   )

--- a/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
@@ -26,6 +26,7 @@ interface ImageProps {
   path: string
   previewSrc(form: any, field: FieldProps): string
   uploadDir(form: any): string
+  clearable?: boolean // defaults to true
 }
 
 export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
@@ -44,9 +45,13 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
           props.input.onChange(file.name)
         })
       }}
-      onClear={() => {
-        props.input.onChange('')
-      }}
+      onClear={
+        props.field.clearable === false
+          ? undefined
+          : () => {
+              props.input.onChange('')
+            }
+      }
     />
   )
 })


### PR DESCRIPTION
Improvement for: https://github.com/tinacms/tinacms/issues/190

Add a delete button to the image-upload. 
Also fixed the upload directory in the demo project, and made its parse handle a clearable image.

TODO: 
- [x] Clearable should be an option
- [x] Needs some style love