### PR TITLE
build(danger): check for milestone

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -60,8 +60,10 @@ function runChecksOnPullRequest() {
     ...danger.git.modified_files,
   ]
 
+  // Files
   allFiles.filter(fileNeedsLicense).forEach(checkFileForLicenseHeader)
 
+  // Packages
   let modifiedPackages = getModifiedPackages(allFiles)
 
   modifiedPackages.forEach(warnIfMissingTestChanges)
@@ -69,7 +71,45 @@ function runChecksOnPullRequest() {
   modifiedPackages.forEach(checkForLicense)
 
   listTouchedPackages(modifiedPackages)
+
+  // Github Actions Workflows
   listTouchedWorkflows(allFiles)
+
+  // Pull Request
+  if (modifiedPackages.length > 0) {
+    checkForMilestone()
+  }
+}
+
+/**
+ * Any PR that modifies one of the packages should be attached to a milestone.
+ */
+function checkForMilestone() {
+  // @ts-ignore
+  if (danger.github.pr.milestone) {
+    // @ts-ignore
+    let milestone: Milestone = danger.github.pr.milestone
+    message(
+      // @ts-ignore
+      `You can expect the changes in this PR to be published on ${formatDate(
+        new Date(milestone.due_on)
+      )}`
+    )
+  } else {
+    warn(`@tinacms/dev please add to a Milestone before merging `)
+  }
+}
+
+// This is missing from the `danger` types
+interface Milestone {
+  due_on: string
+}
+
+function formatDate(date: Date) {
+  const day = date.getDay()
+  const month = date.getMonth() + 1
+  const year = date.getFullYear()
+  return `${year}-${month}-${day}`
 }
 
 /**

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -47,7 +47,15 @@ interface TinaPackage {
   /**
    * The contents of it's `package.json`.
    */
-  packageJson: any
+  packageJson: {
+    name: string
+    scripts: {
+      dev: string
+      build: string
+      watch: string
+    }
+    license: string
+  }
 }
 
 /**
@@ -140,7 +148,11 @@ function checkForNpmScripts({ packageJson }: TinaPackage) {
   }
   let scripts = packageJson.scripts || {}
 
-  let requiredScripts = ['dev', 'build', 'watch']
+  let requiredScripts: (keyof TinaPackage['packageJson']['scripts'])[] = [
+    'dev',
+    'build',
+    'watch',
+  ]
 
   requiredScripts.forEach(scriptName => {
     if (!scripts[scriptName]) {


### PR DESCRIPTION
`tinacms` uses milestones to keep track of what will be published with a new release.

This update reminds the @tinacms/devs to add PRs to a milestone before merging.