### PR TITLE
chore(linting): Turn off react-hooks/exhaustive-deps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,6 @@
     "react/jsx-uses-react": "error",
     "react/jsx-uses-vars": "error",
     "react-hooks/rules-of-hooks": "warn",
-    "react-hooks/exhaustive-deps": "warn"
+    "react-hooks/exhaustive-deps": "off"
   }
 }


### PR DESCRIPTION
https://github.com/tinacms/tinacms/issues/370#issuecomment-546142922

_According to @ncphillips:_

> we need to switch `"react-hooks/exhaustive-deps": "warn"` off entirely. It is a bad rule. The assumption that you want to re-run for all deps is just not correct. Doing so breaks tinacms, so until that's turned off please don't run the auto-fixer.