### PR TITLE
REFERENCE: Media manager

### DIFF
--- a/packages/@tinacms/core/src/plugins.ts
+++ b/packages/@tinacms/core/src/plugins.ts
@@ -264,7 +264,7 @@ export class PluginType<T extends Plugin = Plugin> extends Subscribable {
     }
 
     this.__plugins[p.name] = p
-    this.notifiySubscribers()
+    this.notifySubscribers()
   }
 
   all(): T[] {
@@ -306,7 +306,7 @@ export class PluginType<T extends Plugin = Plugin> extends Subscribable {
     const plugin = this.__plugins[name]
 
     delete this.__plugins[name]
-    this.notifiySubscribers()
+    this.notifySubscribers()
 
     return plugin
   }

--- a/packages/@tinacms/core/src/subscribable.test.ts
+++ b/packages/@tinacms/core/src/subscribable.test.ts
@@ -20,7 +20,7 @@ import { Subscribable } from './subscribable'
 
 class Example extends Subscribable {
   notify() {
-    this.notifiySubscribers()
+    this.notifySubscribers()
   }
 }
 

--- a/packages/@tinacms/core/src/subscribable.ts
+++ b/packages/@tinacms/core/src/subscribable.ts
@@ -96,8 +96,8 @@ export class Subscribable {
    * cup.empty() // Logs: false
    * ```
    */
-  protected notifySubscribers() {
+  protected notifySubscribers(params?: any) {
     // TODO: Catch and log errors.
-    this.__subscribers.forEach(cb => cb())
+    this.__subscribers.forEach(cb => cb(params))
   }
 }

--- a/packages/@tinacms/core/src/subscribable.ts
+++ b/packages/@tinacms/core/src/subscribable.ts
@@ -96,7 +96,7 @@ export class Subscribable {
    * cup.empty() // Logs: false
    * ```
    */
-  protected notifiySubscribers() {
+  protected notifySubscribers() {
     // TODO: Catch and log errors.
     this.__subscribers.forEach(cb => cb())
   }

--- a/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
@@ -28,6 +28,7 @@ interface ImageUploadProps {
   onClear?: () => void
   value?: string
   previewSrc?: string
+  multiple?: boolean
 }
 
 const DropArea = styled.div`
@@ -105,7 +106,12 @@ export const ImageUpload = ({
     isDragActive,
     isDragAccept,
     isDragReject,
-  } = useDropzone({ accept: 'image/*', onDrop, noClick: !!onClick })
+  } = useDropzone({
+    accept: 'image/*',
+    onDrop,
+    noClick: !!onClick,
+    multiple: false,
+  })
 
   const rootProps = getRootProps({ isDragActive, isDragAccept, isDragReject })
   return (

--- a/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/fields/src/ImageUpload/ImageUpload.tsx
@@ -24,6 +24,7 @@ import { TrashIcon } from '@tinacms/icons'
 
 interface ImageUploadProps {
   onDrop: (acceptedFiles: any[]) => void
+  onClick?: () => void
   onClear?: () => void
   value?: string
   previewSrc?: string
@@ -93,6 +94,7 @@ const StyledImageContainer = styled.div`
 
 export const ImageUpload = ({
   onDrop,
+  onClick,
   onClear,
   value,
   previewSrc,
@@ -103,10 +105,11 @@ export const ImageUpload = ({
     isDragActive,
     isDragAccept,
     isDragReject,
-  } = useDropzone({ accept: 'image/*', onDrop })
+  } = useDropzone({ accept: 'image/*', onDrop, noClick: !!onClick })
 
+  const rootProps = getRootProps({ isDragActive, isDragAccept, isDragReject })
   return (
-    <DropArea {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
+    <DropArea {...rootProps} onClick={onClick || rootProps.onClick}>
       <input {...getInputProps()} />
       {value ? (
         <StyledImageContainer>

--- a/packages/@tinacms/react-core/src/use-subscribable.tsx
+++ b/packages/@tinacms/react-core/src/use-subscribable.tsx
@@ -26,9 +26,9 @@ import { Subscribable } from '@tinacms/core'
 export function useSubscribable(subscribable: Subscribable, cb?: Function) {
   const [, s] = React.useState(0)
   React.useEffect(() => {
-    return subscribable.subscribe(() => {
+    return subscribable.subscribe((props: any) => {
       s(x => x + 1)
-      if (cb) cb()
+      if (cb) cb(props)
     })
   })
 }

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -152,6 +152,7 @@ const MediaDropZone = ({
     onDropRejected,
     noClick: true,
     noDragEventsBubbling: false,
+    noKeyboard: true,
   })
 
   return (

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -1,12 +1,22 @@
 import * as React from 'react'
 import { useState, useEffect } from 'react'
-import { MediaProps } from '../media'
 import { useCMS } from '../react-tinacms'
+import { MediaFilter, Media } from '../media'
+
+interface MediaProps {
+  multiple?: boolean
+  selected?: string[]
+  disabled?: MediaFilter
+  filter?: MediaFilter
+  onChoose?(media: Media[]): void
+}
 
 export const MediaManager = (props: MediaProps) => {
   let cms = useCMS()
-  let [media, setMedia] = useState([] as any)
-  let [selected, setSelected] = useState(props.selected)
+  let [allMedia, setMedia] = useState([] as any)
+
+  let { selected, handleClickToSelect } = useSelection(props.selected)
+
   useEffect(() => {
     ;(async () => {
       let media = await cms.media.store.list({ limit: 8, offset: 0 })
@@ -16,13 +26,77 @@ export const MediaManager = (props: MediaProps) => {
 
   return (
     <div style={{ display: 'flex' }}>
-      {media.map((m: any) => (
-        <div
-          style={{ border: '1px dotted', padding: '.5rem', margin: '.5rem' }}
+      <nav>
+        <button
+          disabled={!selected.length}
+          onClick={() => cms.media.store.delete(selected[0])}
         >
-          file: {m.src}
+          Delete {!!selected.length && `${selected.length} items`}
+        </button>
+      </nav>
+      {allMedia.map((media: Media) => (
+        <div
+          key={media.src}
+          style={{
+            border: '2px solid',
+            padding: '.5rem',
+            margin: '.5rem',
+            borderColor: selected.includes(media.reference) ? 'green' : 'black',
+          }}
+          onClick={event => {
+            handleClickToSelect(event, media)
+          }}
+        >
+          file: {media.src}
         </div>
       ))}
     </div>
   )
+}
+
+/**
+ * NOTE: This is curently more complex then necessary.
+ * Using a reducer will be useful once we implement multiselect.
+ */
+function useSelection(preselect: string[] = []) {
+  const [state, dispatch] = React.useReducer(singleSelectReducer, {
+    lastToggled: null,
+    selected: preselect,
+  })
+
+  return {
+    ...state,
+    handleClickToSelect(
+      _: React.MouseEvent<HTMLDivElement, MouseEvent>,
+      media: Media
+    ) {
+      dispatch({
+        type: 'SELECT_MEDIA',
+        selected: [media.reference],
+      })
+    },
+  }
+}
+
+export interface SelectionState {
+  lastToggled: string | null
+  selected: string[]
+}
+
+function singleSelectReducer(
+  state: SelectionState,
+  changes: any
+): SelectionState {
+  switch (changes.type) {
+    case 'SELECT_MEDIA':
+    case 'SHIFT_SELECT_MEDIA':
+      let lastSelected = changes.selected[changes.selected.length - 1]
+      return {
+        ...state,
+        selected:
+          state.selected.indexOf(lastSelected) >= 0 ? [] : [lastSelected],
+      }
+    default:
+      return { ...state, ...changes }
+  }
 }

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -113,10 +113,17 @@ function DeleteButton({ selected, cms }: { selected: string[]; cms: TinaCMS }) {
               <ModalActions>
                 <Button onClick={close}>Cancel</Button>
                 <Button
-                  onClick={() => cms.media.store.delete(selected)}
+                  onClick={async () => {
+                    try {
+                      await cms.media.store.delete(selected)
+                    } catch (e) {
+                      // TODO
+                    }
+                    close()
+                  }}
                   primary
                 >
-                  Create
+                  Delete
                 </Button>
               </ModalActions>
             </ModalPopup>

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -53,9 +53,12 @@ export const MediaManager = (props: MediaProps) => {
         )}
       </nav>
       <MediaDropZone
-        onDrop={files => {
-          console.log('DROP')
-          cms.media.store.persist(files)
+        accept={cms.media.store.accept}
+        onDropAccepted={accepted => {
+          cms.media.store.persist(accepted)
+        }}
+        onDropRejected={rejected => {
+          console.log('REJECTED', rejected)
         }}
       >
         {/* TODO: PREVIEW IMAGE WHILE IT IS BEING UPLOADED */}
@@ -85,11 +88,18 @@ export const MediaManager = (props: MediaProps) => {
 }
 
 interface ImageUploadProps {
-  onDrop: (acceptedFiles: File[]) => void
+  accept: string
+  onDropAccepted: (accepted: File[]) => void
+  onDropRejected: (rejected: File[]) => void
   children: any
 }
 
-const MediaDropZone = ({ onDrop, children }: ImageUploadProps) => {
+const MediaDropZone = ({
+  accept,
+  onDropAccepted,
+  onDropRejected,
+  children,
+}: ImageUploadProps) => {
   const {
     getRootProps,
     getInputProps,
@@ -97,8 +107,9 @@ const MediaDropZone = ({ onDrop, children }: ImageUploadProps) => {
     isDragAccept,
     isDragReject,
   } = useDropzone({
-    accept: '*',
-    onDrop,
+    accept,
+    onDropAccepted,
+    onDropRejected,
     noClick: true,
     noDragEventsBubbling: false,
   })
@@ -117,30 +128,6 @@ const MediaDropZone = ({ onDrop, children }: ImageUploadProps) => {
     </div>
   )
 }
-
-const DropArea = styled.div`
-  border-radius: ${radius('small')};
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  outline: none;
-  cursor: pointer;
-`
-
-const ImgPlaceholder = styled.div`
-  text-align: center;
-  border-radius: ${radius('small')};
-  background-color: ${color.grey(2)};
-  color: ${color.grey(4)};
-  line-height: 1.35;
-  padding: 12px 0;
-  font-size: ${font.size(2)};
-  font-weight: 500;
-  transition: all 85ms ease-out;
-  &:hover {
-    opacity: 0.6;
-  }
-`
 
 /**
  * NOTE: This is curently more complex then necessary.

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -55,7 +55,10 @@ export const MediaManager = (props: MediaProps) => {
       <MediaDropZone
         accept={cms.media.store.accept}
         onDropAccepted={accepted => {
-          cms.media.store.persist(accepted)
+          cms.media.store.persist(
+            // TODO: Where does that `directory` come from?
+            accepted.map(file => ({ file, directory: '' }))
+          )
         }}
         onDropRejected={rejected => {
           console.log('REJECTED', rejected)

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -23,10 +23,10 @@ interface MediaProps {
 }
 
 export const MediaManager = (props: MediaProps) => {
-  let cms = useCMS()
-  let [allMedia, setMedia] = useState([] as any)
+  const cms = useCMS()
+  const [allMedia, setMedia] = useState([] as any)
 
-  let { selected, handleClickToSelect } = useSelection(props.selected)
+  const { selected, handleClickToSelect } = useSelection(props.selected)
 
   useEffect(() => {
     ;(async () => {

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -30,7 +30,7 @@ export const MediaManager = (props: MediaProps) => {
 
   useEffect(() => {
     ;(async () => {
-      let media = await cms.media.store.list({ limit: 8, offset: 0 })
+      const media = await cms.media.store.list({ limit: 8, offset: 0 })
       setMedia(media)
     })()
   }, [])
@@ -213,7 +213,7 @@ function singleSelectReducer(
   switch (changes.type) {
     case 'SELECT_MEDIA':
     case 'SHIFT_SELECT_MEDIA':
-      let lastSelected = changes.selected[changes.selected.length - 1]
+      const lastSelected = changes.selected[changes.selected.length - 1]
       return {
         ...state,
         selected:

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -2,6 +2,9 @@ import * as React from 'react'
 import { useState, useEffect } from 'react'
 import { useCMS } from '../react-tinacms'
 import { MediaFilter, Media } from '../media'
+import { useDropzone } from 'react-dropzone'
+import styled from 'styled-components'
+import { radius, color, font } from '@tinacms/styles'
 
 interface MediaProps {
   multiple?: boolean
@@ -25,7 +28,7 @@ export const MediaManager = (props: MediaProps) => {
   }, [])
 
   return (
-    <div style={{ display: 'flex' }}>
+    <div>
       <nav>
         <button
           disabled={!selected.length}
@@ -49,25 +52,95 @@ export const MediaManager = (props: MediaProps) => {
           </button>
         )}
       </nav>
-      {allMedia.map((media: Media) => (
-        <div
-          key={media.src}
-          style={{
-            border: '2px solid',
-            padding: '.5rem',
-            margin: '.5rem',
-            borderColor: selected.includes(media.reference) ? 'green' : 'black',
-          }}
-          onClick={event => {
-            handleClickToSelect(event, media)
-          }}
-        >
-          file: {media.src}
-        </div>
-      ))}
+      <MediaDropZone
+        onDrop={files => {
+          console.log('DROP')
+          cms.media.store.persist(files)
+        }}
+      >
+        {/* TODO: PREVIEW IMAGE WHILE IT IS BEING UPLOADED */}
+        {allMedia.map((media: Media) => (
+          <div
+            key={media.src}
+            style={{
+              border: '2px solid',
+              padding: '.5rem',
+              margin: '.5rem',
+              borderColor: selected.includes(media.reference)
+                ? 'green'
+                : 'black',
+            }}
+            onClick={event => {
+              handleClickToSelect(event, media)
+              event.stopPropagation()
+              event.preventDefault()
+            }}
+          >
+            file: {media.src}
+          </div>
+        ))}
+      </MediaDropZone>
     </div>
   )
 }
+
+interface ImageUploadProps {
+  onDrop: (acceptedFiles: File[]) => void
+  children: any
+}
+
+const MediaDropZone = ({ onDrop, children }: ImageUploadProps) => {
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({
+    accept: '*',
+    onDrop,
+    noClick: true,
+    noDragEventsBubbling: false,
+  })
+
+  return (
+    <div
+      {...getRootProps({ isDragActive, isDragAccept, isDragReject })}
+      style={{
+        display: 'flex',
+        outline: isDragActive ? '2px solid pink' : '',
+        minHeight: '50vh',
+      }}
+    >
+      <input {...getInputProps()} />
+      {children}
+    </div>
+  )
+}
+
+const DropArea = styled.div`
+  border-radius: ${radius('small')};
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  outline: none;
+  cursor: pointer;
+`
+
+const ImgPlaceholder = styled.div`
+  text-align: center;
+  border-radius: ${radius('small')};
+  background-color: ${color.grey(2)};
+  color: ${color.grey(4)};
+  line-height: 1.35;
+  padding: 12px 0;
+  font-size: ${font.size(2)};
+  font-weight: 500;
+  transition: all 85ms ease-out;
+  &:hover {
+    opacity: 0.6;
+  }
+`
 
 /**
  * NOTE: This is curently more complex then necessary.

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -33,6 +33,21 @@ export const MediaManager = (props: MediaProps) => {
         >
           Delete {!!selected.length && `${selected.length} items`}
         </button>
+        {props.onChoose && (
+          <button
+            disabled={!selected.length}
+            onClick={() => {
+              props.onChoose!(
+                // TODO: `seleted` should be Media[]
+                selected.map(ref =>
+                  allMedia.find((media: Media) => media.reference === ref)
+                )
+              )
+            }}
+          >
+            Choose
+          </button>
+        )}
       </nav>
       {allMedia.map((media: Media) => (
         <div

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -3,8 +3,16 @@ import { useState, useEffect } from 'react'
 import { useCMS } from '../react-tinacms'
 import { MediaFilter, Media } from '../media'
 import { useDropzone } from 'react-dropzone'
-import styled from 'styled-components'
-import { radius, color, font } from '@tinacms/styles'
+import { Button } from '@tinacms/styles'
+import {
+  Modal,
+  ModalHeader,
+  ModalBody,
+  ModalActions,
+} from './modals/ModalProvider'
+import { Dismissible } from 'react-dismissible'
+import { ModalPopup } from './modals/ModalPopup'
+import { TinaCMS } from '../tina-cms'
 
 interface MediaProps {
   multiple?: boolean
@@ -30,12 +38,7 @@ export const MediaManager = (props: MediaProps) => {
   return (
     <div>
       <nav>
-        <button
-          disabled={!selected.length}
-          onClick={() => cms.media.store.delete(selected[0])}
-        >
-          Delete {!!selected.length && `${selected.length} items`}
-        </button>
+        <DeleteButton cms={cms} selected={selected} />
         {props.onChoose && (
           <button
             disabled={!selected.length}
@@ -87,6 +90,40 @@ export const MediaManager = (props: MediaProps) => {
         ))}
       </MediaDropZone>
     </div>
+  )
+}
+
+function DeleteButton({ selected, cms }: { selected: string[]; cms: TinaCMS }) {
+  const [opened, setOpened] = useState(false)
+  const open = () => setOpened(true)
+  const close = () => setOpened(false)
+  return (
+    <>
+      <button disabled={!selected.length} onClick={open}>
+        Delete {!!selected.length && `${selected.length} items`}
+      </button>
+      {opened && (
+        <Modal>
+          <Dismissible onDismiss={close}>
+            <ModalPopup>
+              <ModalHeader close={close}>Deleting Media</ModalHeader>
+              <ModalBody>
+                Are you sure you want to delete these files?
+              </ModalBody>
+              <ModalActions>
+                <Button onClick={close}>Cancel</Button>
+                <Button
+                  onClick={() => cms.media.store.delete(selected)}
+                  primary
+                >
+                  Create
+                </Button>
+              </ModalActions>
+            </ModalPopup>
+          </Dismissible>
+        </Modal>
+      )}
+    </>
   )
 }
 

--- a/packages/tinacms/src/components/MediaManager.tsx
+++ b/packages/tinacms/src/components/MediaManager.tsx
@@ -1,0 +1,28 @@
+import * as React from 'react'
+import { useState, useEffect } from 'react'
+import { MediaProps } from '../media'
+import { useCMS } from '../react-tinacms'
+
+export const MediaManager = (props: MediaProps) => {
+  let cms = useCMS()
+  let [media, setMedia] = useState([] as any)
+  let [selected, setSelected] = useState(props.selected)
+  useEffect(() => {
+    ;(async () => {
+      let media = await cms.media.store.list({ limit: 8, offset: 0 })
+      setMedia(media)
+    })()
+  }, [])
+
+  return (
+    <div style={{ display: 'flex' }}>
+      {media.map((m: any) => (
+        <div
+          style={{ border: '1px dotted', padding: '.5rem', margin: '.5rem' }}
+        >
+          file: {m.src}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -116,7 +116,6 @@ const MediaManagerModal = ({ cms }: { cms: TinaCMS }) => {
         <ModalHeader close={() => setIsOpen(false)}>Media</ModalHeader>
         <ModalBody padded>
           <MediaManager {...(mediaProps as any)} />
-          <button onClick={() => mediaProps.onChoose()}>Choose</button>
         </ModalBody>
       </ModalFullscreen>
     </Modal>

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -111,20 +111,18 @@ const MediaManagerModal = ({ cms }: { cms: TinaCMS }) => {
   }
   return (
     <Modal>
-      <Dismissible onDismiss={() => setIsOpen(false)} escape click>
-        <ModalFullscreen>
-          <ModalHeader close={() => setIsOpen(false)}>Media</ModalHeader>
-          <ModalBody padded>
-            <MediaManager
-              {...mediaProps}
-              onChoose={selected => {
-                mediaProps.onChoose(selected)
-                setIsOpen(false)
-              }}
-            />
-          </ModalBody>
-        </ModalFullscreen>
-      </Dismissible>
+      <ModalFullscreen>
+        <ModalHeader close={() => setIsOpen(false)}>Media</ModalHeader>
+        <ModalBody padded>
+          <MediaManager
+            {...mediaProps}
+            onChoose={selected => {
+              mediaProps.onChoose(selected)
+              setIsOpen(false)
+            }}
+          />
+        </ModalBody>
+      </ModalFullscreen>
     </Modal>
   )
 }

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -31,9 +31,7 @@ import { Sidebar } from './sidebar/Sidebar'
 import { SIDEBAR_WIDTH } from '../Globals'
 import { TinaCMS } from '../tina-cms'
 import { CMSContext, useSubscribable } from '../react-tinacms'
-import { MediaProps } from '../media'
 import { MediaManager } from './MediaManager'
-import { Dismissible } from 'react-dismissible'
 
 const merge = require('lodash.merge')
 
@@ -99,8 +97,8 @@ export const Tina: React.FC<TinaProps> = ({
 }
 
 const MediaManagerModal = ({ cms }: { cms: TinaCMS }) => {
-  let [isOpen, setIsOpen] = useState(false)
-  let [mediaProps, setMediaProps] = useState({} as any)
+  const [isOpen, setIsOpen] = useState(false)
+  const [mediaProps, setMediaProps] = useState({} as any)
   useSubscribable(cms.media, (props: any) => {
     setIsOpen(true)
     setMediaProps(props)

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -33,6 +33,7 @@ import { TinaCMS } from '../tina-cms'
 import { CMSContext, useSubscribable } from '../react-tinacms'
 import { MediaProps } from '../media'
 import { MediaManager } from './MediaManager'
+import { Dismissible } from 'react-dismissible'
 
 const merge = require('lodash.merge')
 
@@ -78,13 +79,11 @@ export const Tina: React.FC<TinaProps> = ({
               >
                 <button
                   onClick={() => {
-                    const options = {
+                    cms.media.open({
                       onChoose: (media: any) => {
-                        return media[0].src
+                        alert(`INSERTING: ${media[0].src}`)
                       },
-                    }
-                    console.log('open medias')
-                    cms.media.open(options)
+                    })
                   }}
                 >
                   Open media
@@ -112,12 +111,20 @@ const MediaManagerModal = ({ cms }: { cms: TinaCMS }) => {
   }
   return (
     <Modal>
-      <ModalFullscreen>
-        <ModalHeader close={() => setIsOpen(false)}>Media</ModalHeader>
-        <ModalBody padded>
-          <MediaManager {...(mediaProps as any)} />
-        </ModalBody>
-      </ModalFullscreen>
+      <Dismissible onDismiss={() => setIsOpen(false)} escape click>
+        <ModalFullscreen>
+          <ModalHeader close={() => setIsOpen(false)}>Media</ModalHeader>
+          <ModalBody padded>
+            <MediaManager
+              {...mediaProps}
+              onChoose={selected => {
+                mediaProps.onChoose(selected)
+                setIsOpen(false)
+              }}
+            />
+          </ModalBody>
+        </ModalFullscreen>
+      </Dismissible>
     </Modal>
   )
 }

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -17,13 +17,22 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { ModalProvider } from './modals/ModalProvider'
+import { useState } from 'react'
+import {
+  ModalProvider,
+  Modal,
+  ModalHeader,
+  ModalBody,
+} from './modals/ModalProvider'
+import { ModalFullscreen } from './modals/ModalFullscreen'
 import styled, { ThemeProvider } from 'styled-components'
 import { TinaReset, Theme, DefaultTheme, ThemeProps } from '@tinacms/styles'
 import { Sidebar } from './sidebar/Sidebar'
 import { SIDEBAR_WIDTH } from '../Globals'
 import { TinaCMS } from '../tina-cms'
 import { CMSContext, useSubscribable } from '../react-tinacms'
+import { MediaProps } from '../media'
+import { MediaManager } from './MediaManager'
 
 const merge = require('lodash.merge')
 
@@ -61,11 +70,56 @@ export const Tina: React.FC<TinaProps> = ({
           <ModalProvider>
             <TinaReset>
               <Sidebar />
+              <div
+                style={{
+                  position: 'absolute',
+                  zIndex: 9999,
+                }}
+              >
+                <button
+                  onClick={() => {
+                    const options = {
+                      onChoose: (media: any) => {
+                        return media[0].src
+                      },
+                    }
+                    console.log('open medias')
+                    cms.media.open(options)
+                  }}
+                >
+                  Open media
+                </button>
+              </div>
+              <MediaManagerModal cms={cms} />
             </TinaReset>
           </ModalProvider>
         </ThemeProvider>
       )}
     </CMSContext.Provider>
+  )
+}
+
+const MediaManagerModal = ({ cms }: { cms: TinaCMS }) => {
+  let [isOpen, setIsOpen] = useState(false)
+  let [mediaProps, setMediaProps] = useState({} as any)
+  useSubscribable(cms.media, (props: any) => {
+    setIsOpen(true)
+    setMediaProps(props)
+  })
+
+  if (!isOpen) {
+    return null
+  }
+  return (
+    <Modal>
+      <ModalFullscreen>
+        <ModalHeader close={() => setIsOpen(false)}>Media</ModalHeader>
+        <ModalBody padded>
+          <MediaManager {...(mediaProps as any)} />
+          <button onClick={() => mediaProps.onChoose()}>Choose</button>
+        </ModalBody>
+      </ModalFullscreen>
+    </Modal>
   )
 }
 

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -1,0 +1,96 @@
+import { Subscribable } from '@tinacms/core'
+
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+/**
+ * Media represents a single media object (file + metadata) in a media store
+ */
+export interface Media {
+  reference: string // internal reference used by the store
+  src: string // filepath or URI to the media object
+  previewSrc: string // filepath or URI to a preview of the media (will this always be a URI?)
+}
+
+export interface MediaListOptions {
+  limit: number
+  offset: number
+}
+
+/**
+ * MediaStore provides an interface for interacting with a media storage service
+ * examples: local filesystem, cloudinary
+ */
+export interface MediaStore {
+  list(options: MediaListOptions): Promise<Media[]>
+  persist(reference: string): Promise<Media>
+  delete(reference: string): Promise<any>
+  find(src: string): Promise<Media> // finds an object in the media store based on the src string (such as one pulled from document)
+}
+
+export type MediaFilter = (
+  media: Media,
+  index: number,
+  allMedia: Media[]
+) => boolean
+
+export interface MediaProps {
+  multiple?: boolean
+  selected?: string[]
+  disabled?: MediaFilter
+  filter?: MediaFilter
+  onChoose(media: Media[]): void
+}
+
+class DummyMedia implements Media {
+  reference: string
+  src: string
+  previewSrc: string
+  constructor(ref: string) {
+    this.reference = ref
+    this.src = `src(${ref})`
+    this.previewSrc = `preview(${ref})`
+  }
+}
+
+class DummyMediaStore implements MediaStore {
+  async list(options: MediaListOptions) {
+    const _ = options
+    return [new DummyMedia('')]
+  }
+  async persist(reference: string) {
+    return new DummyMedia(reference)
+  }
+  async delete(ref: string) {
+    return ref
+  }
+  async find(ref: string) {
+    return new DummyMedia(ref)
+  }
+}
+
+/**
+ * MediaManager is the UI for adding, removing, and selecting media from the MediaStore to use within the CMS.
+ */
+export class MediaManager extends Subscribable {
+  store: MediaStore = new DummyMediaStore()
+
+  open(props: MediaProps) {
+    this.notifySubscribers(props)
+  }
+}

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -76,8 +76,7 @@ class DummyMedia implements Media {
 
 class DummyMediaStore implements MediaStore {
   accept = 'img/png,image/png'
-  async list(options: MediaListOptions) {
-    const _ = options
+  async list(_options: MediaListOptions) {
     return [
       new DummyMedia('terry.jpg'),
       new DummyMedia('toot-toot.jpg'),

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -32,6 +32,11 @@ export interface MediaListOptions {
   offset: number
 }
 
+export interface MediaUploadOptions {
+  directory: string
+  file: File
+}
+
 /**
  * MediaStore provides an interface for interacting with a media storage service
  * examples: local filesystem, cloudinary
@@ -39,7 +44,7 @@ export interface MediaListOptions {
 export interface MediaStore {
   accept: string
   list(options: MediaListOptions): Promise<Media[]>
-  persist(files: File[]): Promise<Media>
+  persist(files: MediaUploadOptions[]): Promise<Media[]>
   delete(reference: string): Promise<any>
   find(src: string): Promise<Media> // finds an object in the media store based on the src string (such as one pulled from document)
 }
@@ -81,10 +86,10 @@ class DummyMediaStore implements MediaStore {
       new DummyMedia('clifford.jpg'),
     ]
   }
-  async persist(files: File[]) {
+  async persist(files: MediaUploadOptions[]) {
     alert('UPLOADING FILES')
     console.log(files)
-    return new DummyMedia('yay.txt')
+    return files.map(({ file }) => new DummyMedia(file.name))
   }
   async delete(ref: string) {
     alert(`Media Deleted: ${ref}`)

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -71,12 +71,19 @@ class DummyMedia implements Media {
 class DummyMediaStore implements MediaStore {
   async list(options: MediaListOptions) {
     const _ = options
-    return [new DummyMedia('')]
+    return [
+      new DummyMedia('terry.jpg'),
+      new DummyMedia('toot-toot.jpg'),
+      new DummyMedia('baby-yoda.jpg'),
+      new DummyMedia('tina.jpg'),
+      new DummyMedia('clifford.jpg'),
+    ]
   }
   async persist(reference: string) {
     return new DummyMedia(reference)
   }
   async delete(ref: string) {
+    alert(`Media Deleted: ${ref}`)
     return ref
   }
   async find(ref: string) {

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -45,7 +45,7 @@ export interface MediaStore {
   accept: string
   list(options: MediaListOptions): Promise<Media[]>
   persist(files: MediaUploadOptions[]): Promise<Media[]>
-  delete(reference: string): Promise<any>
+  delete(reference: string[]): Promise<any>
   find(src: string): Promise<Media> // finds an object in the media store based on the src string (such as one pulled from document)
 }
 
@@ -91,7 +91,7 @@ class DummyMediaStore implements MediaStore {
     console.log(files)
     return files.map(({ file }) => new DummyMedia(file.name))
   }
-  async delete(ref: string) {
+  async delete(ref: string[]) {
     alert(`Media Deleted: ${ref}`)
     return ref
   }

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -37,6 +37,7 @@ export interface MediaListOptions {
  * examples: local filesystem, cloudinary
  */
 export interface MediaStore {
+  accept: string
   list(options: MediaListOptions): Promise<Media[]>
   persist(files: File[]): Promise<Media>
   delete(reference: string): Promise<any>
@@ -69,6 +70,7 @@ class DummyMedia implements Media {
 }
 
 class DummyMediaStore implements MediaStore {
+  accept = 'img/png,image/png'
   async list(options: MediaListOptions) {
     const _ = options
     return [

--- a/packages/tinacms/src/media.ts
+++ b/packages/tinacms/src/media.ts
@@ -38,7 +38,7 @@ export interface MediaListOptions {
  */
 export interface MediaStore {
   list(options: MediaListOptions): Promise<Media[]>
-  persist(reference: string): Promise<Media>
+  persist(files: File[]): Promise<Media>
   delete(reference: string): Promise<any>
   find(src: string): Promise<Media> // finds an object in the media store based on the src string (such as one pulled from document)
 }
@@ -79,8 +79,10 @@ class DummyMediaStore implements MediaStore {
       new DummyMedia('clifford.jpg'),
     ]
   }
-  async persist(reference: string) {
-    return new DummyMedia(reference)
+  async persist(files: File[]) {
+    alert('UPLOADING FILES')
+    console.log(files)
+    return new DummyMedia('yay.txt')
   }
   async delete(ref: string) {
     alert(`Media Deleted: ${ref}`)

--- a/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
@@ -37,14 +37,22 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
     <ImageUpload
       value={props.input.value}
       previewSrc={props.field.previewSrc(props.form.getState().values, props)}
-      onDrop={(acceptedFiles: any[]) => {
-        acceptedFiles.forEach(async (file: any) => {
-          await cms.api.git!.onUploadMedia!({
-            directory: props.field.uploadDir(props.form.getState().values),
-            content: file,
-          })
-          props.input.onChange(file.name)
-        })
+      onDrop={async (acceptedFiles: File[]) => {
+        // TODO: Can we force this to only accept 1 file when dropped?
+        const directory = props.field.uploadDir(props.form.getState().values)
+
+        const allMedia = await cms.media.store.persist(
+          acceptedFiles.map(file => ({
+            directory,
+            file: file,
+          }))
+        )
+
+        if (allMedia.length > 0) {
+          props.input.onChange(allMedia[0].reference)
+        } else {
+          // TODO Handle failure
+        }
       }}
       onClear={
         props.field.clearable === false

--- a/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/ImageFieldPlugin.tsx
@@ -37,19 +37,28 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
     <ImageUpload
       value={props.input.value}
       previewSrc={props.field.previewSrc(props.form.getState().values, props)}
-      onDrop={async (acceptedFiles: File[]) => {
+      onClick={() => {
+        cms.media.open({
+          onChoose([media]) {
+            if (media) {
+              props.input.onChange(media.reference)
+            }
+          },
+        })
+      }}
+      onDrop={async ([file]: File[]) => {
         // TODO: Can we force this to only accept 1 file when dropped?
         const directory = props.field.uploadDir(props.form.getState().values)
 
-        const allMedia = await cms.media.store.persist(
-          acceptedFiles.map(file => ({
+        const [media] = await cms.media.store.persist([
+          {
             directory,
-            file: file,
-          }))
-        )
+            file,
+          },
+        ])
 
-        if (allMedia.length > 0) {
-          props.input.onChange(allMedia[0].reference)
+        if (media) {
+          props.input.onChange(media.reference)
         } else {
           // TODO Handle failure
         }

--- a/packages/tinacms/src/plugins/screens/media-screen.tsx
+++ b/packages/tinacms/src/plugins/screens/media-screen.tsx
@@ -6,9 +6,8 @@ export const MediaScreen: ScreenPlugin = {
   __type: 'screen',
   name: 'Media',
   layout: 'fullscreen',
-  Icon: () => <>M</>,
-  Component(props: any) {
-    console.log('MediaManager', props)
-    return <MediaManager onChoose={() => alert('no')} />
+  Icon: () => null,
+  Component() {
+    return <MediaManager />
   },
 }

--- a/packages/tinacms/src/plugins/screens/media-screen.tsx
+++ b/packages/tinacms/src/plugins/screens/media-screen.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { ScreenPlugin } from '../screen-plugin'
+import { MediaManager } from '../../components/MediaManager'
+
+export const MediaScreen: ScreenPlugin = {
+  __type: 'screen',
+  name: 'Media',
+  layout: 'fullscreen',
+  Icon: () => <>M</>,
+  Component(props: any) {
+    console.log('MediaManager', props)
+    return <MediaManager onChoose={() => alert('no')} />
+  },
+}

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -72,6 +72,6 @@ export class SidebarState extends Subscribable {
 
   set isOpen(nextValue: boolean) {
     this._isOpen = nextValue
-    this.notifiySubscribers()
+    this.notifySubscribers()
   }
 }

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -32,6 +32,7 @@ import GroupListFieldPlugin from './plugins/fields/GroupListFieldPlugin'
 import BlocksFieldPlugin from './plugins/fields/BlocksFieldPlugin'
 import { Form } from '@tinacms/forms'
 import { MediaManager } from './media'
+import { MediaScreen } from './plugins/screens/media-screen'
 
 export class TinaCMS extends CMS {
   sidebar: SidebarState = new SidebarState()
@@ -50,6 +51,7 @@ export class TinaCMS extends CMS {
     this.fields.add(GroupFieldPlugin)
     this.fields.add(GroupListFieldPlugin)
     this.fields.add(BlocksFieldPlugin)
+    this.screens.add(MediaScreen)
   }
 
   get forms() {

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -31,9 +31,11 @@ import GroupFieldPlugin from './plugins/fields/GroupFieldPlugin'
 import GroupListFieldPlugin from './plugins/fields/GroupListFieldPlugin'
 import BlocksFieldPlugin from './plugins/fields/BlocksFieldPlugin'
 import { Form } from '@tinacms/forms'
+import { MediaManager } from './media'
 
 export class TinaCMS extends CMS {
   sidebar: SidebarState = new SidebarState()
+  media: MediaManager = new MediaManager()
 
   constructor(config: CMSConfig | null = null) {
     super(config)


### PR DESCRIPTION
### This PR is a reference for future work.

The work will be split up into multiple PRs rather then done all at once. 

- #733 Media Store with uploading only

### Shows Off

- Media Manager GUI
  - [ ] Looks Pretty
  - Selecting
    - [x] select individual images
    - [ ] select multiple images
  - Deleting images
    - [x] confirmation dialog
    - [x] deletes all selected images
  - Insert Images
    - [x] Allow selected image to be inserted 
  - Upload Images
    - [ ] File picker for images
    - [x] Drag image(s) onto media manager to upload them
- [x] Global Media Manager, implemented as a screen plugin
- [x] Media Dialog `cms.media.open({ ... })`
- Media Store
  - [ ] Dummy media store educates users
- Image Field Plugin
  - [x] File upload happens through `cms.media.store`
  - [x] Clicking opens the Media Dialog
- [ ] Git Media Store
- [ ] `gatsby-tinacms-git` should set the git media store on the cms
 
Things intentionally left out:

* Search
* Pagination
* Metadata management for individual files
* Media Input plugins (i.e. unsplash)

