### PR TITLE
fix: fix block menu not showing all items

### DIFF
--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -98,16 +98,18 @@ const Blocks = function({ tinaForm, form, field, input }: BlockFieldProps) {
             document={frame.document}
             disabled={!visible}
           >
-            {Object.entries(field.templates).map(([name, template]) => (
-              <BlockOption
-                onClick={() => {
-                  addItem(name, template)
-                  setVisible(false)
-                }}
-              >
-                {template.label}
-              </BlockOption>
-            ))}
+            <BlockMenuList>
+              {Object.entries(field.templates).map(([name, template]) => (
+                <BlockOption
+                  onClick={() => {
+                    addItem(name, template)
+                    setVisible(false)
+                  }}
+                >
+                  {template.label}
+                </BlockOption>
+              ))}
+            </BlockMenuList>
           </Dismissible>
         </BlockMenu>
       </GroupListHeader>
@@ -244,6 +246,11 @@ const BlockMenu = styled.div<{ open: boolean }>`
       pointer-events: all;
       transform: translate3d(0, 2.25rem, 0) scale3d(1, 1, 1);
     `};
+`
+
+const BlockMenuList = styled.div`
+  display: flex;
+  flex-direction: column;
 `
 
 const BlockOption = styled.button`


### PR DESCRIPTION
Menu items are stacked horizontally so nothing after the first one is shown.

Before
<img width="299" alt="Screen Shot 2019-10-22 at 21 03 45" src="https://user-images.githubusercontent.com/601264/67327675-32148c00-f510-11e9-9217-a2199d7fadae.png">

After
<img width="295" alt="Screen Shot 2019-10-22 at 21 04 43" src="https://user-images.githubusercontent.com/601264/67327689-39d43080-f510-11e9-80d2-e57f54f8ab32.png">