### PR TITLE
chore: better error messages for tinafield

### DIFF
--- a/packages/@tinacms/form-builder/src/Form.tsx
+++ b/packages/@tinacms/form-builder/src/Form.tsx
@@ -18,6 +18,7 @@ limitations under the License.
 
 import * as React from 'react'
 import { useState, useContext } from 'react'
+import PropTypes from "prop-types"
 import { Form } from '@tinacms/core'
 import { FormBuilder } from './final-form-builder'
 import { Field } from 'react-final-form'
@@ -77,3 +78,10 @@ export function TinaField({
     </Field>
   )
 }
+
+TinaField.propTypes = {
+  name: PropTypes.string,
+  type: PropTypes.string,
+  Component: PropTypes.any.isRequired,
+  children: PropTypes.any
+};

--- a/packages/@tinacms/form-builder/src/Form.tsx
+++ b/packages/@tinacms/form-builder/src/Form.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 
 import * as React from 'react'
 import { useState, useContext } from 'react'
-import PropTypes from "prop-types"
+import PropTypes from 'prop-types'
 import { Form } from '@tinacms/core'
 import { FormBuilder } from './final-form-builder'
 import { Field } from 'react-final-form'


### PR DESCRIPTION
I added proptypes to `TinaField` in order to improve the error message displayed when the `Component` prop is missing.

Now displays:
```
Warning: Failed prop type: The prop `Component` is marked as required in `y`, but its value is `undefined`.
```

Resolves https://github.com/tinacms/tinacms/issues/241