### PR TITLE
Add description to block, group & group list

### DIFF
--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -32,6 +32,12 @@ import { GroupPanel, PanelHeader, PanelBody } from './GroupFieldPlugin'
 import { Dismissible } from 'react-dismissible'
 import { IconButton } from '@tinacms/styles'
 import { useFormPortal } from '@tinacms/react-forms'
+import { FieldDescription } from './wrapFieldWithMeta'
+import {
+  GroupListHeader,
+  GroupListMeta,
+  GroupLabel,
+} from './GroupListFieldPlugin'
 
 export interface BlocksFieldDefinititon extends Field {
   component: 'blocks'
@@ -78,7 +84,7 @@ interface BlockFieldProps {
   tinaForm: Form
 }
 
-const Blocks = function({ tinaForm, form, field, input }: BlockFieldProps) {
+const Blocks = ({ tinaForm, form, field, input }: BlockFieldProps) => {
   const addItem = React.useCallback(
     (name: string, template: BlockTemplate) => {
       let obj: any = {}
@@ -99,7 +105,15 @@ const Blocks = function({ tinaForm, form, field, input }: BlockFieldProps) {
   return (
     <>
       <GroupListHeader>
-        <GroupLabel>{field.label || field.name}</GroupLabel>
+        <GroupListMeta>
+          <GroupLabel>{field.label || field.name}</GroupLabel>
+          {field.description && (
+            <FieldDescription>{field.description}</FieldDescription>
+          )}
+        </GroupListMeta>
+        {field.description && (
+          <FieldDescription>{field.description}</FieldDescription>
+        )}
         <IconButton
           onClick={() => setVisible(true)}
           open={visible}
@@ -358,37 +372,6 @@ const ItemClickTarget = styled.div`
   justify-content: space-between;
   align-items: center;
   padding: 8px;
-`
-
-const GroupLabel = styled.span<{ error?: boolean }>`
-  margin: 0;
-  font-size: var(--tina-font-size-2);
-  font-weight: 500;
-  flex: 1 1 auto;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  color: inherit;
-  transition: all 85ms ease-out;
-  text-align: left;
-
-  ${props =>
-    props.error &&
-    css`
-      color: var(--tina-color-error) !important;
-    `};
-`
-
-const GroupListHeader = styled.div`
-  display: flex;
-  width: 100%;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
-  position: relative;
-  ${GroupLabel} {
-    font-size: var(--tina-font-size-3);
-  }
 `
 
 const GroupListPanel = styled.div`

--- a/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/BlocksFieldPlugin.tsx
@@ -111,9 +111,6 @@ const Blocks = ({ tinaForm, form, field, input }: BlockFieldProps) => {
             <FieldDescription>{field.description}</FieldDescription>
           )}
         </GroupListMeta>
-        {field.description && (
-          <FieldDescription>{field.description}</FieldDescription>
-        )}
         <IconButton
           onClick={() => setVisible(true)}
           open={visible}

--- a/packages/tinacms/src/plugins/fields/GroupFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/GroupFieldPlugin.tsx
@@ -22,6 +22,7 @@ import styled, { keyframes, css, StyledComponent } from 'styled-components'
 import { FieldsBuilder } from '@tinacms/form-builder'
 import { LeftArrowIcon, RightArrowIcon } from '@tinacms/icons'
 import { useFormPortal } from '@tinacms/react-forms'
+import { wrapFieldsWithMeta } from './wrapFieldWithMeta'
 
 export interface GroupFieldDefinititon extends Field {
   component: 'group'
@@ -36,7 +37,7 @@ export interface GroupProps {
   tinaForm: Form
 }
 
-export const Group = function Group({ tinaForm, field }: GroupProps) {
+export const Group = wrapFieldsWithMeta(({ tinaForm, field }: GroupProps) => {
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
   return (
     <>
@@ -52,7 +53,7 @@ export const Group = function Group({ tinaForm, field }: GroupProps) {
       />
     </>
   )
-}
+})
 
 interface PanelProps {
   setExpanded(next: boolean): void

--- a/packages/tinacms/src/plugins/fields/GroupListFieldPlugin.tsx
+++ b/packages/tinacms/src/plugins/fields/GroupListFieldPlugin.tsx
@@ -31,6 +31,7 @@ import {
 } from '@tinacms/icons'
 import { GroupPanel, PanelHeader, PanelBody } from './GroupFieldPlugin'
 import { useFormPortal } from '@tinacms/react-forms'
+import { FieldDescription } from './wrapFieldWithMeta'
 
 interface GroupFieldDefinititon extends Field {
   component: 'group'
@@ -68,7 +69,7 @@ interface GroupProps {
   tinaForm: Form
 }
 
-const Group = function Group({ tinaForm, form, field, input }: GroupProps) {
+const Group = ({ tinaForm, form, field, input }: GroupProps) => {
   const addItem = React.useCallback(() => {
     let obj = {}
     if (typeof field.defaultItem === 'function') {
@@ -91,7 +92,12 @@ const Group = function Group({ tinaForm, form, field, input }: GroupProps) {
   return (
     <>
       <GroupListHeader>
-        <GroupLabel>{field.label || field.name}</GroupLabel>
+        <GroupListMeta>
+          <GroupLabel>{field.label || field.name}</GroupLabel>
+          {field.description && (
+            <FieldDescription>{field.description}</FieldDescription>
+          )}
+        </GroupListMeta>
         <IconButton onClick={addItem} primary small>
           <AddIcon />
         </IconButton>
@@ -189,28 +195,42 @@ const ItemClickTarget = styled.div`
   padding: 8px;
 `
 
-const GroupLabel = styled.span`
+export const GroupLabel = styled.span<{ error?: boolean }>`
   margin: 0;
-  font-size: var(--tina-font-size-2);
-  font-weight: 500;
+  font-size: var(--tina-font-size-1);
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.35;
   flex: 1 1 auto;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: inherit;
+  color: var(--tina-color-grey-8);
   transition: all 85ms ease-out;
   text-align: left;
+
+  ${props =>
+    props.error &&
+    css`
+      color: var(--tina-color-error) !important;
+    `};
 `
 
-const GroupListHeader = styled.div`
+export const GroupListHeader = styled.div`
   display: flex;
   width: 100%;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 12px;
-  ${GroupLabel} {
-    font-size: var(--tina-font-size-3);
+  margin-bottom: 8px;
+  ${FieldDescription} {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
+`
+
+export const GroupListMeta = styled.div`
+  line-height: 1;
 `
 
 const GroupListPanel = styled.div`
@@ -251,7 +271,7 @@ const ItemHeader = styled.div<{ isDragging: boolean }>`
   font-weight: 500;
 
   ${GroupLabel} {
-    color: #282828;
+    color: var(--tina-color-grey-8);
     align-self: center;
     max-width: 100%;
   }

--- a/packages/tinacms/src/plugins/fields/wrapFieldWithMeta.tsx
+++ b/packages/tinacms/src/plugins/fields/wrapFieldWithMeta.tsx
@@ -83,7 +83,7 @@ const FieldLabel = styled.label`
   overflow: hidden;
 `
 
-const FieldDescription = styled.p`
+export const FieldDescription = styled.p`
   color: var(--tina-color-grey-6);
   font-size: var(--tina-font-size-0);
   font-style: italic;


### PR DESCRIPTION
Blocks, groups, and group lists weren't being wrapped with `wrapFieldsWithMeta`. For the group field I simply added this wrapper, but blocks and group lists handle their own labelling so I've added the ability for them to accept a description for now. 

Now all three of these fields will accept a description, and some styling inconsistencies have been fixed.

Closes #910