### PR TITLE
feat: allow user to user enter/return key to create new blog entry

### DIFF
--- a/packages/tinacms/src/components/CreateContent.tsx
+++ b/packages/tinacms/src/components/CreateContent.tsx
@@ -123,7 +123,7 @@ const FormModal = ({ plugin, close }: any) => {
           return (
             <ModalPopup>
               <ModalHeader close={close}>{plugin.name}</ModalHeader>
-              <ModalBody>
+              <ModalBody onKeyPress={(e) => e.charCode === 13 ? handleSubmit() as any : null}>
                 <FieldsBuilder form={form} fields={form.fields} />
               </ModalBody>
               <ModalActions>


### PR DESCRIPTION
A small fix that I think adds to a more seamless UX. In the form modal, upon completion of a new blog post title, user can simply press their 'return' key to create new post rather than having to click (or tab to) 'create' button