### PR TITLE
fix: this was still pointing to the old website repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
 contact_links:
   - name: Website Issues
-    url: https://github.com/tinacms/tinacms-site/issues/new
-    about: If you're reporting on our website, blog, or documentation please visit the tinacms-site repository.
+    url: https://github.com/tinacms/tinacms.org/issues/new
+    about: If you're reporting on our website, blog, or documentation please visit the tinacms.org repository.


### PR DESCRIPTION
This was still pointing to the old website repository. This makes it point to the correct one