### PR TITLE
fix: resets active form to null for multiple list

### DIFF
--- a/packages/tinacms/src/components/FormView.tsx
+++ b/packages/tinacms/src/components/FormView.tsx
@@ -42,15 +42,18 @@ import { FORM_HEADER_HEIGHT, SIDEBAR_HEADER_HEIGHT } from '../Globals'
 import { GroupPanel } from '../plugins/fields'
 
 export const FormsView = () => {
-  const [activeFormId, setActiveFormId] = useState<string>()
+  const [activeFormId, setActiveFormId] = useState()
   const cms = useCMS()
 
   /**
    * If there's only one form, make it the active form.
+   * If there's multiple forms, set to null so the list shows.
    */
   useSubscribable(cms.forms, () => {
     if (cms.forms.all().length === 1) {
       setActiveFormId(cms.forms.all()[0].id)
+    } else {
+      setActiveFormId(null)
     }
   })
 
@@ -73,11 +76,11 @@ export const FormsView = () => {
   /**
    * No Forms
    */
-  if (!forms.length) {
+  if ( !forms.length ) {
     return <NoFormsPlaceholder />
   }
 
-  if (!activeForm) {
+  if ( !activeForm ) {
     return (
       <FormsList
         isEditing={isEditing}


### PR DESCRIPTION
Should fix #438 but opens up new issue

From the thread:
the original problem

The problem is that the number of forms registered with Tina doesn't happen all at once. SoFormsView mounts and at first it thinks it has no forms, then it thinks it has one, then it finally knows it has 2 etc. So essentially this useSubscribable will set the form id when it thinks it has one form and won't update it again even if the component registered more forms down the line. If we add this reset to null, it will fix the initial problem... but opens up a new issue.
the new problem

The problem we run into now is that a flash of the individual form happens when the component only registers one component, but it finally lands on the list. Thoughts on how we could mitigate this?
overarching question

Could we somehow wait to render the FormView until all the forms have been registered to prevent render flashes?

Boot up the gatsby-demo to see the flash I am talking about.

Don't merge until we figure out a way to prevent the flash...
@spbyrne thoughts?

