### PR TITLE
@tincams/api-git warns about missing Repo

### DIFF
--- a/packages/@tinacms/api-git/src/router.ts
+++ b/packages/@tinacms/api-git/src/router.ts
@@ -49,6 +49,22 @@ export function router(repo: Repo, config: Partial<GitRouterConfig> = {}) {
     pushOnCommit,
   }: GitRouterConfig = { ...DEFAULT_OPTIONS, ...config }
 
+  if (!repo) {
+    /**
+     * Incase js users forget to pass in `repo`.
+     */
+    throw new Error(
+      '@tinacms/api-git#router(repo, config): Parameter `repo` is is missing.'
+    )
+  } else if (!(repo instanceof Repo)) {
+    /**
+     * Maintains backwards compatibility. Types are intentionally
+     * left out to discourage people from using it.
+     */
+    const repoConfig: any = repo
+    repo = new Repo(repoConfig.pathToRepo, repoConfig.pathToContent)
+  }
+
   const uploader = createUploader(repo.tmpDir)
 
   const router = express.Router()

--- a/packages/@tinacms/api-git/src/router.ts
+++ b/packages/@tinacms/api-git/src/router.ts
@@ -54,7 +54,7 @@ export function router(repo: Repo, config: Partial<GitRouterConfig> = {}) {
      * Incase js users forget to pass in `repo`.
      */
     throw new Error(
-      '@tinacms/api-git#router(repo, config): Parameter `repo` is is missing.'
+      '@tinacms/api-git#router(repo, config): Parameter `repo` is missing.'
     )
   } else if (!(repo instanceof Repo)) {
     /**


### PR DESCRIPTION
There was an API change in `@tinacms/api-git#router`. It was accounted for in the gatsby plugin but not for Next. This adds a warning about that and updates the `demo-next`. 