### PR TITLE
fix(json): don't leak 'fields' into rawJson

### DIFF
--- a/packages/gatsby-tinacms-json/gatsby-node.js
+++ b/packages/gatsby-tinacms-json/gatsby-node.js
@@ -29,7 +29,7 @@ exports.setFieldsOnGraphQLNodeType = ({ type, getNode }) => {
     rawJson: {
       type: GraphQLString,
       args: {},
-      resolve: ({ children, id, internal, parent, ...data }) => {
+      resolve: ({ children, id, internal, parent, fields, ...data }) => {
         return JSON.stringify(data)
       },
     },


### PR DESCRIPTION
The `fields` key in a node's top level is generated by plugins and shouldn't be persisted to the source file. When it is, aside from data corruption, Gatsby throws the following error:

```
gatsby-transformer-json" threw an error while running the onCreateNode lifecycle:

Plugins creating nodes can not set data on the reserved field "fields"
      as this is reserved for plugins which wish to extend your nodes.
```