### PR TITLE
feat: allow user to use enter/return key to create new blog entry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,14 @@
 			}
 		},
 		"@babel/core": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
-			"integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
+			"integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
 				"@babel/generator": "^7.7.4",
 				"@babel/helpers": "^7.7.4",
-				"@babel/parser": "^7.7.4",
+				"@babel/parser": "^7.7.5",
 				"@babel/template": "^7.7.4",
 				"@babel/traverse": "^7.7.4",
 				"@babel/types": "^7.7.4",
@@ -177,9 +177,9 @@
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.4.tgz",
-			"integrity": "sha512-ehGBu4mXrhs0FxAqN8tWkzF8GSIGAiEumu4ONZ/hD9M88uHcD+Yu2ttKfOCgwzoesJOJrtQh7trI5YPbRtMmnA==",
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.7.5.tgz",
+			"integrity": "sha512-A7pSxyJf1gN5qXVcidwLWydjftUN878VkalhXX5iQDuGyiGK3sOrrKKHF4/A4fwHtnsotv/NipwAeLzY4KQPvw==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-simple-access": "^7.7.4",
@@ -282,9 +282,9 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-			"integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g=="
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+			"integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.7.4",
@@ -306,13 +306,13 @@
 			}
 		},
 		"@babel/plugin-proposal-decorators": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.6.0.tgz",
-			"integrity": "sha512-ZSyYw9trQI50sES6YxREXKu+4b7MAg6Qx2cvyDDYjP2Hpzd3FleOUwC9cqn1+za8d0A2ZU8SHujxFao956efUg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.7.4.tgz",
+			"integrity": "sha512-GftcVDcLCwVdzKmwOBDjATd548+IE+mBo7ttgatqNDR7VG7GqIuZPtRWlMLHbhTXhcnFZiGER8iIYl1n/imtsg==",
 			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.6.0",
+				"@babel/helper-create-class-features-plugin": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-syntax-decorators": "^7.2.0"
+				"@babel/plugin-syntax-decorators": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-dynamic-import": {
@@ -333,6 +333,24 @@
 				"@babel/plugin-syntax-json-strings": "^7.7.4"
 			}
 		},
+		"@babel/plugin-proposal-nullish-coalescing-operator": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+			"integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-numeric-separator": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.7.4.tgz",
+			"integrity": "sha512-CG605v7lLpVgVldSY6kxsN9ui1DxFOyepBfuX2AzU2TNriMAYApoU55mrGw9Jr4TlrTzPCG10CL8YXyi+E/iPw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-numeric-separator": "^7.7.4"
+			}
+		},
 		"@babel/plugin-proposal-object-rest-spread": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.7.4.tgz",
@@ -349,6 +367,15 @@
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/plugin-syntax-optional-catch-binding": "^7.7.4"
+			}
+		},
+		"@babel/plugin-proposal-optional-chaining": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.4.tgz",
+			"integrity": "sha512-JmgaS+ygAWDR/STPe3/7y0lNlHgS+19qZ9aC06nYLwQ/XB7c0q5Xs+ksFU3EDnp9EiEsO0dnRAOKeyLHTZuW3A==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0",
+				"@babel/plugin-syntax-optional-chaining": "^7.7.4"
 			}
 		},
 		"@babel/plugin-proposal-unicode-property-regex": {
@@ -416,6 +443,22 @@
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
 		},
+		"@babel/plugin-syntax-nullish-coalescing-operator": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+			"integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-numeric-separator": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.7.4.tgz",
+			"integrity": "sha512-vmlUUBlLuFnbpaR+1kKIdo62xQEN+THWbtAHSEilo+0rHl2dKKCn6GLUVKpI848wL/T0ZPQgAy8asRJ9yYEjog==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
 		"@babel/plugin-syntax-object-rest-spread": {
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.7.4.tgz",
@@ -428,6 +471,14 @@
 			"version": "7.7.4",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.7.4.tgz",
 			"integrity": "sha512-4ZSuzWgFxqHRE31Glu+fEr/MirNZOMYmD/0BhBWyLyOOQz/gTAl7QmWm2hX1QxEIXsr2vkdlwxIzTyiYRC4xcQ==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.0.0"
+			}
+		},
+		"@babel/plugin-syntax-optional-chaining": {
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.7.4.tgz",
+			"integrity": "sha512-2MqYD5WjZSbJdUagnJvIdSfkb/ucOC9/1fRJxm7GAxY6YQLWlUvkfxoNbUPcPLHJyetKUDQ4+yyuUyAoc0HriA==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0"
 			}
@@ -583,21 +634,21 @@
 			}
 		},
 		"@babel/plugin-transform-modules-amd": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.4.tgz",
-			"integrity": "sha512-/542/5LNA18YDtg1F+QHvvUSlxdvjZoD/aldQwkq+E3WCkbEjNSN9zdrOXaSlfg3IfGi22ijzecklF/A7kVZFQ==",
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.7.5.tgz",
+			"integrity": "sha512-CT57FG4A2ZUNU1v+HdvDSDrjNWBrtCmSH6YbbgN3Lrf0Di/q/lWRxZrE72p3+HCCz9UjfZOEBdphgC0nzOS6DQ==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.4",
+				"@babel/helper-module-transforms": "^7.7.5",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
 			}
 		},
 		"@babel/plugin-transform-modules-commonjs": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.4.tgz",
-			"integrity": "sha512-k8iVS7Jhc367IcNF53KCwIXtKAH7czev866ThsTgy8CwlXjnKZna2VHwChglzLleYrcHz1eQEIJlGRQxB53nqA==",
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.7.5.tgz",
+			"integrity": "sha512-9Cq4zTFExwFhQI6MT1aFxgqhIsMWQWDVwOgLzl7PTWJHsNaqFvklAU+Oz6AQLAS0dJKTwZSOCo20INwktxpi3Q==",
 			"requires": {
-				"@babel/helper-module-transforms": "^7.7.4",
+				"@babel/helper-module-transforms": "^7.7.5",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"@babel/helper-simple-access": "^7.7.4",
 				"babel-plugin-dynamic-import-node": "^2.3.0"
@@ -711,9 +762,9 @@
 			}
 		},
 		"@babel/plugin-transform-regenerator": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.4.tgz",
-			"integrity": "sha512-e7MWl5UJvmPEwFJTwkBlPmqixCtr9yAASBqff4ggXTNicZiwbF8Eefzm6NVgfiBp7JdAGItecnctKTgH44q2Jw==",
+			"version": "7.7.5",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.7.5.tgz",
+			"integrity": "sha512-/8I8tPvX2FkuEyWbjRCt4qTAgZK0DVy8QRguhA524UH48RfGJy94On2ri+dCuwOpcerPRl9O4ebQkRcVzIaGBw==",
 			"requires": {
 				"regenerator-transform": "^0.14.0"
 			}
@@ -727,11 +778,11 @@
 			}
 		},
 		"@babel/plugin-transform-runtime": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.6.0.tgz",
-			"integrity": "sha512-Da8tMf7uClzwUm/pnJ1S93m/aRXmoYNDD7TkHua8xBDdaAs54uZpTWvEt6NGwmoVMb9mZbntfTqmG2oSzN/7Vg==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
+			"integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.0.0",
+				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
 				"resolve": "^1.8.1",
 				"semver": "^5.5.1"
@@ -815,9 +866,9 @@
 			}
 		},
 		"@babel/preset-env": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",
-			"integrity": "sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==",
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.6.tgz",
+			"integrity": "sha512-k5hO17iF/Q7tR9Jv8PdNBZWYW6RofxhnxKjBMc0nG4JTaWvOTiPoO/RLFwAKcA4FpmuBFm6jkoqaRJLGi0zdaQ==",
 			"requires": {
 				"@babel/helper-module-imports": "^7.7.4",
 				"@babel/helper-plugin-utils": "^7.0.0",
@@ -847,8 +898,8 @@
 				"@babel/plugin-transform-function-name": "^7.7.4",
 				"@babel/plugin-transform-literals": "^7.7.4",
 				"@babel/plugin-transform-member-expression-literals": "^7.7.4",
-				"@babel/plugin-transform-modules-amd": "^7.7.4",
-				"@babel/plugin-transform-modules-commonjs": "^7.7.4",
+				"@babel/plugin-transform-modules-amd": "^7.7.5",
+				"@babel/plugin-transform-modules-commonjs": "^7.7.5",
 				"@babel/plugin-transform-modules-systemjs": "^7.7.4",
 				"@babel/plugin-transform-modules-umd": "^7.7.4",
 				"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
@@ -856,7 +907,7 @@
 				"@babel/plugin-transform-object-super": "^7.7.4",
 				"@babel/plugin-transform-parameters": "^7.7.4",
 				"@babel/plugin-transform-property-literals": "^7.7.4",
-				"@babel/plugin-transform-regenerator": "^7.7.4",
+				"@babel/plugin-transform-regenerator": "^7.7.5",
 				"@babel/plugin-transform-reserved-words": "^7.7.4",
 				"@babel/plugin-transform-shorthand-properties": "^7.7.4",
 				"@babel/plugin-transform-spread": "^7.7.4",
@@ -866,7 +917,7 @@
 				"@babel/plugin-transform-unicode-regex": "^7.7.4",
 				"@babel/types": "^7.7.4",
 				"browserslist": "^4.6.0",
-				"core-js-compat": "^3.1.1",
+				"core-js-compat": "^3.4.7",
 				"invariant": "^2.2.2",
 				"js-levenshtein": "^1.1.3",
 				"semver": "^5.5.0"
@@ -894,12 +945,12 @@
 			}
 		},
 		"@babel/preset-typescript": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.6.0.tgz",
-			"integrity": "sha512-4xKw3tTcCm0qApyT6PqM9qniseCE79xGHiUnNdKGdxNsGUc2X7WwZybqIpnTmoukg3nhPceI5KPNzNqLNeIJww==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.7.4.tgz",
+			"integrity": "sha512-rqrjxfdiHPsnuPur0jKrIIGQCIgoTWMTjlbWE69G4QJ6TIOVnnRnIJhUxNTL/VwDmEAVX08Tq3B1nirer5341w==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.0.0",
-				"@babel/plugin-transform-typescript": "^7.6.0"
+				"@babel/plugin-transform-typescript": "^7.7.4"
 			}
 		},
 		"@babel/runtime": {
@@ -911,25 +962,25 @@
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.4.tgz",
-			"integrity": "sha512-hKNcmHQbBSJFnZ82ewYtWDZ3fXkP/l1XcfRtm7c8gHPM/DMecJtFFBEp7KMLZTuHwwb7RfemHdsEnd7L916Z6A==",
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.6.tgz",
+			"integrity": "sha512-QYp/8xdH8iMin3pH5gtT/rUuttVfIcOhWBC3wh9Eh/qs4jEe39+3DpCDLgWXhMQgiCTOH8mrLSvQ0OHOCcox9g==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.4.tgz",
-			"integrity": "sha512-BBIEhzk8McXDcB3IbOi8zQPzzINUp4zcLesVlBSOcyGhzPUU8Xezk5GAG7Sy5GVhGmAO0zGd2qRSeY2g4Obqxw==",
+			"version": "7.7.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.7.6.tgz",
+			"integrity": "sha512-NrRUehqG0sMSCaP+0XV/vOvvjNl4BQOWq3Qys1Q2KTEm5tGMo9h0dHnIzeKerj0a7SIB8LP5kYg/T1raE3FoKQ==",
 			"requires": {
 				"core-js-pure": "^3.0.0",
 				"regenerator-runtime": "^0.13.2"
@@ -1373,9 +1424,9 @@
 					"integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
 				},
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"fbjs": {
 					"version": "1.0.0",
@@ -1755,9 +1806,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1789,9 +1840,9 @@
 					}
 				},
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"file-type": {
 					"version": "9.0.0",
@@ -1810,9 +1861,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1827,9 +1878,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1844,9 +1895,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1860,9 +1911,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1876,9 +1927,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1893,9 +1944,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1909,9 +1960,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1925,9 +1976,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1941,9 +1992,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1957,9 +2008,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1973,9 +2024,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -1989,9 +2040,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2005,9 +2056,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2021,9 +2072,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2037,9 +2088,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2053,9 +2104,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2070,9 +2121,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2086,9 +2137,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2102,9 +2153,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2118,9 +2169,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2151,9 +2202,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2168,9 +2219,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2184,9 +2235,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2205,9 +2256,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -2220,9 +2271,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -4097,11 +4148,6 @@
 				"webpack-hot-middleware": "^2.25.0"
 			},
 			"dependencies": {
-				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-				},
 				"regenerator-runtime": {
 					"version": "0.12.1",
 					"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
@@ -4434,9 +4480,9 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.0.tgz",
-			"integrity": "sha512-c1mZUu4up5cp9KROs/QAw0gTeHrw/x7m52LcnvMxxOZ03DmLwPV0MlGmlgzV3cnSdjhJOZsj7E7FHeioai+egw==",
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}
@@ -4478,8 +4524,7 @@
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"optional": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/color-string": {
 			"version": "1.5.0",
@@ -5785,19 +5830,18 @@
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
 		},
 		"array.prototype.flat": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.2.tgz",
-			"integrity": "sha512-VXjh7lAL4KXKF2hY4FnEW9eRW6IhdvFW1sN/JwLbmECbCgACCnBHNyP3lFiYuttr0jxRN9Bsc5+G27dMseSWqQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz",
+			"integrity": "sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.15.0",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.17.0-next.1"
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.16.2",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-					"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
@@ -5807,6 +5851,7 @@
 						"is-regex": "^1.0.4",
 						"object-inspect": "^1.7.0",
 						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
 						"string.prototype.trimleft": "^2.1.0",
 						"string.prototype.trimright": "^2.1.0"
 					}
@@ -5834,19 +5879,70 @@
 			}
 		},
 		"array.prototype.flatmap": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.2.tgz",
-			"integrity": "sha512-ZZtPLE74KNE+0XcPv/vQmcivxN+8FhwOLvt2udHauO0aDEpsXDQrmd5HuJGpgPVyaV8HvkDPWnJ2iaem0oCKtA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz",
+			"integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.15.0",
+				"es-abstract": "^1.17.0-next.1",
 				"function-bind": "^1.1.1"
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.16.2",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-					"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+				}
+			}
+		},
+		"array.prototype.map": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.1.tgz",
+			"integrity": "sha512-qWw0c1MYCp8Ta2N5l5S1xdNPT5NE2KGzmPe6ZeuLFEwhtNTQGzQkT37r3RoDwZwc7nEPSQyp0ohWbwDTdIwvQg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.16.0",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.4"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.16.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
+					"integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
@@ -6026,9 +6122,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -6116,9 +6212,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -6362,9 +6458,9 @@
 			}
 		},
 		"babel-plugin-macros": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.7.1.tgz",
-			"integrity": "sha512-HNM284amlKSQ6FddI4jLXD+XTqF0cTYOe5uemOIZxHJHnamC+OhFQ57rMF9sgnYhkJQptVl9U1SKVZsV9/GLQQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
@@ -6507,9 +6603,9 @@
 			}
 		},
 		"babel-plugin-named-asset-import": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.4.tgz",
-			"integrity": "sha512-S6d+tEzc5Af1tKIMbsf2QirCcPdQ+mKUCY2H1nJj1DyA1ShwpsoxEOAwbWsG5gcXNV/olpvQd9vrUWRx4bnhpw=="
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.5.tgz",
+			"integrity": "sha512-sGhfINU+AuMw9oFAdIn/nD5sem3pn/WgxAfDZ//Q3CnF+5uaho7C7shh2rKLk6sKE/XkfmyibghocwKdVjLIKg=="
 		},
 		"babel-plugin-react-docgen": {
 			"version": "3.2.0",
@@ -6540,9 +6636,9 @@
 			}
 		},
 		"babel-plugin-remove-graphql-queries": {
-			"version": "2.7.17",
-			"resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.17.tgz",
-			"integrity": "sha512-zPAq5DEtucSMppt4U2zB1i9SiGMLOYtjNGoOo5PLw8f5jlihLTYYaPG3Sg2S4+tiB9k+tiWMa07FKXb6lV+rRA=="
+			"version": "2.7.19",
+			"resolved": "https://registry.npmjs.org/babel-plugin-remove-graphql-queries/-/babel-plugin-remove-graphql-queries-2.7.19.tgz",
+			"integrity": "sha512-/DS620ztyyrqrqjmz/KHDt++ktn+4RdvfDf5KCUmt6iJOglgNm7uHkE+snuvvL/xhNNuuPBLErc23Q0cR6MSiQ=="
 		},
 		"babel-plugin-styled-components": {
 			"version": "1.10.6",
@@ -6695,26 +6791,37 @@
 			}
 		},
 		"babel-preset-gatsby": {
-			"version": "0.2.23",
-			"resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.23.tgz",
-			"integrity": "sha512-IuhRMH6TCbTbJ4NFnHg2UQUZv24t3mRc9ow6qMeyL9mklI8vbXSi/bFVO6ES4xy3k5qmUdElXAK5RSpw8/1hbw==",
+			"version": "0.2.26",
+			"resolved": "https://registry.npmjs.org/babel-preset-gatsby/-/babel-preset-gatsby-0.2.26.tgz",
+			"integrity": "sha512-qOM26AhAPW5xetUj579jBFICg16sqFHf3dPptRXi3zS7HpEHbtsOvB9VB68MEUj+WZrrlbR/EQuT69GA1XiBdQ==",
 			"requires": {
 				"@babel/plugin-proposal-class-properties": "^7.7.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
+				"@babel/plugin-proposal-optional-chaining": "^7.7.5",
 				"@babel/plugin-syntax-dynamic-import": "^7.7.4",
-				"@babel/plugin-transform-runtime": "^7.7.4",
+				"@babel/plugin-transform-runtime": "^7.7.6",
 				"@babel/plugin-transform-spread": "^7.7.4",
-				"@babel/preset-env": "^7.7.4",
+				"@babel/preset-env": "^7.7.6",
 				"@babel/preset-react": "^7.7.4",
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"babel-plugin-dynamic-import-node": "^2.3.0",
-				"babel-plugin-macros": "^2.7.1",
+				"babel-plugin-macros": "^2.8.0",
 				"babel-plugin-transform-react-remove-prop-types": "^0.4.24"
 			},
 			"dependencies": {
+				"@babel/plugin-proposal-optional-chaining": {
+					"version": "7.7.5",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.7.5.tgz",
+					"integrity": "sha512-sOwFqT8JSchtJeDD+CjmWCaiFoLxY4Ps7NjvwHC/U7l4e9i5pTRNt8nDMIFSOUL+ncFbYSwruHM8WknYItWdXw==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-optional-chaining": "^7.7.4"
+					}
+				},
 				"@babel/plugin-transform-runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.4.tgz",
-					"integrity": "sha512-O8kSkS5fP74Ad/8pfsCMGa8sBRdLxYoSReaARRNSz3FbFQj3z/QUvoUmJ28gn9BO93YfnXc3j+Xyaqe8cKDNBQ==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.7.6.tgz",
+					"integrity": "sha512-tajQY+YmXR7JjTwRvwL4HePqoL3DYxpYXIHKVvrOIvJmeHe2y1w4tz5qz9ObUDC9m76rCzIMPyn4eERuwA4a4A==",
 					"requires": {
 						"@babel/helper-module-imports": "^7.7.4",
 						"@babel/helper-plugin-utils": "^7.0.0",
@@ -6723,9 +6830,9 @@
 					}
 				},
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -6772,41 +6879,44 @@
 			}
 		},
 		"babel-preset-react-app": {
-			"version": "9.0.2",
-			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.0.2.tgz",
-			"integrity": "sha512-aXD+CTH8Chn8sNJr4tO/trWKqe5sSE4hdO76j9fhVezJSzmpWYWUSc5JoPmdSxADwef5kQFNGKXd433vvkd2VQ==",
+			"version": "9.1.0",
+			"resolved": "https://registry.npmjs.org/babel-preset-react-app/-/babel-preset-react-app-9.1.0.tgz",
+			"integrity": "sha512-0qMOv/pCcCQWxX1eNyKD9GlzZTdzZIK/Pq3O6TGe65tZSJTSplw1pFlaPujm0GjBj4g3GeCQbP08vvzlH7OGHg==",
 			"requires": {
-				"@babel/core": "7.6.0",
-				"@babel/plugin-proposal-class-properties": "7.5.5",
-				"@babel/plugin-proposal-decorators": "7.6.0",
-				"@babel/plugin-proposal-object-rest-spread": "7.5.5",
-				"@babel/plugin-syntax-dynamic-import": "7.2.0",
-				"@babel/plugin-transform-destructuring": "7.6.0",
-				"@babel/plugin-transform-flow-strip-types": "7.4.4",
-				"@babel/plugin-transform-react-display-name": "7.2.0",
-				"@babel/plugin-transform-runtime": "7.6.0",
-				"@babel/preset-env": "7.6.0",
-				"@babel/preset-react": "7.0.0",
-				"@babel/preset-typescript": "7.6.0",
-				"@babel/runtime": "7.6.0",
+				"@babel/core": "7.7.4",
+				"@babel/plugin-proposal-class-properties": "7.7.4",
+				"@babel/plugin-proposal-decorators": "7.7.4",
+				"@babel/plugin-proposal-nullish-coalescing-operator": "7.7.4",
+				"@babel/plugin-proposal-numeric-separator": "7.7.4",
+				"@babel/plugin-proposal-object-rest-spread": "7.7.4",
+				"@babel/plugin-proposal-optional-chaining": "7.7.4",
+				"@babel/plugin-syntax-dynamic-import": "7.7.4",
+				"@babel/plugin-transform-destructuring": "7.7.4",
+				"@babel/plugin-transform-flow-strip-types": "7.7.4",
+				"@babel/plugin-transform-react-display-name": "7.7.4",
+				"@babel/plugin-transform-runtime": "7.7.4",
+				"@babel/preset-env": "7.7.4",
+				"@babel/preset-react": "7.7.4",
+				"@babel/preset-typescript": "7.7.4",
+				"@babel/runtime": "7.7.4",
 				"babel-plugin-dynamic-import-node": "2.3.0",
-				"babel-plugin-macros": "2.6.1",
+				"babel-plugin-macros": "2.7.1",
 				"babel-plugin-transform-react-remove-prop-types": "0.4.24"
 			},
 			"dependencies": {
 				"@babel/core": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.6.0.tgz",
-					"integrity": "sha512-FuRhDRtsd6IptKpHXAa+4WPZYY2ZzgowkbLBecEDDSje1X/apG7jQM33or3NdOmjXBKWGOg4JmSiRfUfuTtHXw==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
+					"integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/generator": "^7.6.0",
-						"@babel/helpers": "^7.6.0",
-						"@babel/parser": "^7.6.0",
-						"@babel/template": "^7.6.0",
-						"@babel/traverse": "^7.6.0",
-						"@babel/types": "^7.6.0",
-						"convert-source-map": "^1.1.0",
+						"@babel/generator": "^7.7.4",
+						"@babel/helpers": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"convert-source-map": "^1.7.0",
 						"debug": "^4.1.0",
 						"json5": "^2.1.0",
 						"lodash": "^4.17.13",
@@ -6815,107 +6925,57 @@
 						"source-map": "^0.5.0"
 					}
 				},
-				"@babel/plugin-proposal-class-properties": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.5.5.tgz",
-					"integrity": "sha512-AF79FsnWFxjlaosgdi421vmYG6/jg79bVD0dpD44QdgobzHKuLZ6S3vl8la9qIeSwGi8i1fS0O1mfuDAAdo1/A==",
-					"requires": {
-						"@babel/helper-create-class-features-plugin": "^7.5.5",
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-proposal-object-rest-spread": {
-					"version": "7.5.5",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.5.tgz",
-					"integrity": "sha512-F2DxJJSQ7f64FyTVl5cw/9MWn6naXGdk3Q3UhDbFEEHv+EilCPoeRD3Zh/Utx1CJz4uyKlQ4uH+bJPbEhMV7Zw==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0"
-					}
-				},
-				"@babel/plugin-syntax-dynamic-import": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz",
-					"integrity": "sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-destructuring": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.6.0.tgz",
-					"integrity": "sha512-2bGIS5P1v4+sWTCnKNDZDxbGvEqi0ijeqM/YqHtVGrvG2y0ySgnEEhXErvE9dA0bnIzY9bIzdFK0jFA46ASIIQ==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
-				"@babel/plugin-transform-flow-strip-types": {
-					"version": "7.4.4",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.4.4.tgz",
-					"integrity": "sha512-WyVedfeEIILYEaWGAUWzVNyqG4sfsNooMhXWsu/YzOvVGcsnPb5PguysjJqI3t3qiaYj0BR8T2f5njdjTGe44Q==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-syntax-flow": "^7.2.0"
-					}
-				},
-				"@babel/plugin-transform-react-display-name": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.2.0.tgz",
-					"integrity": "sha512-Htf/tPa5haZvRMiNSQSFifK12gtr/8vwfr+A9y69uF0QcU77AVu4K7MiHEkTxF7lQoHOL0F9ErqgfNEAKgXj7A==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0"
-					}
-				},
 				"@babel/preset-env": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.6.0.tgz",
-					"integrity": "sha512-1efzxFv/TcPsNXlRhMzRnkBFMeIqBBgzwmZwlFDw5Ubj0AGLeufxugirwZmkkX/ayi3owsSqoQ4fw8LkfK9SYg==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.7.4.tgz",
+					"integrity": "sha512-Dg+ciGJjwvC1NIe/DGblMbcGq1HOtKbw8RLl4nIjlfcILKEOkWT/vRqPpumswABEBVudii6dnVwrBtzD7ibm4g==",
 					"requires": {
-						"@babel/helper-module-imports": "^7.0.0",
+						"@babel/helper-module-imports": "^7.7.4",
 						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-proposal-async-generator-functions": "^7.2.0",
-						"@babel/plugin-proposal-dynamic-import": "^7.5.0",
-						"@babel/plugin-proposal-json-strings": "^7.2.0",
-						"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
-						"@babel/plugin-proposal-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-proposal-unicode-property-regex": "^7.4.4",
-						"@babel/plugin-syntax-async-generators": "^7.2.0",
-						"@babel/plugin-syntax-dynamic-import": "^7.2.0",
-						"@babel/plugin-syntax-json-strings": "^7.2.0",
-						"@babel/plugin-syntax-object-rest-spread": "^7.2.0",
-						"@babel/plugin-syntax-optional-catch-binding": "^7.2.0",
-						"@babel/plugin-transform-arrow-functions": "^7.2.0",
-						"@babel/plugin-transform-async-to-generator": "^7.5.0",
-						"@babel/plugin-transform-block-scoped-functions": "^7.2.0",
-						"@babel/plugin-transform-block-scoping": "^7.6.0",
-						"@babel/plugin-transform-classes": "^7.5.5",
-						"@babel/plugin-transform-computed-properties": "^7.2.0",
-						"@babel/plugin-transform-destructuring": "^7.6.0",
-						"@babel/plugin-transform-dotall-regex": "^7.4.4",
-						"@babel/plugin-transform-duplicate-keys": "^7.5.0",
-						"@babel/plugin-transform-exponentiation-operator": "^7.2.0",
-						"@babel/plugin-transform-for-of": "^7.4.4",
-						"@babel/plugin-transform-function-name": "^7.4.4",
-						"@babel/plugin-transform-literals": "^7.2.0",
-						"@babel/plugin-transform-member-expression-literals": "^7.2.0",
-						"@babel/plugin-transform-modules-amd": "^7.5.0",
-						"@babel/plugin-transform-modules-commonjs": "^7.6.0",
-						"@babel/plugin-transform-modules-systemjs": "^7.5.0",
-						"@babel/plugin-transform-modules-umd": "^7.2.0",
-						"@babel/plugin-transform-named-capturing-groups-regex": "^7.6.0",
-						"@babel/plugin-transform-new-target": "^7.4.4",
-						"@babel/plugin-transform-object-super": "^7.5.5",
-						"@babel/plugin-transform-parameters": "^7.4.4",
-						"@babel/plugin-transform-property-literals": "^7.2.0",
-						"@babel/plugin-transform-regenerator": "^7.4.5",
-						"@babel/plugin-transform-reserved-words": "^7.2.0",
-						"@babel/plugin-transform-shorthand-properties": "^7.2.0",
-						"@babel/plugin-transform-spread": "^7.2.0",
-						"@babel/plugin-transform-sticky-regex": "^7.2.0",
-						"@babel/plugin-transform-template-literals": "^7.4.4",
-						"@babel/plugin-transform-typeof-symbol": "^7.2.0",
-						"@babel/plugin-transform-unicode-regex": "^7.4.4",
-						"@babel/types": "^7.6.0",
+						"@babel/plugin-proposal-async-generator-functions": "^7.7.4",
+						"@babel/plugin-proposal-dynamic-import": "^7.7.4",
+						"@babel/plugin-proposal-json-strings": "^7.7.4",
+						"@babel/plugin-proposal-object-rest-spread": "^7.7.4",
+						"@babel/plugin-proposal-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-proposal-unicode-property-regex": "^7.7.4",
+						"@babel/plugin-syntax-async-generators": "^7.7.4",
+						"@babel/plugin-syntax-dynamic-import": "^7.7.4",
+						"@babel/plugin-syntax-json-strings": "^7.7.4",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4",
+						"@babel/plugin-syntax-optional-catch-binding": "^7.7.4",
+						"@babel/plugin-syntax-top-level-await": "^7.7.4",
+						"@babel/plugin-transform-arrow-functions": "^7.7.4",
+						"@babel/plugin-transform-async-to-generator": "^7.7.4",
+						"@babel/plugin-transform-block-scoped-functions": "^7.7.4",
+						"@babel/plugin-transform-block-scoping": "^7.7.4",
+						"@babel/plugin-transform-classes": "^7.7.4",
+						"@babel/plugin-transform-computed-properties": "^7.7.4",
+						"@babel/plugin-transform-destructuring": "^7.7.4",
+						"@babel/plugin-transform-dotall-regex": "^7.7.4",
+						"@babel/plugin-transform-duplicate-keys": "^7.7.4",
+						"@babel/plugin-transform-exponentiation-operator": "^7.7.4",
+						"@babel/plugin-transform-for-of": "^7.7.4",
+						"@babel/plugin-transform-function-name": "^7.7.4",
+						"@babel/plugin-transform-literals": "^7.7.4",
+						"@babel/plugin-transform-member-expression-literals": "^7.7.4",
+						"@babel/plugin-transform-modules-amd": "^7.7.4",
+						"@babel/plugin-transform-modules-commonjs": "^7.7.4",
+						"@babel/plugin-transform-modules-systemjs": "^7.7.4",
+						"@babel/plugin-transform-modules-umd": "^7.7.4",
+						"@babel/plugin-transform-named-capturing-groups-regex": "^7.7.4",
+						"@babel/plugin-transform-new-target": "^7.7.4",
+						"@babel/plugin-transform-object-super": "^7.7.4",
+						"@babel/plugin-transform-parameters": "^7.7.4",
+						"@babel/plugin-transform-property-literals": "^7.7.4",
+						"@babel/plugin-transform-regenerator": "^7.7.4",
+						"@babel/plugin-transform-reserved-words": "^7.7.4",
+						"@babel/plugin-transform-shorthand-properties": "^7.7.4",
+						"@babel/plugin-transform-spread": "^7.7.4",
+						"@babel/plugin-transform-sticky-regex": "^7.7.4",
+						"@babel/plugin-transform-template-literals": "^7.7.4",
+						"@babel/plugin-transform-typeof-symbol": "^7.7.4",
+						"@babel/plugin-transform-unicode-regex": "^7.7.4",
+						"@babel/types": "^7.7.4",
 						"browserslist": "^4.6.0",
 						"core-js-compat": "^3.1.1",
 						"invariant": "^2.2.2",
@@ -6923,35 +6983,75 @@
 						"semver": "^5.5.0"
 					}
 				},
-				"@babel/preset-react": {
-					"version": "7.0.0",
-					"resolved": "https://registry.npmjs.org/@babel/preset-react/-/preset-react-7.0.0.tgz",
-					"integrity": "sha512-oayxyPS4Zj+hF6Et11BwuBkmpgT/zMxyuZgFrMeZID6Hdh3dGlk4sHCAhdBCpuCKW2ppBfl2uCCetlrUIJRY3w==",
-					"requires": {
-						"@babel/helper-plugin-utils": "^7.0.0",
-						"@babel/plugin-transform-react-display-name": "^7.0.0",
-						"@babel/plugin-transform-react-jsx": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-self": "^7.0.0",
-						"@babel/plugin-transform-react-jsx-source": "^7.0.0"
-					}
-				},
 				"@babel/runtime": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-					"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+					"version": "7.7.4",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
 				},
 				"babel-plugin-macros": {
-					"version": "2.6.1",
-					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
-					"integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
+					"version": "2.7.1",
+					"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.7.1.tgz",
+					"integrity": "sha512-HNM284amlKSQ6FddI4jLXD+XTqF0cTYOe5uemOIZxHJHnamC+OhFQ57rMF9sgnYhkJQptVl9U1SKVZsV9/GLQQ==",
 					"requires": {
-						"@babel/runtime": "^7.4.2",
-						"cosmiconfig": "^5.2.0",
-						"resolve": "^1.10.0"
+						"@babel/runtime": "^7.7.2",
+						"cosmiconfig": "^6.0.0",
+						"resolve": "^1.12.0"
+					},
+					"dependencies": {
+						"resolve": {
+							"version": "1.13.1",
+							"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+							"integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+							"requires": {
+								"path-parse": "^1.0.6"
+							}
+						}
 					}
+				},
+				"cosmiconfig": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
+					"requires": {
+						"@types/parse-json": "^4.0.0",
+						"import-fresh": "^3.1.0",
+						"parse-json": "^5.0.0",
+						"path-type": "^4.0.0",
+						"yaml": "^1.7.2"
+					}
+				},
+				"import-fresh": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+					"requires": {
+						"parent-module": "^1.0.0",
+						"resolve-from": "^4.0.0"
+					}
+				},
+				"parse-json": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"error-ex": "^1.3.1",
+						"json-parse-better-errors": "^1.0.1",
+						"lines-and-columns": "^1.1.6"
+					}
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+				},
+				"resolve-from": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				},
 				"source-map": {
 					"version": "0.5.7",
@@ -6970,9 +7070,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"regenerator-runtime": {
 					"version": "0.11.1",
@@ -7618,13 +7718,13 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-			"integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+			"version": "4.8.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+			"integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001012",
-				"electron-to-chromium": "^1.3.317",
-				"node-releases": "^1.1.41"
+				"caniuse-lite": "^1.0.30001015",
+				"electron-to-chromium": "^1.3.322",
+				"node-releases": "^1.1.42"
 			}
 		},
 		"bs-logger": {
@@ -8244,19 +8344,50 @@
 			}
 		},
 		"cli-truncate": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.0.0.tgz",
-			"integrity": "sha512-C4hp+8GCIFVsUUiXcw+ce+7wexVWImw8rQrgMBFsqerx9LvvcGlwm6sMjQYAEmV/Xb87xc1b5Ttx505MSpZVqg==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+			"integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
 			"optional": true,
 			"requires": {
-				"slice-ansi": "^2.1.0",
-				"string-width": "^4.1.0"
+				"slice-ansi": "^3.0.0",
+				"string-width": "^4.2.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+					"optional": true
+				},
+				"ansi-styles": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+					"integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+					"optional": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"astral-regex": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+					"integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+					"optional": true
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"optional": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 					"optional": true
 				},
 				"emoji-regex": {
@@ -8270,6 +8401,17 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 					"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
 					"optional": true
+				},
+				"slice-ansi": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+					"integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+					"optional": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					}
 				},
 				"string-width": {
 					"version": "4.2.0",
@@ -9532,16 +9674,16 @@
 			}
 		},
 		"core-js": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.7.tgz",
-			"integrity": "sha512-qaPVGw30J1wQ0GR3GvoPqlGf9GZfKKF4kFC7kiHlcsPTqH3txrs9crCp3ZiMAXuSenhz89Jnl4GZs/67S5VOSg=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.5.0.tgz",
+			"integrity": "sha512-Ifh3kj78gzQ7NAoJXeTu+XwzDld0QRIwjBLRqAMhuLhP3d2Av5wmgE9ycfnvK6NAEjTkQ1sDPeoEZAWO3Hx1Uw=="
 		},
 		"core-js-compat": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.4.7.tgz",
-			"integrity": "sha512-57+mgz/P/xsGdjwQYkwtBZR3LuISaxD1dEwVDtbk8xJMqAmwqaxLOvnNT7kdJ7jYE/NjNptyzXi+IQFMi/2fCw==",
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.5.0.tgz",
+			"integrity": "sha512-E7iJB72svRjJTnm9HDvujzNVMCm3ZcDYEedkJ/sDTNsy/0yooCd9Cg7GSzE7b4e0LfIkjijdB1tqg0pGwxWeWg==",
 			"requires": {
-				"browserslist": "^4.8.0",
+				"browserslist": "^4.8.2",
 				"semver": "^6.3.0"
 			},
 			"dependencies": {
@@ -9553,9 +9695,9 @@
 			}
 		},
 		"core-js-pure": {
-			"version": "3.4.7",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.4.7.tgz",
-			"integrity": "sha512-Am3uRS8WCdTFA3lP7LtKR0PxgqYzjAMGKXaZKSNSC/8sqU0Wfq8R/YzoRs2rqtOVEunfgH+0q3O0BKOg0AvjPw=="
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.5.0.tgz",
+			"integrity": "sha512-wB0QtKAofWigiISuT1Tej3hKgq932fB//Lf1VoPbiLpTYlHY0nIDhgF+q1na0DAKFHH5wGCirkAknOmDN8ijXA=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -9859,9 +10001,9 @@
 			}
 		},
 		"css-loader": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.2.1.tgz",
-			"integrity": "sha512-q40kYdcBNzMvkIImCL2O+wk8dh+RGwPPV9Dfz3n7XtOYPXqe2Z6VgtvoxjkLHz02gmhepG9sOAJOUlx+3hHsBg==",
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/css-loader/-/css-loader-3.3.2.tgz",
+			"integrity": "sha512-4XSiURS+YEK2fQhmSaM1onnUm0VKWNf6WWBYjkp9YbSDGCBTVZ5XOM6Gkxo8tLgQlzkZOBJvk9trHlDk4gjEYg==",
 			"requires": {
 				"camelcase": "^5.3.1",
 				"cssesc": "^3.0.0",
@@ -11100,9 +11242,9 @@
 			}
 		},
 		"dotenv": {
-			"version": "6.2.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+			"version": "8.2.0",
+			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+			"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
 		},
 		"dotenv-defaults": {
 			"version": "1.0.2",
@@ -11110,6 +11252,13 @@
 			"integrity": "sha512-iXFvHtXl/hZPiFj++1hBg4lbKwGM+t/GlvELDnRtOFdjXyWP7mubkVr+eZGWG62kdsbulXAef6v/j6kiWc/xGA==",
 			"requires": {
 				"dotenv": "^6.2.0"
+			},
+			"dependencies": {
+				"dotenv": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+					"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+				}
 			}
 		},
 		"dotenv-expand": {
@@ -11542,6 +11691,69 @@
 				"string.prototype.trimright": "^2.0.0"
 			}
 		},
+		"es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA=="
+		},
+		"es-get-iterator": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.0.1.tgz",
+			"integrity": "sha512-pswpctxWRElQDcP0RJy0qmNrpf6nH9SeQl8dra5fFHBPHKfpVIST27Kv4j5enE8JhIssRBI4QPMrNvcyIPhapQ==",
+			"requires": {
+				"es-abstract": "^1.16.2",
+				"has-symbols": "^1.0.1",
+				"is-arguments": "^1.0.4",
+				"is-map": "^2.0.0",
+				"is-set": "^2.0.0",
+				"is-string": "^1.0.4",
+				"isarray": "^2.0.5"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.16.3",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
+					"integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				},
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw=="
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+				}
+			}
+		},
 		"es-to-primitive": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
@@ -11819,11 +12031,11 @@
 			}
 		},
 		"eslint-module-utils": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.1.tgz",
-			"integrity": "sha512-H6DOj+ejw7Tesdgbfs4jeS4YMFrT8uI8xwd1gtQqXssaR0EQ26L+2O/w6wkYFy2MymON0fTwHmXBvvfLNZVZEw==",
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.5.0.tgz",
+			"integrity": "sha512-kCo8pZaNz2dsAW7nCUjuVoI11EBXXpIzfNxmaoLhXoRDOnqXLC4iSGVRdZPhOitfbdEfMEfKOiENaK6wDPZEGw==",
 			"requires": {
-				"debug": "^2.6.8",
+				"debug": "^2.6.9",
 				"pkg-dir": "^2.0.0"
 			},
 			"dependencies": {
@@ -11911,21 +12123,22 @@
 			}
 		},
 		"eslint-plugin-import": {
-			"version": "2.18.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.18.2.tgz",
-			"integrity": "sha512-5ohpsHAiUBRNaBWAF08izwUGlbrJoJJ+W9/TBwsGoR1MnlgfwMIKrFeSjWbt6moabiXW9xNvtFz+97KHRfI4HQ==",
+			"version": "2.19.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.19.1.tgz",
+			"integrity": "sha512-x68131aKoCZlCae7rDXKSAQmbT5DQuManyXo2sK6fJJ0aK5CWAkv6A6HJZGgqC8IhjQxYPgo6/IY4Oz8AFsbBw==",
 			"requires": {
 				"array-includes": "^3.0.3",
+				"array.prototype.flat": "^1.2.1",
 				"contains-path": "^0.1.0",
 				"debug": "^2.6.9",
 				"doctrine": "1.5.0",
 				"eslint-import-resolver-node": "^0.3.2",
-				"eslint-module-utils": "^2.4.0",
+				"eslint-module-utils": "^2.4.1",
 				"has": "^1.0.3",
 				"minimatch": "^3.0.4",
 				"object.values": "^1.1.0",
 				"read-pkg-up": "^2.0.0",
-				"resolve": "^1.11.0"
+				"resolve": "^1.12.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -11949,6 +12162,14 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				},
+				"resolve": {
+					"version": "1.13.1",
+					"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+					"integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+					"requires": {
+						"path-parse": "^1.0.6"
+					}
 				}
 			}
 		},
@@ -12082,9 +12303,9 @@
 			"integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
 		},
 		"event-source-polyfill": {
-			"version": "1.0.9",
-			"resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.9.tgz",
-			"integrity": "sha512-+x0BMKTYwZcmGmlkHK0GsXkX1+otfEwqu3QitN0wmWuHaZniw3HeIx1k5OjWX3JUHQHlPS4yONol6eokS1ZAWg=="
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/event-source-polyfill/-/event-source-polyfill-1.0.11.tgz",
+			"integrity": "sha512-fbo96OutP0Bb+gIYTTy8LGhNWySdetsFElCn/vhOzQL3cXWsS70TP/aRUe32U7F+PuOZH/tvb40tZgoJV8/Ilw=="
 		},
 		"event-target-shim": {
 			"version": "5.0.1",
@@ -12551,11 +12772,11 @@
 			}
 		},
 		"fb-watchman": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.0.tgz",
-			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.1.tgz",
+			"integrity": "sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==",
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.1.1"
 			}
 		},
 		"fbjs": {
@@ -12743,9 +12964,9 @@
 			}
 		},
 		"find-cache-dir": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.1.0.tgz",
-			"integrity": "sha512-zw+EFiNBNPgI2NTrKkDd1xd7q0cs6wr/iWnr/oUkI0yF9K9GqQ+riIt4aiyFaaqpaWbxPrJXHI+QvmNUQbX+0Q==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.2.0.tgz",
+			"integrity": "sha512-1JKclkYYsf1q9WIJKLZa9S9muC+08RIjzAlLrK4QcYLJMS6mk9yombQ9qf+zJ7H9LS800k0s44L4sDq9VYzqyg==",
 			"requires": {
 				"commondir": "^1.0.1",
 				"make-dir": "^3.0.0",
@@ -13034,9 +13255,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
-			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
+			"version": "1.2.10",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.10.tgz",
+			"integrity": "sha512-Dw5DScF/8AWhWzWRbnQrFJfeR/TOJZjRr9Du9kfmd8t234ICcVeDBlauFl/jVcE5ZewhlPoCFvIqp0SE3kAVxA==",
 			"optional": true,
 			"requires": {
 				"nan": "^2.12.1",
@@ -13082,7 +13303,7 @@
 					}
 				},
 				"chownr": {
-					"version": "1.1.1",
+					"version": "1.1.3",
 					"bundled": true,
 					"optional": true
 				},
@@ -13107,7 +13328,7 @@
 					"optional": true
 				},
 				"debug": {
-					"version": "4.1.1",
+					"version": "3.2.6",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -13130,11 +13351,11 @@
 					"optional": true
 				},
 				"fs-minipass": {
-					"version": "1.2.5",
+					"version": "1.2.7",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.6.0"
 					}
 				},
 				"fs.realpath": {
@@ -13158,7 +13379,7 @@
 					}
 				},
 				"glob": {
-					"version": "7.1.3",
+					"version": "7.1.6",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -13184,7 +13405,7 @@
 					}
 				},
 				"ignore-walk": {
-					"version": "3.0.1",
+					"version": "3.0.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -13201,7 +13422,7 @@
 					}
 				},
 				"inherits": {
-					"version": "2.0.3",
+					"version": "2.0.4",
 					"bundled": true,
 					"optional": true
 				},
@@ -13237,7 +13458,7 @@
 					"optional": true
 				},
 				"minipass": {
-					"version": "2.3.5",
+					"version": "2.9.0",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -13246,11 +13467,11 @@
 					}
 				},
 				"minizlib": {
-					"version": "1.2.1",
+					"version": "1.3.3",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "^2.9.0"
 					}
 				},
 				"mkdirp": {
@@ -13262,16 +13483,16 @@
 					}
 				},
 				"ms": {
-					"version": "2.1.1",
+					"version": "2.1.2",
 					"bundled": true,
 					"optional": true
 				},
 				"needle": {
-					"version": "2.3.0",
+					"version": "2.4.0",
 					"bundled": true,
 					"optional": true,
 					"requires": {
-						"debug": "^4.1.0",
+						"debug": "^3.2.6",
 						"iconv-lite": "^0.4.4",
 						"sax": "^1.2.4"
 					}
@@ -13303,12 +13524,20 @@
 					}
 				},
 				"npm-bundled": {
-					"version": "1.0.6",
+					"version": "1.1.1",
+					"bundled": true,
+					"optional": true,
+					"requires": {
+						"npm-normalize-package-bin": "^1.0.1"
+					}
+				},
+				"npm-normalize-package-bin": {
+					"version": "1.0.1",
 					"bundled": true,
 					"optional": true
 				},
 				"npm-packlist": {
-					"version": "1.4.1",
+					"version": "1.4.7",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -13370,7 +13599,7 @@
 					"optional": true
 				},
 				"process-nextick-args": {
-					"version": "2.0.0",
+					"version": "2.0.1",
 					"bundled": true,
 					"optional": true
 				},
@@ -13407,7 +13636,7 @@
 					}
 				},
 				"rimraf": {
-					"version": "2.6.3",
+					"version": "2.7.1",
 					"bundled": true,
 					"optional": true,
 					"requires": {
@@ -13430,7 +13659,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "5.7.0",
+					"version": "5.7.1",
 					"bundled": true,
 					"optional": true
 				},
@@ -13476,17 +13705,17 @@
 					"optional": true
 				},
 				"tar": {
-					"version": "4.4.8",
+					"version": "4.4.13",
 					"bundled": true,
 					"optional": true,
 					"requires": {
 						"chownr": "^1.1.1",
 						"fs-minipass": "^1.2.5",
-						"minipass": "^2.3.4",
-						"minizlib": "^1.1.1",
+						"minipass": "^2.8.6",
+						"minizlib": "^1.2.1",
 						"mkdirp": "^0.5.0",
 						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.2"
+						"yallist": "^3.0.3"
 					}
 				},
 				"util-deprecate": {
@@ -13508,7 +13737,7 @@
 					"optional": true
 				},
 				"yallist": {
-					"version": "3.0.3",
+					"version": "3.1.1",
 					"bundled": true,
 					"optional": true
 				}
@@ -13839,9 +14068,9 @@
 					}
 				},
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"cross-spawn": {
 					"version": "6.0.5",
@@ -13919,15 +14148,10 @@
 						"is-obj": "^2.0.0"
 					}
 				},
-				"dotenv": {
-					"version": "8.2.0",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-					"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-				},
 				"es-abstract": {
-					"version": "1.16.2",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-					"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
@@ -13937,6 +14161,7 @@
 						"is-regex": "^1.0.4",
 						"object-inspect": "^1.7.0",
 						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
 						"string.prototype.trimleft": "^2.1.0",
 						"string.prototype.trimright": "^2.1.0"
 					}
@@ -14136,6 +14361,27 @@
 						"to-regex-range": "^5.0.1"
 					}
 				},
+				"find-cache-dir": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+					"integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+					"requires": {
+						"commondir": "^1.0.1",
+						"make-dir": "^2.0.0",
+						"pkg-dir": "^3.0.0"
+					},
+					"dependencies": {
+						"make-dir": {
+							"version": "2.1.0",
+							"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+							"integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+							"requires": {
+								"pify": "^4.0.1",
+								"semver": "^5.6.0"
+							}
+						}
+					}
+				},
 				"fsevents": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
@@ -14143,29 +14389,29 @@
 					"optional": true
 				},
 				"gatsby-cli": {
-					"version": "2.8.15",
-					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.15.tgz",
-					"integrity": "sha512-dBts5O84j7XaCRiiZKFlDQuRm44eQyv1KrzWs/a4un52n9BVzC4FkRu/nafTkI8pNObFKC20VfoK3sHKHst2Rg==",
+					"version": "2.8.18",
+					"resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.8.18.tgz",
+					"integrity": "sha512-LN0PW3OrI8QQ/9+65oNhT1gi7jJAljT4YZSbTE1mqcaSIkH8NryeccI64LcTOydHtSJFHsE2fanmmIl/nmAdgg==",
 					"requires": {
 						"@babel/code-frame": "^7.5.5",
-						"@babel/runtime": "^7.7.4",
+						"@babel/runtime": "^7.7.6",
 						"@hapi/joi": "^15.1.1",
 						"better-opn": "^1.0.0",
-						"bluebird": "^3.7.1",
+						"bluebird": "^3.7.2",
 						"chalk": "^2.4.2",
 						"clipboardy": "^2.1.0",
 						"common-tags": "^1.8.0",
 						"configstore": "^5.0.0",
 						"convert-hrtime": "^3.0.0",
-						"core-js": "^2.6.10",
+						"core-js": "^2.6.11",
 						"envinfo": "^7.5.0",
 						"execa": "^3.4.0",
 						"fs-exists-cached": "^1.0.0",
 						"fs-extra": "^8.1.0",
-						"gatsby-core-utils": "^1.0.22",
-						"gatsby-telemetry": "^1.1.41",
+						"gatsby-core-utils": "^1.0.24",
+						"gatsby-telemetry": "^1.1.44",
 						"hosted-git-info": "^3.0.2",
-						"ink": "^2.5.0",
+						"ink": "^2.6.0",
 						"ink-spinner": "^3.0.1",
 						"is-valid-path": "^0.1.1",
 						"lodash": "^4.17.15",
@@ -14191,9 +14437,9 @@
 					},
 					"dependencies": {
 						"@babel/runtime": {
-							"version": "7.7.4",
-							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-							"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+							"version": "7.7.6",
+							"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+							"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 							"requires": {
 								"regenerator-runtime": "^0.13.2"
 							}
@@ -14425,11 +14671,6 @@
 						}
 					}
 				},
-				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
-				},
 				"normalize-path": {
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
@@ -14459,12 +14700,12 @@
 					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
 				},
 				"object.fromentries": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.1.tgz",
-					"integrity": "sha512-PUQv8Hbg3j2QX0IQYv3iAGCbGcu4yY4KQ92/dhA4sFSixBmSmp13UpDLs6jGK8rBtbmhNNIK99LD2k293jpiGA==",
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+					"integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
 					"requires": {
 						"define-properties": "^1.1.3",
-						"es-abstract": "^1.15.0",
+						"es-abstract": "^1.17.0-next.1",
 						"function-bind": "^1.1.1",
 						"has": "^1.0.3"
 					}
@@ -14770,6 +15011,11 @@
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
 					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				},
+				"serialize-javascript": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+					"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+				},
 				"shebang-regex": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
@@ -14829,6 +15075,39 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"requires": {
 						"ansi-regex": "^3.0.0"
+					}
+				},
+				"terser-webpack-plugin": {
+					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
+					"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+					"requires": {
+						"cacache": "^12.0.2",
+						"find-cache-dir": "^2.1.0",
+						"is-wsl": "^1.1.0",
+						"schema-utils": "^1.0.0",
+						"serialize-javascript": "^1.7.0",
+						"source-map": "^0.6.1",
+						"terser": "^4.1.2",
+						"webpack-sources": "^1.4.0",
+						"worker-farm": "^1.7.0"
+					},
+					"dependencies": {
+						"is-wsl": {
+							"version": "1.1.0",
+							"resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+							"integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+						},
+						"schema-utils": {
+							"version": "1.0.0",
+							"resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+							"integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+							"requires": {
+								"ajv": "^6.1.0",
+								"ajv-errors": "^1.0.0",
+								"ajv-keywords": "^3.1.0"
+							}
+						}
 					}
 				},
 				"to-regex-range": {
@@ -14893,26 +15172,26 @@
 			}
 		},
 		"gatsby-core-utils": {
-			"version": "1.0.22",
-			"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.22.tgz",
-			"integrity": "sha512-38W+lWb7pPiv7AjGxDx/MSWwmgnPtOejNHSxRcMXhrXNSWpiWCDoNTBM6UCXnbky82kUx4DPX5gXgw7u2s+/rA==",
+			"version": "1.0.24",
+			"resolved": "https://registry.npmjs.org/gatsby-core-utils/-/gatsby-core-utils-1.0.24.tgz",
+			"integrity": "sha512-2GPJVnqVTDO1xyZWR2lITilGTzw/hP3EE5Lq/QEjvmOPX6sLes1Gd3mTewd0PpOVZkjzn93u7kZKWEGidQO2vw==",
 			"requires": {
 				"ci-info": "2.0.0",
 				"node-object-hash": "^2.0.0"
 			}
 		},
 		"gatsby-graphiql-explorer": {
-			"version": "0.2.29",
-			"resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.29.tgz",
-			"integrity": "sha512-qKnG1h/BSBkdPX5eUcFRVvHb0BA7WLnqeJ8NMH2AOv5VSK8YEwUdJVimZHz8M/59MKBtFAQyDCRU258sc1oWrQ==",
+			"version": "0.2.31",
+			"resolved": "https://registry.npmjs.org/gatsby-graphiql-explorer/-/gatsby-graphiql-explorer-0.2.31.tgz",
+			"integrity": "sha512-pAK/HG/Ryw2ZDWb/5rnSBmPf8KsnFGlO/zS9m2IdLjnQS0kA0b9UbfZ5bjkg7pwPPLhWilEX+uON0l51N4gnmg==",
 			"requires": {
-				"@babel/runtime": "^7.7.4"
+				"@babel/runtime": "^7.7.6"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -14920,19 +15199,19 @@
 			}
 		},
 		"gatsby-image": {
-			"version": "2.2.34",
-			"resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.34.tgz",
-			"integrity": "sha512-eGrmA56s9QBSG4XI8EfXC6e5N7DajZp0SMh6RqmDY0hvFoO5/cchTAz04LttQGRsx495SAFhsKQekcDg5mwTuA==",
+			"version": "2.2.36",
+			"resolved": "https://registry.npmjs.org/gatsby-image/-/gatsby-image-2.2.36.tgz",
+			"integrity": "sha512-a5a/+busxSnKUWdZuWvCrMybLpHS6czK2Ltrt2Xa6ZIkGL/bZU4KR6t5ku8iO91Q0u32ss81WA2JwUCcctVDdA==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"object-fit-images": "^3.2.4",
 				"prop-types": "^15.7.2"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -14940,19 +15219,19 @@
 			}
 		},
 		"gatsby-link": {
-			"version": "2.2.25",
-			"resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.25.tgz",
-			"integrity": "sha512-P3Gt5ryW1bFBjAuKoJQsGSZcyEG7vFliHelnOLlAakkJ+wLQz4Wq2o4BAb6lB4wPzO7HzXRJD6RuxQrd9tmkPg==",
+			"version": "2.2.27",
+			"resolved": "https://registry.npmjs.org/gatsby-link/-/gatsby-link-2.2.27.tgz",
+			"integrity": "sha512-Jiz6ShReB25plqTKsTAVpfFvN1K/JziNhr1z8Q6p+dPzQaNWfEC61kpRKE69J1WWycvRdxCSZEkOgY/0nlAifg==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"@types/reach__router": "^1.2.6",
 				"prop-types": "^15.7.2"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -14960,24 +15239,24 @@
 			}
 		},
 		"gatsby-page-utils": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.33.tgz",
-			"integrity": "sha512-0FweVMQc5JklMwPPbwcXRo5N3ydRKrNI+YZzr6731kON1tvCKB7EbbrwMvZLEedv4BNP+XUe33FuT7LsAaUE3g==",
+			"version": "0.0.35",
+			"resolved": "https://registry.npmjs.org/gatsby-page-utils/-/gatsby-page-utils-0.0.35.tgz",
+			"integrity": "sha512-fZl8cnRqg1sUV9DDAOi66EPxPWmk/KZCE4bALWIy5xGVlPPZ8EHnwZZnoq23gBVUJN/tGkAdVlWlO/8uUZZ3QA==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"bluebird": "^3.7.1",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
 				"chokidar": "3.3.0",
 				"fs-exists-cached": "^1.0.0",
-				"gatsby-core-utils": "^1.0.22",
+				"gatsby-core-utils": "^1.0.24",
 				"glob": "^7.1.6",
 				"lodash": "^4.17.15",
 				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15091,11 +15370,11 @@
 			}
 		},
 		"gatsby-plugin-feed": {
-			"version": "2.3.22",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.22.tgz",
-			"integrity": "sha512-oDu0/ybRRCQQyb5K29lRXrsPvHncZuT7MOLa0QgX+sxiflNolUmZQnSO103hMS8CKyAxz1O0emfwxvBxBl1MXw==",
+			"version": "2.3.25",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-feed/-/gatsby-plugin-feed-2.3.25.tgz",
+			"integrity": "sha512-a2Asudmf2np+C8k2MqjUPbHABdoBgKgbIX+HvsZAniAiFIBhxEC6QudQP0rNqdo7+OGhPUpSTYawcalrnmtNRA==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"@hapi/joi": "^15.1.1",
 				"fs-extra": "^8.1.0",
 				"lodash.merge": "^4.6.2",
@@ -15103,9 +15382,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15113,17 +15392,17 @@
 			}
 		},
 		"gatsby-plugin-google-analytics": {
-			"version": "2.1.29",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.29.tgz",
-			"integrity": "sha512-vRMmXyam7LUwD+xdWCLQTbe5pT8FOX3vcIJdwckY/c3x3/GFIkx9bRJ1/N8z9x9dAci3g0HoTQZ6BkcqcNhzkA==",
+			"version": "2.1.31",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-google-analytics/-/gatsby-plugin-google-analytics-2.1.31.tgz",
+			"integrity": "sha512-vwx2eB703Yatp1ZQ0lQDiAG3k9gyvDEENRmtp+myfadI8Sgtq+LA+3OYGLeT0MYdifUTW0Lhcp3qoIrng/41zg==",
 			"requires": {
-				"@babel/runtime": "^7.7.4"
+				"@babel/runtime": "^7.7.6"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15131,20 +15410,20 @@
 			}
 		},
 		"gatsby-plugin-manifest": {
-			"version": "2.2.31",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.31.tgz",
-			"integrity": "sha512-kU49eQQ4HqIVjKa3aMOvKFoDIZD0MahHZg3KluNpgRDw89JgUMivfTrCoTYq364ZCjwRxqYVFIm2CFf5WPRkhQ==",
+			"version": "2.2.33",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.2.33.tgz",
+			"integrity": "sha512-J9u5Kmw8tY+BsSylred8KYRXDLTP3Rgz8EU7yNgfxGod+Qypm3x3laOz+hqLjWSVB4QyArlSss88Pqvyx7Rw4A==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"gatsby-core-utils": "^1.0.22",
+				"@babel/runtime": "^7.7.6",
+				"gatsby-core-utils": "^1.0.24",
 				"semver": "^5.7.1",
-				"sharp": "^0.23.3"
+				"sharp": "^0.23.4"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15170,23 +15449,23 @@
 			}
 		},
 		"gatsby-plugin-page-creator": {
-			"version": "2.1.33",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.33.tgz",
-			"integrity": "sha512-y1KuApvgLSjSbZumLFk32vNRCbiZjhE2nIR4fVbZZ9XevgPxJgBU+Hn6+xM+mYF4/4qxV7ij1f289U+caWFn5g==",
+			"version": "2.1.36",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-page-creator/-/gatsby-plugin-page-creator-2.1.36.tgz",
+			"integrity": "sha512-NDfEUBCNtcaL6Jbn5akigNv93mt28KKpnOcnPYH2VB28JHPeJJlFfhy/hHlRYQ8UR2Q8WDd4JZBnKhJvEbvlzQ==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"bluebird": "^3.7.1",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
 				"fs-exists-cached": "^1.0.0",
-				"gatsby-page-utils": "^0.0.33",
+				"gatsby-page-utils": "^0.0.35",
 				"glob": "^7.1.6",
 				"lodash": "^4.17.15",
 				"micromatch": "^3.1.10"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15212,17 +15491,17 @@
 			}
 		},
 		"gatsby-plugin-react-helmet": {
-			"version": "3.1.16",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.16.tgz",
-			"integrity": "sha512-U8JL1o2WBYdr8x1qyA9FSFc1A6snYUuCW/WFqfYQjDcv6VFyPJhw5gQnmh5n+4yGcPhV3ktYDMSWKnXFegNu4A==",
+			"version": "3.1.18",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-react-helmet/-/gatsby-plugin-react-helmet-3.1.18.tgz",
+			"integrity": "sha512-wwKH6Z5NK0Gl2hDfMnWNGE41GjWpZGq0eKczPydTJc/1SbPykBFCBrjYgrAPB2ZrRnA8AV06cRwPddJC0mY7sw==",
 			"requires": {
-				"@babel/runtime": "^7.7.4"
+				"@babel/runtime": "^7.7.6"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15230,15 +15509,15 @@
 			}
 		},
 		"gatsby-plugin-sharp": {
-			"version": "2.3.5",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.3.5.tgz",
-			"integrity": "sha512-2POz9S1n3Xh2+5nhkJ5Zgp+dZxtgNd/00Q3cjnNGajSciRHeA+wvYilWxiDtudu1gLt5dIRVizj2zRuXgcQYWA==",
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-sharp/-/gatsby-plugin-sharp-2.3.7.tgz",
+			"integrity": "sha512-dXPjalm+V94oTo6PktOuJPgoTM+iP+WGPtlvif7+5gL/GxplnQ+M2piOM+ttKF2b/BdnN0Rkfq3ZWeaXwow9KQ==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"async": "^2.6.3",
-				"bluebird": "^3.7.1",
+				"bluebird": "^3.7.2",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.22",
+				"gatsby-core-utils": "^1.0.24",
 				"got": "^8.3.2",
 				"imagemin": "^6.1.0",
 				"imagemin-mozjpeg": "^8.0.0",
@@ -15251,15 +15530,15 @@
 				"probe-image-size": "^4.1.1",
 				"progress": "^2.0.3",
 				"semver": "^5.7.1",
-				"sharp": "^0.23.3",
+				"sharp": "^0.23.4",
 				"svgo": "1.3.2",
 				"uuid": "^3.3.3"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15287,17 +15566,17 @@
 			}
 		},
 		"gatsby-plugin-typography": {
-			"version": "2.3.18",
-			"resolved": "https://registry.npmjs.org/gatsby-plugin-typography/-/gatsby-plugin-typography-2.3.18.tgz",
-			"integrity": "sha512-fpSpQWvbMF0mXu54FKTARIczTavyUf6QciP0MQJigVq79OBsRlszxujy9vyblk39DO0rytJtMAoB4PGVOxawTQ==",
+			"version": "2.3.20",
+			"resolved": "https://registry.npmjs.org/gatsby-plugin-typography/-/gatsby-plugin-typography-2.3.20.tgz",
+			"integrity": "sha512-D2wYovyQQgeCxX53jZyzgtcrh5+oT3scN/H0w7EGHKTEC2NSLkYDaHi6pfyrE11C0I4W2rl76Qb382k3hT+KxQ==",
 			"requires": {
-				"@babel/runtime": "^7.7.4"
+				"@babel/runtime": "^7.7.6"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15305,19 +15584,19 @@
 			}
 		},
 		"gatsby-react-router-scroll": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.17.tgz",
-			"integrity": "sha512-5enc2qvcZwD4Omdr78gUfqH/4uOPW7UJE6d3EQAbGyaO6cD0dpjAGsLHHXkcjSTRIult2w6cvru7fI5suJnZtg==",
+			"version": "2.1.19",
+			"resolved": "https://registry.npmjs.org/gatsby-react-router-scroll/-/gatsby-react-router-scroll-2.1.19.tgz",
+			"integrity": "sha512-qK6kE48Efzf8zOsmRw6UiZH7VXuv4ti6taGu5je1D9IGDgMpETKXRA0jmKB1up50XQ4WXvyyLASOqWK3UdDNYw==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"scroll-behavior": "^0.9.10",
 				"warning": "^3.0.0"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15325,11 +15604,11 @@
 			}
 		},
 		"gatsby-remark-copy-linked-files": {
-			"version": "2.1.31",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.31.tgz",
-			"integrity": "sha512-ZlcHsTTiI0kvQWoBL7U0Y+L2od9uOD2aGsKVUATsOx2flsaozgRYcSVHQU3Tui5nJ2W5d5HRVXFRW4OxYZqTKQ==",
+			"version": "2.1.33",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-copy-linked-files/-/gatsby-remark-copy-linked-files-2.1.33.tgz",
+			"integrity": "sha512-hRXwxlaFk39tfl2hCUL6vPg89IguQRfP+mrfJzyoDN3urFFVuw8D3+98xALaoidah6o9PIqtUEphvX1V6YKKTw==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"cheerio": "^1.0.0-rc.3",
 				"fs-extra": "^8.1.0",
 				"is-relative-url": "^3.0.0",
@@ -15340,9 +15619,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15350,14 +15629,14 @@
 			}
 		},
 		"gatsby-remark-images": {
-			"version": "3.1.35",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.35.tgz",
-			"integrity": "sha512-K5uxdcH3qrkxoAkcmqBiKf1WU3zeU79fqnBxOITT1cjk+ru5mCdpessMLklnVM9fqKbR/MyNu5Jjp7i89ObtNw==",
+			"version": "3.1.38",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-images/-/gatsby-remark-images-3.1.38.tgz",
+			"integrity": "sha512-eMEq3anD/cCgCh2ZgcWhR/ejvd25R1tki2bS3jLEl0ceafJbOGvWD1hpSDL/N9KtpsX2zyVOTZn56tg5oRhTrQ==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.3",
-				"gatsby-core-utils": "^1.0.22",
+				"gatsby-core-utils": "^1.0.24",
 				"is-relative-url": "^3.0.0",
 				"lodash": "^4.17.15",
 				"mdast-util-definitions": "^1.2.5",
@@ -15368,9 +15647,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15393,19 +15672,19 @@
 			}
 		},
 		"gatsby-remark-prismjs": {
-			"version": "3.3.25",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.25.tgz",
-			"integrity": "sha512-5iyToxbK6uYKTS6jRd1tqj1oNzHIIpUUdmXD3eAHhxzWxLPFKIrO6h6pNqIiaQ98x8sxedqsa9nzMXfNeMZIEw==",
+			"version": "3.3.27",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-prismjs/-/gatsby-remark-prismjs-3.3.27.tgz",
+			"integrity": "sha512-xuTUK1dYxU64RfVO1zpP8nLSQssVz6xn306vEJ3kDPikRGYrv0hx5zyK3j3k9OR7P1jUyC7YUsrObUsvrv+FHA==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"parse-numeric-range": "^0.0.2",
 				"unist-util-visit": "^1.4.1"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15413,11 +15692,11 @@
 			}
 		},
 		"gatsby-remark-responsive-iframe": {
-			"version": "2.2.28",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-2.2.28.tgz",
-			"integrity": "sha512-8yFTsF47BUH+DhZSUp2d/rRVZP9D5hPh1JYdZTAk9P4BcclMTjr1IpATJ3M9rRoaBPI/QJORwVg/TG3fnfvjFQ==",
+			"version": "2.2.30",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-responsive-iframe/-/gatsby-remark-responsive-iframe-2.2.30.tgz",
+			"integrity": "sha512-mwzK7lmr2yR5IHNmJECMIO1okDF0dM+FJDJ8QkJWw+NlDM7v8WRzJaT9ab9DGIXuzpSVJv2uHZ3cAYkljw4N6w==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"cheerio": "^1.0.0-rc.3",
 				"common-tags": "^1.8.0",
 				"lodash": "^4.17.15",
@@ -15425,9 +15704,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15435,20 +15714,20 @@
 			}
 		},
 		"gatsby-remark-smartypants": {
-			"version": "2.1.17",
-			"resolved": "https://registry.npmjs.org/gatsby-remark-smartypants/-/gatsby-remark-smartypants-2.1.17.tgz",
-			"integrity": "sha512-KCzBWhdy2k4jJfNxcuet1ZwDblMlcFa6jaFIJ9XtDYXlGbSKmysgLXqweQw0MgHA03DkwvM9SjA4mr/4f0YwDA==",
+			"version": "2.1.19",
+			"resolved": "https://registry.npmjs.org/gatsby-remark-smartypants/-/gatsby-remark-smartypants-2.1.19.tgz",
+			"integrity": "sha512-gviw/Ebqq1vBZ6JI7UpibyHc4lwYGaf58D5nRMR1TLOnEdut7bI647OlfSQfs4FwgeQ56yDt0bWhLVK9L6gm+g==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"retext": "^5.0.0",
 				"retext-smartypants": "^3.0.3",
 				"unist-util-visit": "^1.4.1"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15456,17 +15735,17 @@
 			}
 		},
 		"gatsby-source-filesystem": {
-			"version": "2.1.40",
-			"resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.40.tgz",
-			"integrity": "sha512-lCiuNbrb7yl97JjViP+O/TM0rtgDAFJsiebTsY3aUXOzlzIcfVDS7j7ag/H+aGAk9vs1BgGoa+8XSWjP3i90Og==",
+			"version": "2.1.42",
+			"resolved": "https://registry.npmjs.org/gatsby-source-filesystem/-/gatsby-source-filesystem-2.1.42.tgz",
+			"integrity": "sha512-kX1Uclv4M9C+MB6tfvY7URkpQ7Zl6+ESrf5DhcBN2+faaXLjaN7DzbWOlyzMI/lBlvA39ukCh9gSSlx807TJsA==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
+				"@babel/runtime": "^7.7.6",
 				"better-queue": "^3.8.10",
-				"bluebird": "^3.7.1",
+				"bluebird": "^3.7.2",
 				"chokidar": "3.3.0",
 				"file-type": "^12.4.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.22",
+				"gatsby-core-utils": "^1.0.24",
 				"got": "^7.1.0",
 				"md5-file": "^3.2.3",
 				"mime": "^2.4.4",
@@ -15474,13 +15753,13 @@
 				"progress": "^2.0.3",
 				"read-chunk": "^3.2.0",
 				"valid-url": "^1.0.9",
-				"xstate": "^4.6.7"
+				"xstate": "^4.7.2"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15638,18 +15917,18 @@
 			}
 		},
 		"gatsby-telemetry": {
-			"version": "1.1.41",
-			"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.41.tgz",
-			"integrity": "sha512-ObkSd6zvlyxnLuGyB0EhvXcD6rnhpQ+w3Adu3ozSYIsNG1Q/VyXN08AAhsbzEPfEPbz8AlyGsjGLeYbEtC2xXw==",
+			"version": "1.1.44",
+			"resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.1.44.tgz",
+			"integrity": "sha512-N8sx4ysLp3kCTuqhB+U6l84i/pIE7xqpbs8u3EyVovr05P7igM2asBIvw/VfOIddxNvb99fBjZbBm6BI1Sh6iA==",
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/runtime": "^7.7.4",
-				"bluebird": "^3.7.1",
-				"boxen": "^4.1.0",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
+				"boxen": "^4.2.0",
 				"configstore": "^5.0.0",
 				"envinfo": "^7.5.0",
 				"fs-extra": "^8.1.0",
-				"gatsby-core-utils": "^1.0.22",
+				"gatsby-core-utils": "^1.0.24",
 				"git-up": "4.0.1",
 				"is-docker": "2.0.0",
 				"lodash": "^4.17.15",
@@ -15662,9 +15941,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15674,25 +15953,56 @@
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
 					"integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
 				},
+				"ansi-styles": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+					"integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
 				"bluebird": {
 					"version": "3.7.2",
 					"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
 					"integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
 				},
 				"boxen": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.1.0.tgz",
-					"integrity": "sha512-Iwq1qOkmEsl0EVABa864Bbj3HCL4186DRZgFW/NrFs5y5GMM3ljsxzMLgOHdWISDRvcM8beh8q4tTNzXz+mSKg==",
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/boxen/-/boxen-4.2.0.tgz",
+					"integrity": "sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==",
 					"requires": {
 						"ansi-align": "^3.0.0",
 						"camelcase": "^5.3.1",
-						"chalk": "^2.4.2",
+						"chalk": "^3.0.0",
 						"cli-boxes": "^2.2.0",
 						"string-width": "^4.1.0",
 						"term-size": "^2.1.0",
-						"type-fest": "^0.5.2",
+						"type-fest": "^0.8.1",
 						"widest-line": "^3.1.0"
 					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 				},
 				"configstore": {
 					"version": "5.0.0",
@@ -15725,6 +16035,11 @@
 					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 					"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
 				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
 				"is-fullwidth-code-point": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -15742,11 +16057,6 @@
 					"requires": {
 						"semver": "^6.0.0"
 					}
-				},
-				"node-fetch": {
-					"version": "2.6.0",
-					"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-					"integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
 				},
 				"semver": {
 					"version": "6.3.0",
@@ -15776,15 +16086,23 @@
 						"ansi-regex": "^5.0.0"
 					}
 				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				},
 				"term-size": {
 					"version": "2.1.0",
 					"resolved": "https://registry.npmjs.org/term-size/-/term-size-2.1.0.tgz",
 					"integrity": "sha512-I42EWhJ+2aeNQawGx1VtpO0DFI9YcfuvAMNIdKyf/6sRbHJ4P+ZQ/zIT87tE+ln1ymAGcCJds4dolfSAS0AcNg=="
 				},
 				"type-fest": {
-					"version": "0.5.2",
-					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.5.2.tgz",
-					"integrity": "sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw=="
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+					"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA=="
 				},
 				"unique-string": {
 					"version": "2.0.0",
@@ -15826,18 +16144,18 @@
 			}
 		},
 		"gatsby-transformer-json": {
-			"version": "2.2.20",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-2.2.20.tgz",
-			"integrity": "sha512-bUT1/AEUp6IXJVdOYb+A0TONO1RK4Ijyvd98vCIHUlWxB3M1bNiE9Du0nYnG4RUbZFfc1V8Oqj+vP57nMXVmJA==",
+			"version": "2.2.22",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-json/-/gatsby-transformer-json-2.2.22.tgz",
+			"integrity": "sha512-JZBgWDvIzXbiDQ0NCQ+eX3yNcDYM0C4wLiOi0QZwKSRTLZqs1BWNB+ZrUik2iA5w4kgLGUtEoqW7kh5l+bg59Q==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"bluebird": "^3.7.1"
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15850,13 +16168,13 @@
 			}
 		},
 		"gatsby-transformer-remark": {
-			"version": "2.6.39",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.6.39.tgz",
-			"integrity": "sha512-l8xdIT4xcBorph5h4WmOXIdt1cSdfFJo9mcl6LHC2Pt3qkzhY5b2zZi5dZtxAcqOQz7I61nwARknnNkN+6w5PA==",
+			"version": "2.6.42",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-remark/-/gatsby-transformer-remark-2.6.42.tgz",
+			"integrity": "sha512-GJtzLU0jSNrKUTrkaXRzfXLNP4i6bPtfaJadr33FhP1FPDBGw8O0OQ3/tekM/z3Tjb6/1hL3BebPyuQ15yWI/A==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"bluebird": "^3.7.1",
-				"gatsby-core-utils": "^1.0.22",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
+				"gatsby-core-utils": "^1.0.24",
 				"gray-matter": "^4.0.2",
 				"hast-util-raw": "^4.0.0",
 				"hast-util-to-html": "^4.0.1",
@@ -15878,9 +16196,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15893,23 +16211,23 @@
 			}
 		},
 		"gatsby-transformer-sharp": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.3.6.tgz",
-			"integrity": "sha512-7BnppSw9RFE6QnsFMRcH8MXWQZZM9KCW53xu95abHEslHo8lYnn5vKaeuCrNMKa+jwaMcmllvYfPmTsZquaH3A==",
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/gatsby-transformer-sharp/-/gatsby-transformer-sharp-2.3.9.tgz",
+			"integrity": "sha512-R5mZyniGAxMd7MA46l4eCdrRT9vP5Uz5TbaKdOWMAXpTu1KLFyRQAigjtcINV/haC4xS8Q4NezdpxpZ2Bw8DHg==",
 			"requires": {
-				"@babel/runtime": "^7.7.4",
-				"bluebird": "^3.7.1",
+				"@babel/runtime": "^7.7.6",
+				"bluebird": "^3.7.2",
 				"fs-extra": "^8.1.0",
 				"potrace": "^2.1.2",
 				"probe-image-size": "^4.1.1",
 				"semver": "^5.7.1",
-				"sharp": "^0.23.3"
+				"sharp": "^0.23.4"
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -15953,9 +16271,9 @@
 			"integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
 		},
 		"get-own-enumerable-property-symbols": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.1.tgz",
-			"integrity": "sha512-09/VS4iek66Dh2bctjRkowueRJbY1JDGR1L/zRxO1Qk8Uxs6PnqaNSqalpizPT+CDjre3hnEsuzvhgomz9qYrA=="
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-3.0.2.tgz",
+			"integrity": "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="
 		},
 		"get-pkg-repo": {
 			"version": "1.4.0",
@@ -18450,6 +18768,11 @@
 			"resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-2.0.0.tgz",
 			"integrity": "sha1-LhmX+m6RZuqsAkLarkQ0A+TvHZc="
 		},
+		"is-map": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.0.tgz",
+			"integrity": "sha512-ptj+FffEGJN9hLuakga2S3mYQt5PVN+w7+fL3SAgxKhlCePSt24Q3fiSozhvphbwCQ0+QPA1rJnLSoS2LnbCVw=="
+		},
 		"is-module": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -18603,6 +18926,11 @@
 			"resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
 			"integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg=="
 		},
+		"is-set": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.0.tgz",
+			"integrity": "sha512-So5/xwRDzU3X7kOt2vpvrsj/Asx5E7Q5IyX6itksB96FJgyydSe9tFwfCq7IZ8URDS4h45FhNgfENToTgBfmgw=="
+		},
 		"is-ssh": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
@@ -18615,6 +18943,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
 			"integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+		},
+		"is-string": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+			"integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ="
 		},
 		"is-svg": {
 			"version": "3.0.0",
@@ -18824,6 +19157,14 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/iterall/-/iterall-1.2.2.tgz",
 			"integrity": "sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA=="
+		},
+		"iterate-value": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.1.tgz",
+			"integrity": "sha512-xc6jTbwPOWEdD26y41BpJBqh/w3kuEcsQxTypXD+xYQA2+OZIfemmkm725cnRbm1cHj4SMLUO1+7oIA97e88gg==",
+			"requires": {
+				"es-get-iterator": "^1.0.1"
+			}
 		},
 		"jest": {
 			"version": "24.9.0",
@@ -19647,9 +19988,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				}
 			}
 		},
@@ -20306,13 +20647,6 @@
 				"core-js": "^3.0.4",
 				"dotenv": "^8.0.0",
 				"dotenv-expand": "^5.1.0"
-			},
-			"dependencies": {
-				"dotenv": {
-					"version": "8.2.0",
-					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-					"integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
-				}
 			}
 		},
 		"lcid": {
@@ -23283,9 +23617,9 @@
 			"integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
 		},
 		"postcss": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-			"integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+			"version": "7.0.24",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
+			"integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
 			"requires": {
 				"chalk": "^2.4.2",
 				"source-map": "^0.6.1",
@@ -24456,23 +24790,105 @@
 			}
 		},
 		"promise.allsettled": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.1.tgz",
-			"integrity": "sha512-3ST7RS7TY3TYLOIe+OACZFvcWVe1osbgz2x07nTb446pa3t4GUZWidMDzQ4zf9jC2l6mRa1/3X81icFYbi+D/g==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+			"integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
 			"requires": {
+				"array.prototype.map": "^1.0.1",
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.13.0",
-				"function-bind": "^1.1.1"
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"iterate-value": "^1.0.0"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+				}
 			}
 		},
 		"promise.prototype.finally": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.1.tgz",
-			"integrity": "sha512-gnt8tThx0heJoI3Ms8a/JdkYBVhYP/wv+T7yQimR+kdOEJL21xTFbiJhMRqnSPcr54UVvMbsscDk2w+ivyaLPw==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/promise.prototype.finally/-/promise.prototype.finally-3.1.2.tgz",
+			"integrity": "sha512-A2HuJWl2opDH0EafgdjwEw7HysI8ff/n4lW4QEVBCUXFk9QeGecBWv0Deph0UmLe3tTNYegz8MOjsVuE6SMoJA==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.13.0",
+				"es-abstract": "^1.17.0-next.0",
 				"function-bind": "^1.1.1"
+			},
+			"dependencies": {
+				"es-abstract": {
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
+					"requires": {
+						"es-to-primitive": "^1.2.1",
+						"function-bind": "^1.1.1",
+						"has": "^1.0.3",
+						"has-symbols": "^1.0.1",
+						"is-callable": "^1.1.4",
+						"is-regex": "^1.0.4",
+						"object-inspect": "^1.7.0",
+						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
+						"string.prototype.trimleft": "^2.1.0",
+						"string.prototype.trimright": "^2.1.0"
+					}
+				},
+				"es-to-primitive": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+					"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+					"requires": {
+						"is-callable": "^1.1.4",
+						"is-date-object": "^1.0.1",
+						"is-symbol": "^1.0.2"
+					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
+				},
+				"object-inspect": {
+					"version": "1.7.0",
+					"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+					"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+				}
 			}
 		},
 		"prompts": {
@@ -24543,9 +24959,9 @@
 			}
 		},
 		"prosemirror-history": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.1.2.tgz",
-			"integrity": "sha512-erhxYS5gm/6MiXP8jUoJBgc8IbaqjHDVPl9KGg5JrMZOSSOwHv85+4Fb0Q7sYtv2fYwAjOSw/kSA9vkxJ6wOwA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.1.3.tgz",
+			"integrity": "sha512-zGDotijea+vnfnyyUGyiy1wfOQhf0B/b6zYcCouBV8yo6JmrE9X23M5q7Nf/nATywEZbgRLG70R4DmfSTC+gfg==",
 			"requires": {
 				"prosemirror-state": "^1.2.2",
 				"prosemirror-transform": "^1.0.0",
@@ -24617,9 +25033,9 @@
 			}
 		},
 		"prosemirror-view": {
-			"version": "1.13.4",
-			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.13.4.tgz",
-			"integrity": "sha512-mtgWEK16uYQFk3kijRlkSpAmDuy7rxYuv0pgyEBDmLT1PCPY8380CoaYnP8znUT6BXIGlJ8oTveK3M50U+B0vw==",
+			"version": "1.13.6",
+			"resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.13.6.tgz",
+			"integrity": "sha512-6Wg4Lxmbhlw5D3Db3JSxk4zProZdYywx6QX8yiEV+ReRXJz1IqtdXg+QEywQ5tEgrWhTYtpM8WmDhDYRguKNxA==",
 			"requires": {
 				"prosemirror-model": "^1.1.0",
 				"prosemirror-state": "^1.0.0",
@@ -24849,23 +25265,18 @@
 			}
 		},
 		"react-app-polyfill": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.4.tgz",
-			"integrity": "sha512-5Vte6ki7jpNsNCUKaboyofAhmURmCn2Y6Hu7ydJ6Iu4dct1CIGoh/1FT7gUZKAbowVX2lxVPlijvp1nKxfAl4w==",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/react-app-polyfill/-/react-app-polyfill-1.0.5.tgz",
+			"integrity": "sha512-RcbV6+msbvZJZUIK/LX3UafPtoaDSJgUWu4sqBxHKTVmBsnlU2QWCKJRBRmgjxu+ivW/GPINbPWRM4Ppa6Lbgw==",
 			"requires": {
-				"core-js": "3.2.1",
-				"object-assign": "4.1.1",
-				"promise": "8.0.3",
-				"raf": "3.4.1",
-				"regenerator-runtime": "0.13.3",
-				"whatwg-fetch": "3.0.0"
+				"core-js": "^3.4.1",
+				"object-assign": "^4.1.1",
+				"promise": "^8.0.3",
+				"raf": "^3.4.1",
+				"regenerator-runtime": "^0.13.3",
+				"whatwg-fetch": "^3.0.0"
 			},
 			"dependencies": {
-				"core-js": {
-					"version": "3.2.1",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-					"integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
-				},
 				"promise": {
 					"version": "8.0.3",
 					"resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
@@ -25140,9 +25551,9 @@
 			}
 		},
 		"react-draggable": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.1.0.tgz",
-			"integrity": "sha512-Or/qe70cfymshqoC8Lsp0ukTzijJObehb7Vfl7tb5JRxoV+b6PDkOGoqYaWBzZ59k9dH/bwraLGsnlW78/3vrA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/react-draggable/-/react-draggable-4.2.0.tgz",
+			"integrity": "sha512-5wFq//gEoeTYprnd4ze8GrFc+Rbnx+9RkOMR3vk4EbWxj02U6L6T3yrlKeiw4X5CtjD2ma2+b3WujghcXNRzkw==",
 			"requires": {
 				"classnames": "^2.2.5",
 				"prop-types": "^15.6.0"
@@ -25168,9 +25579,9 @@
 			}
 		},
 		"react-error-overlay": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.3.tgz",
-			"integrity": "sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw=="
+			"version": "6.0.4",
+			"resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.4.tgz",
+			"integrity": "sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA=="
 		},
 		"react-fast-compare": {
 			"version": "2.0.4",
@@ -25279,12 +25690,13 @@
 			"integrity": "sha512-8ltIY3bC7oGhj2nPAvWOGi+xGFybPNhJM0V1H8hY/whNcXgmDeaeoCMPPd8VatrpTsUWjb/vGzrmu6SrXVty3A=="
 		},
 		"react-popper": {
-			"version": "1.3.6",
-			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.6.tgz",
-			"integrity": "sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==",
+			"version": "1.3.7",
+			"resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.7.tgz",
+			"integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
 			"requires": {
 				"@babel/runtime": "^7.1.2",
 				"create-react-context": "^0.3.0",
+				"deep-equal": "^1.1.1",
 				"popper.js": "^1.14.4",
 				"prop-types": "^15.6.1",
 				"typed-styles": "^0.0.7",
@@ -25320,9 +25732,9 @@
 			},
 			"dependencies": {
 				"@babel/runtime": {
-					"version": "7.7.4",
-					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-					"integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+					"version": "7.7.6",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.6.tgz",
+					"integrity": "sha512-BWAJxpNVa0QlE5gZdWjSxXtemZyZ9RmrmVozxt3NUXeZhVIJ5ANyqmMc0JDrivBZyxUuQvFxlvH4OWWOogGfUw==",
 					"requires": {
 						"regenerator-runtime": "^0.13.2"
 					}
@@ -25634,6 +26046,11 @@
 						"pify": "^3.0.0",
 						"rimraf": "^2.2.8"
 					}
+				},
+				"dotenv": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
+					"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
 				},
 				"dotenv-expand": {
 					"version": "4.2.0",
@@ -26128,6 +26545,11 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.0.0.tgz",
 					"integrity": "sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ=="
+				},
+				"serialize-javascript": {
+					"version": "1.9.1",
+					"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
+					"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
 				},
 				"sockjs-client": {
 					"version": "1.3.0",
@@ -26971,9 +27393,9 @@
 			"integrity": "sha512-5qxzGZjDs9w4tzT3TPhCJqWdCc3RLYwy9J2NB0nm5Lz+S273lvWcpjaTGHsT1dc6Hhfq41uSEOw8wBmxrKOuyg=="
 		},
 		"regjsparser": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.0.tgz",
-			"integrity": "sha512-RQ7YyokLiQBomUJuUG8iGVvkgOLxwyZM8k6d3q5SAXpg4r5TZJZigKFvC6PpD+qQ98bCDC5YelPeA3EucDoNeQ==",
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.6.1.tgz",
+			"integrity": "sha512-7LutE94sz/NKSYegK+/4E77+8DipxF+Qn2Tmu362AcmsF2NYq/wx3+ObvU90TKEhjf7hQoFXo23ajjrXP7eUgg==",
 			"requires": {
 				"jsesc": "~0.5.0"
 			},
@@ -27000,9 +27422,9 @@
 			},
 			"dependencies": {
 				"core-js": {
-					"version": "2.6.10",
-					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-					"integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+					"version": "2.6.11",
+					"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+					"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 				},
 				"fbjs": {
 					"version": "1.0.0",
@@ -27538,14 +27960,14 @@
 			}
 		},
 		"rollup-plugin-terser": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.2.tgz",
-			"integrity": "sha512-sWKBCOS+vUkRtHtEiJPAf+WnBqk/C402fBD9AVHxSIXMqjsY7MnYWKYEUqGixtr0c8+1DjzUEPlNgOYQPVrS1g==",
+			"version": "5.1.3",
+			"resolved": "https://registry.npmjs.org/rollup-plugin-terser/-/rollup-plugin-terser-5.1.3.tgz",
+			"integrity": "sha512-FuFuXE5QUJ7snyxHLPp/0LFXJhdomKlIx/aK7Tg88Yubsx/UU/lmInoJafXJ4jwVVNcORJ1wRUC5T9cy5yk0wA==",
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
 				"jest-worker": "^24.6.0",
 				"rollup-pluginutils": "^2.8.1",
-				"serialize-javascript": "^1.7.0",
+				"serialize-javascript": "^2.1.2",
 				"terser": "^4.1.0"
 			}
 		},
@@ -27713,9 +28135,9 @@
 			}
 		},
 		"sade": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.6.1.tgz",
-			"integrity": "sha512-USHm9quYNmJwFwhOnEuJohdnBhUOKV1mhL0koHSJMLJaesRX0nuDuzbWmtUBbUmXkwTalLtUBzDlEnU940BiQA==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.0.tgz",
+			"integrity": "sha512-HSkPpZzN7q4EFN5PVW8nTfDn1rJZh4sKbPQqz33AXokIo6SMDeVJ3RA4e0ZASlnMK6PywEMZxKXudEn5dxSWew==",
 			"requires": {
 				"mri": "^1.1.0"
 			}
@@ -28037,9 +28459,9 @@
 			}
 		},
 		"serialize-javascript": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.9.1.tgz",
-			"integrity": "sha512-0Vb/54WJ6k5v8sSWN09S0ora+Hnr+cX40r9F170nT+mSkaxltoE/7R3OrIdBSUv1OoiobH1QoWQbCnAO+e8J1A=="
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-2.1.2.tgz",
+			"integrity": "sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ=="
 		},
 		"serve-favicon": {
 			"version": "2.5.0",
@@ -28211,9 +28633,9 @@
 			"integrity": "sha512-LUMFi+RppPlrHzbqmFnINTrazo0lPNwhcgzuAXVVcfy/mqPDrQmHAyz5bvV0gDAuRFrk804V0HpQ6u9sZ0tBeg=="
 		},
 		"shallow-equal": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz",
-			"integrity": "sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA=="
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.1.tgz",
+			"integrity": "sha512-S4vJDjHHMBaiZuT9NPb616CSmLf618jawtv3sufLl6ivK8WocjAo58cXwbRV1cgqxH0Qbv+iUt6m05eqEa2IRA=="
 		},
 		"shallowequal": {
 			"version": "1.1.0",
@@ -28221,9 +28643,9 @@
 			"integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
 		},
 		"sharp": {
-			"version": "0.23.3",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.3.tgz",
-			"integrity": "sha512-pjT4zyviQteXMC1Z8USIiSwQFQbZTlU5J59/UoygE25hh+sSb7PSYI/MZ2MCB1COtxWQuoUAaG3TYIOLon26Mg==",
+			"version": "0.23.4",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.23.4.tgz",
+			"integrity": "sha512-fJMagt6cT0UDy9XCsgyLi0eiwWWhQRxbwGmqQT6sY8Av4s0SVsT/deg8fobBQCTDU5iXRgz0rAeXoE2LBZ8g+Q==",
 			"requires": {
 				"color": "^3.1.2",
 				"detect-libc": "^1.0.3",
@@ -29177,21 +29599,20 @@
 			}
 		},
 		"string.prototype.matchall": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.0.tgz",
-			"integrity": "sha512-/cSuf1qsUaPicdvXcVZJ98fM9FmvkXvw7PKSM5pTtlj4R9VLQc7B51fOZBMsGfv9UXhUhdpxSrEsGe2ObsR2cw==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.1.tgz",
+			"integrity": "sha512-vIObm+BWuKKJovfh2/PPCAmePTDdubrgCkhQnbP0oAwD7Jj8IyIM57Hu7Ma7oDdg4oVdh5S1Rd8RviBIPZ8Pfg==",
 			"requires": {
 				"define-properties": "^1.1.3",
-				"es-abstract": "^1.15.0",
-				"function-bind": "^1.1.1",
-				"has-symbols": "^1.0.0",
+				"es-abstract": "^1.17.0-next.1",
+				"has-symbols": "^1.0.1",
 				"regexp.prototype.flags": "^1.2.0"
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.16.2",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-					"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
@@ -29201,15 +29622,9 @@
 						"is-regex": "^1.0.4",
 						"object-inspect": "^1.7.0",
 						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
 						"string.prototype.trimleft": "^2.1.0",
 						"string.prototype.trimright": "^2.1.0"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-							"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-						}
 					}
 				},
 				"es-to-primitive": {
@@ -29221,6 +29636,11 @@
 						"is-date-object": "^1.0.1",
 						"is-symbol": "^1.0.2"
 					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 				},
 				"object-inspect": {
 					"version": "1.7.0",
@@ -29537,18 +29957,18 @@
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
 		},
 		"symbol.prototype.description": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/symbol.prototype.description/-/symbol.prototype.description-1.0.1.tgz",
-			"integrity": "sha512-smeS1BCkN6lcz1XveFK+cfvfBmNJ6dcPi6lgOnLUU8Po8SmV+rtmYGObbNOisW9RHWMyUfsgMA+eTQg+b3v9Vg==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/symbol.prototype.description/-/symbol.prototype.description-1.0.2.tgz",
+			"integrity": "sha512-2CW5SU4/Ki1cYOOHcL2cXK4rxSg5hCU1TwZ7X4euKhV9VnfqKslh7T6/UyKkubA8cq2tOmsOv7m3ZUmQslBRuw==",
 			"requires": {
-				"es-abstract": "^1.16.0",
-				"has-symbols": "^1.0.0"
+				"es-abstract": "^1.17.0-next.1",
+				"has-symbols": "^1.0.1"
 			},
 			"dependencies": {
 				"es-abstract": {
-					"version": "1.16.2",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-					"integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+					"version": "1.17.0-next.1",
+					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+					"integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
 					"requires": {
 						"es-to-primitive": "^1.2.1",
 						"function-bind": "^1.1.1",
@@ -29558,15 +29978,9 @@
 						"is-regex": "^1.0.4",
 						"object-inspect": "^1.7.0",
 						"object-keys": "^1.1.1",
+						"object.assign": "^4.1.0",
 						"string.prototype.trimleft": "^2.1.0",
 						"string.prototype.trimright": "^2.1.0"
-					},
-					"dependencies": {
-						"has-symbols": {
-							"version": "1.0.1",
-							"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-							"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-						}
 					}
 				},
 				"es-to-primitive": {
@@ -29578,6 +29992,11 @@
 						"is-date-object": "^1.0.1",
 						"is-symbol": "^1.0.2"
 					}
+				},
+				"has-symbols": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+					"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 				},
 				"object-inspect": {
 					"version": "1.7.0",
@@ -29793,15 +30212,15 @@
 			}
 		},
 		"terser-webpack-plugin": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.1.tgz",
-			"integrity": "sha512-ZXmmfiwtCLfz8WKZyYUuuHf3dMYEjg8NrjHMb0JqHVHVOSkzp3cW2/XG1fP3tRhqEqSzMwzzRQGtAPbs4Cncxg==",
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.3.tgz",
+			"integrity": "sha512-QMxecFz/gHQwteWwSo5nTc6UaICqN1bMedC5sMtUc7y3Ha3Q8y6ZO0iCR8pq4RJC8Hjf0FEPEHZqcMB/+DFCrA==",
 			"requires": {
 				"cacache": "^12.0.2",
 				"find-cache-dir": "^2.1.0",
 				"is-wsl": "^1.1.0",
 				"schema-utils": "^1.0.0",
-				"serialize-javascript": "^1.7.0",
+				"serialize-javascript": "^2.1.2",
 				"source-map": "^0.6.1",
 				"terser": "^4.1.2",
 				"webpack-sources": "^1.4.0",
@@ -30269,11 +30688,11 @@
 			},
 			"dependencies": {
 				"@typescript-eslint/eslint-plugin": {
-					"version": "2.10.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.10.0.tgz",
-					"integrity": "sha512-rT51fNLW0u3fnDGnAHVC5nu+Das+y2CpW10yqvf6/j5xbuUV3FxA3mBaIbM24CXODXjbgUznNb4Kg9XZOUxKAw==",
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
+					"integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
 					"requires": {
-						"@typescript-eslint/experimental-utils": "2.10.0",
+						"@typescript-eslint/experimental-utils": "2.11.0",
 						"eslint-utils": "^1.4.3",
 						"functional-red-black-tree": "^1.0.1",
 						"regexpp": "^3.0.0",
@@ -30281,30 +30700,30 @@
 					}
 				},
 				"@typescript-eslint/experimental-utils": {
-					"version": "2.10.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.10.0.tgz",
-					"integrity": "sha512-FZhWq6hWWZBP76aZ7bkrfzTMP31CCefVIImrwP3giPLcoXocmLTmr92NLZxuIcTL4GTEOE33jQMWy9PwelL+yQ==",
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
+					"integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
 					"requires": {
 						"@types/json-schema": "^7.0.3",
-						"@typescript-eslint/typescript-estree": "2.10.0",
+						"@typescript-eslint/typescript-estree": "2.11.0",
 						"eslint-scope": "^5.0.0"
 					}
 				},
 				"@typescript-eslint/parser": {
-					"version": "2.10.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.10.0.tgz",
-					"integrity": "sha512-wQNiBokcP5ZsTuB+i4BlmVWq6o+oAhd8en2eSm/EE9m7BgZUIfEeYFd6z3S+T7bgNuloeiHA1/cevvbBDLr98g==",
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
+					"integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
 					"requires": {
 						"@types/eslint-visitor-keys": "^1.0.0",
-						"@typescript-eslint/experimental-utils": "2.10.0",
-						"@typescript-eslint/typescript-estree": "2.10.0",
+						"@typescript-eslint/experimental-utils": "2.11.0",
+						"@typescript-eslint/typescript-estree": "2.11.0",
 						"eslint-visitor-keys": "^1.1.0"
 					}
 				},
 				"@typescript-eslint/typescript-estree": {
-					"version": "2.10.0",
-					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.10.0.tgz",
-					"integrity": "sha512-oOYnplddQNm/LGVkqbkAwx4TIBuuZ36cAQq9v3nFIU9FmhemHuVzAesMSXNQDdAzCa5bFgCrfD3JWhYVKlRN2g==",
+					"version": "2.11.0",
+					"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
+					"integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
 					"requires": {
 						"debug": "^4.1.1",
 						"eslint-visitor-keys": "^1.1.0",
@@ -30339,9 +30758,9 @@
 					}
 				},
 				"eslint-config-react-app": {
-					"version": "5.0.2",
-					"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.0.2.tgz",
-					"integrity": "sha512-VhlESAQM83uULJ9jsvcKxx2Ab0yrmjUt8kDz5DyhTQufqWE0ssAnejlWri5LXv25xoXfdqOyeDPdfJS9dXKagQ==",
+					"version": "5.1.0",
+					"resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-5.1.0.tgz",
+					"integrity": "sha512-hBaxisHC6HXRVvxX+/t1n8mOdmCVIKgkXsf2WoUkJi7upHJTwYTsdCmx01QPOjKNT34QMQQ9sL0tVBlbiMFjxA==",
 					"requires": {
 						"confusing-browser-globals": "^1.0.9"
 					}
@@ -32381,9 +32800,9 @@
 			"integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
 		},
 		"xstate": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.2.tgz",
-			"integrity": "sha512-vAIEf5CuLPNgH5obVP7WS1U+I91L+vSKLpradVn6AhbyFrccWlNQwFVuYktInafgkvA6z4w9rLkuRKBZ5izkSA=="
+			"version": "4.7.3",
+			"resolved": "https://registry.npmjs.org/xstate/-/xstate-4.7.3.tgz",
+			"integrity": "sha512-+1KyOB2JTv4kQQlZnEiDxSpEaIJnqslMa/479sc1KU3NMRP0caIV3p55Sr27GFS1EXQvnJ+n84bnWx77qplDWg=="
 		},
 		"xtend": {
 			"version": "4.0.2",

--- a/packages/@tinacms/api-git/package-lock.json
+++ b/packages/@tinacms/api-git/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinacms/api-git",
-  "version": "0.4.6",
+  "version": "0.5.0-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/@tinacms/react-core/package-lock.json
+++ b/packages/@tinacms/react-core/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/react-core",
-	"version": "0.2.0",
+	"version": "0.2.1-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/demo-gatsby/content/blog/1600-ampitheatre-parkway,-mountain-view,-ca/index.md
+++ b/packages/demo-gatsby/content/blog/1600-ampitheatre-parkway,-mountain-view,-ca/index.md
@@ -1,0 +1,7 @@
+---
+title: '1600 Ampitheatre Parkway, Mountain View, CA'
+date: 2019-12-14T03:50:32.900Z
+heading_color: pink
+description: 'My new post. '
+---
+# 1600 Ampitheatre Parkway, Mountain View, CA

--- a/packages/demo-gatsby/content/blog/a-new-post./index.md
+++ b/packages/demo-gatsby/content/blog/a-new-post./index.md
@@ -1,0 +1,7 @@
+---
+title: A new post.
+date: 2019-12-14T03:49:39.202Z
+heading_color: pink
+description: 'My new post. '
+---
+# A new post.

--- a/packages/react-dismissible/package-lock.json
+++ b/packages/react-dismissible/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-dismissible",
-	"version": "1.0.17",
+	"version": "1.0.18-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-tinacms-blocks/package-lock.json
+++ b/packages/react-tinacms-blocks/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "react-tinacms-blocks",
-	"version": "0.1.0",
+	"version": "0.1.1-alpha.0",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/tinacms/src/components/CreateContent.tsx
+++ b/packages/tinacms/src/components/CreateContent.tsx
@@ -99,7 +99,9 @@ const CreateContentButton = ({ plugin, onClick }: any) => {
   )
 }
 
-const FormModal = ({ plugin, close }: any) => {
+export const FormModal = ({ plugin, close }: any) => {
+  console.log("plugin", plugin);
+  console.log("close", close);
   const cms = useCMS()
   const form: Form = useMemo(
     () =>
@@ -123,7 +125,7 @@ const FormModal = ({ plugin, close }: any) => {
           return (
             <ModalPopup>
               <ModalHeader close={close}>{plugin.name}</ModalHeader>
-              <ModalBody>
+              <ModalBody onKeyPress={(e) => e.charCode === 13 ? handleSubmit() as any : null}>
                 <FieldsBuilder form={form} fields={form.fields} />
               </ModalBody>
               <ModalActions>

--- a/packages/tinacms/src/plugins/fields/dateFormat.test.ts
+++ b/packages/tinacms/src/plugins/fields/dateFormat.test.ts
@@ -58,8 +58,6 @@ describe('date format', () => {
         const date = moment(dateString, dateFormat)
         const result = parse(date, 'date', { dateFormat: 'MM YYYY' }) as Date
 
-        console.log('mmm ' + result)
-        console.log('month: ' + result.getMonth())
         expect(result.getMonth()).toEqual(6)
         expect(result.getFullYear()).toEqual(1972)
       })


### PR DESCRIPTION
A small fix that I think adds to a more seamless UX. In the form modal, upon completion of a new blog post title, user can simply press their 'return' key to create new post rather than having to click (or tab to) 'create' button