### PR TITLE
Blocks item props

### DIFF
--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -186,14 +186,21 @@ const heading = {
   defaultItem: {
     text: "",
   },
+  itemProps: block => ({
+    label: `${block.text}`,
+  }),
   fields: [{ name: "text", component: "text", label: "Text" }],
 }
 
 const image = {
-  label: "img",
+  label: "Image",
   defaultItem: {
     text: "",
   },
+  itemProps: block => ({
+    key: `${block.src}`,
+    label: `${block.alt}`,
+  }),
   fields: [
     { name: "src", component: "text", label: "Source URL" },
     { name: "alt", component: "text", label: "Alt Text" },

--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -51,7 +51,7 @@ interface BlocksFieldDefinititon extends Field {
 
 interface BlockTemplate {
   label: string
-  defaultItem: object
+  defaultItem?: object | (() => object)
   key: string
   fields: Field[]
 }
@@ -67,8 +67,13 @@ interface BlockFieldProps {
 const Blocks = function({ tinaForm, form, field, input }: BlockFieldProps) {
   const frame = useFrameContext()
   const addItem = React.useCallback(
-    (name, template) => {
-      const obj = template.defaultItem || {}
+    (name: string, template: BlockTemplate) => {
+      let obj: any = {}
+      if (typeof template.defaultItem === 'function') {
+        obj = template.defaultItem()
+      } else {
+        obj = template.defaultItem || {}
+      }
       obj._template = name
       form.mutators.insert(field.name, 0, obj)
     },


### PR DESCRIPTION
Two features were added to Block templates in this PR:

* `itemProps` lets you programmatically set the `key` and `label`
* `defaultItem` can be a function

```javascript
const heading = {
  label: "Heading",
  defaultItem: {
    text: "",
  },
  itemProps: block => ({
    label: `${block.text}`,
  }),
  fields: [{ name: "text", component: "text", label: "Text" }],
}

const image = {
  label: "Image",
  defaultItem: () => ({
    text: "",
  }),
  itemProps: block => ({
    key: `${block.src}`,
    label: `${block.alt}`,
  }),
  fields: [
    { name: "src", component: "text", label: "Source URL" },
    { name: "alt", component: "text", label: "Alt Text" },
  ],
}```
