### PR TITLE
fix spelling in case of no items

### DIFF
--- a/packages/demo-gatsby/data/author.json
+++ b/packages/demo-gatsby/data/author.json
@@ -1,6 +1,6 @@
 {
-  "firstName": "Ziv",
-  "lastName": "Kalderon",
+  "firstName": "Nolan",
+  "lastName": "Phillips",
   "location": "Charlottetown",
   "social": {
     "twitter": "ncphi"

--- a/packages/demo-gatsby/data/author.json
+++ b/packages/demo-gatsby/data/author.json
@@ -1,6 +1,6 @@
 {
-  "firstName": "Nolan",
-  "lastName": "Phillips",
+  "firstName": "Ziv",
+  "lastName": "Kalderon",
   "location": "Charlottetown",
   "social": {
     "twitter": "ncphi"

--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -183,7 +183,7 @@ const Blocks = function({ tinaForm, form, field, input }: BlockFieldProps) {
   )
 }
 
-const EmptyState = () => <EmptyList>There's no items</EmptyList>
+const EmptyState = () => <EmptyList>There are no items</EmptyList>
 
 interface BlockListItemProps {
   tinaForm: Form

--- a/packages/tinacms/src/plugins/fields/GroupListFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/GroupListFieldPlugin.tsx
@@ -120,7 +120,7 @@ const Group = function Group({ tinaForm, form, field, input }: GroupProps) {
   )
 }
 
-const EmptyState = () => <EmptyList>There's no items</EmptyList>
+const EmptyState = () => <EmptyList>There are no items</EmptyList>
 
 interface ItemProps {
   tinaForm: Form


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
Fix #756 
Changed spelling from  "There's no items" to  "There are no items