### PR TITLE
fix: renamed Tina to TinaProvider

### DIFF
--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -28,14 +28,14 @@ import { Alerts } from './Alerts'
 
 const merge = require('lodash.merge')
 
-export interface TinaProps {
+export interface TinaProviderProps {
   cms: TinaCMS
   hidden?: boolean
   theme?: Theme
   position?: SidebarPosition
 }
 
-export const Tina: React.FC<TinaProps> = ({
+export const TinaProvider: React.FC<TinaProviderProps> = ({
   cms,
   children,
   hidden,
@@ -77,6 +77,11 @@ export const Tina: React.FC<TinaProps> = ({
     </CMSContext.Provider>
   )
 }
+
+/**
+ * @deprecated This has been renamed to `TinaProvider`.
+ */
+export const Tina = TinaProvider
 
 const SiteWrapper = styled.div<{ open: boolean; position: SidebarPosition }>`
   opacity: 1 !important;

--- a/packages/tinacms/src/components/Tina.tsx
+++ b/packages/tinacms/src/components/Tina.tsx
@@ -83,6 +83,11 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
  */
 export const Tina = TinaProvider
 
+/**
+ * @deprecated This has been renamed to `TinaProviderProps`.
+ */
+export type TinaProps = TinaProviderProps
+
 const SiteWrapper = styled.div<{ open: boolean; position: SidebarPosition }>`
   opacity: 1 !important;
   background-color: transparent !important;

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -30,7 +30,13 @@ export { TinaCMS as CMS } from './tina-cms'
 /**
  * Tina Sidebar
  */
-export { Tina, TinaProviderProps as TinaProps } from './components/Tina'
+export {
+  TinaProvider,
+  TinaProviderProps,
+  // Deprecated aliases to the previous exports
+  Tina,
+  TinaProps,
+} from './components/Tina'
 export { useSidebar } from './components/sidebar/SidebarProvider'
 
 /**

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -30,7 +30,7 @@ export { TinaCMS as CMS } from './tina-cms'
 /**
  * Tina Sidebar
  */
-export { Tina, TinaProps } from './components/Tina'
+export { Tina, TinaProviderProps as TinaProps } from './components/Tina'
 export { useSidebar } from './components/sidebar/SidebarProvider'
 
 /**


### PR DESCRIPTION
The new name the purpose of the component.

The old name is still accessible, but it has been deprecated

```tsx
import { TinaCMS, TinaProvider } from "tinacms"

const cms = new TinaCMS()

function App () {
  return <TinaProvider cms={cms}> ... </TinaProvider>
}
```