### PR TITLE
fix: link to site repository in DangerJS

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -166,7 +166,7 @@ ${changes
 const fileLink = (file: string) => {
   const filename = file.split('/').pop()
 
-  return `[${filename}](https://github.com/tinacms/tinacms-site/tree/master/${file})`
+  return `[${filename}](https://github.com/tinacms/tinacms.org/tree/master/${file})`
 }
 
 /**


### PR DESCRIPTION
The file link was still pointing to the former repository.