### PR TITLE
New Package: react-tinacms-blocks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16003,6 +16003,11 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
 					"integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
 				}
 			}
 		},
@@ -25764,6 +25769,12 @@
 						"once": "^1.3.0",
 						"path-is-absolute": "^1.0.0"
 					}
+				},
+				"slash": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+					"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+					"dev": true
 				}
 			}
 		},
@@ -27519,9 +27530,9 @@
 			"integrity": "sha512-/ekMoM4NJ59ivGSfKapeG+FWtrmWvA1p6FBZwXrqojw90vJu8lBmrTxCMuBCydKtkaUe2zt4PlxeTKpjwMbyig=="
 		},
 		"slash": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-			"integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
 		},
 		"slice-ansi": {
 			"version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3838,7 +3838,8 @@
 		"@sheerun/mutationobserver-shim": {
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
-			"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q=="
+			"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+			"dev": true
 		},
 		"@sindresorhus/is": {
 			"version": "0.7.0",
@@ -4342,6 +4343,7 @@
 			"version": "6.10.1",
 			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.10.1.tgz",
 			"integrity": "sha512-5BPKxaO+zSJDUbVZBRNf9KrmDkm/EcjjaHSg3F9+031VZyPACKXlwLBjVzZxheunT9m72DoIq7WvyE457/Xweg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.2",
 				"@sheerun/mutationobserver-shim": "^0.3.2",
@@ -4351,10 +4353,28 @@
 				"wait-for-expect": "^3.0.0"
 			}
 		},
+		"@testing-library/jest-dom": {
+			"version": "4.2.4",
+			"resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-4.2.4.tgz",
+			"integrity": "sha512-j31Bn0rQo12fhCWOUWy9fl7wtqkp7In/YP2p5ZFyRuiiB9Qs3g+hS4gAmDWONbAHcRmVooNJ5eOHQDCOmUFXHg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.5.1",
+				"chalk": "^2.4.1",
+				"css": "^2.2.3",
+				"css.escape": "^1.5.1",
+				"jest-diff": "^24.0.0",
+				"jest-matcher-utils": "^24.0.0",
+				"lodash": "^4.17.11",
+				"pretty-format": "^24.0.0",
+				"redent": "^3.0.0"
+			}
+		},
 		"@testing-library/react": {
 			"version": "9.3.2",
 			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.3.2.tgz",
 			"integrity": "sha512-J6ftWtm218tOLS175MF9eWCxGp+X+cUXCpkPIin8KAXWtyZbr9CbqJ8M8QNd6spZxJDAGlw+leLG4MJWLlqVgg==",
+			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.6.0",
 				"@testing-library/dom": "^6.3.0",
@@ -4885,6 +4905,7 @@
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.10.0.tgz",
 			"integrity": "sha512-mL/GMlyQxiZplbUuFNwA0vAI3k3uJNSf6slr5AVve9TXmfLfyefNT0uHHnxwdYuPMxYD5gI/+dgAvc/5opW9JQ==",
+			"dev": true,
 			"requires": {
 				"pretty-format": "^24.3.0"
 			}
@@ -4893,6 +4914,7 @@
 			"version": "9.1.2",
 			"resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
 			"integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
+			"dev": true,
 			"requires": {
 				"@types/react-dom": "*",
 				"@types/testing-library__dom": "*"
@@ -9551,6 +9573,18 @@
 			"resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
 			"integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
 		},
+		"css": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
+			"integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"source-map": "^0.6.1",
+				"source-map-resolve": "^0.5.2",
+				"urix": "^0.1.0"
+			}
+		},
 		"css-blank-pseudo": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/css-blank-pseudo/-/css-blank-pseudo-0.1.4.tgz",
@@ -9751,6 +9785,12 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
 			"integrity": "sha512-a+EPoD+uZiNfh+5fxw2nO9QwFa6nJe2Or35fGY6Ipw1R3R4AGz1d1TEZrCegvw2YTmZ0jXirGYlzxxpYSHwpEg=="
+		},
+		"css.escape": {
+			"version": "1.5.1",
+			"resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+			"integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
+			"dev": true
 		},
 		"cssdb": {
 			"version": "4.4.0",
@@ -20603,6 +20643,12 @@
 				"dom-walk": "^0.1.0"
 			}
 		},
+		"min-indent": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.0.tgz",
+			"integrity": "sha1-z8RcN+nsDY8KDsPdTvf3w6vjklY=",
+			"dev": true
+		},
 		"mini-css-extract-plugin": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz",
@@ -25958,6 +26004,24 @@
 				"minimatch": "3.0.4"
 			}
 		},
+		"redent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+			"dev": true,
+			"requires": {
+				"indent-string": "^4.0.0",
+				"strip-indent": "^3.0.0"
+			},
+			"dependencies": {
+				"indent-string": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+					"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+					"dev": true
+				}
+			}
+		},
 		"redux": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/redux/-/redux-4.0.4.tgz",
@@ -28402,6 +28466,15 @@
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
 			"integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
 		},
+		"strip-indent": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+			"dev": true,
+			"requires": {
+				"min-indent": "^1.0.0"
+			}
+		},
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -30378,7 +30451,8 @@
 		"wait-for-expect": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
-			"integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw=="
+			"integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+			"dev": true
 		},
 		"walker": {
 			"version": "1.0.7",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "watch": "lerna run watch --parallel --reject-cycles"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^4.2.4",
+    "@testing-library/react": "^9.3.2",
     "@types/jest": "^24.0.15",
     "@types/vfile-message": "^2.0.0",
     "@typescript-eslint/eslint-plugin": "^2.3.0",

--- a/packages/demo-gatsby/package.json
+++ b/packages/demo-gatsby/package.json
@@ -37,6 +37,7 @@
     "lodash.get": "^4.4.2",
     "prismjs": "^1.16.0",
     "react": "^16.8.6",
+    "react-tinacms-blocks": "0.0.0",
     "react-dom": "^16.8.6",
     "react-helmet": "^5.2.1",
     "react-typography": "^0.16.19",

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -26,6 +26,8 @@ import { rhythm } from "../utils/typography"
 import { liveRemarkForm, DeleteAction } from "gatsby-tinacms-remark"
 import Img from "gatsby-image"
 import { TinaField, Wysiwyg, Toggle } from "tinacms"
+import { Blocks } from "react-tinacms-blocks"
+
 const get = require("lodash.get")
 
 const PlainText = props => (
@@ -119,20 +121,13 @@ function BlogPostTemplate(props) {
             <small style={{ color: "fuchsia" }}>Draft</small>
           )}
         </TinaField>
-        {blocks.map(({ _template, ...block }) => {
-          switch (_template) {
-            case "heading":
-              return <h1>{block.text}</h1>
-            case "image":
-              return (
-                <p>
-                  <img {...block} />
-                </p>
-              )
-            default:
-              return "What"
-          }
-        })}
+        <Blocks
+          data={blocks}
+          templates={{
+            heading,
+            image,
+          }}
+        />
         <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
           <div
             dangerouslySetInnerHTML={{
@@ -189,6 +184,9 @@ const heading = {
     label: `${block.text}`,
   }),
   fields: [{ name: "text", component: "text", label: "Text" }],
+  Component(props) {
+    return <h1>{props.data.text}</h1>
+  },
 }
 
 const image = {
@@ -204,6 +202,13 @@ const image = {
     { name: "src", component: "text", label: "Source URL" },
     { name: "alt", component: "text", label: "Alt Text" },
   ],
+  Component(props) {
+    return (
+      <p>
+        <img {...props.data} />
+      </p>
+    )
+  },
 }
 
 const BlogPostForm = {

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -122,6 +122,7 @@ function BlogPostTemplate(props) {
           )}
         </TinaField>
         <Blocks
+          name="rawFrontmatter.blocks"
           data={blocks}
           templates={{
             heading,
@@ -185,8 +186,27 @@ const heading = {
   }),
   fields: [{ name: "text", component: "text", label: "Text" }],
   Component(props) {
-    return <h1>{props.data.text}</h1>
+    return (
+      <TinaField
+        name={`${props.name}.${props.index}.text`}
+        Component={EditableHeadingBlock}
+      >
+        <HeadingBlock {...props} />
+      </TinaField>
+    )
   },
+}
+
+const EditableHeadingBlock = props => {
+  return (
+    <h1>
+      <PlainText {...props} />
+    </h1>
+  )
+}
+
+const HeadingBlock = props => {
+  return <h1>{props.data.text}</h1>
 }
 
 const image = {
@@ -205,6 +225,14 @@ const image = {
   Component(props) {
     return (
       <p>
+        <TinaField
+          name={`${props.name}.${props.index}.src`}
+          Component={PlainText}
+        />
+        <TinaField
+          name={`${props.name}.${props.index}.alt`}
+          Component={PlainText}
+        />
         <img {...props.data} />
       </p>
     )

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -124,9 +124,9 @@ function BlogPostTemplate(props) {
         <Blocks
           name="rawFrontmatter.blocks"
           data={blocks}
-          templates={{
-            heading,
-            image,
+          components={{
+            heading: EditableHeading,
+            image: EditableImage,
           }}
         />
         <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
@@ -176,6 +176,9 @@ function BlogPostTemplate(props) {
   )
 }
 
+/**
+ * HEADING BLOCK
+ */
 const heading = {
   label: "Heading",
   defaultItem: {
@@ -185,16 +188,17 @@ const heading = {
     label: `${block.text}`,
   }),
   fields: [{ name: "text", component: "text", label: "Text" }],
-  Component(props) {
-    return (
-      <TinaField
-        name={`${props.name}.${props.index}.text`}
-        Component={EditableHeadingBlock}
-      >
-        <HeadingBlock {...props} />
-      </TinaField>
-    )
-  },
+}
+
+function EditableHeading(props) {
+  return (
+    <TinaField
+      name={`${props.name}.${props.index}.text`}
+      Component={EditableHeadingBlock}
+    >
+      <HeadingBlock {...props} />
+    </TinaField>
+  )
 }
 
 const EditableHeadingBlock = props => {
@@ -209,6 +213,10 @@ const HeadingBlock = props => {
   return <h1>{props.data.text}</h1>
 }
 
+/**
+ * IMAGE BLOCK
+ */
+// Image Block Template
 const image = {
   label: "Image",
   defaultItem: {
@@ -222,23 +230,28 @@ const image = {
     { name: "src", component: "text", label: "Source URL" },
     { name: "alt", component: "text", label: "Alt Text" },
   ],
-  Component(props) {
-    return (
-      <p>
-        <TinaField
-          name={`${props.name}.${props.index}.src`}
-          Component={PlainText}
-        />
-        <TinaField
-          name={`${props.name}.${props.index}.alt`}
-          Component={PlainText}
-        />
-        <img {...props.data} />
-      </p>
-    )
-  },
 }
 
+// Image Block Component
+function EditableImage(props) {
+  return (
+    <p>
+      <TinaField
+        name={`${props.name}.${props.index}.src`}
+        Component={PlainText}
+      />
+      <TinaField
+        name={`${props.name}.${props.index}.alt`}
+        Component={PlainText}
+      />
+      <img {...props.data} />
+    </p>
+  )
+}
+
+/**
+ * Blog Post Form
+ */
 const BlogPostForm = {
   actions: [DeleteAction],
   fields: [

--- a/packages/react-dismissible/package-lock.json
+++ b/packages/react-dismissible/package-lock.json
@@ -1,0 +1,233 @@
+{
+	"name": "react-dismissible",
+	"version": "1.0.16",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@testing-library/react": {
+			"version": "9.3.2",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-9.3.2.tgz",
+			"integrity": "sha512-J6ftWtm218tOLS175MF9eWCxGp+X+cUXCpkPIin8KAXWtyZbr9CbqJ8M8QNd6spZxJDAGlw+leLG4MJWLlqVgg==",
+			"dev": true,
+			"requires": {
+				"@babel/runtime": "^7.6.0",
+				"@testing-library/dom": "^6.3.0",
+				"@types/testing-library__react": "^9.1.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@sheerun/mutationobserver-shim": {
+					"version": "0.3.2",
+					"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz",
+					"integrity": "sha512-vTCdPp/T/Q3oSqwHmZ5Kpa9oI7iLtGl3RQaA/NyLHikvcrPxACkkKVr/XzkSPJWXHRhKGzVvb0urJsbMlRxi1Q==",
+					"dev": true
+				},
+				"@testing-library/dom": {
+					"version": "6.10.1",
+					"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-6.10.1.tgz",
+					"integrity": "sha512-5BPKxaO+zSJDUbVZBRNf9KrmDkm/EcjjaHSg3F9+031VZyPACKXlwLBjVzZxheunT9m72DoIq7WvyE457/Xweg==",
+					"dev": true,
+					"requires": {
+						"@babel/runtime": "^7.6.2",
+						"@sheerun/mutationobserver-shim": "^0.3.2",
+						"@types/testing-library__dom": "^6.0.0",
+						"aria-query": "3.0.0",
+						"pretty-format": "^24.9.0",
+						"wait-for-expect": "^3.0.0"
+					}
+				},
+				"@types/istanbul-lib-coverage": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+					"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+					"dev": true
+				},
+				"@types/istanbul-lib-report": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+					"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+					"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*",
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/prop-types": {
+					"version": "15.7.3",
+					"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
+					"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
+					"dev": true
+				},
+				"@types/react": {
+					"version": "16.9.13",
+					"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.13.tgz",
+					"integrity": "sha512-LikzRslbiufJYHyzbHSW0GrAiff8QYLMBFeZmSxzCYGXKxi8m/1PHX+rsVOwhr7mJNq+VIu2Dhf7U6mjFERK6w==",
+					"dev": true,
+					"requires": {
+						"@types/prop-types": "*",
+						"csstype": "^2.2.0"
+					}
+				},
+				"@types/react-dom": {
+					"version": "16.9.4",
+					"resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-16.9.4.tgz",
+					"integrity": "sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==",
+					"dev": true,
+					"requires": {
+						"@types/react": "*"
+					}
+				},
+				"@types/testing-library__dom": {
+					"version": "6.10.0",
+					"resolved": "https://registry.npmjs.org/@types/testing-library__dom/-/testing-library__dom-6.10.0.tgz",
+					"integrity": "sha512-mL/GMlyQxiZplbUuFNwA0vAI3k3uJNSf6slr5AVve9TXmfLfyefNT0uHHnxwdYuPMxYD5gI/+dgAvc/5opW9JQ==",
+					"dev": true,
+					"requires": {
+						"pretty-format": "^24.3.0"
+					}
+				},
+				"@types/testing-library__react": {
+					"version": "9.1.2",
+					"resolved": "https://registry.npmjs.org/@types/testing-library__react/-/testing-library__react-9.1.2.tgz",
+					"integrity": "sha512-CYaMqrswQ+cJACy268jsLAw355DZtPZGt3Jwmmotlcu8O/tkoXBI6AeZ84oZBJsIsesozPKzWzmv/0TIU+1E9Q==",
+					"dev": true,
+					"requires": {
+						"@types/react-dom": "*",
+						"@types/testing-library__dom": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "13.0.3",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
+					"integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"@types/yargs-parser": {
+					"version": "13.1.0",
+					"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+					"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"aria-query": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+					"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+					"dev": true,
+					"requires": {
+						"ast-types-flow": "0.0.7",
+						"commander": "^2.11.0"
+					}
+				},
+				"ast-types-flow": {
+					"version": "0.0.7",
+					"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+					"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
+					"dev": true
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"dev": true
+				},
+				"csstype": {
+					"version": "2.6.7",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.7.tgz",
+					"integrity": "sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"react-is": {
+					"version": "16.12.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+					"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+					"dev": true
+				},
+				"regenerator-runtime": {
+					"version": "0.13.3",
+					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
+					"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
+					"dev": true
+				},
+				"wait-for-expect": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
+					"integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+					"dev": true
+				}
+			}
+		}
+	}
+}

--- a/packages/react-tinacms-blocks/.gitignore
+++ b/packages/react-tinacms-blocks/.gitignore
@@ -1,0 +1,9 @@
+*.log
+.DS_Store
+node_modules
+.cache
+.rts2_cache_cjs
+.rts2_cache_esm
+.rts2_cache_umd
+.rts2_cache_system
+dist

--- a/packages/react-tinacms-blocks/CHANGELOG.md
+++ b/packages/react-tinacms-blocks/CHANGELOG.md
@@ -1,8 +1,0 @@
-# Change Log
-
-All notable changes to this project will be documented in this file.
-See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
-
-## 0.1.1-alpha.0 (2019-11-25)
-
-**Note:** Version bump only for package @tinacms/react-core

--- a/packages/react-tinacms-blocks/CHANGELOG.md
+++ b/packages/react-tinacms-blocks/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
+
+## 0.1.1-alpha.0 (2019-11-25)
+
+**Note:** Version bump only for package @tinacms/react-core

--- a/packages/react-tinacms-blocks/README.md
+++ b/packages/react-tinacms-blocks/README.md
@@ -1,0 +1,1 @@
+# react-tinacms-blocks

--- a/packages/react-tinacms-blocks/package-lock.json
+++ b/packages/react-tinacms-blocks/package-lock.json
@@ -1,0 +1,174 @@
+{
+	"name": "react-tinacms-blocks",
+	"version": "0.0.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@types/jest": {
+			"version": "24.0.23",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-24.0.23.tgz",
+			"integrity": "sha512-L7MBvwfNpe7yVPTXLn32df/EK+AMBFAFvZrRuArGs7npEWnlziUXK+5GMIUTI4NIuwok3XibsjXCs5HxviYXjg==",
+			"dev": true,
+			"requires": {
+				"jest-diff": "^24.3.0"
+			},
+			"dependencies": {
+				"@jest/types": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+					"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "^2.0.0",
+						"@types/istanbul-reports": "^1.1.1",
+						"@types/yargs": "^13.0.0"
+					}
+				},
+				"@types/istanbul-lib-coverage": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz",
+					"integrity": "sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==",
+					"dev": true
+				},
+				"@types/istanbul-lib-report": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-1.1.1.tgz",
+					"integrity": "sha512-3BUTyMzbZa2DtDI2BkERNC6jJw2Mr2Y0oGI7mRxYNBPxppbtEK1F66u3bKwU2g+wxwWI7PAoRpJnOY1grJqzHg==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*"
+					}
+				},
+				"@types/istanbul-reports": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz",
+					"integrity": "sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==",
+					"dev": true,
+					"requires": {
+						"@types/istanbul-lib-coverage": "*",
+						"@types/istanbul-lib-report": "*"
+					}
+				},
+				"@types/yargs": {
+					"version": "13.0.3",
+					"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.3.tgz",
+					"integrity": "sha512-K8/LfZq2duW33XW/tFwEAfnZlqIfVsoyRB3kfXdPXYhl0nfM8mmh7GS0jg7WrX2Dgq/0Ha/pR1PaR+BvmWwjiQ==",
+					"dev": true,
+					"requires": {
+						"@types/yargs-parser": "*"
+					}
+				},
+				"@types/yargs-parser": {
+					"version": "13.1.0",
+					"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
+					"integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg==",
+					"dev": true
+				},
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+					"dev": true
+				},
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"diff-sequences": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-24.9.0.tgz",
+					"integrity": "sha512-Dj6Wk3tWyTE+Fo1rW8v0Xhwk80um6yFYKbuAxc9c3EZxIHFDYwbi34Uk42u1CdnIiVorvt4RmlSDjIPyzGC2ew==",
+					"dev": true
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"jest-diff": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-24.9.0.tgz",
+					"integrity": "sha512-qMfrTs8AdJE2iqrTp0hzh7kTd2PQWrsFyj9tORoKmu32xjPjeE4NyjVRDz8ybYwqS2ik8N4hsIpiVTyFeo2lBQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.1",
+						"diff-sequences": "^24.9.0",
+						"jest-get-type": "^24.9.0",
+						"pretty-format": "^24.9.0"
+					}
+				},
+				"jest-get-type": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-24.9.0.tgz",
+					"integrity": "sha512-lUseMzAley4LhIcpSP9Jf+fTrQ4a1yHQwLNeeVa2cEmbCGeoZAtYPOIv8JaxLD/sUpKxetKGP+gsHl8f8TSj8Q==",
+					"dev": true
+				},
+				"pretty-format": {
+					"version": "24.9.0",
+					"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+					"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+					"dev": true,
+					"requires": {
+						"@jest/types": "^24.9.0",
+						"ansi-regex": "^4.0.0",
+						"ansi-styles": "^3.2.0",
+						"react-is": "^16.8.4"
+					}
+				},
+				"react-is": {
+					"version": "16.12.0",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+					"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		}
+	}
+}

--- a/packages/react-tinacms-blocks/package.json
+++ b/packages/react-tinacms-blocks/package.json
@@ -1,5 +1,4 @@
 {
-  "private": true,
   "name": "react-tinacms-blocks",
   "version": "0.0.0",
   "license": "Apache-2.0",

--- a/packages/react-tinacms-blocks/package.json
+++ b/packages/react-tinacms-blocks/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "name": "react-tinacms-blocks",
   "version": "0.0.0",
   "license": "Apache-2.0",

--- a/packages/react-tinacms-blocks/package.json
+++ b/packages/react-tinacms-blocks/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "react-tinacms-blocks",
+  "version": "0.0.0",
+  "license": "Apache-2.0",
+  "main": "dist/index.js",
+  "module": "dist/react-tinacms-blocks.esm.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "watch": "tsdx watch",
+    "build": "tsdx build",
+    "dev": "tsdx build",
+    "test": "tsdx test --env=jsdom",
+    "lint": "tsdx lint"
+  },
+  "dependencies": {
+    "tinacms": "^0.10.0-alpha.0"
+  },
+  "peerDependencies": {
+    "react": ">=16.8"
+  },
+  "devDependencies": {
+    "@types/jest": "^24.0.23",
+    "tsdx": "^0.11.0"
+  }
+}

--- a/packages/react-tinacms-blocks/package.json
+++ b/packages/react-tinacms-blocks/package.json
@@ -16,9 +16,7 @@
     "test": "tsdx test --env=jsdom",
     "lint": "tsdx lint"
   },
-  "dependencies": {
-    "tinacms": "^0.10.0-alpha.0"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "react": ">=16.8"
   },

--- a/packages/react-tinacms-blocks/src/blocks.spec.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.spec.tsx
@@ -1,0 +1,105 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import { Blocks } from './blocks'
+
+describe('Blocks', () => {
+  describe('without data', () => {
+    it('renders nothing into the containing element', () => {
+      const renderedBlock = render(<Blocks name="" data={[]} templates={{}} />)
+
+      expect(renderedBlock.container.children).toHaveLength(0)
+    })
+  })
+
+  describe('with some data', () => {
+    const text = 'Hello World'
+    const data = [{ _template: 'heading', text }]
+
+    describe('when there are no templates', () => {
+      it('renders nothing into the containing element', () => {
+        const renderedBlock = render(
+          <Blocks name="" data={data} templates={{}} />
+        )
+
+        expect(renderedBlock.container.children).toHaveLength(0)
+      })
+
+      describe("if (process.env.NODE_ENV === 'development')", () => {
+        afterEachResetProcessEnv()
+
+        it('throws an error', () => {
+          process.env.NODE_ENV = 'development'
+
+          const rendering = () =>
+            render(<Blocks name="" data={data} templates={{}} />)
+
+          expect(rendering).toThrow()
+        })
+      })
+    })
+
+    describe('when there is a matching template', () => {
+      const heading = {
+        key: '',
+        label: 'Heading',
+        fields: [],
+        Component() {
+          return <h1>{text}</h1>
+        },
+      }
+      describe('and it has Component defined', () => {
+        it('renders that Component', () => {
+          const renderedBlock = render(
+            <Blocks name="" data={data} templates={{ heading }} />
+          )
+
+          const headingBlock = renderedBlock.queryByText(text)
+
+          expect(headingBlock).not.toBeNull()
+        })
+      })
+      describe('and it does not have a Component defined', () => {
+        const headingWithoutComponent = { ...heading, Component: null }
+
+        it('renders nothing into the containing element', () => {
+          const renderedBlock = render(
+            <Blocks
+              name=""
+              data={data}
+              templates={{ heading: headingWithoutComponent }}
+            />
+          )
+
+          expect(renderedBlock.container.children).toHaveLength(0)
+        })
+
+        describe("if (process.env.NODE_ENV === 'development')", () => {
+          afterEachResetProcessEnv()
+
+          it('throws an error', () => {
+            process.env.NODE_ENV = 'development'
+
+            const rendering = () =>
+              render(<Blocks name="" data={data} templates={{}} />)
+
+            expect(rendering).toThrow()
+          })
+        })
+      })
+    })
+  })
+})
+
+function afterEachResetProcessEnv() {
+  const OLD_ENV = process.env
+
+  beforeEach(() => {
+    jest.resetModules() // this is important
+    process.env = { ...OLD_ENV }
+    delete process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    process.env = OLD_ENV
+  })
+}

--- a/packages/react-tinacms-blocks/src/blocks.spec.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.spec.tsx
@@ -80,7 +80,13 @@ describe('Blocks', () => {
             process.env.NODE_ENV = 'development'
 
             const rendering = () =>
-              render(<Blocks name="" data={data} templates={{}} />)
+              render(
+                <Blocks
+                  name=""
+                  data={data}
+                  templates={{ heading: headingWithoutComponent }}
+                />
+              )
 
             expect(rendering).toThrow()
           })

--- a/packages/react-tinacms-blocks/src/blocks.spec.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.spec.tsx
@@ -22,7 +22,7 @@ import { Blocks } from './blocks'
 describe('Blocks', () => {
   describe('without data', () => {
     it('renders nothing into the containing element', () => {
-      const renderedBlock = render(<Blocks name="" data={[]} templates={{}} />)
+      const renderedBlock = render(<Blocks name="" data={[]} components={{}} />)
 
       expect(renderedBlock.container.children).toHaveLength(0)
     })
@@ -32,10 +32,10 @@ describe('Blocks', () => {
     const text = 'Hello World'
     const data = [{ _template: 'heading', text }]
 
-    describe('when there are no templates', () => {
+    describe('when there are no components', () => {
       it('renders nothing into the containing element', () => {
         const renderedBlock = render(
-          <Blocks name="" data={data} templates={{}} />
+          <Blocks name="" data={data} components={{}} />
         )
 
         expect(renderedBlock.container.children).toHaveLength(0)
@@ -48,66 +48,24 @@ describe('Blocks', () => {
           process.env.NODE_ENV = 'development'
 
           const rendering = () =>
-            render(<Blocks name="" data={data} templates={{}} />)
+            render(<Blocks name="" data={data} components={{}} />)
 
           expect(rendering).toThrow()
         })
       })
     })
 
-    describe('when there is a matching template', () => {
-      const heading = {
-        key: '',
-        label: 'Heading',
-        fields: [],
-        Component() {
-          return <h1>{text}</h1>
-        },
-      }
-      describe('and it has Component defined', () => {
-        it('renders that Component', () => {
-          const renderedBlock = render(
-            <Blocks name="" data={data} templates={{ heading }} />
-          )
+    describe('when there is a matching component', () => {
+      const heading = () => <h1>{text}</h1>
 
-          const headingBlock = renderedBlock.queryByText(text)
+      it('renders that Component', () => {
+        const renderedBlock = render(
+          <Blocks name="" data={data} components={{ heading }} />
+        )
 
-          expect(headingBlock).not.toBeNull()
-        })
-      })
-      describe('and it does not have a Component defined', () => {
-        const headingWithoutComponent = { ...heading, Component: null }
+        const headingBlock = renderedBlock.queryByText(text)
 
-        it('renders nothing into the containing element', () => {
-          const renderedBlock = render(
-            <Blocks
-              name=""
-              data={data}
-              templates={{ heading: headingWithoutComponent }}
-            />
-          )
-
-          expect(renderedBlock.container.children).toHaveLength(0)
-        })
-
-        describe("if (process.env.NODE_ENV === 'development')", () => {
-          afterEachResetProcessEnv()
-
-          it('throws an error', () => {
-            process.env.NODE_ENV = 'development'
-
-            const rendering = () =>
-              render(
-                <Blocks
-                  name=""
-                  data={data}
-                  templates={{ heading: headingWithoutComponent }}
-                />
-              )
-
-            expect(rendering).toThrow()
-          })
-        })
+        expect(headingBlock).not.toBeNull()
       })
     })
   })

--- a/packages/react-tinacms-blocks/src/blocks.spec.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.spec.tsx
@@ -1,3 +1,20 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 import React from 'react'
 import { render } from '@testing-library/react'
 import { Blocks } from './blocks'

--- a/packages/react-tinacms-blocks/src/blocks.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.tsx
@@ -1,0 +1,61 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+import * as React from 'react'
+import { BlockTemplate as DefaultBlockTemplate } from 'tinacms'
+
+export interface BlockTemplate extends DefaultBlockTemplate {
+  Component: any
+}
+
+export interface BlocksProps {
+  name: string
+  data: any[]
+  templates: {
+    [key: string]: BlockTemplate
+  }
+}
+
+export function Blocks({ name, data = [], templates = {} }: BlocksProps) {
+  return (
+    <>
+      {data.map((data, index) => {
+        const template = templates[data._template]
+
+        if (!template) {
+          return nullOrError('Unrecognized Block Type: ' + data._template)
+        }
+
+        if (!template.Component) {
+          return nullOrError(
+            `The "${template.label}" block template is missing the Component`
+          )
+        }
+
+        return <template.Component data={data} index={index} name={name} />
+      })}
+    </>
+  )
+}
+
+const nullOrError = (message: string) => {
+  if (process.env.NODE_ENV === 'development') {
+    throw new Error(message)
+  }
+
+  return null
+}

--- a/packages/react-tinacms-blocks/src/blocks.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.tsx
@@ -52,6 +52,12 @@ export function Blocks({ name, data = [], templates = {} }: BlocksProps) {
   )
 }
 
+/**
+ * Conditionally return `null` or throw an Error depending on NODE_ENV.o
+ *
+ * Useful if you want to provide the developer with some information
+ * while they are developing, but then fail silently in production.
+ */
 const nullOrError = (message: string) => {
   if (process.env.NODE_ENV === 'development') {
     throw new Error(message)

--- a/packages/react-tinacms-blocks/src/blocks.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.tsx
@@ -16,37 +16,26 @@ limitations under the License.
 
 */
 import * as React from 'react'
-import { BlockTemplate as DefaultBlockTemplate } from 'tinacms'
-
-export interface BlockTemplate extends DefaultBlockTemplate {
-  Component: any
-}
 
 export interface BlocksProps {
   name: string
   data: any[]
-  templates: {
-    [key: string]: BlockTemplate
+  components: {
+    [key: string]: any // Todo: React Component
   }
 }
 
-export function Blocks({ name, data = [], templates = {} }: BlocksProps) {
+export function Blocks({ name, data = [], components = {} }: BlocksProps) {
   return (
     <>
       {data.map((data, index) => {
-        const template = templates[data._template]
+        const Component = components[data._template]
 
-        if (!template) {
+        if (!Component) {
           return nullOrError('Unrecognized Block Type: ' + data._template)
         }
 
-        if (!template.Component) {
-          return nullOrError(
-            `The "${template.label}" block template is missing the Component`
-          )
-        }
-
-        return <template.Component data={data} index={index} name={name} />
+        return <Component data={data} index={index} name={name} />
       })}
     </>
   )

--- a/packages/react-tinacms-blocks/src/index.tsx
+++ b/packages/react-tinacms-blocks/src/index.tsx
@@ -15,43 +15,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-import * as React from 'react'
-import { BlockTemplate as DefaultBlockTemplate } from 'tinacms'
 
-interface BlockTemplate extends DefaultBlockTemplate {
-  Component: any
-}
-
-interface BlocksProps {
-  name: string
-  data: any[]
-  templates: {
-    [key: string]: BlockTemplate
-  }
-}
-
-export function Blocks({ name, data = [], templates = {} }: BlocksProps) {
-  return data.map((data, index) => {
-    const template = templates[data._template]
-
-    if (!template) {
-      return nullOrError('Unrecognized Block Type: ' + data._template)
-    }
-
-    if (!template.Component) {
-      return nullOrError(
-        `The "${template.label}" block template is missing the Component`
-      )
-    }
-
-    return <template.Component data={data} index={index} name={name} />
-  })
-}
-
-const nullOrError = (message: string) => {
-  if (process.env.NODE_ENV) {
-    throw new Error(message)
-  }
-
-  return null
-}
+export { Blocks, BlocksProps, BlockTemplate } from './blocks'

--- a/packages/react-tinacms-blocks/src/index.tsx
+++ b/packages/react-tinacms-blocks/src/index.tsx
@@ -1,0 +1,57 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+import * as React from 'react'
+import { BlockTemplate as DefaultBlockTemplate } from 'tinacms'
+
+interface BlockTemplate extends DefaultBlockTemplate {
+  Component: any
+}
+
+interface BlocksProps {
+  name: string
+  data: any[]
+  templates: {
+    [key: string]: BlockTemplate
+  }
+}
+
+export function Blocks({ name, data = [], templates = {} }: BlocksProps) {
+  return data.map((data, index) => {
+    const template = templates[data._template]
+
+    if (!template) {
+      return nullOrError('Unrecognized Block Type: ' + data._template)
+    }
+
+    if (!template.Component) {
+      return nullOrError(
+        `The "${template.label}" block template is missing the Component`
+      )
+    }
+
+    return <template.Component data={data} index={index} name={name} />
+  })
+}
+
+const nullOrError = (message: string) => {
+  if (process.env.NODE_ENV) {
+    throw new Error(message)
+  }
+
+  return null
+}

--- a/packages/react-tinacms-blocks/src/index.tsx
+++ b/packages/react-tinacms-blocks/src/index.tsx
@@ -16,4 +16,4 @@ limitations under the License.
 
 */
 
-export { Blocks, BlocksProps, BlockTemplate } from './blocks'
+export { Blocks, BlocksProps } from './blocks'

--- a/packages/react-tinacms-blocks/tsconfig.json
+++ b/packages/react-tinacms-blocks/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "include": ["src", "types", "test"],
+  "compilerOptions": {
+    "target": "es5",
+    "module": "esnext",
+    "lib": ["dom", "esnext"],
+    "importHelpers": true,
+    "declaration": true,
+    "sourceMap": true,
+    "rootDir": "./",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "*": ["src/*", "node_modules/*"]
+    },
+    "jsx": "react",
+    "esModuleInterop": true
+  }
+}

--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -40,7 +40,7 @@ import {
 } from '@tinacms/styles'
 import { useFrameContext } from '../../components/SyledFrame'
 
-interface BlocksFieldDefinititon extends Field {
+export interface BlocksFieldDefinititon extends Field {
   component: 'blocks'
   defaultItem: object
   templates: {
@@ -48,7 +48,7 @@ interface BlocksFieldDefinititon extends Field {
   }
 }
 
-interface BlockTemplate {
+export interface BlockTemplate {
   label: string
   defaultItem?: object | (() => object)
   key: string

--- a/packages/tinacms/src/plugins/fields/index.ts
+++ b/packages/tinacms/src/plugins/fields/index.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 */
 
+export * from './BlocksFieldPlugin'
 export * from './TextFieldPlugin'
 export * from './MarkdownFieldPlugin'
 export * from './TextareaFieldPlugin'


### PR DESCRIPTION
`react-tinacms-blocks` provides a re-usable `Blocks` component that knows how to render data from the tinacms `BlocksFieldPlugin`. 

**Usage**

```js
import { Blocks } from "react-tinacms-blocks"

const PageBlogForm = {
  // ...
}

export default remarkForm(function Page(props) {
  const { frontmatter } = props.data.markdownRemark

  return (
    <Blocks 
      name="rawFrontmatter.blocks"
      data={props.data.markdownRemark} 
      templates={{ heading, banner, content }}
     />
  )
}, PageBlockForm)
```

**Test Output**
```
 PASS  src/blocks.spec.tsx
  Blocks
    without data
      ✓ renders nothing into the containing element (2ms)
    with some data
      when there are no templates
        ✓ renders nothing into the containing element (1ms)
        if (process.env.NODE_ENV === 'development')
          ✓ throws an error (3ms)
      when there is a matching template
        and it has Component defined
          ✓ renders that Component (2ms)
        and it does not have a Component defined
          ✓ renders nothing into the containing element
          if (process.env.NODE_ENV === 'development')
            ✓ throws an error (5ms)
```