### PR TITLE
feat(useGlobalForm): add hook for registering global forms

### DIFF
--- a/packages/@tinacms/react-core/src/use-form.ts
+++ b/packages/@tinacms/react-core/src/use-form.ts
@@ -20,7 +20,7 @@ import { FormOptions, Form, Field } from '@tinacms/core'
 import * as React from 'react'
 import { usePlugins } from './use-plugin'
 
-interface WatchableFormValue {
+export interface WatchableFormValue {
   values: any
   label: FormOptions<any>['label']
   fields: FormOptions<any>['fields']

--- a/packages/demo-gatsby/src/pages/index.js
+++ b/packages/demo-gatsby/src/pages/index.js
@@ -23,14 +23,14 @@ import Bio from "../components/bio"
 import Layout from "../components/layout"
 import SEO from "../components/seo"
 import { rhythm } from "../utils/typography"
-import { useForm, usePlugin, GlobalFormPlugin } from "tinacms"
+import { useGlobalForm } from "tinacms"
 
 function BlogIndex(props) {
   const { data } = props
   const siteTitle = data.site.siteMetadata.title
   const posts = data.allMarkdownRemark.edges
 
-  const [styles, form] = useForm({
+  const [styles] = useGlobalForm({
     id: "blog-index-styles",
     label: "Blog Styles",
     initialValues: {
@@ -64,8 +64,6 @@ function BlogIndex(props) {
       alert("Saving doesn't do anything.")
     },
   })
-
-  useGlobalFormPlugin(form)
 
   return (
     <Layout location={props.location} title={siteTitle}>
@@ -138,12 +136,3 @@ export const pageQuery = graphql`
     }
   }
 `
-
-function useGlobalFormPlugin(form) {
-  const GlobalForm = React.useMemo(() => {
-    if (!form) return
-    return new GlobalFormPlugin(form)
-  }, [form])
-
-  usePlugin(GlobalForm)
-}

--- a/packages/tinacms/src/react-tinacms/use-form.ts
+++ b/packages/tinacms/src/react-tinacms/use-form.ts
@@ -1,3 +1,8 @@
+import { FormOptions, Form } from '@tinacms/core'
+import { GlobalFormPlugin } from '../plugins/screens'
+import { useMemo } from 'react'
+import { useForm, WatchableFormValue, usePlugins } from '@tinacms/react-core'
+
 /**
 
 Copyright 2019 Forestry.io Inc
@@ -16,4 +21,21 @@ limitations under the License.
 
 */
 
-export { useLocalForm, useForm } from '@tinacms/react-core'
+export { useLocalForm, useForm, WatchableFormValue } from '@tinacms/react-core'
+
+export function useGlobalForm<FormShape = any>(
+  options: FormOptions<any>,
+  watch: Partial<WatchableFormValue> = {}
+): [FormShape, Form | undefined] {
+  const [values, form] = useForm(options, watch)
+
+  const GlobalForm = useMemo(() => {
+    if (!form) return
+
+    return new GlobalFormPlugin(form)
+  }, [form])
+
+  usePlugins(GlobalForm)
+
+  return [values, form]
+}


### PR DESCRIPTION
```js
const [ values, form] = useGlobalForm({
 id: "blog-index-styles",
    label: "Blog Styles",
    initialValues: {
      backgroundColor: "",
      hideBio: false,
      date: "2019 03 04",
      thumbnail: "",
    },
    fields: [
      {
        name: "backgroundColor",
        label: "Heading Color",
        component: "color",
        colorFormat: "HeX",
      },
      {
        name: "hideBio",
        label: "Hide Bio",
        component: "toggle",
      },
      {
        name: "date",
        label: "Date",
        component: "date",
        dateFormat: "YYYY MM DD",
        timeFormat: null,
      },
    ],
    onSubmit() {
      alert("Saving doesn't do anything.")
    },
})
```