### PR TITLE
gatsby-tinacms-json throws helpful errors if improperly configured

### DIFF
--- a/packages/gatsby-tinacms-json/index.ts
+++ b/packages/gatsby-tinacms-json/index.ts
@@ -132,5 +132,16 @@ export function JsonForm({ data, render, ...options }: JsonFormProps) {
 }
 
 function validateJsonNode(jsonNode: JsonNode) {
-  // TODO
+  if (typeof jsonNode.fileRelativePath === 'undefined') {
+    throw new Error(ERROR_MISSING_REMARK_PATH)
+  }
 }
+
+export const ERROR_MISSING_REMARK_PATH =
+  'useJsonForm(jsonNode) Required attribute `fileRelativePath` was not found on the `jsonNode`.' +
+  `
+
+1. Check if the \`gatsby-tinacms-json\` was added to the \`gatsby-config.js\`.
+2. Check if the \`fileRelativePath\` attribute is included in the GraphQL query.
+
+  `

--- a/packages/gatsby-tinacms-json/index.ts
+++ b/packages/gatsby-tinacms-json/index.ts
@@ -135,6 +135,10 @@ function validateJsonNode(jsonNode: JsonNode) {
   if (typeof jsonNode.fileRelativePath === 'undefined') {
     throw new Error(ERROR_MISSING_REMARK_PATH)
   }
+
+  if (typeof jsonNode.rawJson === 'undefined') {
+    throw new Error(ERROR_MISSING_RAW_JSON)
+  }
 }
 
 export const ERROR_MISSING_REMARK_PATH =
@@ -143,5 +147,14 @@ export const ERROR_MISSING_REMARK_PATH =
 
 1. Check if the \`gatsby-tinacms-json\` was added to the \`gatsby-config.js\`.
 2. Check if the \`fileRelativePath\` attribute is included in the GraphQL query.
+
+  `
+
+export const ERROR_MISSING_RAW_JSON =
+  'useJsonForm(jsonNode) Required attribute `rawJson` was not found on the `jsonNode`.' +
+  `
+
+1. Check if the \`gatsby-tinacms-json\` was added to the \`gatsby-config.js\`.
+2. Check if the \`rawJson\` attribute is included in the GraphQL query.
 
   `


### PR DESCRIPTION
## Missing `fileRelativePath`

<img width="1025" alt="image" src="https://user-images.githubusercontent.com/824015/67708141-e4b57600-f978-11e9-8e43-78c47d44996b.png">

## Missing `rawJson`

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/824015/67708808-02cfa600-f97a-11e9-8992-6069af14a134.png">
