### PR TITLE
chore: avoid double-sourcing content in gats demo

### DIFF
--- a/packages/demo-gatsby/gatsby-config.js
+++ b/packages/demo-gatsby/gatsby-config.js
@@ -69,6 +69,7 @@ module.exports = {
       options: {
         path: `${__dirname}/content`,
         name: `content`,
+        ignore: ["*/*"],
       },
     },
     {


### PR DESCRIPTION
This is likely causing some weird bugs in the gatsby demo, I suspect it is the cause of #783 