### PR TITLE
chore: make close prop optional

### DIFF
--- a/packages/@tinacms/react-modals/src/ModalProvider.tsx
+++ b/packages/@tinacms/react-modals/src/ModalProvider.tsx
@@ -127,7 +127,7 @@ const CloseButton = styled.div`
 
 export interface ModalHeaderProps {
   children: ReactNode
-  close(): void
+  close?(): void
 }
 
 export const ModalHeader = styled(
@@ -135,9 +135,11 @@ export const ModalHeader = styled(
     return (
       <div {...styleProps}>
         <ModalTitle>{children}</ModalTitle>
-        <CloseButton onClick={close}>
-          <CloseIcon />
-        </CloseButton>
+        {close && (
+          <CloseButton onClick={close}>
+            <CloseIcon />
+          </CloseButton>
+        )}
       </div>
     )
   }


### PR DESCRIPTION
You no longer need to provide a 'close' function to the `ModalHeader` component.

closes #950