### PR TITLE
fix(blocks): move defaults inside function

### DIFF
--- a/packages/react-tinacms-blocks/src/blocks.tsx
+++ b/packages/react-tinacms-blocks/src/blocks.tsx
@@ -25,7 +25,10 @@ export interface BlocksProps {
   }
 }
 
-export function Blocks({ name, data = [], components = {} }: BlocksProps) {
+export function Blocks({ name, data, components }: BlocksProps) {
+  data = data || []
+  components = components || {}
+
   return (
     <>
       {data.map((data, index) => {

--- a/packages/react-tinacms-blocks/src/inline-blocks.tsx
+++ b/packages/react-tinacms-blocks/src/inline-blocks.tsx
@@ -77,11 +77,14 @@ function createEditableBlocks({
 
 function EditableBlocks({
   name,
-  data = [],
-  components = {},
+  data,
+  components,
   form,
   renderBefore,
 }: InlineBlocksProps) {
+  data = data || []
+  components = components || {}
+
   const move = useCallback(
     (from: number, to: number) => {
       form.finalForm.mutators.move(name, from, to)


### PR DESCRIPTION
I've moved the defaulting behaviour for data & components inside the Blocks & EditableBlocks functions to prevent crashing when an empty value is passed.