### PR TITLE
feat(rollup) Add ts plugin for better style components experience

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36170,6 +36170,12 @@
       "integrity": "sha512-EgOVgL/4xfVrCMbhYKUQTdF37SQn4Iw73H5BgCrF1Abdun7Kwy/QZsE/ssAy0y4LxBbvua3PIbFsbRczWWnDdQ==",
       "dev": true
     },
+    "typescript-plugin-styled-components": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.4.4.tgz",
+      "integrity": "sha512-w5S5lSpzRFM+61KNNpGtlF46DuTJTyzfWM4g6ic9m189ILEoU3sgoTNHNS2MxQhXsGtQZwAlINKG+Dwy0euwUg==",
+      "dev": true
+    },
     "typography": {
       "version": "0.16.19",
       "resolved": "https://registry.npmjs.org/typography/-/typography-0.16.19.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "tsdx": "^0.11.0",
     "tslib": "^1.10.0",
     "typedoc": "^0.16.2",
-    "typescript": "^3.8.2"
+    "typescript": "^3.8.2",
+    "typescript-plugin-styled-components": "^1.4.4"
   },
   "dependencies": {
     "danger": "^9.2.0",

--- a/packages/@tinacms/scripts/bin/scripts.js
+++ b/packages/@tinacms/scripts/bin/scripts.js
@@ -24,6 +24,8 @@ const rollupReplace = require('rollup-plugin-replace')
 const rollupCommonJs = require('rollup-plugin-commonjs')
 const typescript = require('typescript')
 const { uglify } = require('rollup-plugin-uglify')
+const createStyledComponentsTransformer = require('typescript-plugin-styled-components')
+  .default
 
 // Source https://github.com/facebook/create-react-app/blob/master/packages/react-scripts/bin/react-scripts.js#L11-L16
 // Makes the script crash on unhandled rejections instead of silently
@@ -95,6 +97,11 @@ function createBuildOptions(options = {}) {
         include: [
           path.join(absolutePath, 'src', '*.ts+(|x)'),
           path.join(absolutePath, 'src', '**/*.ts+(|x)'),
+        ],
+        transformers: [
+          () => ({
+            before: [createStyledComponentsTransformer()],
+          }),
         ],
       }),
       rollupReplace({


### PR DESCRIPTION
Original PR by @maciekgrzybek 

- install and add typescript-plugin-styled-components to the rollup config
- plugins creates better developer experience by adding meaningful class names
