### PR TITLE
fix: tinacms constructor accepts media.store

### DIFF
--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -41,15 +41,21 @@ export declare type SidebarPosition = 'fixed' | 'float' | 'displace' | 'overlay'
 
 export interface TinaCMSConfig extends CMSConfig {
   sidebar?: SidebarStateOptions
+  media?: {
+    store: MediaStore
+  }
 }
 
 export class TinaCMS extends CMS {
   sidebar: SidebarState
-  media = new MediaManager(new DummyMediaStore())
+  media: MediaManager
   alerts = new Alerts()
 
-  constructor({ sidebar, ...config }: TinaCMSConfig = {}) {
+  constructor({ sidebar, media, ...config }: TinaCMSConfig = {}) {
     super(config)
+
+    const mediaStore = media?.store || new DummyMediaStore()
+    this.media = new MediaManager(mediaStore)
 
     this.sidebar = new SidebarState(sidebar)
     this.fields.add(TextFieldPlugin)


### PR DESCRIPTION
I noticed @kendallstrautman had to stop using `withTina` because a media store needed to be added to the `demo-next`. This PR removes that need.