### PR TITLE
Wysiwyg passthrough

### DIFF
--- a/packages/react-tinacms-editor/src/Wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/Wysiwyg.tsx
@@ -26,7 +26,7 @@ import { ProseMirrorCss } from './ProseMirrorCss'
 import { Format } from './Translator'
 import Menu from './state/plugins/Menu'
 
-interface Wysiwyg {
+export interface WysiwygProps {
   input: any
   plugins?: Plugin[]
   sticky?: boolean
@@ -44,7 +44,7 @@ export const Wysiwyg = styled(
     upload,
     previewUrl,
     ...styleProps
-  }: any) => {
+  }: WysiwygProps) => {
     const { elRef: prosemirrorEl, editorView, translator } = useProsemirror(
       input,
       ALL_PLUGINS,
@@ -67,7 +67,7 @@ export const Wysiwyg = styled(
             imageUpload={upload}
           />
         )}
-        <div {...styleProps} ref={prosemirrorEl} />
+        <div {...styleProps} ref={prosemirrorEl as any} />
       </WysiwygWrapper>
     )
   }

--- a/packages/react-tinacms-inline/src/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-inline/src/inline-wysiwyg.tsx
@@ -18,26 +18,23 @@ limitations under the License.
 
 import * as React from 'react'
 import { InlineField } from './inline-field'
-import { Wysiwyg } from 'react-tinacms-editor'
+import { Wysiwyg, WysiwygProps } from 'react-tinacms-editor'
 
-interface InlineWysiwygFieldProps {
+interface InlineWysiwygFieldProps extends Omit<WysiwygProps, 'input'> {
   name: string
-  sticky?: string
   children: any
-  format?: 'markdown' | 'html'
 }
 
 export function InlineWysiwyg({
   name,
-  sticky,
   children,
-  format,
+  ...wysiwygProps
 }: InlineWysiwygFieldProps) {
   return (
     <InlineField name={name}>
       {({ input, status }: any) => {
         if (status === 'active') {
-          return <Wysiwyg sticky={sticky} format={format} input={input} />
+          return <Wysiwyg input={input} {...wysiwygProps} />
         }
         return <>{children}</>
       }}


### PR DESCRIPTION
Refactor `InlineWysiwyg` to accepts all props–except `input`–acceptable by `Wysiwyg`  