### PR TITLE
feat: use form options label when provided

### DIFF
--- a/packages/gatsby-tinacms-json/src/use-json-form.ts
+++ b/packages/gatsby-tinacms-json/src/use-json-form.ts
@@ -43,7 +43,7 @@ export function useJsonForm(
 
   /* eslint-disable-next-line react-hooks/rules-of-hooks */
   const cms = useCMS()
-  const label = jsonNode.fileRelativePath
+  const label = formOptions.label || jsonNode.fileRelativePath
   const id = jsonNode.fileRelativePath
 
   /**


### PR DESCRIPTION
Updating `useJsonForm` to use the same label logic as `useRemarkForm`; look for a provided label first and use `fileRelativePath` as a fallback.