### PR TITLE
fix(git): set branchname on push (required for cloud pushes)

### DIFF
--- a/packages/@tinacms/api-git/src/commit.ts
+++ b/packages/@tinacms/api-git/src/commit.ts
@@ -47,7 +47,10 @@ export async function commit({
 
   const repo = openRepo(pathRoot)
 
+  const branchName = await repo.revparse('--abbrev-ref HEAD')
+  console.log(`branchName ${branchName}`)
+
   await repo.add(files)
   const commitResult = await repo.commit(message, files, options)
-  return push ? await repo.push() : commitResult
+  return push ? await repo.push('origin', branchName) : commitResult
 }

--- a/packages/@tinacms/api-git/src/commit.ts
+++ b/packages/@tinacms/api-git/src/commit.ts
@@ -48,7 +48,6 @@ export async function commit({
   const repo = openRepo(pathRoot)
 
   const branchName = await repo.revparse('--abbrev-ref HEAD')
-  console.log(`branchName ${branchName}`)
 
   await repo.add(files)
   const commitResult = await repo.commit(message, files, options)


### PR DESCRIPTION
On Tina Teams, the push will fail unless we explicitly set the branchname

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
