### PR TITLE
Refactor tinacms

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -115,7 +115,9 @@ async function checkForDocsChanges(files: string[]) {
     })
   })
 
-  warnUpdateDoc(potentialDocChanges)
+  if (potentialDocChanges.length > 0) {
+    warnUpdateDoc(potentialDocChanges)
+  }
 }
 
 const warnUpdateDoc = (changes: [string, Dep][]) =>

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -25,8 +25,7 @@ import SEO from "../components/seo"
 import { rhythm } from "../utils/typography"
 import { liveRemarkForm, DeleteAction } from "gatsby-tinacms-remark"
 import Img from "gatsby-image"
-import { TinaField } from "@tinacms/form-builder"
-import { Wysiwyg, Toggle } from "@tinacms/fields"
+import { TinaField, Wysiwyg, Toggle } from "tinacms"
 const get = require("lodash.get")
 
 const PlainText = props => (

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -28,9 +28,9 @@ import { CMSContext } from '../react-tinacms'
 
 const merge = require('lodash.merge')
 
-type SidebarPosition = 'fixed' | 'float' | 'displace' | 'overlay'
+export type SidebarPosition = 'fixed' | 'float' | 'displace' | 'overlay'
 
-interface TinaProps {
+export interface TinaProps {
   cms: TinaCMS
   position: SidebarPosition
   hidden?: boolean

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -16,22 +16,48 @@ limitations under the License.
 
 */
 
-// Components
-export * from './components/Tina'
-export * from './components/sidebar/SidebarProvider'
-export * from './components/modals/ModalProvider'
-export { ActionButton } from './components/ActionsMenu'
-export { FieldMeta } from './plugins/fields/wrapFieldWithMeta'
-
-// React
+/**
+ * TinaCMS Core Types & React Interfaces
+ */
 export * from './react-tinacms'
 
-// Plugins
-export * from './plugins/create-content-form-plugin'
-export * from './plugins/screen-plugin'
-export * from './plugins/fields'
-export { GlobalFormPlugin } from './plugins/screens'
-
-// TinaCMS Instance
+/**
+ * The Tina CMS Class
+ */
 export { TinaCMS } from './tina-cms'
 export { TinaCMS as CMS } from './tina-cms'
+
+/**
+ * Tina Sidebar
+ */
+export { Tina, TinaProps, SidebarPosition } from './components/Tina'
+export { useSidebar } from './components/sidebar/SidebarProvider'
+
+/**
+ * Plugins
+ */
+
+// Plugin Types
+export { AddContentPlugin } from './plugins/create-content-form-plugin'
+export { ScreenPlugin } from './plugins/screen-plugin'
+export { GlobalFormPlugin } from './plugins/screens'
+
+// Pre-registered Plugins
+export * from './plugins/fields'
+
+/**
+ * REACT COMPONENTS
+ */
+
+// Inline Editing Components
+export { TinaField, TinaForm } from '@tinacms/form-builder'
+
+// Field/Input Component
+export { Wysiwyg, Toggle, Input } from '@tinacms/fields'
+export { FieldMeta } from './plugins/fields/wrapFieldWithMeta'
+
+// Modal Components
+export * from './components/modals/ModalProvider'
+
+// Form Actions Components
+export { ActionButton } from './components/ActionsMenu'


### PR DESCRIPTION
The `tinacms` package now re-exports the inputs from `@tinacms/fields` and the inline editing components from `@tinacms/form-builder`. Which means this:

```js
import { liveRemarkForm } from 'gatsby-tinacms-remark'
import { Wysiwyg } from '@tinacms/fields'
import { TinaField } from '@tinacms/form-builder'

const Template = ({ data, isEditing, setIsEditing }) => (
  <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
    <section class="content" dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }}></section>
    <button onClick={() => setIsEditing(p => !p)}>{isEditing ? 'Preview' : 'Edit'}</button>
  </TinaField>
)

export default liveRemarkForm(Template)
```

Can now be done like this:

```js
import { liveRemarkForm } from 'gatsby-tinacms-remark'
import { Wysiwyg } from 'tinacms'

const Template = ({ data, isEditing, setIsEditing }) => (
  <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
    <section class="content" dangerouslySetInnerHTML={{ __html: data.markdownRemark.html }}></section>
    <button onClick={() => setIsEditing(p => !p)}>{isEditing ? 'Preview' : 'Edit'}</button>
  </TinaField>
)

export default liveRemarkForm(Template)
```

Note: The above example comes from [the docs](https://tinacms.org/docs/gatsby/inline-editing)