### PR TITLE
Support Gatsby on Windows #382

### DIFF
--- a/packages/gatsby-tinacms-remark/gatsby-node.js
+++ b/packages/gatsby-tinacms-remark/gatsby-node.js
@@ -15,10 +15,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-const { GraphQLString } = require("gatsby/graphql")
+const { GraphQLString } = require("gatsby/graphql");
+const slash = require("slash");
 
 exports.setFieldsOnGraphQLNodeType = ({ type }) => {
-  const pathRoot = process.cwd()
+  const pathRoot = slash(process.cwd());
   if (type.name === `MarkdownRemark`) {
     return {
       rawFrontmatter: {


### PR DESCRIPTION
On Windows the resolution for `fileRelativePath` was  incorrect because the 
`source.fileAbsolutePath` has been normalised to use forward slashes on both `win32` and `posix`.
So that it reads like
    
    C:/project/tinacms/content/hello-world/index.md

To correctly calculate the relativePath, on windows, we need to turn `process.cwd()`
from 

    C:\project\tinacms\

to

    C:/project/tinacms/

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
