### PR TITLE
Fix: Adjusts pluginArray to never be empty

### DIFF
--- a/packages/react-tinacms/src/use-plugin.tsx
+++ b/packages/react-tinacms/src/use-plugin.tsx
@@ -34,24 +34,26 @@ export const usePlugin = usePlugins
 export function usePlugins(plugins?: Plugin | Plugin[]) {
   const cms = useCMS()
 
-  let pluginArray: Plugin[]
+  let pluginArray: (Plugin | undefined)[]
 
   if (Array.isArray(plugins)) {
     pluginArray = plugins
-  } else if (plugins) {
-    pluginArray = [plugins]
   } else {
-    pluginArray = []
+    pluginArray = [plugins]
   }
 
   React.useEffect(() => {
     pluginArray.forEach(plugin => {
-      cms.plugins.add(plugin)
+      if (plugin) {
+        cms.plugins.add(plugin);
+      }
     })
 
     return () => {
       pluginArray.forEach(plugin => {
-        cms.plugins.remove(plugin)
+        if (plugin) {
+          cms.plugins.remove(plugin);
+        }
       })
     }
   }, [cms.plugins, ...pluginArray])


### PR DESCRIPTION
In UsePlugins, the pluginArray was empty during initial renders as the forms register. For some reason in brevifolia-next-tinacms, this was causing the useEffect hook to not fire since the number of array items changed. This fix ensures that there is always at least 1 item in the pluginArray so the hook will run. The plugin won't be added if its undefined or null. 