### PR TITLE
fix(deps): tinacms, react, and next are peerDeps

### DIFF
--- a/packages/next-tinacms-json/package.json
+++ b/packages/next-tinacms-json/package.json
@@ -21,17 +21,14 @@
     "react": ">=16",
     "tinacms": ">=0.11"
   },
-  "dependencies": {
-    "next": ">=9",
-    "react": ">=16",
-    "tinacms": "^0.11.3"
-  },
   "devDependencies": {
     "@types/jest": "^24.0.25",
     "@types/react": "^16.9.17",
     "@types/react-dom": "^16.9.4",
+    "next": "^9.2.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "tinacms": "^0.11.3",
     "tsdx": "^0.11.0",
     "tslib": "^1.10.0",
     "typescript": "^3.7.4"


### PR DESCRIPTION
If a package is a plugin for another package, then the parent should be a peerDep

This PR corrects that issue for `next-tinacms-json`