### PR TITLE
usePlugin accepts multiple plugins

### DIFF
--- a/packages/react-tinacms/src/use-plugin.tsx
+++ b/packages/react-tinacms/src/use-plugin.tsx
@@ -23,12 +23,24 @@ import { useCMS } from './use-cms'
 /**
  * A React Hook for adding Plugins to the CMS.
  *
- * @param plugin Plugin
+ * @alias usePlugins
  */
-export function usePlugin(plugin: Plugin) {
+export const usePlugin = usePlugins
+
+/**
+ *
+ * @alias usePlugin
+ */
+export function usePlugins(...plugins: Plugin[]) {
   const cms = useCMS()
   React.useEffect(() => {
-    cms.plugins.add(plugin)
-    return () => cms.plugins.remove(plugin)
-  }, [cms.plugins, plugin])
+    plugins.forEach(plugin => {
+      cms.plugins.add(plugin)
+    })
+    return () => {
+      plugins.forEach(plugin => {
+        cms.plugins.remove(plugin)
+      })
+    }
+  }, [cms.plugins, ...plugins])
 }

--- a/packages/react-tinacms/src/use-plugin.tsx
+++ b/packages/react-tinacms/src/use-plugin.tsx
@@ -31,16 +31,26 @@ export const usePlugin = usePlugins
  *
  * @alias usePlugin
  */
-export function usePlugins(...plugins: Plugin[]) {
+export function usePlugins(plugins: Plugin | Plugin[]) {
   const cms = useCMS()
+
+  let pluginArray: Plugin[]
+
+  if (Array.isArray(plugins)) {
+    pluginArray = plugins
+  } else {
+    pluginArray = [plugins]
+  }
+
   React.useEffect(() => {
-    plugins.forEach(plugin => {
+    pluginArray.forEach(plugin => {
       cms.plugins.add(plugin)
     })
+
     return () => {
-      plugins.forEach(plugin => {
+      pluginArray.forEach(plugin => {
         cms.plugins.remove(plugin)
       })
     }
-  }, [cms.plugins, ...plugins])
+  }, [cms.plugins, ...pluginArray])
 }

--- a/packages/react-tinacms/src/with-plugin.tsx
+++ b/packages/react-tinacms/src/with-plugin.tsx
@@ -25,10 +25,20 @@ import * as React from 'react'
  *
  * @param Component A React Component
  * @param plugin Plugin
+ * @alias withPlugin
  */
-export function withPlugin(Component: any, plugin: Plugin) {
+export function withPlugins(Component: any, ...plugins: Plugin[]) {
   return (props: any) => {
-    usePlugin(plugin)
+    usePlugin(...plugins)
     return <Component {...props} />
   }
 }
+
+/**
+ * A Higher-Order-Component for adding Plugins to the CMS.
+ *
+ * @param Component A React Component
+ * @param plugin Plugin
+ * @alias withPlugins
+ */
+export const withPlugin = withPlugins

--- a/packages/react-tinacms/src/with-plugin.tsx
+++ b/packages/react-tinacms/src/with-plugin.tsx
@@ -27,9 +27,9 @@ import * as React from 'react'
  * @param plugin Plugin
  * @alias withPlugin
  */
-export function withPlugins(Component: any, ...plugins: Plugin[]) {
+export function withPlugins(Component: any, plugins: Plugin | Plugin[]) {
   return (props: any) => {
-    usePlugin(...plugins)
+    usePlugin(plugins)
     return <Component {...props} />
   }
 }


### PR DESCRIPTION
## Previously

```ts
function usePlugin(plugin: Plugin): void 
function withPlugin(component: any, plugin: Plugin): void 
```

## Now

The above functions accept a single Plugin or a list of Plugin.

```ts
function usePlugin(plugins: Plugin | Plugin[]): void 
function withPlugin(component: any, plugins: Plugin | Plugin[]): void 
```

There's also an alias that's pluralized:

```ts
function usePlugins(plugins: Plugin | Plugin[]): void 
function withPlugins(component: any, plugins: Plugin | Plugin[]): void 
```

## Example

**usePlugin•*

```js
export default function Layourt(props) {
  usePlugins([
    CreatePostPlugin,
    CreateEventPlugin,
  ])

  return <div>...</div>
}
```

**withPlugin**

```js
export default withPlugin(Layout, [
  CreatePostPlugin,
  CreateEventPlugin,
])
```

## Why?

Right now if you want to include multiple plugins you need to wrap multiple times:

```js
export default withPlugin(withPlugin(Layout, CreatePostPlugin), CreateEventPlugin)
```