### PR TITLE
build: only lint once

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1
         with:
-          node-version: '10.x'           
-           
+          node-version: '10.x'
+
       - if: matrix.os == 'windows-latest'
         run: |
           npm install --global --production windows-build-tools@4.0.0
           npm install --global --production node-gyp
-          
+
       - name: Install
         run: |
           npm ci
@@ -31,4 +31,5 @@ jobs:
         run: npm run test
 
       - name: Lint
+        if: matrix.os == 'ubuntu-latest'
         run: npm run lint


### PR DESCRIPTION
fixes #751

## Purpose

Only execute `npm run lint` on ubuntu

## Background

The linting job currently runs 3 times. Once for Mac, Ubuntu, and Windows. This results in a 3x as many linting warnings as is necessary. This PR will reduce noise from our CI, and also make it run a tiny bit faster.
