### PR TITLE
feat: useScreenPlugin

### DIFF
--- a/packages/demo-next/pages/index.js
+++ b/packages/demo-next/pages/index.js
@@ -17,11 +17,32 @@ limitations under the License.
 */
 
 import { inlineJsonForm } from 'next-tinacms-json'
+import { useScreenPlugin } from 'tinacms'
 
 import Layout from '../components/Layout'
 import BlogList from '../components/BlogList'
 
+function Component({ title }) {
+  return <h1>{title}</h1>
+}
+
+function useGasPlugin(props, deps) {
+  useScreenPlugin(
+    {
+      name: 'Some Heading',
+      Icon: () => '',
+      Component,
+      props,
+    },
+    deps
+  )
+}
+
 function Index(props) {
+  const title = 'Example Screen'
+
+  useGasPlugin({ title }, [title])
+
   return (
     <Layout
       pathname="/"

--- a/packages/tinacms/src/plugins/screen-plugin.tsx
+++ b/packages/tinacms/src/plugins/screen-plugin.tsx
@@ -17,10 +17,34 @@ limitations under the License.
 */
 
 import { Plugin } from '@tinacms/core'
+import React from 'react'
 
 export interface ScreenPlugin extends Plugin {
   __type: 'screen'
   Component: any
   Icon: any
   layout: 'fullscreen' | 'popup'
+}
+
+export interface ScreenOptions<T = {}> {
+  name: string
+  Component: React.FC<T>
+  Icon: any
+  layout?: ScreenPlugin['layout']
+  props?: T
+}
+
+export function createScreen({
+  Component,
+  props,
+  ...options
+}: ScreenOptions): ScreenPlugin {
+  return {
+    __type: 'screen',
+    layout: 'popup',
+    ...options,
+    Component(screenProps: any) {
+      return <Component {...screenProps} {...props} />
+    },
+  }
 }

--- a/packages/tinacms/src/react-tinacms/use-screen-plugin.tsx
+++ b/packages/tinacms/src/react-tinacms/use-screen-plugin.tsx
@@ -15,15 +15,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+import type { DependencyList } from "react"
+import { usePlugins } from '@tinacms/react-core'
+import { useMemo } from 'react'
+import { createScreen, ScreenOptions } from "../plugins/screen-plugin"
 
-export * from './use-cms'
-export * from './use-form'
-export * from './use-plugin'
-export * from './use-screen-plugin'
-export * from './use-subscribable'
-export * from './use-watch-form-values'
-export * from './with-plugin'
-export * from './with-tina'
+export function useScreenPlugin(options: ScreenOptions, deps?: DependencyList ) {
+  const memo = useMemo(() => {
+    return createScreen(options)
+  }, deps)
 
-export { Plugin } from '@tinacms/core'
-export { Form, FormOptions, Field } from '@tinacms/forms'
+  usePlugins(memo)
+}


### PR DESCRIPTION
Creating reusable screens is a bit benedict cumbersome at the moment. This PR aims to address this by introducing two new functions:

* `createScreen` a function for creating screen plugin objects, and
* `useScreenPlugin` a function that calls memos a call to `createScreen` and registers the plugin.