### PR TITLE
Fix @tinacms/api-git `/show/:path` endpoint

### DIFF
--- a/packages/@tinacms/api-git/src/router.ts
+++ b/packages/@tinacms/api-git/src/router.ts
@@ -302,7 +302,7 @@ export function router(config: GitRouterConfig = {}) {
 
   router.get('/show/:fileRelativePath', async (req, res) => {
     try {
-      const fileRelativePath = path
+      const fileRelativePath = path.posix
         .join(CONTENT_REL_PATH, req.params.fileRelativePath)
         .replace(/^\/*/, '')
 

--- a/packages/demo-gatsby/src/components/bio.js
+++ b/packages/demo-gatsby/src/components/bio.js
@@ -26,7 +26,7 @@ limitations under the License.
 import React from "react"
 import { useStaticQuery, graphql } from "gatsby"
 import Image from "gatsby-image"
-import { useJsonForm } from "gatsby-tinacms-json"
+import { useLocalJsonForm } from "gatsby-tinacms-json"
 
 import { rhythm } from "../utils/typography"
 
@@ -74,7 +74,7 @@ const Bio = () => {
     }
   `)
 
-  const [author] = useJsonForm(data.dataJson, {
+  const [author] = useLocalJsonForm(data.dataJson, {
     label: "Author",
     fields,
   })


### PR DESCRIPTION


Possible fix for several reports

There are three pieces to this bug.

First, on windows path's can contain forward slashes, or
double back slashes. For example

    data/author.json

or

    data\\author.json

Second, Node's `path.join` returns the second on Windows.

Third, the `git show` command behaves oddly with the former:

    git show HEAD:data/author.json

Returns the contents of the file

    git show HEAD:data/dne.json

Throws an error, and finally

    git show HEAD:data\\author.json

returns an empty string.

This very well may be a bug in Git. I'm not sure.

