### PR TITLE
refactor(sidebar state): moved onto TinaCMS

### DIFF
--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -18,13 +18,12 @@ limitations under the License.
 
 import * as React from 'react'
 import { ModalProvider } from './modals/ModalProvider'
-import { SidebarContext } from './sidebar/SidebarProvider'
 import styled, { ThemeProvider } from 'styled-components'
 import { TinaReset, Theme, DefaultTheme, ThemeProps } from '@tinacms/styles'
 import { Sidebar } from './sidebar/Sidebar'
 import { SIDEBAR_WIDTH } from '../Globals'
 import { TinaCMS } from '../tina-cms'
-import { CMSContext } from '../react-tinacms'
+import { CMSContext, useSubscribable } from '../react-tinacms'
 
 const merge = require('lodash.merge')
 
@@ -44,15 +43,7 @@ export const Tina: React.FC<TinaProps> = ({
   hidden,
   theme: themeOverrides,
 }) => {
-  const [isOpen, setIsOpen] = React.useState(false)
-
-  const props = {
-    isOpen,
-    setIsOpen,
-    position,
-    hidden,
-  }
-
+  useSubscribable(cms.sidebar)
   const theme: ThemeProps['theme'] = React.useMemo(
     () => ({
       tinacms: merge(DefaultTheme, themeOverrides) as Theme,
@@ -62,20 +53,18 @@ export const Tina: React.FC<TinaProps> = ({
 
   return (
     <CMSContext.Provider value={cms}>
-      <SidebarContext.Provider value={props}>
-        <SiteWrapper open={isOpen} position={position}>
-          {children}
-        </SiteWrapper>
-        {!hidden && (
-          <ThemeProvider theme={theme}>
-            <ModalProvider>
-              <TinaReset>
-                <Sidebar />
-              </TinaReset>
-            </ModalProvider>
-          </ThemeProvider>
-        )}
-      </SidebarContext.Provider>
+      <SiteWrapper open={cms.sidebar.isOpen} position={position}>
+        {children}
+      </SiteWrapper>
+      {!hidden && (
+        <ThemeProvider theme={theme}>
+          <ModalProvider>
+            <TinaReset>
+              <Sidebar />
+            </TinaReset>
+          </ModalProvider>
+        </ThemeProvider>
+      )}
     </CMSContext.Provider>
   )
 }

--- a/packages/tinacms/src/components/sidebar/Sidebar.tsx
+++ b/packages/tinacms/src/components/sidebar/Sidebar.tsx
@@ -32,20 +32,20 @@ import {
 import { padding, color, radius, font, timing } from '@tinacms/styles'
 import { SIDEBAR_WIDTH, Z_INDEX, SIDEBAR_HEADER_HEIGHT } from '../../Globals'
 import { CreateContentMenu } from '../CreateContent'
-import { useSidebar } from './SidebarProvider'
 import { ScreenPlugin } from '../../plugins/screen-plugin'
 import { useSubscribable, useCMS } from '../../react-tinacms'
+import { SidebarState } from '../../tina-cms'
 
 export const Sidebar = () => {
   const cms = useCMS()
-  const sidebar = useSidebar()
+  useSubscribable(cms.sidebar)
   useSubscribable(cms.screens)
   const [menuIsVisible, setMenuVisibility] = useState(false)
   const [ActiveView, setActiveView] = useState<ScreenPlugin | null>(null)
 
   return (
-    <SidebarContainer open={sidebar.isOpen}>
-      <SidebarWrapper open={sidebar.isOpen}>
+    <SidebarContainer open={cms.sidebar.isOpen}>
+      <SidebarWrapper open={cms.sidebar.isOpen}>
         <SidebarHeader>
           <MenuToggle
             onClick={() => setMenuVisibility(!menuIsVisible)}
@@ -88,7 +88,7 @@ export const Sidebar = () => {
           </ActiveViewModal>
         )}
       </SidebarWrapper>
-      <SidebarToggle {...sidebar} />
+      <SidebarToggle sidebar={cms.sidebar} />
     </SidebarContainer>
   )
 }
@@ -149,10 +149,10 @@ const Watermark = styled(({ ...styleProps }: any) => {
   }
 `
 
-const SidebarToggle = (sidebar: any) => {
+const SidebarToggle = ({ sidebar }: { sidebar: SidebarState }) => {
   return (
     <SidebarToggleButton
-      onClick={() => sidebar.setIsOpen(!sidebar.isOpen)}
+      onClick={() => (sidebar.isOpen = !sidebar.isOpen)}
       open={sidebar.isOpen}
     >
       {sidebar.isOpen ? <LeftArrowIcon /> : <EditIcon />}

--- a/packages/tinacms/src/components/sidebar/SidebarProvider.tsx
+++ b/packages/tinacms/src/components/sidebar/SidebarProvider.tsx
@@ -16,21 +16,11 @@ limitations under the License.
 
 */
 
-import * as React from 'react'
+import { useCMS, useSubscribable } from '../../react-tinacms'
 
-interface SidebarProps {
-  isOpen: boolean
-  setIsOpen: (_isOpen: boolean) => void
-}
+export function useSidebar() {
+  const sidebar = useCMS().sidebar
 
-export const SidebarContext = React.createContext<SidebarProps | null>(null)
-
-export function useSidebar(): SidebarProps {
-  const sidebar = React.useContext(SidebarContext)
-
-  if (!sidebar) {
-    throw new Error('No Sidebar context provided')
-  }
-
+  useSubscribable(sidebar)
   return sidebar
 }

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import { CMS, PluginType } from '@tinacms/core'
+import { CMS, PluginType, Subscribable } from '@tinacms/core'
 import { FieldPlugin } from '@tinacms/form-builder'
 import { ScreenPlugin } from './plugins/screen-plugin'
 import TextFieldPlugin from './plugins/fields/TextFieldPlugin'
@@ -33,6 +33,8 @@ import BlocksFieldPlugin from './plugins/fields/BlocksFieldPlugin'
 import { Form } from '@tinacms/forms'
 
 export class TinaCMS extends CMS {
+  sidebar: SidebarState = new SidebarState()
+
   constructor() {
     super()
     this.fields.add(TextFieldPlugin)
@@ -58,5 +60,18 @@ export class TinaCMS extends CMS {
 
   get screens(): PluginType<ScreenPlugin> {
     return this.plugins.findOrCreateMap('screen')
+  }
+}
+
+export class SidebarState extends Subscribable {
+  private _isOpen: boolean = false
+
+  get isOpen() {
+    return this._isOpen
+  }
+
+  set isOpen(nextValue: boolean) {
+    this._isOpen = nextValue
+    this.notifiySubscribers()
   }
 }


### PR DESCRIPTION
Looking for everyone's thoughts on this. 

I started mulling over the Sidebar state after checking out @weibenfalk's thoughts on configuring the text on the Save/Reset buttons.

This change reifies the sidebar state and places it on the TinaCMS class as a property. I think this approach has a couple benefits:

1. The API feels more righter
1. It removes the need for the `SidebarContext` in the React app, instead relying on the pre-existinig CMSContext. 

Here is how it would be used.

### Checking sidebar state:

    cms.sidebar.isOpen

### Changing sidebar state:

    cms.sidebar.isOpen = true

### Subscribing Option 1

    import { useCMS, useSubscribable } from "tinacms"
    const cms = useCMS()

    useSubscribable(cms.sidebar)

### Subscribing Option 2:

    const sidebar = useSidebar()
