### PR TITLE
build(danger): ignore more development deps

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -359,12 +359,17 @@ function getModifiedPackages(allFiles: string[]) {
 function checkDeps(tinaPackage: TinaPackage) {
   const DEPCHECK_OPTIONS = {
     ignoreMatches: [
-      'jest',
-      '@types/jest',
-      'tsdx',
+      '@babel/*',
       '@types/*',
-      'typescript',
+      'jest',
+      'tsdx',
+      'ts-jest',
       'tslib',
+      'typescript',
+      '*-loader',
+      '*-webpack-plugin',
+      '@storybook/*',
+      '@sambego/*',
     ],
   }
   const packagePath = path.resolve(


### PR DESCRIPTION
Fine tuning the config for depcheck

Once things are really ironed out I'm going to switch it from a warning to a failure