### PR TITLE
build: npm run nuke

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "bootstrap": "lerna bootstrap --hoist --reject-cycles --force-local",
     "bs": "npm run bootstrap",
     "dev": "lerna run dev --reject-cycles",
+    "nuke": "lerna clean && find packages -name 'build' -type d -prune -exec rm -rf '{}' + && find packages -name '.rts2_cache' -type d -prune -exec rm -rf '{}' +",
     "test": "lerna run test --reject-cycles",
     "watch": "lerna run watch --parallel --reject-cylcles"
   },


### PR DESCRIPTION
running `npm run nuke` deletes all the following from packages:
* node_modules
* build
* .rts2_cache