### PR TITLE
build: attempt to publish canary releases

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - canary
 
 jobs:
   build:

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -22,4 +22,4 @@ jobs:
         run: npm run build
 
       - name: Release Canary
-        run: ./node_modules/.bin/lerna publish --canary --pre-id canary --dist-tag canary
+        run: ./node_modules/.bin/lerna publish --canary --yes --pre-id canary --dist-tag canary

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -1,0 +1,25 @@
+name: Release Canary
+
+on:
+  push:
+    branches:
+      - master
+      - canary
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install
+        run: npm ci
+
+      - name: Bootstrap
+        run: npm run bs
+
+      - name: Build
+        run: npm run build
+
+      - name: Release Canary
+        run: lerna publish --canary --pre-id canary --dist-tag canary

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -23,3 +23,5 @@ jobs:
 
       - name: Release Canary
         run: ./node_modules/.bin/lerna publish --canary --yes --pre-id canary --dist-tag canary
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -22,4 +22,4 @@ jobs:
         run: npm run build
 
       - name: Release Canary
-        run: lerna publish --canary --pre-id canary --dist-tag canary
+        run: ./node_modules/.bin/lerna publish --canary --pre-id canary --dist-tag canary

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -25,4 +25,4 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN}}" > ~/.npmrc
 
       - name: Release Canary
-        run: ./node_modules/.bin/lerna publish --canary --yes --pre-id canary --dist-tag canary
+        run: ./node_modules/.bin/lerna publish --canary --yes --preid canary --dist-tag canary

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Release Canary
         run: ./node_modules/.bin/lerna publish --canary --yes --pre-id canary --dist-tag canary
         env:
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Authorize NPM
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_AUTH_TOKEN}}" > ~/.npmrc
+
       - name: Release Canary
         run: ./node_modules/.bin/lerna publish --canary --yes --pre-id canary --dist-tag canary
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/packages/gatsby-plugin-tinacms/index.ts
+++ b/packages/gatsby-plugin-tinacms/index.ts
@@ -15,5 +15,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-
-// no-op

--- a/packages/gatsby-plugin-tinacms/index.ts
+++ b/packages/gatsby-plugin-tinacms/index.ts
@@ -15,3 +15,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+
+// no-op

--- a/packages/gatsby-tinacms-json/index.ts
+++ b/packages/gatsby-tinacms-json/index.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 */
 
+// TODO: Move to `use-json-form.ts`
 import { Form, FormOptions, Field } from '@tinacms/core'
 import { useCMSForm, useCMS, useWatchFormValues } from 'react-tinacms'
 import { useMemo, useCallback, useState, useEffect } from 'react'

--- a/packages/gatsby-tinacms-remark/index.ts
+++ b/packages/gatsby-tinacms-remark/index.ts
@@ -18,6 +18,7 @@ limitations under the License.
 
 /**
  * Top-level `index.js` is required for gatsby to recognize
- * the package as a valid plugin.
+ * the package as a valid plugin. This just exports the src
+ * dir, which is compiled typescript.
  */
 export * from './src'

--- a/packages/gatsby-tinacms-remark/index.ts
+++ b/packages/gatsby-tinacms-remark/index.ts
@@ -16,4 +16,8 @@ limitations under the License.
 
 */
 
+/**
+ * Top-level `index.js` is required for gatsby to recognize
+ * the package as a valid plugin.
+ */
 export * from './src'

--- a/packages/gatsby-tinacms-remark/index.ts
+++ b/packages/gatsby-tinacms-remark/index.ts
@@ -17,6 +17,8 @@ limitations under the License.
 */
 
 /**
+ * ## gatsby plugin entry
+ *
  * Top-level `index.js` is required for gatsby to recognize
  * the package as a valid plugin. This just exports the src
  * dir, which is compiled typescript.

--- a/packages/gatsby-tinacms-remark/index.ts
+++ b/packages/gatsby-tinacms-remark/index.ts
@@ -17,8 +17,6 @@ limitations under the License.
 */
 
 /**
- * # gatsby plugin entry
- *
  * Top-level `index.js` is required for gatsby to recognize
  * the package as a valid plugin. This just exports the src
  * dir, which is compiled typescript.

--- a/packages/gatsby-tinacms-remark/index.ts
+++ b/packages/gatsby-tinacms-remark/index.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 /**
- * ## gatsby plugin entry
+ * # gatsby plugin entry
  *
  * Top-level `index.js` is required for gatsby to recognize
  * the package as a valid plugin. This just exports the src


### PR DESCRIPTION
will happen on `master` and `canary` branches

canary versions could be installed like:

    yarn add tinacms@canary

I'm not exactly sure how valuable this will be in practice. When deciding what to publish, lerna only looks at packages changed between `HEAD` and `HEAD~1`. If you changed `gatsby-tinacms-git` in this latest commit, and `gatsby-tinacms-remark` in the previous. It would only publish `gatsby-tinacms-git`.

My hope is that in merging a PR it will recognize all packages modified by that PR, not just the ones  modified in that PRs last commit.

P.S. I'm going to squash and merge this branch