### PR TITLE
fix(useJsonForm): update writeToDisk when file is changed

### DIFF
--- a/packages/next-tinacms-json/src/use-json-form.ts
+++ b/packages/next-tinacms-json/src/use-json-form.ts
@@ -80,12 +80,15 @@ export function useJsonForm<T = any>(
     { values: jsonFile.data, label }
   )
 
-  const writeToDisk = useCallback(formState => {
-    cms.api.git.writeToDisk({
-      fileRelativePath: jsonFile.fileRelativePath,
-      content: JSON.stringify(formState.values, null, 2),
-    })
-  }, [])
+  const writeToDisk = useCallback(
+    formState => {
+      cms.api.git.writeToDisk({
+        fileRelativePath: jsonFile.fileRelativePath,
+        content: JSON.stringify(formState.values, null, 2),
+      })
+    },
+    [jsonFile.fileRelativePath]
+  )
 
   useWatchFormValues(form, writeToDisk)
 


### PR DESCRIPTION
Similar to #790

Risk of writing to wrong file becuase writeToDisk would not update
if the fileRelativePath was changed, thus always writing to the first
file that was encountered.
