### PR TITLE
fix(useForm): ensure form is created in useEffect

### DIFF
--- a/packages/@tinacms/react-core/src/use-form.ts
+++ b/packages/@tinacms/react-core/src/use-form.ts
@@ -50,15 +50,11 @@ export function useForm<FormShape = any>(
   watch: Partial<WatchableFormValue> = {}
 ): [FormShape, Form | undefined] {
   const [, setValues] = React.useState(options.initialValues)
-  const [form, setForm] = React.useState<Form>(() => {
-    return createForm(options, (form: any) => {
-      setValues(form.values)
-    })
-  })
+  const [form, setForm] = React.useState<Form>()
 
   React.useEffect(
     function() {
-      if (form.id === options.id) return
+      if (form && form.id === options.id) return
       setForm(
         createForm(options, (form: any) => {
           setValues(form.values)


### PR DESCRIPTION
Next.js appears to run useState hooks in SSR; client-only code should stay inside of useEffect.
With the addition of `loadInitialValues`, Form constructors are now sometimes running client-only code and thus forms should only be created inside of a `useEffect`