### PR TITLE
chore(react-tinacms-inline): adjust add block logic for single block

### DIFF
--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -32,7 +32,12 @@ export function AddBlockMenu({ templates, addBlock }: AddBlockMenuProps) {
 
   const handleOpenBlockMenu = (event: React.MouseEvent) => {
     event.stopPropagation()
-    setIsOpen(isOpen => !isOpen)
+    templates.length == 1
+      ? addBlock({
+          _template: templates[0].type,
+          ...templates[0].defaultItem,
+        })
+      : setIsOpen(isOpen => !isOpen)
   }
 
   React.useEffect(() => {


### PR DESCRIPTION
With this PR, if there's only one block, clicking the 'Add Block' button will automatically add the block and the entire `AddBlockMenu` won't open. Wanted to add this to semi-mimic group-list behavior until we make that field, mostly for tinacms.org.
