### PR TITLE
Fix gatsby plugin dependency

### DIFF
--- a/packages/@tinacms/api-git/package-lock.json
+++ b/packages/@tinacms/api-git/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinacms/api-git",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/@tinacms/react-core/package-lock.json
+++ b/packages/@tinacms/react-core/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinacms/react-core",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/gatsby-plugin-tinacms/package.json
+++ b/packages/gatsby-plugin-tinacms/package.json
@@ -31,12 +31,17 @@
     "dev": "tsc",
     "build": "tsc"
   },
-  "dependencies": {
-    "@tinacms/core": "^0.6.0",
+  "devDependencies": {
     "@types/cors": "^2.8.5",
     "@types/express": "^4.17.0",
     "@types/js-yaml": "^3.12.1",
     "@types/lodash.throttle": "^4.1.6",
+    "tinacms": "^0.11.2"
+  },
+  "peerDependencies": {
+    "tinacms": ">=0.11"
+  },
+  "dependencies": {
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "js-yaml": "^3.13.1",

--- a/packages/gatsby-tinacms-git/package.json
+++ b/packages/gatsby-tinacms-git/package.json
@@ -35,20 +35,25 @@
     "dev": "tsc",
     "build": "tsc"
   },
-  "dependencies": {
-    "@tinacms/api-git": "^0.5.2",
-    "@tinacms/core": "^0.6.0",
-    "@tinacms/git-client": "^0.4.1",
+  "devDependencies": {
     "@types/cors": "^2.8.5",
     "@types/express": "^4.17.0",
     "@types/js-yaml": "^3.12.1",
     "@types/lodash.throttle": "^4.1.6",
+    "gatsby-plugin-tinacms": "^0.1.19",
+    "tinacms": "^0.11.2"
+  },
+  "peerDependencies": {
+    "gatsby-plugin-tinacms": "^>=0.1.19",
+    "tinacms": ">=0.11"
+  },
+  "dependencies": {
+    "@tinacms/api-git": "^0.5.2",
+    "@tinacms/git-client": "^0.4.1",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "gatsby-plugin-tinacms": "^0.1.19",
     "js-yaml": "^3.13.1",
     "lodash.throttle": "^4.1.1",
-    "simple-git": "1.124.0",
-    "tinacms": "^0.11.2"
+    "simple-git": "1.124.0"
   }
 }

--- a/packages/gatsby-tinacms-json/package.json
+++ b/packages/gatsby-tinacms-json/package.json
@@ -34,13 +34,16 @@
     "@tinacms/scripts": "^0.1.11",
     "@types/jest": "^24.0.15",
     "jest": "^24.8.0",
+    "gatsby-plugin-tinacms": "^0.1.19",
+    "tinacms": "^0.11.2",
     "ts-jest": "^24.0.2"
   },
+  "peerDependencies": {
+    "gatsby-plugin-tinacms": ">=0.1.19",
+    "tinacms": "^>=0.11"
+  },
   "dependencies": {
-    "@tinacms/core": "^0.6.0",
-    "gatsby-plugin-tinacms": "^0.1.19",
     "graphql": "^14.5.8",
-    "slash": "^3.0.0",
-    "tinacms": "^0.11.2"
+    "slash": "^3.0.0"
   }
 }

--- a/packages/gatsby-tinacms-remark/package.json
+++ b/packages/gatsby-tinacms-remark/package.json
@@ -34,17 +34,16 @@
     "@tinacms/scripts": "^0.1.11",
     "@types/jest": "^24.0.15",
     "jest": "^24.8.0",
+    "tinacms": "^0.11.2",
     "ts-jest": "^24.0.2"
   },
   "dependencies": {
-    "@tinacms/core": "^0.6.0",
-    "@tinacms/form-builder": "^0.2.11",
     "gray-matter": "^4.0.2",
     "lodash.get": "^4.4.2",
-    "slash": "^3.0.0",
-    "tinacms": "^0.11.2"
+    "slash": "^3.0.0"
   },
   "peerDependencies": {
-    "gatsby-transformer-remark": ">=2.1.1"
+    "gatsby-transformer-remark": ">=2.1.1",
+    "tinacms": "^0.11.2"
   }
 }

--- a/packages/gatsby-tinacms-remark/src/remarkFormHoc.tsx
+++ b/packages/gatsby-tinacms-remark/src/remarkFormHoc.tsx
@@ -17,8 +17,7 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { FormOptions, Form } from 'tinacms'
-import { TinaForm } from '@tinacms/form-builder'
+import { FormOptions, Form, TinaForm } from 'tinacms'
 import { useLocalRemarkForm, useGlobalRemarkForm } from './useRemarkForm'
 import { ERROR_INVALID_QUERY_NAME } from './errors'
 

--- a/packages/next-tinacms-json/package-lock.json
+++ b/packages/next-tinacms-json/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "next-tinacms-json",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/packages/react-dismissible/package-lock.json
+++ b/packages/react-dismissible/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dismissible",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/react-tinacms-blocks/package-lock.json
+++ b/packages/react-tinacms-blocks/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinacms-blocks",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR is trying to fix some dependency issues that come up. 

The various gatsby plugins are currently depending directly on `tinacms` which can break your build. 

This PR makes `tinacms` a peerDep of all each the plugins. 

Similarly, the sub-plugins now have `gatsby-plugin-tinacms` as a peerDep rather then a dep.

### !Breaking!

This would require a change to docs describe how to get started with TinaCMS. 

```yarn add gatsby-plugin-tinacms styled-components```

will now need to be

```yarn add tinacms gatsby-plugin-tinacms styled-components```

We should make sure to update any effected blog posts and notify anyone else who wrote a blog post.