### PR TITLE
fix: lerna warning on bootstrap

### DIFF
--- a/packages/react-tinacms-inline/package.json
+++ b/packages/react-tinacms-inline/package.json
@@ -24,7 +24,6 @@
   "devDependencies": {
     "@tinacms/icons": "^0.4.1",
     "@tinacms/styles": "^0.1.2",
-    "@types/jest": "^24.0.23",
     "tinacms": "^0.13.0"
   }
 }


### PR DESCRIPTION
### Before


```
lerna info versioning independent
lerna info Bootstrapping 26 packages
lerna WARN EHOIST_ROOT_VERSION The repository root depends on @types/jest@^24.0.25, which differs from the more common @types/jest@^24.0.23.
lerna WARN EHOIST_PKG_VERSION "react-tinacms-inline" package depends on @types/jest@^24.0.23, which differs from the hoisted @types/jest@^24.0.25.
```

### After

```
lerna info Bootstrapping 26 packages
lerna info Installing external dependencies
lerna info hoist Installing hoisted dependencies into root
lerna info hoist Pruning hoisted dependencies
lerna info hoist Finished pruning hoisted dependencies
````