### PR TITLE
fix(tinacms): if single form, FormView no longer renders form list

### DIFF
--- a/packages/tinacms/src/components/FormView.tsx
+++ b/packages/tinacms/src/components/FormView.tsx
@@ -47,17 +47,36 @@ export const FormsView = () => {
 
   /**
    * If there's only one form, make it the active form.
+   *
+   * TODO: There's an issue where the forms register one
+   * by one, so the 'active form' always gets set as if there
+   * were only one form, even when there are multiple
    */
-  useSubscribable(cms.forms, () => {
+
+  function setSingleActiveForm() {
     if (cms.forms.all().length === 1) {
       setActiveFormId(cms.forms.all()[0].id)
     }
+  }
+
+  /*
+   ** Subscribes the forms to the CMS,
+   ** passing a callback to set active form
+   */
+  useSubscribable(cms.forms, () => {
+    setSingleActiveForm()
   })
+
+  /*
+   ** Sets single active form on componentDidMount
+   */
+  React.useEffect(() => {
+    setSingleActiveForm()
+  }, [])
 
   const forms = cms.forms.all()
   const isMultiform = forms.length > 1
   const activeForm = activeFormId ? cms.forms.find(activeFormId) : null
-
   const isEditing = !!activeForm
 
   /**
@@ -67,7 +86,7 @@ export const FormsView = () => {
     return <NoFormsPlaceholder />
   }
 
-  if (!activeForm) {
+  if (isMultiform && !activeForm) {
     return (
       <FormsList
         isEditing={isEditing}
@@ -78,13 +97,17 @@ export const FormsView = () => {
   }
 
   return (
-    <FormWrapper isEditing={isEditing} isMultiform={isMultiform}>
-      <FormView
-        activeForm={activeForm}
-        setActiveFormId={setActiveFormId}
-        isMultiform={isMultiform}
-      />
-    </FormWrapper>
+    <>
+      {activeForm && (
+        <FormWrapper isEditing={isEditing} isMultiform={isMultiform}>
+          <FormView
+            activeForm={activeForm}
+            setActiveFormId={setActiveFormId}
+            isMultiform={isMultiform}
+          />
+        </FormWrapper>
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION
A crack at fixing #778. In a nutshell, the callback passed to `useSubscribable` was only being called after navigating to a new page, or some other update. So I added an initial `useEffect` to set the active form on first render. Also, the form list will only render when there are multiple forms, and if no active form is set, but there is a form on the cms, nothing will render until the active form is set. Did some testing in the `gatsby-demo` and it seems to work but feel free to poke holes.

We still have the multiple form issue - https://github.com/tinacms/tinacms/issues/438... and essentially the form almost always behaves as if there is only one on first go. 