### PR TITLE
Update docs on releasing to npm

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,7 @@ The exact commands vary slightly depending on the type of release being made.
 1. **Clean the CHANGELOGs**
 
    ```
-   lcc **
+   lcc ** && git commit -am "chore: clean changelogs"
    ```
 
 1. **Publish to NPM:**
@@ -155,7 +155,7 @@ The exact commands vary slightly depending on the type of release being made.
 1. **Clean the CHANGELOGs**
 
    ```
-   lcc **
+   lcc ** && git commit -am "chore: clean changelogs"
    ```
 
 1) **Publish to NPM:**
@@ -190,7 +190,7 @@ The exact commands vary slightly depending on the type of release being made.
 1. **Clean the CHANGELOGs**
 
    ```
-   lcc **
+   lcc ** && git commit -am "chore: clean changelogs"
    ```
 
 1. **Publish to NPM:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,7 +126,7 @@ The exact commands vary slightly depending on the type of release being made.
 
 1. **Publish to NPM:**
    ```
-   lerna publish from-git --dist-tag next
+   lerna publish from-package --dist-tag next
    ```
 1. **Push CHANGELOGs and git tags to Github:**
    ```
@@ -161,7 +161,7 @@ The exact commands vary slightly depending on the type of release being made.
 1) **Publish to NPM:**
 
    ```
-   lerna publish from-git
+   lerna publish from-package
    ```
 
 1) **Push CHANGELOGs and git tags to Github:**
@@ -195,7 +195,7 @@ The exact commands vary slightly depending on the type of release being made.
 
 1. **Publish to NPM:**
    ```
-   lerna publish from-git
+   lerna publish from-package
    ```
 1. **Push CHANGELOGs and git tags to Github:**
    ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ The exact commands vary slightly depending on the type of release being made.
      --conventional-commits \
      --conventional-prerelease \
      --no-push \
-     --allow-branch master \
+     --allow-branch next \
      -m "chore(publish): prerelease"
    ```
 
@@ -145,7 +145,7 @@ The exact commands vary slightly depending on the type of release being made.
      --conventional-commits \
      --conventional-graduate \
      --no-push \
-     --allow-branch master \
+     --allow-branch next \
      -m "chore(publish): graduation"
    ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,8 +83,11 @@ The general release process looks like this:
 1. **Clean the CHANGELOGs**
 
    Lerna sometimes adds empty changelog entries. For example, if `react-tinacms` is changed
-   then `tinacms` will get get a patch update with only the dependency updated. The following
-   script removes those entries from the changelog:
+   then `tinacms` will get get a patch update with only the dependency updated. Make sure to install `lerna-clean-changelog-cli`:
+
+   ```
+   npm i -g lerna-clean-changelogs-cli
+   ```
 
 1. **Publish to NPM:**
 
@@ -153,7 +156,6 @@ The exact commands vary slightly depending on the type of release being made.
 
    ```
    lcc **
-   ``
    ```
 
 1) **Publish to NPM:**
@@ -189,8 +191,6 @@ The exact commands vary slightly depending on the type of release being made.
 
    ```
    lcc **
-   ``
-
    ```
 
 1. **Publish to NPM:**


### PR DESCRIPTION
* switch branches where releases can be done from
* update `lcc` command and make sure it's installed
* release `from-package` instead of `from-git`
