### PR TITLE
TinaCMS constructor config is now optional

### DIFF
--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -107,14 +107,14 @@ export class CMS {
   /**
    * @hidden
    */
-  constructor(config: CMSConfig | null = null) {
+  constructor(config: CMSConfig = {}) {
     this.plugins = new PluginTypeManager()
 
-    if (config && config.plugins) {
+    if (config.plugins) {
       config.plugins.forEach(plugin => this.plugins.add(plugin))
     }
 
-    if (config && config.apis) {
+    if (config.apis) {
       Object.entries(config.apis).forEach(([name, api]) =>
         this.registerApi(name, api)
       )

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -48,7 +48,7 @@ export class TinaCMS extends CMS {
   media = new MediaManager(new DummyMediaStore())
   alerts = new Alerts()
 
-  constructor({ sidebar, ...config }: TinaCMSConfig) {
+  constructor({ sidebar, ...config }: TinaCMSConfig = {}) {
     super(config)
 
     this.sidebar = new SidebarState(sidebar)


### PR DESCRIPTION
Before this was required

    new TinaCMS({})

Now we can just do this

    new TinaCMS()