### PR TITLE
fix: fixed typo in dangerfile.ts

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -130,7 +130,7 @@ Update Docs for tinacms#${danger.github.pr.number}
   )}&body=${updateDocBody(changes)}">Create Issue</a>
 `)
 
-const updateDocTitle = (chagnes: [string, Dep][]) =>
+const updateDocTitle = (changes: [string, Dep][]) =>
   encodeURIComponent(`Update Docs for tinacms#${danger.github.pr.number}`)
 
 const updateDocBody = (changes: [string, Dep][]) =>

--- a/packages/gatsby-tinacms-git/gatsby-browser.ts
+++ b/packages/gatsby-tinacms-git/gatsby-browser.ts
@@ -35,7 +35,7 @@ exports.onClientEntry = () => {
 const ERROR_TINACMS_NOT_FOUND = `\`window.tinacms\` not found
 
 1. Make sure to add \`gatsby-plugin-tinacms\` to your \`gatsby-config.js\`
-2. Make sure \`gatsby-tinamcms-git\` is a sub-plugin of \`gatsby-plugin-tinacms\`
+2. Make sure \`gatsby-tinacms-git\` is a sub-plugin of \`gatsby-plugin-tinacms\`
 
 {
   resolve: "gatsby-plugin-tinacms",


### PR DESCRIPTION
I was reading through the dangerfile.ts and found a small typo in the` updateDocTitle` function parameter. I simply updated `chagnes` to `changes` to match the param naming convention seen in the rest of the file. 