### PR TITLE
fix: duplicate exports

### DIFF
--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -59,14 +59,6 @@ export * from '@tinacms/fields'
 // Inline Editing Components
 export * from '@tinacms/form-builder'
 
-// Field/Input Component
-export {
-  Toggle,
-  Select,
-  NumberInput,
-  Input,
-  wrapFieldsWithMeta,
-} from '@tinacms/fields'
 export { Wysiwyg } from 'react-tinacms-editor'
 
 // Modal Components


### PR DESCRIPTION
This was causing an error:

```
There was an error compiling the html.js component for the development server.
See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html TypeError: Cannot redefine property: Input
> 1 | !function(n,t){"object"==typeof exports&&"undefined"!=typeof module?t(exports,require("@ti
```