### PR TITLE
fix(Blocks): add placeholder for invalid blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10386,9 +10386,9 @@
 			"dev": true
 		},
 		"deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-			"integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
 			"requires": {
 				"is-arguments": "^1.0.4",
 				"is-date-object": "^1.0.1",
@@ -26708,6 +26708,11 @@
 						"x-is-string": "^0.1.0"
 					}
 				},
+				"unist-util-stringify-position": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+					"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+				},
 				"vfile": {
 					"version": "3.0.1",
 					"resolved": "https://registry.npmjs.org/vfile/-/vfile-3.0.1.tgz",
@@ -26717,6 +26722,14 @@
 						"replace-ext": "1.0.0",
 						"unist-util-stringify-position": "^1.0.0",
 						"vfile-message": "^1.0.0"
+					}
+				},
+				"vfile-message": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+					"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+					"requires": {
+						"unist-util-stringify-position": "^1.1.1"
 					}
 				}
 			}
@@ -30100,9 +30113,12 @@
 			}
 		},
 		"unist-util-stringify-position": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
-			"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-2.0.2.tgz",
+			"integrity": "sha512-nK5n8OGhZ7ZgUwoUbL8uiVRwAbZyzBsB/Ddrlbu6jwwubFza4oe15KlyEaLNMXQW1svOQq4xesUeqA85YrIUQA==",
+			"requires": {
+				"@types/unist": "^2.0.2"
+			}
 		},
 		"unist-util-visit": {
 			"version": "1.4.1",
@@ -30496,6 +30512,21 @@
 				"replace-ext": "1.0.0",
 				"unist-util-stringify-position": "^1.0.0",
 				"vfile-message": "^1.0.0"
+			},
+			"dependencies": {
+				"unist-util-stringify-position": {
+					"version": "1.1.2",
+					"resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz",
+					"integrity": "sha512-pNCVrk64LZv1kElr0N1wPiHEUoXNVFERp+mlTg/s9R5Lwg87f9bM/3sQB99w+N9D/qnM9ar3+AKDBwo/gm/iQQ=="
+				},
+				"vfile-message": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
+					"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+					"requires": {
+						"unist-util-stringify-position": "^1.1.1"
+					}
+				}
 			}
 		},
 		"vfile-location": {
@@ -30504,11 +30535,12 @@
 			"integrity": "sha512-sSFdyCP3G6Ka0CEmN83A2YCMKIieHx0EDaj5IDP4g1pa5ZJ4FJDvpO0WODLxo4LUX4oe52gmSCK7Jw4SBghqxA=="
 		},
 		"vfile-message": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-1.1.1.tgz",
-			"integrity": "sha512-1WmsopSGhWt5laNir+633LszXvZ+Z/lxveBf6yhGsqnQIhlhzooZae7zV6YVM1Sdkw68dtAW3ow0pOdPANugvA==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-2.0.2.tgz",
+			"integrity": "sha512-gNV2Y2fDvDOOqq8bEe7cF3DXU6QgV4uA9zMR2P8tix11l1r7zju3zry3wZ8sx+BEfuO6WQ7z2QzfWTvqHQiwsA==",
 			"requires": {
-				"unist-util-stringify-position": "^1.1.1"
+				"@types/unist": "^2.0.0",
+				"unist-util-stringify-position": "^2.0.0"
 			}
 		},
 		"vm-browserify": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/jest": "^24.0.15",
     "@typescript-eslint/eslint-plugin": "^2.3.0",
     "@typescript-eslint/parser": "^2.3.0",
+    "@types/vfile-message": "^2.0.0",
     "commander": "^2.20.0",
     "eslint": "^6.4.0",
     "eslint-config-prettier": "^6.3.0",

--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -142,18 +142,26 @@ const Blocks = function({ tinaForm, form, field, input }: BlockFieldProps) {
       <GroupListPanel>
         <ItemList>
           <Droppable droppableId={field.name} type={field.name}>
-            {(provider) => (
+            {provider => (
               <div ref={provider.innerRef} className="edit-page--list-parent">
                 {items.length === 0 && <EmptyState />}
                 {items.map((block: any, index: any) => {
                   const template = field.templates[block._template]
+
                   if (!template) {
-                    // TODO: if no template return invalid entry
+                    return (
+                      <InvalidBlockListItem
+                        index={index}
+                        field={field}
+                        tinaForm={tinaForm}
+                      />
+                    )
                   }
+
                   const itemProps = (item: object) => {
                     if (!template.itemProps) return {}
                     return template.itemProps(item)
-                  };
+                  }
 
                   return (
                     <BlockListItem
@@ -237,6 +245,46 @@ const BlockListItem = ({
             template={template}
           />
         </>
+      )}
+    </Draggable>
+  )
+}
+
+const InvalidBlockListItem = ({
+  tinaForm,
+  field,
+  index,
+}: {
+  tinaForm: Form
+  field: Field
+  index: number
+}) => {
+  const removeItem = React.useCallback(() => {
+    tinaForm.finalForm.mutators.remove(field.name, index)
+  }, [tinaForm, field, index])
+
+  return (
+    <Draggable
+      key={index}
+      type={field.name}
+      draggableId={`${field.name}.${index}`}
+      index={index}
+    >
+      {(provider, snapshot) => (
+        <ItemHeader
+          ref={provider.innerRef}
+          isDragging={snapshot.isDragging}
+          {...provider.draggableProps}
+          {...provider.dragHandleProps}
+        >
+          <DragHandle />
+          <ItemClickTarget>
+            <GroupLabel>Invalid Block</GroupLabel>
+          </ItemClickTarget>
+          <DeleteButton onClick={removeItem}>
+            <TrashIcon />
+          </DeleteButton>
+        </ItemHeader>
       )}
     </Draggable>
   )

--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -279,7 +279,7 @@ const InvalidBlockListItem = ({
         >
           <DragHandle />
           <ItemClickTarget>
-            <GroupLabel>Invalid Block</GroupLabel>
+            <GroupLabel error>Invalid Block</GroupLabel>
           </ItemClickTarget>
           <DeleteButton onClick={removeItem}>
             <TrashIcon />
@@ -363,7 +363,7 @@ const ItemClickTarget = styled.div`
   padding: 0.5rem;
 `
 
-const GroupLabel = styled.span`
+const GroupLabel = styled.span<{ error?: boolean }>`
   margin: 0;
   font-size: ${font.size(2)};
   font-weight: 500;
@@ -374,6 +374,12 @@ const GroupLabel = styled.span`
   color: inherit;
   transition: all 85ms ease-out;
   text-align: left;
+
+  ${props =>
+    props.error &&
+    css`
+      color: ${color.error()} !important;
+    `};
 `
 
 const GroupListHeader = styled.div`


### PR DESCRIPTION
Render a placeholder block that can't be clicked into if a block item's `_template` field does not reference a known block type

<img width="339" alt="image" src="https://user-images.githubusercontent.com/824015/68709710-9dc8a280-056c-11ea-98e0-7772a1cd4acb.png">
