### PR TITLE
build: make react a peer dependency >=16.8

### DIFF
--- a/packages/@tinacms/core/package.json
+++ b/packages/@tinacms/core/package.json
@@ -31,7 +31,6 @@
     "@types/jest": "^24.0.15",
     "@types/react": "^16.8.23",
     "jest": "^24.8.0",
-    "react": "^16.8.6",
     "ts-jest": "^24.0.2"
   },
   "dependencies": {
@@ -39,6 +38,6 @@
     "final-form-arrays": "^3.0.1"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": ">=16.8"
   }
 }

--- a/packages/@tinacms/fields/package.json
+++ b/packages/@tinacms/fields/package.json
@@ -51,10 +51,8 @@
     "awesome-typescript-loader": "^5.2.1",
     "babel-loader": "^8.0.6",
     "jest": "^24.8.0",
-    "react": "^16.8.6",
     "react-docgen-typescript-loader": "^3.1.0",
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
-    "react-dom": "^16.8.6",
     "ts-jest": "^24.0.2"
   },
   "dependencies": {
@@ -84,7 +82,7 @@
     "styled-components": "^4.3.2"
   },
   "peerDependencies": {
-    "react": "^16.8.6",
+    "react": ">=16.8",
     "react-dom": "^16.8.6"
   }
 }

--- a/packages/@tinacms/fields/package.json
+++ b/packages/@tinacms/fields/package.json
@@ -83,6 +83,6 @@
   },
   "peerDependencies": {
     "react": ">=16.8",
-    "react-dom": "^16.8.6"
+    "react-dom": ">=16.8"
   }
 }

--- a/packages/demo-cra/package.json
+++ b/packages/demo-cra/package.json
@@ -4,15 +4,19 @@
   "private": true,
   "dependencies": {
     "react-tinacms": "0.4.0",
-    "tinacms": "0.4.0",
+    "tinacms": "0.4.0"
+  },
+  "devDependencies": {
     "@types/jest": "^24.0.15",
     "@types/node": "12.6.8",
     "@types/react": "^16.8.23",
     "@types/react-dom": "^16.8.5",
-    "react": "^16.8.6",
-    "react-dom": "^16.8.6",
     "react-scripts": "3.0.1",
     "typescript": "^3.5.3"
+  },
+  "peerDependencies": {
+    "react": ">=16.8",
+    "react-dom": ">=16.8"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/packages/gatsby-tinacms-git/package.json
+++ b/packages/gatsby-tinacms-git/package.json
@@ -45,11 +45,13 @@
     "@types/lodash.throttle": "^4.1.6",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "gatsby-plugin-tinacms": "^0.1.7",
     "js-yaml": "^3.13.1",
     "lodash.throttle": "^4.1.1",
     "react-tinacms": "^0.4.0",
     "simple-git": "1.124.0",
     "tinacms": "^0.4.0"
+  },
+  "peerDependencies": {
+    "gatsby-plugin-tinacms": "^0.1.7"
   }
 }

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -31,9 +31,9 @@
     "@tinacms/scripts": "^0.1.5",
     "@types/jest": "^24.0.15",
     "@types/lodash.merge": "^4.6.6",
+    "@types/react-beautiful-dnd": "^11.0.3",
     "@types/styled-components": "4.1.8",
     "jest": "^24.8.0",
-    "react": "^16.8.6",
     "ts-jest": "^24.0.2"
   },
   "dependencies": {
@@ -42,7 +42,6 @@
     "@tinacms/form-builder": "^0.1.6",
     "@tinacms/icons": "^0.3.3",
     "@tinacms/styles": "^0.0.7",
-    "@types/react-beautiful-dnd": "^11.0.3",
     "lodash.merge": "^4.6.2",
     "react-beautiful-dnd": "^11.0.5",
     "react-datetime": "^2.16.3",
@@ -52,6 +51,6 @@
     "styled-components": "^4.3.2"
   },
   "peerDependencies": {
-    "react": "^16.8.6"
+    "react": ">=16.8"
   }
 }


### PR DESCRIPTION
Make sure all `tinacms/tinacms` packages declare `react` and `react-dom` as peer dependencies.

https://nodejs.org/en/blog/npm/peer-dependencies/#using-peer-dependencies

```json
  "peerDependencies": {
    "react": ">=16.8",
    "react-dom": ">=16.8"
  }
```

I chose `16.8` because we use React Hooks heavily, and that's the version where hooks were introduced.

What prompted me to look into this, was a issue #362. A similar change will probably have to be made for `styled-components`. 