### PR TITLE
fix(useJsonForm): writes out all data Closes #450

### DIFF
--- a/packages/gatsby-tinacms-json/src/use-json-form.ts
+++ b/packages/gatsby-tinacms-json/src/use-json-form.ts
@@ -111,10 +111,10 @@ export function useJsonForm(
 
   /* eslint-disable-next-line react-hooks/rules-of-hooks */
   const writeToDisk = useCallback(formState => {
-    const { fileRelativePath, rawJson, ...data } = formState.values.rawJson
+    const { rawJson, jsonNode } = formState.values
     cms.api.git.onChange!({
-      fileRelativePath: formState.values.jsonNode.fileRelativePath,
-      content: JSON.stringify(data, null, 2),
+      fileRelativePath: jsonNode.fileRelativePath,
+      content: JSON.stringify(rawJson, null, 2),
     })
   }, [])
 


### PR DESCRIPTION
useJsonForm was only writing out fields if they had
been queried for in the gatsby GraphQL query.
