### PR TITLE
react-tinacms-blocks: Add support for inline editing

### DIFF
--- a/packages/demo-gatsby/src/components/blog-blocks.js
+++ b/packages/demo-gatsby/src/components/blog-blocks.js
@@ -1,0 +1,164 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+import React from "react"
+import { TinaField } from "tinacms"
+import { InlineBlocks } from "react-tinacms-blocks"
+
+export function BlogBlocks({ form, data }) {
+  return (
+    <InlineBlocks
+      form={form}
+      name="rawFrontmatter.blocks"
+      data={data}
+      components={BLOCK_COMPONENTS}
+      renderBefore={props => (
+        <>
+          <br />
+          <BlocksActions {...props} />
+        </>
+      )}
+    />
+  )
+}
+/**
+ * Blocks Components
+ */
+const BLOCK_COMPONENTS = {
+  heading: EditableHeading,
+  image: EditableImage,
+}
+
+function BlocksActions({ index, insert, remove, move }) {
+  const hasIndex = index || index === 0
+  return (
+    <>
+      {insert && (
+        <button
+          onClick={() =>
+            insert(
+              { _template: "heading", ...heading.defaultItem },
+              (index || -1) + 1
+            )
+          }
+        >
+          Add Heading
+        </button>
+      )}
+      {insert && (
+        <button
+          onClick={() =>
+            insert(
+              { _template: "image", ...image.defaultItem },
+              (index || -1) + 1
+            )
+          }
+        >
+          Add Image
+        </button>
+      )}
+      {hasIndex && move && (
+        <button onClick={() => move(index, index - 1)} disabled={index === 0}>
+          Up
+        </button>
+      )}
+      {hasIndex && move && (
+        <button onClick={() => move(index, index + 1)}>Down</button>
+      )}
+      {hasIndex && remove && (
+        <button onClick={() => remove(index)}>Remove</button>
+      )}
+    </>
+  )
+}
+
+function EditableHeading(props) {
+  return (
+    <div style={{ border: "5px solid purple" }}>
+      <h1>
+        <TinaField
+          name={`${props.name}.${props.index}.text`}
+          Component={PlainText}
+        >
+          {props.data.text}
+        </TinaField>
+      </h1>
+      <BlocksActions
+        {...props}
+        defaultItem={{ _template: "heading", ...heading.defaultItem }}
+      />
+    </div>
+  )
+}
+
+// Image Block Component
+function EditableImage(props) {
+  return (
+    <p style={{ border: "5px solid green" }}>
+      <TinaField
+        name={`${props.name}.${props.index}.src`}
+        Component={PlainText}
+      />
+      <TinaField
+        name={`${props.name}.${props.index}.alt`}
+        Component={PlainText}
+      />
+      <img {...props.data} />
+      <BlocksActions
+        {...props}
+        defaultItem={{ _template: "image", ...image.defaultItem }}
+      />
+    </p>
+  )
+}
+
+function PlainText(props) {
+  return <input style={{ background: "transparent " }} {...props.input} />
+}
+
+/**
+ * HEADING BLOCK
+ */
+const heading = {
+  label: "Heading",
+  defaultItem: {
+    text: "",
+  },
+  itemProps: block => ({
+    label: `${block.text}`,
+  }),
+  fields: [{ name: "text", component: "text", label: "Text" }],
+}
+
+/**
+ * IMAGE BLOCK
+ */
+// Image Block Template
+const image = {
+  label: "Image",
+  defaultItem: {
+    text: "",
+  },
+  itemProps: block => ({
+    key: `${block.src}`,
+    label: `${block.alt}`,
+  }),
+  fields: [
+    { name: "src", component: "text", label: "Source URL" },
+    { name: "alt", component: "text", label: "Alt Text" },
+  ],
+}

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -26,7 +26,7 @@ import { rhythm } from "../utils/typography"
 import { liveRemarkForm, DeleteAction } from "gatsby-tinacms-remark"
 import Img from "gatsby-image"
 import { TinaField, Wysiwyg, Toggle } from "tinacms"
-import { InlineBlocks } from "react-tinacms-blocks"
+import { BlogBlocks } from "../components/blog-blocks"
 
 const get = require("lodash.get")
 
@@ -122,18 +122,7 @@ function BlogPostTemplate(props) {
             <small style={{ color: "fuchsia" }}>Draft</small>
           )}
         </TinaField>
-        <InlineBlocks
-          form={form}
-          name="rawFrontmatter.blocks"
-          data={blocks}
-          components={BLOCK_COMPONENTS}
-          renderBefore={props => (
-            <>
-              <br />
-              <BlocksActions {...props} />
-            </>
-          )}
-        />
+        <BlogBlocks form={form} data={blocks} />
         <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
           <div
             dangerouslySetInnerHTML={{
@@ -178,134 +167,6 @@ function BlogPostTemplate(props) {
         </li>
       </ul>
     </Layout>
-  )
-}
-
-/**
- * Blocks Components
- */
-
-const BLOCK_COMPONENTS = {
-  heading: EditableHeading,
-  image: EditableImage,
-}
-
-/**
- * HEADING BLOCK
- */
-const heading = {
-  label: "Heading",
-  defaultItem: {
-    text: "",
-  },
-  itemProps: block => ({
-    label: `${block.text}`,
-  }),
-  fields: [{ name: "text", component: "text", label: "Text" }],
-}
-const BlocksActions = ({ index, insert, remove, move }) => {
-  const hasIndex = index || index === 0
-  return (
-    <>
-      {insert && (
-        <button
-          onClick={() =>
-            insert(
-              { _template: "heading", ...heading.defaultItem },
-              (index || -1) + 1
-            )
-          }
-        >
-          Add Heading
-        </button>
-      )}
-      {insert && (
-        <button
-          onClick={() =>
-            insert(
-              { _template: "image", ...image.defaultItem },
-              (index || -1) + 1
-            )
-          }
-        >
-          Add Image
-        </button>
-      )}
-      {hasIndex && move && (
-        <button onClick={() => move(index, index - 1)} disabled={index === 0}>
-          Up
-        </button>
-      )}
-      {hasIndex && move && (
-        <button onClick={() => move(index, index + 1)}>Down</button>
-      )}
-      {hasIndex && remove && (
-        <button onClick={() => remove(index)}>Remove</button>
-      )}
-    </>
-  )
-}
-
-function EditableHeading(props) {
-  return (
-    <div style={{ border: "5px solid purple" }}>
-      <h1>
-        <TinaField
-          name={`${props.name}.${props.index}.text`}
-          Component={PlainText}
-        >
-          {props.data.text}
-        </TinaField>
-      </h1>
-      <BlocksActions
-        {...props}
-        defaultItem={{ _template: "heading", ...heading.defaultItem }}
-      />
-    </div>
-  )
-}
-
-const HeadingBlock = props => {
-  return <h1>{props.data.text}</h1>
-}
-
-/**
- * IMAGE BLOCK
- */
-// Image Block Template
-const image = {
-  label: "Image",
-  defaultItem: {
-    text: "",
-  },
-  itemProps: block => ({
-    key: `${block.src}`,
-    label: `${block.alt}`,
-  }),
-  fields: [
-    { name: "src", component: "text", label: "Source URL" },
-    { name: "alt", component: "text", label: "Alt Text" },
-  ],
-}
-
-// Image Block Component
-function EditableImage(props) {
-  return (
-    <p style={{ border: "5px solid green" }}>
-      <TinaField
-        name={`${props.name}.${props.index}.src`}
-        Component={PlainText}
-      />
-      <TinaField
-        name={`${props.name}.${props.index}.alt`}
-        Component={PlainText}
-      />
-      <img {...props.data} />
-      <BlocksActions
-        {...props}
-        defaultItem={{ _template: "image", ...image.defaultItem }}
-      />
-    </p>
   )
 }
 

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -26,7 +26,7 @@ import { rhythm } from "../utils/typography"
 import { liveRemarkForm, DeleteAction } from "gatsby-tinacms-remark"
 import Img from "gatsby-image"
 import { TinaField, Wysiwyg, Toggle } from "tinacms"
-import { Blocks } from "react-tinacms-blocks"
+import { InlineBlocks } from "react-tinacms-blocks"
 
 const get = require("lodash.get")
 
@@ -41,6 +41,7 @@ const MyToggle = props => (
 )
 
 function BlogPostTemplate(props) {
+  const form = props.form
   const post = props.data.markdownRemark
   const siteTitle = props.data.site.siteMetadata.title
   const { previous, next } = props.pageContext
@@ -121,13 +122,11 @@ function BlogPostTemplate(props) {
             <small style={{ color: "fuchsia" }}>Draft</small>
           )}
         </TinaField>
-        <Blocks
+        <InlineBlocks
+          form={form}
           name="rawFrontmatter.blocks"
           data={blocks}
-          components={{
-            heading: EditableHeading,
-            image: EditableImage,
-          }}
+          components={BLOCK_COMPONENTS}
         />
         <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
           <div
@@ -177,6 +176,15 @@ function BlogPostTemplate(props) {
 }
 
 /**
+ * Blocks Components
+ */
+
+const BLOCK_COMPONENTS = {
+  heading: EditableHeading,
+  image: EditableImage,
+}
+
+/**
  * HEADING BLOCK
  */
 const heading = {
@@ -189,23 +197,50 @@ const heading = {
   }),
   fields: [{ name: "text", component: "text", label: "Text" }],
 }
-
-function EditableHeading(props) {
+const BlocksActions = ({ index, insert, remove, move }) => {
   return (
-    <TinaField
-      name={`${props.name}.${props.index}.text`}
-      Component={EditableHeadingBlock}
-    >
-      <HeadingBlock {...props} />
-    </TinaField>
+    <>
+      {insert && (
+        <button
+          onClick={() =>
+            insert({ _template: "heading", ...heading.defaultItem }, index)
+          }
+        >
+          Add Heading
+        </button>
+      )}
+      {insert && (
+        <button
+          onClick={() =>
+            insert({ _template: "image", ...image.defaultItem }, index)
+          }
+        >
+          Add Image
+        </button>
+      )}
+      {move && <button onClick={() => move(index, index - 1)}>Up</button>}
+      {move && <button onClick={() => move(index, index + 1)}>Down</button>}
+      {remove && <button onClick={() => remove(index)}>Remove</button>}
+    </>
   )
 }
 
-const EditableHeadingBlock = props => {
+function EditableHeading(props) {
   return (
-    <h1>
-      <PlainText {...props} />
-    </h1>
+    <div style={{ border: "5px solid purple" }}>
+      <BlocksActions
+        {...props}
+        defaultItem={{ _template: "heading", ...heading.defaultItem }}
+      />
+      <h1>
+        <TinaField
+          name={`${props.name}.${props.index}.text`}
+          Component={PlainText}
+        >
+          {props.data.text}
+        </TinaField>
+      </h1>
+    </div>
   )
 }
 
@@ -235,7 +270,11 @@ const image = {
 // Image Block Component
 function EditableImage(props) {
   return (
-    <p>
+    <p style={{ border: "5px solid green" }}>
+      <BlocksActions
+        {...props}
+        defaultItem={{ _template: "image", ...image.defaultItem }}
+      />
       <TinaField
         name={`${props.name}.${props.index}.src`}
         Component={PlainText}

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -210,7 +210,10 @@ const BlocksActions = ({ index, insert, remove, move }) => {
       {insert && (
         <button
           onClick={() =>
-            insert({ _template: "heading", ...heading.defaultItem }, index || 0)
+            insert(
+              { _template: "heading", ...heading.defaultItem },
+              (index || -1) + 1
+            )
           }
         >
           Add Heading
@@ -219,7 +222,10 @@ const BlocksActions = ({ index, insert, remove, move }) => {
       {insert && (
         <button
           onClick={() =>
-            insert({ _template: "image", ...image.defaultItem }, index || 0)
+            insert(
+              { _template: "image", ...image.defaultItem },
+              (index || -1) + 1
+            )
           }
         >
           Add Image
@@ -309,15 +315,6 @@ function EditableImage(props) {
 const BlogPostForm = {
   actions: [DeleteAction],
   fields: [
-    {
-      label: "Blocks",
-      name: "frontmatter.blocks",
-      component: "blocks",
-      templates: {
-        heading,
-        image,
-      },
-    },
     {
       label: "Gallery",
       name: "frontmatter.gallery",
@@ -430,23 +427,6 @@ const BlogPostForm = {
         if (!gastbyImageNode) return ""
         return gastbyImageNode.childImageSharp.fluid.src
       },
-    },
-    { label: "Body", name: "rawMarkdownBody", component: "markdown" },
-    { name: "hr", component: () => <hr /> },
-    {
-      label: "Commit Name",
-      name: "__commit_name",
-      component: "text",
-    },
-    {
-      label: "Commit Email",
-      name: "__commit_email",
-      component: "text",
-    },
-    {
-      label: "Commit Message (Optional)",
-      name: "__commit_message",
-      component: "textarea",
     },
   ],
 }

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -127,6 +127,12 @@ function BlogPostTemplate(props) {
           name="rawFrontmatter.blocks"
           data={blocks}
           components={BLOCK_COMPONENTS}
+          renderBefore={props => (
+            <>
+              <br />
+              <BlocksActions {...props} />
+            </>
+          )}
         />
         <TinaField name="rawMarkdownBody" Component={Wysiwyg}>
           <div
@@ -198,12 +204,13 @@ const heading = {
   fields: [{ name: "text", component: "text", label: "Text" }],
 }
 const BlocksActions = ({ index, insert, remove, move }) => {
+  const hasIndex = index || index === 0
   return (
     <>
       {insert && (
         <button
           onClick={() =>
-            insert({ _template: "heading", ...heading.defaultItem }, index)
+            insert({ _template: "heading", ...heading.defaultItem }, index || 0)
           }
         >
           Add Heading
@@ -212,15 +219,23 @@ const BlocksActions = ({ index, insert, remove, move }) => {
       {insert && (
         <button
           onClick={() =>
-            insert({ _template: "image", ...image.defaultItem }, index)
+            insert({ _template: "image", ...image.defaultItem }, index || 0)
           }
         >
           Add Image
         </button>
       )}
-      {move && <button onClick={() => move(index, index - 1)}>Up</button>}
-      {move && <button onClick={() => move(index, index + 1)}>Down</button>}
-      {remove && <button onClick={() => remove(index)}>Remove</button>}
+      {hasIndex && move && (
+        <button onClick={() => move(index, index - 1)} disabled={index === 0}>
+          Up
+        </button>
+      )}
+      {hasIndex && move && (
+        <button onClick={() => move(index, index + 1)}>Down</button>
+      )}
+      {hasIndex && remove && (
+        <button onClick={() => remove(index)}>Remove</button>
+      )}
     </>
   )
 }
@@ -228,10 +243,6 @@ const BlocksActions = ({ index, insert, remove, move }) => {
 function EditableHeading(props) {
   return (
     <div style={{ border: "5px solid purple" }}>
-      <BlocksActions
-        {...props}
-        defaultItem={{ _template: "heading", ...heading.defaultItem }}
-      />
       <h1>
         <TinaField
           name={`${props.name}.${props.index}.text`}
@@ -240,6 +251,10 @@ function EditableHeading(props) {
           {props.data.text}
         </TinaField>
       </h1>
+      <BlocksActions
+        {...props}
+        defaultItem={{ _template: "heading", ...heading.defaultItem }}
+      />
     </div>
   )
 }
@@ -271,10 +286,6 @@ const image = {
 function EditableImage(props) {
   return (
     <p style={{ border: "5px solid green" }}>
-      <BlocksActions
-        {...props}
-        defaultItem={{ _template: "image", ...image.defaultItem }}
-      />
       <TinaField
         name={`${props.name}.${props.index}.src`}
         Component={PlainText}
@@ -284,6 +295,10 @@ function EditableImage(props) {
         Component={PlainText}
       />
       <img {...props.data} />
+      <BlocksActions
+        {...props}
+        defaultItem={{ _template: "image", ...image.defaultItem }}
+      />
     </p>
   )
 }

--- a/packages/gatsby-tinacms-remark/src/remarkFormHoc.tsx
+++ b/packages/gatsby-tinacms-remark/src/remarkFormHoc.tsx
@@ -52,6 +52,7 @@ export function liveRemarkForm(Component: any, options: RemarkFormProps = {}) {
               {...props}
               data={{ ...props.data, markdownRemark }}
               {...editingProps}
+              form={form}
             />
           )
         }}

--- a/packages/react-tinacms-blocks/package.json
+++ b/packages/react-tinacms-blocks/package.json
@@ -16,6 +16,7 @@
     "lint": "tsdx lint"
   },
   "peerDependencies": {
+    "tinacms": ">=0.10",
     "react": ">=16.8"
   },
   "devDependencies": {

--- a/packages/react-tinacms-blocks/package.json
+++ b/packages/react-tinacms-blocks/package.json
@@ -20,6 +20,7 @@
     "react": ">=16.8"
   },
   "devDependencies": {
+    "tinacms": "0.10.0-alpha.1",
     "@types/jest": "^24.0.23",
     "tsdx": "^0.11.0"
   }

--- a/packages/react-tinacms-blocks/src/index.tsx
+++ b/packages/react-tinacms-blocks/src/index.tsx
@@ -17,3 +17,4 @@ limitations under the License.
 */
 
 export { Blocks, BlocksProps } from './blocks'
+export { InlineBlocks, InlineBlocksProps } from './inline-blocks'

--- a/packages/react-tinacms-blocks/src/inline-blocks.tsx
+++ b/packages/react-tinacms-blocks/src/inline-blocks.tsx
@@ -1,3 +1,20 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
 import React, { useCallback } from 'react'
 import { TinaField, Form } from 'tinacms'
 

--- a/packages/react-tinacms-blocks/src/inline-blocks.tsx
+++ b/packages/react-tinacms-blocks/src/inline-blocks.tsx
@@ -3,14 +3,30 @@ import { TinaField, Form } from 'tinacms'
 
 import { Blocks, BlocksProps } from './blocks'
 
+export interface BlocksRenderProps {
+  insert(obj: any, index: number): void
+  move(from: number, to: number): void
+  remove(index: number): void
+}
 export interface InlineBlocksProps extends BlocksProps {
   // TODO: We shouldn't have to pass this in.
   form: Form
+  renderBefore(props: BlocksRenderProps): any // TODO: Proper types
 }
 
-export function InlineBlocks({ name, form, ...props }: InlineBlocksProps) {
+export function InlineBlocks({
+  name,
+  form,
+  renderBefore,
+  ...props
+}: InlineBlocksProps) {
   const EditableBlocks = React.useMemo(
-    () => createEditableBlocks(form, props.components),
+    () =>
+      createEditableBlocks({
+        form,
+        components: props.components,
+        renderBefore,
+      }),
     [form, props.components]
   )
   return (
@@ -20,10 +36,15 @@ export function InlineBlocks({ name, form, ...props }: InlineBlocksProps) {
   )
 }
 
-function createEditableBlocks(
-  form: Form,
+function createEditableBlocks({
+  form,
+  components,
+  renderBefore,
+}: {
+  form: Form
   components: InlineBlocksProps['components']
-) {
+  renderBefore: any
+}) {
   return function(props: any) {
     return (
       <EditableBlocks
@@ -31,16 +52,18 @@ function createEditableBlocks(
         components={components}
         data={props.input.value}
         form={form}
+        renderBefore={renderBefore}
       />
     )
   }
 }
 
-export function EditableBlocks({
+function EditableBlocks({
   name,
   data = [],
   components = {},
   form,
+  renderBefore,
 }: InlineBlocksProps) {
   const move = useCallback(
     (from: number, to: number) => {
@@ -65,6 +88,7 @@ export function EditableBlocks({
 
   return (
     <>
+      {renderBefore && renderBefore({ insert, move, remove })}
       {data.map((data, index) => {
         const Component = components[data._template]
 

--- a/packages/react-tinacms-blocks/src/inline-blocks.tsx
+++ b/packages/react-tinacms-blocks/src/inline-blocks.tsx
@@ -1,0 +1,84 @@
+import React, { useCallback } from 'react'
+import { TinaField, Form } from 'tinacms'
+
+import { Blocks, BlocksProps } from './blocks'
+
+export interface InlineBlocksProps extends BlocksProps {
+  // TODO: We shouldn't have to pass this in.
+  form: Form
+}
+
+export function InlineBlocks({ name, form, ...props }: InlineBlocksProps) {
+  const EditableBlocks = React.useMemo(
+    () => createEditableBlocks(form, props.components),
+    [form, props.components]
+  )
+  return (
+    <TinaField name={name} Component={EditableBlocks}>
+      <Blocks name={name} {...props} />
+    </TinaField>
+  )
+}
+
+function createEditableBlocks(
+  form: Form,
+  components: InlineBlocksProps['components']
+) {
+  return function(props: any) {
+    return (
+      <EditableBlocks
+        name={props.input.name}
+        components={components}
+        data={props.input.value}
+        form={form}
+      />
+    )
+  }
+}
+
+export function EditableBlocks({
+  name,
+  data = [],
+  components = {},
+  form,
+}: InlineBlocksProps) {
+  const move = useCallback(
+    (from: number, to: number) => {
+      form.finalForm.mutators.move(name, from, to)
+    },
+    [form, name]
+  )
+
+  const remove = React.useCallback(
+    (index: number) => {
+      form.finalForm.mutators.remove(name, index)
+    },
+    [form, name]
+  )
+
+  const insert = React.useCallback(
+    (block: any, index: number) => {
+      form.finalForm.mutators.insert(name, index, block)
+    },
+    [form, name]
+  )
+
+  return (
+    <>
+      {data.map((data, index) => {
+        const Component = components[data._template]
+
+        return (
+          <Component
+            data={data}
+            index={index}
+            name={name}
+            move={move}
+            remove={remove}
+            insert={insert}
+          />
+        )
+      })}
+    </>
+  )
+}


### PR DESCRIPTION
Adds support for adding, removing, and moving blocks while editing content inline.

<img width="560" alt="image" src="https://user-images.githubusercontent.com/824015/69884893-ea241a00-12b0-11ea-8631-785064b01aa9.png">
