### PR TITLE
fix: disregard intermittent null vals from gatsby

### DIFF
--- a/packages/gatsby-tinacms-json/src/use-json-form.ts
+++ b/packages/gatsby-tinacms-json/src/use-json-form.ts
@@ -34,9 +34,11 @@ interface JsonNode {
 }
 
 export function useJsonForm(
-  jsonNode: JsonNode | null,
+  _jsonNode: JsonNode | null,
   formOptions: Partial<FormOptions<any>> = {}
 ): [JsonNode | null, Form | null] {
+  const jsonNode = usePersistentValue(_jsonNode)
+
   /**
    * We're returning early here which means all the hooks called by this hook
    * violate the rules of hooks. In the case of the check for
@@ -199,3 +201,13 @@ export const ERROR_MISSING_RAW_JSON =
 1. Check if the \`gatsby-tinacms-json\` was added to the \`gatsby-config.js\`.
 2. Check if the \`rawJson\` attribute is included in the GraphQL query.
 `
+
+function usePersistentValue<T>(nextData: T): T {
+  const [data, setData] = React.useState(nextData)
+
+  React.useEffect(() => {
+    setData(nextData || data)
+  }, [nextData])
+
+  return data
+}

--- a/packages/gatsby-tinacms-remark/src/useRemarkForm.tsx
+++ b/packages/gatsby-tinacms-remark/src/useRemarkForm.tsx
@@ -38,9 +38,11 @@ import * as React from 'react'
 const matter = require('gray-matter')
 
 export function useRemarkForm(
-  markdownRemark: RemarkNode | null | undefined,
+  _markdownRemark: RemarkNode | null | undefined,
   formOverrrides: Partial<FormOptions<any>> = {}
 ): [RemarkNode | null | undefined, Form | null | undefined] {
+  const markdownRemark = usePersistentValue(_markdownRemark)
+
   /**
    * We're returning early here which means all the hooks called by this hook
    * violate the rules of hooks. In the case of the check for
@@ -211,4 +213,14 @@ function validateMarkdownRemark(markdownRemark: RemarkNode) {
   if (typeof markdownRemark.rawMarkdownBody === 'undefined') {
     throw new Error(ERROR_MISSING_REMARK_RAW_MARKDOWN)
   }
+}
+
+function usePersistentValue<T>(nextData: T): T {
+  const [data, setData] = React.useState(nextData)
+
+  React.useEffect(() => {
+    setData(nextData || data)
+  }, [nextData])
+
+  return data
 }


### PR DESCRIPTION
Gatsby occasionally sends the browser null values when it's updating it's database, which russells Tina's jimmies. 

This PR makes Tina ignore those null values and just keep using the last valid query result. 

Potentially addresses #611 and #534 