### PR TITLE
withTina HOC

### DIFF
--- a/packages/@tinacms/core/src/cms.test.ts
+++ b/packages/@tinacms/core/src/cms.test.ts
@@ -1,0 +1,51 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import { CMS } from './cms'
+
+describe('CMS', () => {
+    describe('When instantiated with no arguments', () => {
+        it('instantiates without error', () => {
+            const cms = new CMS()
+            expect(cms).toBeInstanceOf(CMS)
+        })
+    })
+    describe('When configured with a plugin', () => {
+        it('instantiates with the plugin', () => {
+            const p =  { __type: 'test', name: 'Example' }
+            const cms = new CMS({
+                plugins: [
+                   p
+                ]
+            })
+            expect(cms).toBeInstanceOf(CMS)
+            expect(cms.plugins.all('test')).toContain(p)
+        })
+    })
+    describe('When configured with an api', () => {
+        it('instantiates with the api', () => {
+            const cms = new CMS({
+                apis: {
+                    test: { foo: 'bar' }
+                }
+            })
+            expect(cms).toBeInstanceOf(CMS)
+            expect(cms.api.test).toHaveProperty('foo')
+        })
+    })
+})

--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -23,7 +23,7 @@ limitations under the License.
  * @packageDocumentation
  */
 
-import { PluginTypeManager } from './plugins'
+import { Plugin, PluginTypeManager } from './plugins'
 
 /**
  * A [[CMS]] is the core object of any content management system.
@@ -65,6 +65,11 @@ import { PluginTypeManager } from './plugins'
  * cms.colors.all()
  * ```
  */
+export interface CMSConfig {
+  plugins?: Array<Plugin>
+  apis?: { [key: string]: any }
+}
+
 export class CMS {
   /**
    * An object for managing CMSs plugins.
@@ -102,8 +107,16 @@ export class CMS {
   /**
    * @hidden
    */
-  constructor() {
+  constructor(config: CMSConfig | null = null) {
     this.plugins = new PluginTypeManager()
+
+    if (config && config.plugins) {
+      config.plugins.forEach(plugin => this.plugins.add(plugin))
+    }
+
+    if (config && config.apis) {
+      Object.entries(config.apis).forEach(([name, api]) => this.registerApi(name, api))
+    }
   }
 
   /**

--- a/packages/demo-next/pages/_app.js
+++ b/packages/demo-next/pages/_app.js
@@ -21,14 +21,7 @@ import App from 'next/app'
 import { withTina } from 'tinacms'
 import { GitClient } from '@tinacms/git-client'
 
-class MyApp extends App {
-  render() {
-    const { Component, pageProps } = this.props
-    return <Component {...pageProps} />
-  }
-}
-
-export default withTina(MyApp, {
+export default withTina(App, {
   cms: {
     apis: {
       git: new GitClient('http://localhost:3000/___tina')

--- a/packages/demo-next/pages/_app.js
+++ b/packages/demo-next/pages/_app.js
@@ -18,28 +18,23 @@ limitations under the License.
 
 import React from 'react'
 import App from 'next/app'
-import { Tina, TinaCMS } from 'tinacms'
+import { withTina } from 'tinacms'
 import { GitClient } from '@tinacms/git-client'
 
 class MyApp extends App {
-  constructor() {
-    super()
-    this.cms = new TinaCMS()
-    const client = new GitClient('http://localhost:3000/___tina')
-    this.cms.registerApi('git', client)
-  }
-  options = {
-      sidebar: {
-        hidden: process.env.NODE_ENV === "production"
-      }
-  }
   render() {
     const { Component, pageProps } = this.props
-    return (
-      <Tina cms={this.cms} {...this.options.sidebar}>
-        <Component {...pageProps} />
-      </Tina>
-    )
+    return <Component {...pageProps} />
   }
 }
-export default MyApp
+
+export default withTina(MyApp, {
+  cms: {
+    apis: {
+      git: new GitClient('http://localhost:3000/___tina')
+    }
+  },
+  sidebar: {
+    hidden: process.env.NODE_ENV === 'production'
+  }
+})

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -46,6 +46,7 @@
     "@tinacms/react-core": "^0.2.4",
     "@tinacms/styles": "^0.1.1",
     "@types/react-beautiful-dnd": "^11.0.3",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",
     "react-beautiful-dnd": "^11.0.5",
     "react-datetime": "^2.16.3",

--- a/packages/tinacms/src/react-tinacms/index.ts
+++ b/packages/tinacms/src/react-tinacms/index.ts
@@ -22,6 +22,7 @@ export * from './use-plugin'
 export * from './use-subscribable'
 export * from './use-watch-form-values'
 export * from './with-plugin'
+export * from './with-tina'
 
 export { Plugin } from '@tinacms/core'
 export { Form, FormOptions, Field } from '@tinacms/forms'

--- a/packages/tinacms/src/react-tinacms/with-tina.tsx
+++ b/packages/tinacms/src/react-tinacms/with-tina.tsx
@@ -1,0 +1,61 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import { CMSConfig } from '@tinacms/core'
+import { Tina, TinaProps } from '../components/Tina'
+import { TinaCMS } from '../tina-cms'
+
+export interface TinaConfig {
+    cms?: CMSConfig,
+    sidebar?: {
+        position?: TinaProps["position"],
+        hidden?: TinaProps["hidden"],
+        theme?: TinaProps["theme"]
+    }
+}
+
+function mergeDefaultConfig(config?: TinaConfig) {
+    // TODO maybe use lodash/fp/defaultsDeep
+    // Using lodash/fp libs requires installing all of lodash so requires consideration
+    const merge = require('lodash.merge')
+    const cloneDeep = require('lodash.clonedeep')
+    return merge({
+        cms: {
+            plugins: [],
+            apis: {},
+        },
+        sidebar: {
+            position: 'displace',
+            hidden: false,
+            theme: {}
+        }
+    }, cloneDeep(config))
+}
+
+export function withTina(Component: any, config?: TinaConfig) {
+    return (props: any) => {
+        const safeConfig = React.useMemo(() => mergeDefaultConfig(config), [config])
+        const cms = React.useMemo(() => new TinaCMS(safeConfig.cms), [safeConfig])
+        return (
+        <Tina cms={cms} {...safeConfig.sidebar}>
+            <Component {...props} />
+        </Tina>
+        )
+    }
+}

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import { CMS, PluginType, Subscribable } from '@tinacms/core'
+import { CMS, CMSConfig, PluginType, Subscribable } from '@tinacms/core'
 import { FieldPlugin } from '@tinacms/form-builder'
 import { ScreenPlugin } from './plugins/screen-plugin'
 import TextFieldPlugin from './plugins/fields/TextFieldPlugin'
@@ -35,8 +35,8 @@ import { Form } from '@tinacms/forms'
 export class TinaCMS extends CMS {
   sidebar: SidebarState = new SidebarState()
 
-  constructor() {
-    super()
+  constructor(config: CMSConfig | null = null) {
+    super(config)
     this.fields.add(TextFieldPlugin)
     this.fields.add(TextareaFieldPlugin)
     this.fields.add(DateFieldPlugin)


### PR DESCRIPTION
This PR aims to improve the DX of bootstrapping Tina on a project by doing the following: 

1. introduce a higher-order component `withTina` to wrap a component with the `<Tina>` CMS provider
2. Allow configuration of CMS/plugins more declaratively by passing a config object to the `TinaCMS` class. Since using the HOC option no longer gives you access to the CMS instance up front this also provides us with a way to configure the CMS by passing this information to the HOC as well.

Consider the current Next.js example of boostrapping Tina in `_app.js`:

```javascript
import React from 'react'
import App from 'next/app'
import { Tina, TinaCMS } from 'tinacms'
import { GitClient } from '@tinacms/git-client'

class MyApp extends App {
  constructor() {
    super()
    this.cms = new TinaCMS()
    const client = new GitClient('http://localhost:3000/___tina')
    this.cms.registerApi('git', client)
  }
  options = {
      sidebar: {
        hidden: process.env.NODE_ENV === "production"
      }
  }
  render() {
    const { Component, pageProps } = this.props
    return (
      <Tina cms={this.cms} {...this.options.sidebar}>
        <Component {...pageProps} />
      </Tina>
    )
  }
}
export default MyApp
```

Using the `withTina` HOC, this implementation can be simplified to the following:

```javascript
import React from 'react'
import App from 'next/app'
import { withTina } from 'tinacms'
import { GitClient } from '@tinacms/git-client'

export default withTina(App, {
  cms: {
    apis: {
      git: new GitClient('http://localhost:3000/___tina')
    }
  },
  sidebar: {
    hidden: process.env.NODE_ENV === 'production'
  }
})
```