### PR TITLE
WIP - fix(git): fix comitting when global name & email isn't set

### DIFF
--- a/packages/@tinacms/api-git/src/commit.ts
+++ b/packages/@tinacms/api-git/src/commit.ts
@@ -38,14 +38,16 @@ export async function commit({
   pathRoot,
   push,
 }: CommitOptions) {
+  const repo = openRepo(pathRoot)
+
   let options
   if (email) {
     options = {
       '--author': `"${name || email} <${email}>"`,
     }
+    repo.addConfig('user.name', name || email)
+    repo.addConfig('user.email', email)
   }
-
-  const repo = openRepo(pathRoot)
 
   await repo.add(files)
   const commitResult = await repo.commit(message, files, options)


### PR DESCRIPTION
DO NOT MERGE - 
We may want these set through environment variables instead of gatsby-config settings. Needs discussion

If you don't have a global git `user.name` & `user.email` set, the commit will fail.
This sets your repo's git committer username & email. It might not be ideal to set this on your repo, but I haven't had any luck setting it on an individual commit

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
