### PR TITLE
fix: server should start without an origin

### DIFF
--- a/packages/@tinacms/api-git/src/router.test.ts
+++ b/packages/@tinacms/api-git/src/router.test.ts
@@ -38,6 +38,44 @@ describe('updateRemoteToSSH', () => {
 
   let repo: any
 
+  describe('without a remote', () => {
+    beforeEach(() => {
+      repo = {
+        getRemotes: jest.fn().mockImplementation(() => {
+          return Promise.resolve([])
+        }),
+        removeRemote: jest.fn(),
+        addRemote: jest.fn(),
+      }
+      mock = require('./open-repo').openRepo
+      mock.mockImplementation(() => {
+        return repo
+      })
+    })
+
+    it('does not throw an error', async () => {
+      expect(async () => {
+        await updateRemoteToSSH('./')
+      }).not.toThrowError()
+    })
+
+    it('does not tryto remove a remote', async () => {
+      await updateRemoteToSSH('./')
+      expect(repo.removeRemote).not.toHaveBeenCalledWith(
+        'origin',
+        'git@github.com:tinacms/tunacms.git'
+      )
+    })
+
+    it('does not try to add a remote', async () => {
+      await updateRemoteToSSH('./')
+      expect(repo.addRemote).not.toHaveBeenCalledWith(
+        'origin',
+        'git@github.com:tinacms/tunacms.git'
+      )
+    })
+  })
+
   describe('with http remote', () => {
     beforeEach(() => {
       repo = {

--- a/packages/@tinacms/api-git/src/router.ts
+++ b/packages/@tinacms/api-git/src/router.ts
@@ -61,7 +61,8 @@ export async function updateRemoteToSSH(pathRoot: string) {
   const originRemotes = remotes.filter((r: any) => r.name == 'origin')
 
   if (!originRemotes.length) {
-    throw new Error('No origin remote on the given rpeo')
+    console.warn('No origin remote on the given repo')
+    return
   }
 
   const originURL = originRemotes[0].refs.push
@@ -123,6 +124,8 @@ export function router(config: GitRouterConfig = {}) {
   const router = express.Router()
   router.use(express.json())
 
+  // TODO: There shold be some way of making sure this only happens
+  //       in a cloud editing environment.
   configureGitRemote(REPO_ABSOLUTE_PATH)
 
   router.delete('/:relPath', (req: any, res: any) => {


### PR DESCRIPTION
fixes #596

The Git API was failing to start for repositories without remotes.
