### PR TITLE
Feat: Adds minmax height to markdown field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14051,9 +14051,9 @@
 					"optional": true
 				},
 				"gatsby-cli": {
-					"version": "2.8.9",
-					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.9.tgz",
-					"integrity": "sha512-SgCiF84meMK5R2Hf6PxNF3H33CtX0yXvg62ywzis0LJDAY0Xd3kAP6NwxxM5+6pogkH94qibeHIIWqhRb07C8g==",
+					"version": "2.8.10",
+					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.10.tgz",
+					"integrity": "sha512-+CppwajSd+inSWpJqxmDkzqC7SJ/sSujhQiVys6Szb9qrUbOmtG4qLVJu3GXbszkzolaSlsF9iws4veyLhlytw==",
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
 						"@babel/runtime": "^7.7.2",
@@ -14800,9 +14800,9 @@
 			}
 		},
 		"gatsby-image": {
-			"version": "2.2.31",
-			"resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.31.tgz",
-			"integrity": "sha512-DRRDCsATxhvoG6NcO1zlbQFMVTWbmp2XtM+humcC7IPy+Uq5wP4NREV/ICBx3d/hcAabg0vyjHNjrGeDo0ZBbw==",
+			"version": "2.2.32",
+			"resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.32.tgz",
+			"integrity": "sha512-pzGkBgH55qb3DQeBaOHYN4n4b8njaBv5d1Om2W10k120vnDZgM6/64ooULTA1Ljyj9q2S7emfB9tyr6ooOaKOQ==",
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"object-fit-images": "^3.2.4",
@@ -15048,9 +15048,9 @@
 			}
 		},
 		"gatsby-plugin-sharp": {
-			"version": "2.2.37",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.37.tgz",
-			"integrity": "sha512-efx5oC34QIaXpzzFs71faIwPMVxrur7LvHCfrKMstSmFXmim9yixuDQVYusIbY4eqebnj5o7XmIRcMCCvzivEg==",
+			"version": "2.2.38",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.2.38.tgz",
+			"integrity": "sha512-jICICypzxy7HdVZI9lcTgVZjw5M7udCL9HYOyZ5ioVlrk/LyTOfru3dBUIVEVP7Ho9/wtRH3159fmbQV6Dy7WA==",
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"async": "^2.6.3",
@@ -15488,9 +15488,9 @@
 			}
 		},
 		"gatsby-transformer-remark": {
-			"version": "2.6.33",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.6.33.tgz",
-			"integrity": "sha512-LkS4rlTUZUb+UPOfE2ZYEe87B0ly5fP7KIZ3PruhM7Exyn13zKR+jqif5jW6uz0Hy6OADwk0NFnJu+WHJkpyMA==",
+			"version": "2.6.34",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.6.34.tgz",
+			"integrity": "sha512-WiVy+Vw9Q+3DFJOnaDNcvnfFhHt7CDOikSU5dXVo2CqmH3gxC1unjLMGKVmwfc9G6OojmwTWYpsc9+s5rVckUg==",
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"bluebird": "^3.7.1",
@@ -15523,9 +15523,9 @@
 			}
 		},
 		"gatsby-transformer-sharp": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.3.3.tgz",
-			"integrity": "sha512-e4k/5jSlysoCtuYKJ9iv9DrJUvy6ZbbQUeyXP0wi2KJjhEFG7t0Kcu71vZKpDC+HN0BeApSrsBWHaJvvhD0dlw==",
+			"version": "2.3.4",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.3.4.tgz",
+			"integrity": "sha512-TTCCB4vjvrl20Au4yRN9bJqdLqnc8d0Fb+Gsobmf7yhVNJC+eodBdp2ji6mO0JJTwN/JvZk3SJBE2Aa1i8Ezrg==",
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"bluebird": "^3.7.1",

--- a/packages/@tinacms/api-git/package-lock.json
+++ b/packages/@tinacms/api-git/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinacms/api-git",
-  "version": "0.4.2-alpha.0",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-tinacms-remark/package-lock.json
+++ b/packages/gatsby-tinacms-remark/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gatsby-tinacms-remark",
-  "version": "0.5.0-alpha.0",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/tinacms/src/plugins/fields/MarkdownFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/MarkdownFieldPlugin.tsx
@@ -34,7 +34,9 @@ const FramedWysiwyg = (props: any) => {
 
 export const MarkdownField = wrapFieldsWithMeta(styled(FramedWysiwyg)`
   position: relative;
-  height: 100%;
+  min-height: 15rem;
+  max-height: 25rem;
+  overflow-y: scroll;
 
   > [contenteditable] {
     ${InputCss}


### PR DESCRIPTION
Simply adds `min-height`, `max-height`, & `overflow-y` properties on the markdown field. Partially addresses #230 - doesn't make it configurable, but I'm not sure how useful that would be given that most folks will probably gravitate towards inline editing. 