### PR TITLE
style: set transition property to width

### DIFF
--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -92,7 +92,7 @@ const SiteWrapper = styled.div<{ open: boolean; position: SidebarPosition }>`
     isFixed(props.position) && props.open
       ? 'calc(100% - ' + SIDEBAR_WIDTH + 'px)'
       : '100%'} !important;
-  transition: all ${props => (props.open ? 150 : 200)}ms ease-out !important;
+  transition: width ${props => (props.open ? 150 : 200)}ms ease-out !important;
 `
 
 function isFixed(position: SidebarPosition): boolean {


### PR DESCRIPTION
This sets the `SiteWrapper` component to only animate `width` instead of `all`. 

Closes #944