### PR TITLE
Add CreateRemarkPlugin class

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -182,12 +182,16 @@ function fileNeedsLicense(filepath: string) {
  *
  */
 function checkFileForLicenseHeader(filepath: string) {
-  let content = fs.readFileSync(path.resolve(`./${filepath}`), {
-    encoding: 'utf8',
-  })
+  try {
+    let content = fs.readFileSync(path.resolve(`./${filepath}`), {
+      encoding: 'utf8',
+    })
 
-  if (isMissingHeader(content)) {
-    fail(`${filepath} is missing the license header`)
+    if (isMissingHeader(content)) {
+      fail(`${filepath} is missing the license header`)
+    }
+  } catch {
+    // The file was deleted. That's okay.
   }
 }
 

--- a/packages/gatsby-tinacms-remark/src/create-remark-plugin.ts
+++ b/packages/gatsby-tinacms-remark/src/create-remark-plugin.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import { toMarkdownString } from './to-markdown'
-import { CMS, Field } from '@tinacms/core'
+import { CMS, Field, Form } from '@tinacms/core'
 import { AddContentPlugin } from 'tinacms'
 
 type MaybePromise<T> = Promise<T> | T
@@ -35,38 +35,57 @@ const MISSING_FILENAME_MESSAGE =
 const MISSING_FIELDS_MESSAGE =
   'createRemarkButton must be given `fields: Field[]` with at least 1 item'
 
+/**
+ *
+ * @deprecated in favour of calling `CreateRemarkPlugin` class directly.
+ */
 export function createRemarkButton<FormShape = any, FrontmatterShape = any>(
   options: CreateRemarkButtonOptions<FormShape, FrontmatterShape>
-): AddContentPlugin {
-  if (!options.filename) {
-    console.error(MISSING_FILENAME_MESSAGE)
-    throw new Error(MISSING_FILENAME_MESSAGE)
-  }
-  if (!options.fields || options.fields.length === 0) {
-    console.error(MISSING_FIELDS_MESSAGE)
-    throw new Error(MISSING_FIELDS_MESSAGE)
-  }
-  const formatFilename = options.filename
-  const createFrontmatter = options.frontmatter || (() => ({}))
-  const createBody = options.body || (() => '')
-  return {
-    __type: 'content-button',
-    name: options.label,
-    fields: options.fields,
-    onSubmit: async (form: any, cms: CMS) => {
-      const filename = await formatFilename(form)
-      const rawFrontmatter = await createFrontmatter(form)
-      const rawMarkdownBody = await createBody(form)
+): AddContentPlugin<FormShape> {
+  return new CreateRemarkPlugin<FormShape, FrontmatterShape>(options)
+}
 
-      const fileRelativePath = filename
-      cms.api.git!.onChange!({
+export class CreateRemarkPlugin<FormShape = any, FrontmatterShape = any>
+  implements AddContentPlugin<FormShape> {
+  __type: 'content-button' = 'content-button'
+  name: AddContentPlugin<FormShape>['name']
+  fields: AddContentPlugin<FormShape>['fields']
+
+  // Remark Specific
+  filename: (form: FormShape) => MaybePromise<string>
+  frontmatter: (form: FormShape) => MaybePromise<FrontmatterShape>
+  body: (form: any) => MaybePromise<string>
+
+  constructor(options: CreateRemarkButtonOptions<FormShape, FrontmatterShape>) {
+    if (!options.filename) {
+      console.error(MISSING_FILENAME_MESSAGE)
+      throw new Error(MISSING_FILENAME_MESSAGE)
+    }
+
+    if (!options.fields || options.fields.length === 0) {
+      console.error(MISSING_FIELDS_MESSAGE)
+      throw new Error(MISSING_FIELDS_MESSAGE)
+    }
+
+    this.name = options.label
+    this.fields = options.fields
+    this.filename = options.filename
+    this.frontmatter = options.frontmatter || (() => ({} as FrontmatterShape))
+    this.body = options.body || (() => '')
+  }
+
+  async onSubmit(form: FormShape, cms: CMS) {
+    const fileRelativePath = await this.filename(form)
+    const rawFrontmatter = await this.frontmatter(form)
+    const rawMarkdownBody = await this.body(form)
+
+    cms.api.git!.onChange!({
+      fileRelativePath,
+      content: toMarkdownString({
         fileRelativePath,
-        content: toMarkdownString({
-          fileRelativePath,
-          rawFrontmatter,
-          rawMarkdownBody,
-        }),
-      })
-    },
+        rawFrontmatter,
+        rawMarkdownBody,
+      }),
+    })
   }
 }

--- a/packages/gatsby-tinacms-remark/src/index.ts
+++ b/packages/gatsby-tinacms-remark/src/index.ts
@@ -19,4 +19,4 @@ limitations under the License.
 export * from './useRemarkForm'
 export * from './remarkFormHoc'
 export * from './RemarkForm'
-export * from './create-remark-plugin'
+export * from './remark-creator-plugin'

--- a/packages/gatsby-tinacms-remark/src/remark-creator-plugin.ts
+++ b/packages/gatsby-tinacms-remark/src/remark-creator-plugin.ts
@@ -42,10 +42,10 @@ const MISSING_FIELDS_MESSAGE =
 export function createRemarkButton<FormShape = any, FrontmatterShape = any>(
   options: CreateRemarkButtonOptions<FormShape, FrontmatterShape>
 ): AddContentPlugin<FormShape> {
-  return new CreateRemarkPlugin<FormShape, FrontmatterShape>(options)
+  return new RemarkCreatorPlugin<FormShape, FrontmatterShape>(options)
 }
 
-export class CreateRemarkPlugin<FormShape = any, FrontmatterShape = any>
+export class RemarkCreatorPlugin<FormShape = any, FrontmatterShape = any>
   implements AddContentPlugin<FormShape> {
   __type: 'content-button' = 'content-button'
   name: AddContentPlugin<FormShape>['name']

--- a/packages/tinacms/src/plugins/create-content-form-plugin.ts
+++ b/packages/tinacms/src/plugins/create-content-form-plugin.ts
@@ -19,8 +19,8 @@ limitations under the License.
 import { TinaCMS } from '../tina-cms'
 import { Field, Plugin } from '@tinacms/core'
 
-export interface AddContentPlugin extends Plugin {
+export interface AddContentPlugin<FormShape> extends Plugin {
   __type: 'content-button'
-  onSubmit(value: string, cms: TinaCMS): Promise<void> | void
+  onSubmit(value: FormShape, cms: TinaCMS): Promise<void> | void
   fields: Field[]
 }


### PR DESCRIPTION
Deprecates `createRemarkButton` in favour of a class.

```
let PostCreatorPlugin = new RemarkCreatorPlugin({
  // ...
})
```

Will require an update to the docs.
