### PR TITLE
Fix gatsby tinacms remark deps

### DIFF
--- a/packages/gatsby-tinacms-remark/package.json
+++ b/packages/gatsby-tinacms-remark/package.json
@@ -33,12 +33,14 @@
   "devDependencies": {
     "@tinacms/scripts": "^0.1.11",
     "@types/jest": "^24.0.15",
+    "@types/js-yaml": "^3.12.1",
     "jest": "^24.8.0",
     "tinacms": "^0.11.3",
     "ts-jest": "^24.0.2"
   },
   "dependencies": {
     "gray-matter": "^4.0.2",
+    "js-yaml": "^3.13.1",
     "lodash.get": "^4.4.2",
     "slash": "^3.0.0"
   },

--- a/packages/gatsby-tinacms-remark/package.json
+++ b/packages/gatsby-tinacms-remark/package.json
@@ -34,17 +34,16 @@
     "@tinacms/scripts": "^0.1.11",
     "@types/jest": "^24.0.15",
     "jest": "^24.8.0",
+    "tinacms": "^0.11.3",
     "ts-jest": "^24.0.2"
   },
   "dependencies": {
-    "@tinacms/core": "^0.6.1",
-    "@tinacms/form-builder": "^0.2.12",
     "gray-matter": "^4.0.2",
     "lodash.get": "^4.4.2",
-    "slash": "^3.0.0",
-    "tinacms": "^0.11.3"
+    "slash": "^3.0.0"
   },
   "peerDependencies": {
-    "gatsby-transformer-remark": ">=2.1.1"
+    "gatsby-transformer-remark": ">=2.1.1",
+    "tinacms": ">=0.11"
   }
 }

--- a/packages/gatsby-tinacms-remark/src/remarkFormHoc.tsx
+++ b/packages/gatsby-tinacms-remark/src/remarkFormHoc.tsx
@@ -17,8 +17,7 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { FormOptions, Form } from 'tinacms'
-import { TinaForm } from '@tinacms/form-builder'
+import { FormOptions, Form, TinaForm } from 'tinacms'
 import { useLocalRemarkForm, useGlobalRemarkForm } from './useRemarkForm'
 import { ERROR_INVALID_QUERY_NAME } from './errors'
 


### PR DESCRIPTION
This PR fixes a couple things

* `gatsby-tinacms-remark` is a plugin for `tinacms` and should therefore have it as a `peerDependency`. This will not break anything for existing users since `gatsby-plugin-tinacms` depends directly on `tinacms`.
* `js-yaml` wasn't listed as a dependency