### PR TITLE
fix(repo): issue missing ssh_key warning in setup

### DIFF
--- a/packages/@tinacms/api-git/src/configure.ts
+++ b/packages/@tinacms/api-git/src/configure.ts
@@ -48,6 +48,13 @@ export async function configureGitRemote(
 ) {
   if (sshKey) {
     createSSHKey(repo, sshKey)
+  } else {
+    console.warn(
+      'No SSH key set. You may be unable to make commits using TinaCMS. ' +
+        'The TinaCMS git server requires an SSH key to work in cloud ' +
+        'editing environments. Please visit the documentation to learn ' +
+        'more: https://tinacms.org/docs/gatsby/configure-git-plugin'
+    )
   }
   if (gitRemote) {
     await repo.updateOrigin(gitRemote)

--- a/packages/@tinacms/api-git/src/repo.ts
+++ b/packages/@tinacms/api-git/src/repo.ts
@@ -177,7 +177,10 @@ export class Repo {
         '-F /dev/null',
       ]
     } catch {
-      console.warn('No SSH key set.')
+      /**
+       * Throws if SSH does not exist.
+       * Not that there's anything wrong with that.
+       */
     }
 
     /**


### PR DESCRIPTION
This was happening when opening repo. It was
only for the sake of cloud editing environments.
Now, we will issue that warning in the repo configuration phase.
