### PR TITLE
other: renames type content-button --> content-creator

### DIFF
--- a/packages/gatsby-tinacms-json/src/create-json-plugin.ts
+++ b/packages/gatsby-tinacms-json/src/create-json-plugin.ts
@@ -35,7 +35,7 @@ const MISSING_FIELDS_MESSAGE =
 
 export class JsonCreatorPlugin<FormShape = any, FrontmatterShape = any>
   implements AddContentPlugin<FormShape> {
-  __type: 'content-button' = 'content-button'
+  __type: 'content-creator' = 'content-creator'
   name: AddContentPlugin<FormShape>['name']
   fields: AddContentPlugin<FormShape>['fields']
 

--- a/packages/gatsby-tinacms-remark/src/remark-creator-plugin.ts
+++ b/packages/gatsby-tinacms-remark/src/remark-creator-plugin.ts
@@ -46,7 +46,7 @@ export function createRemarkButton<FormShape = any, FrontmatterShape = any>(
 
 export class RemarkCreatorPlugin<FormShape = any, FrontmatterShape = any>
   implements AddContentPlugin<FormShape> {
-  __type: 'content-button' = 'content-button'
+  __type: 'content-creator' = 'content-creator'
   name: AddContentPlugin<FormShape>['name']
   fields: AddContentPlugin<FormShape>['fields']
 

--- a/packages/tinacms/src/components/CreateContent.tsx
+++ b/packages/tinacms/src/components/CreateContent.tsx
@@ -46,7 +46,7 @@ export const CreateContentMenu = () => {
   const frame = useFrameContext()
   const [visible, setVisible] = React.useState(false)
 
-  const contentCreatorPlugins = cms.plugins.findOrCreateMap('content-button')
+  const contentCreatorPlugins = cms.plugins.findOrCreateMap('content-creator')
 
   useSubscribable(contentCreatorPlugins)
 

--- a/packages/tinacms/src/plugins/create-content-form-plugin.ts
+++ b/packages/tinacms/src/plugins/create-content-form-plugin.ts
@@ -20,7 +20,7 @@ import { TinaCMS } from '../tina-cms'
 import { Field, Plugin } from '@tinacms/core'
 
 export interface AddContentPlugin<FormShape> extends Plugin {
-  __type: 'content-button'
+  __type: 'content-creator'
   onSubmit(value: FormShape, cms: TinaCMS): Promise<void> | void
   fields: Field[]
 }


### PR DESCRIPTION
Opt for more semantic name of plugin type, `content-creator` versus `content-button`. 