### PR TITLE
feat(git): implement branch summary API

### DIFF
--- a/packages/@tinacms/api-git/src/router.ts
+++ b/packages/@tinacms/api-git/src/router.ts
@@ -146,6 +146,47 @@ export function router(config: GitRouterConfig = {}) {
       })
   })
 
+  router.get('/branch', async (req, res) => {
+    try {
+      let summary = await openRepo(REPO_ABSOLUTE_PATH).branchLocal()
+      res.send({ status: 'success', branch: summary.branches[summary.current] })
+    } catch(e) {
+      // TODO: More intelligently respond
+      res.status(500)
+      res.json({ status: 'failure', message: e.message })
+    }
+  })
+
+  router.get('/branches', async (req, res) => {
+    try {
+      let summary = await openRepo(REPO_ABSOLUTE_PATH).branchLocal()
+      res.send({ status: 'success', branches: summary.all })
+    } catch(e) {
+      // TODO: More intelligently respond
+      res.status(500)
+      res.json({ status: 'failure', message: e.message })
+    }
+  })
+
+  router.get('/branches/:name', async (req, res) => {
+    try {
+      let summary = await openRepo(REPO_ABSOLUTE_PATH).branchLocal()
+      let branch = summary.branches[req.params.name];
+
+      if (!branch) {
+        res.status(404);
+        res.json({ status: 'failure', message: `Branch not found: ${String(branch)}` });
+        return;
+      }
+
+      res.send({ status: 'success', branch })
+    } catch(e) {
+      // TODO: More intelligently respond
+      res.status(500)
+      res.json({ status: 'failure', message: e.message })
+    }
+  })
+
   router.get('/show/:fileRelativePath', async (req, res) => {
     try {
       let fileRelativePath = path

--- a/packages/@tinacms/git-client/src/git-client.ts
+++ b/packages/@tinacms/git-client/src/git-client.ts
@@ -164,4 +164,37 @@ export class GitClient {
       return response.json()
     })
   }
+
+  /**
+   * Get information about a local branch by name, or the current branch if no
+   * name is specified.
+   */
+  branch(name?: string) {
+    return fetch(
+      `${this.baseUrl}/${name ? `branches/${name}` : 'branch'}`,
+      {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      }
+    ).then(response => {
+      return response.json()
+    })
+  }
+
+  /**
+   * Get a list of the names of all local branches.
+   */
+  branches() {
+    return fetch(
+      `${this.baseUrl}/branches`,
+      {
+        headers: {
+          'Content-Type': 'application/json; charset=utf-8',
+        },
+      }
+    ).then(response => {
+      return response.json()
+    })
+  }
 }


### PR DESCRIPTION
closes #333 

<details><summary>Old Version (one endpoint)</summary>
This adds a branch API endpoint which returns a summary of branch information. The branch summary includes information about which branch is currently checked out, all available local branch names in a convenient array, and a dictionary to look up detailed information about each branch by name. The information for each branch includes the commit sha, the most recent commit message, and whether or not it is the current branch. There is also a `detached` flag which indicates whether the working copy is in a detached state. If we are detached, the detached commit is handled as an additional branch.

<details><summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/605824/67256691-b15e7d00-f488-11e9-9bdf-db8ae9d739fb.png)

</details>

## Response

Here I have the `debugging-branch` branch checked out, and local branches include `debugging-branch`, `branch` (the branch for this PR), and `master` (I apologize for these confusing branch names).

```json
{
  "summary":{
    "detached":false,
    "current":"debugging-branch",
    "all":[
      "branch",
      "debugging-branch",
      "master"
    ],
    "branches":{
      "branch":{
        "current":false,
        "name":"branch",
        "commit":"a1d84d45",
        "label":"add branch summary to client"
      },
      "debugging-branch":{
        "current":true,
        "name":"debugging-branch",
        "commit":"de99455d",
        "label":"debug run branch"
      },
      "master":{
        "current":false,
        "name":"master",
        "commit":"d4d79988",
        "label":"Merge pull request #340 from tinacms/docs-changes"
      }
    }
  },
  "status":"success"
}
```

## Detached Response

Here I just checked out `HEAD` directly to illustrate the detached state.

```json
{
  "summary":{
    "detached":true,
    "current":"de99455d",
    "all":[
      "de99455d",
      "branch",
      "debugging-branch",
      "master"
    ],
    "branches":{
      "de99455d":{
        "current":true,
        "name":"de99455d",
        "commit":"de99455d",
        "label":"debug run branch"
      },
      "branch":{
        "current":false,
        "name":"branch",
        "commit":"7363adf1",
        "label":"feat(git): add branch summary to client"
      },
      "debugging-branch":{
        "current":false,
        "name":"debugging-branch",
        "commit":"de99455d",
        "label":"debug run branch"
      },
      "master":{
        "current":false,
        "name":"master",
        "commit":"d4d79988",
        "label":"Merge pull request #340 from tinacms/docs-changes"
      }
    }
  },
  "status":"success"
}
```
</details>

This adds an API for basic and granular information about branches. It also adds corresponding methods to the git client. There are two new methods:

- `branches: void => Promise<{ branches: string[] }>` Responds with a list of local branch names.
- `branch: ?string => Promise<{ branch: BranchInfo }>` Responds with information about the given branch by name, or information about the currently checked out branch when no name is specified, where `BranchInfo` is:

```javascript
type BranchInfo = {
  name: string,
  commit: string,
  label: string,
  current: boolean,
}
```

These methods hit three new endpoints:

**`/branch`**:

```json
{
  "status": "success",
  "branch": {
    "current": true,
    "name": "develop",
    "commit": "8cc4fb51",
    "label": "Tina commit"
  }
}
```

**`/branches`**:

```json
{
  "status": "success",
  "branches": [
    "branch",
    "debugging-branch",
    "develop",
    "master",
    "push-on-commit"
  ]
}
```

**`/branch/:name`**:

```json
{
  "status": "success",
  "branch": {
    "current": false,
    "name": "master",
    "commit": "4413a6e4",
    "label": "[ahead 1] feat(git): implement pushOnCommit option"
  }
}
```