### PR TITLE
style: add z-index custom properties

### DIFF
--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -103,7 +103,7 @@ export const Popover = styled.div`
   transform: translate3d(-50%, 5px, 0) scale3d(1, 1, 1);
   transform-origin: 50% -8px;
   animation: ${ColorPopupKeyframes} 85ms ease-out both 1;
-  z-index: 99999 !important;
+  z-index: var(--tina-z-index-2);
   &:before {
     content: '';
     position: absolute;
@@ -115,7 +115,7 @@ export const Popover = styled.div`
     height: 13px;
     clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
     background-color: white;
-    z-index: 100;
+    z-index: var(--tina-z-index-1);
   }
 `
 
@@ -127,7 +127,7 @@ export const Cover = styled.div`
   left: 0;
   width: 100%;
   height: 100vh;
-  z-index: 800;
+  z-index: var(--tina-z-index-1);
 `
 
 interface Props {

--- a/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
@@ -325,7 +325,7 @@ const BlockMenu = styled.div<{ open: boolean }>`
   box-shadow: var(--tina-shadow-big);
   background-color: white;
   overflow: hidden;
-  z-index: 950;
+  z-index: var(--tina-z-index-1);
   ${props =>
     props.open &&
     css`

--- a/packages/@tinacms/fields/src/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupFieldPlugin.tsx
@@ -188,7 +188,7 @@ export const GroupPanel = styled.div<{ isExpanded: boolean }>`
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
-  z-index: 950;
+  z-index: var(--tina-z-index-1);
   pointer-events: ${p => (p.isExpanded ? 'all' : 'none')};
 
   > * {

--- a/packages/@tinacms/react-forms/src/FormActions.tsx
+++ b/packages/@tinacms/react-forms/src/FormActions.tsx
@@ -95,7 +95,7 @@ const ActionsOverlay = styled.div<{ open: boolean }>`
   box-shadow: var(--tina-shadow-big);
   background-color: white;
   overflow: hidden;
-  z-index: 950;
+  z-index: var(--tina-z-index-1);
   ${props =>
     props.open &&
     css`

--- a/packages/@tinacms/react-modals/src/ModalFullscreen.tsx
+++ b/packages/@tinacms/react-modals/src/ModalFullscreen.tsx
@@ -34,7 +34,7 @@ const ModalFullscreenKeyframes = keyframes`
 export const ModalFullscreen = styled.div`
   display: flex;
   flex-direction: column;
-  z-index: 1;
+  z-index: var(--tina-z-index-0);
   overflow: visible;
   background-color: #fff;
   border-radius: 0;

--- a/packages/@tinacms/react-modals/src/ModalPopup.tsx
+++ b/packages/@tinacms/react-modals/src/ModalPopup.tsx
@@ -32,7 +32,7 @@ const ModalPopupKeyframes = keyframes`
 
 export const ModalPopup: StyledComponent<'div', {}, {}> = styled.div`
   display: block;
-  z-index: 1;
+  z-index: var(--tina-z-index-0);
   overflow: visible; /* Keep this as "visible", select component needs to overflow */
   background-color: var(--tina-color-grey-1);
   border-radius: var(--tina-radius-small);

--- a/packages/@tinacms/react-modals/src/ModalProvider.tsx
+++ b/packages/@tinacms/react-modals/src/ModalProvider.tsx
@@ -22,7 +22,6 @@ import { createPortal } from 'react-dom'
 import styled, { StyledComponent } from 'styled-components'
 import { CloseIcon } from '@tinacms/icons'
 import { Button, TinaReset } from '@tinacms/styles'
-export const Z_INDEX = 2147000000
 
 interface Props {
   children: any
@@ -100,7 +99,7 @@ export const ModalOverlay = styled.div`
   background: rgba(0, 0, 0, 0.5);
   overflow: auto;
   padding: 0;
-  z-index: ${Z_INDEX + 100};
+  z-index: var(--tina-z-index-3);
 `
 
 const ModalTitle = styled.h2`

--- a/packages/@tinacms/styles/src/Styles.tsx
+++ b/packages/@tinacms/styles/src/Styles.tsx
@@ -72,6 +72,12 @@ const theme = css`
     --tina-timing-short: 85ms;
     --tina-timing-medium: 150ms;
     --tina-timing-long: 250ms;
+
+    --tina-z-index-0: 500;
+    --tina-z-index-1: 1000;
+    --tina-z-index-2: 1500;
+    --tina-z-index-3: 2000;
+    --tina-z-index-4: 2500;
   }
 `
 

--- a/packages/react-tinacms-blocks/src/inline-blocks.tsx
+++ b/packages/react-tinacms-blocks/src/inline-blocks.tsx
@@ -295,7 +295,7 @@ const BlocksMenu = styled.div<BlocksUIProps>`
   box-shadow: var(--tina-shadow-big);
   background-color: white;
   overflow: hidden;
-  z-index: 950;
+  z-index: var(--tina-z-index-1);
   ${props =>
     props.open &&
     css`
@@ -392,7 +392,6 @@ const BlocksActions = styled(
 )`
   display: flex;
   position: absolute;
-  // z-index: 1000;
   top: -24px;
   right: -20px;
   transform: translate3d(0, calc(-100% + 16px), 0);
@@ -458,7 +457,7 @@ const BlockFocusOutline = styled.div<BlocksUIProps>`
     border-radius: var(--tina-radius-big);
     opacity: 0;
     pointer-events: none;
-    z-index: 1000;
+    z-index: var(--tina-z-index-1);
     transition: all 150ms ease-out;
     transition-delay: 300ms;
   }
@@ -475,7 +474,7 @@ const BlockFocusOutline = styled.div<BlocksUIProps>`
     width: auto;
     pointer-events: none;
     opacity: 0;
-    z-index: 1500;
+    z-index: var(--tina-z-index-2);
     transition: all 150ms ease-out;
     transition-delay: 300ms;
     margin: 0;

--- a/packages/react-tinacms-editor/src/state/plugins/Menu/FloatingTableMenu/AddRowMenu.tsx
+++ b/packages/react-tinacms-editor/src/state/plugins/Menu/FloatingTableMenu/AddRowMenu.tsx
@@ -117,7 +117,7 @@ const ColumnDivider = styled.div<
   position: absolute;
   background: #0574e4;
   left: ${-1 * borderWidth}px;
-  z-index: 1000;
+  z-index: var(--tina-z-index-1);
   bottom: ${-1 * borderWidth}px;
   height: ${2 * borderWidth}px;
   width: ${({ width }) => `${width + controlSize - borderWidth}px`};

--- a/packages/react-tinacms-editor/src/state/plugins/Menu/MenuComponents.tsx
+++ b/packages/react-tinacms-editor/src/state/plugins/Menu/MenuComponents.tsx
@@ -44,7 +44,7 @@ type MenuWrapperProps = {
 export const MenuWrapper = styled.div<MenuWrapperProps>`
   position: relative;
   margin-bottom: 14px;
-  z-index: 900;
+  z-index: var(--tina-z-index-1);
 
   ${props =>
     props.menuFixed &&
@@ -69,7 +69,7 @@ export const MenuContainer = styled.div`
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.12);
   border: 1px solid var(--tina-color-grey-2);
   overflow: hidden;
-  z-index: 100;
+  z-index: var(--tina-z-index-0);
 `
 
 const MenuItem = css`

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -187,7 +187,6 @@ export interface BlockWrapperProps {
 
 const BlockWrapper = styled.div<BlockWrapperProps>`
   position: relative;
-  /* z-index: 100; */
 
   &:hover {
     &:after {
@@ -207,7 +206,6 @@ const BlockWrapper = styled.div<BlockWrapperProps>`
     border-radius: var(--tina-radius-big);
     opacity: 0;
     pointer-events: none;
-    /* z-index: 1000; */
     transition: all var(--tina-timing-medium) ease-out;
   }
 

--- a/packages/react-tinacms-inline/src/styles/input-focus-wrapper.tsx
+++ b/packages/react-tinacms-inline/src/styles/input-focus-wrapper.tsx
@@ -45,7 +45,6 @@ export const InputFocusWrapper = styled.div`
     border-radius: var(--tina-radius-big);
     opacity: 0;
     pointer-events: none;
-    /* z-index: 1000; */
     transition: all var(--tina-timing-medium) ease-out;
   }
 `

--- a/packages/tinacms/src/Globals.tsx
+++ b/packages/tinacms/src/Globals.tsx
@@ -20,4 +20,3 @@ export const SIDEBAR_WIDTH = 340 // px
 export const SIDEBAR_HEADER_HEIGHT = 60 // px
 export const FORM_HEADER_HEIGHT = 40 // px
 export const FORM_FOOTER_HEIGHT = 60 // px
-export const Z_INDEX = 2147000000

--- a/packages/tinacms/src/components/sidebar/CreateContentMenu.tsx
+++ b/packages/tinacms/src/components/sidebar/CreateContentMenu.tsx
@@ -156,7 +156,7 @@ const ContentMenu = styled.div<{ open: boolean }>`
   box-shadow: var(--tina-shadow-big);
   background-color: white;
   overflow: hidden;
-  z-index: 950;
+  z-index: var(--tina-z-index-1);
 
   ${props =>
     props.open &&

--- a/packages/tinacms/src/components/sidebar/Sidebar.tsx
+++ b/packages/tinacms/src/components/sidebar/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
   TinaIcon,
 } from '@tinacms/icons'
 import { TinaReset } from '@tinacms/styles'
-import { SIDEBAR_WIDTH, Z_INDEX, SIDEBAR_HEADER_HEIGHT } from '../../Globals'
+import { SIDEBAR_WIDTH, SIDEBAR_HEADER_HEIGHT } from '../../Globals'
 import { CreateContentMenu } from './CreateContentMenu'
 import { ScreenPlugin } from '../../plugins/screen-plugin'
 import { useSubscribable, useCMS } from '../../react-tinacms'
@@ -230,7 +230,7 @@ const SidebarHeader = styled.div`
   display: grid;
   grid-template-areas: 'hamburger actions';
   align-items: center;
-  z-index: 1050;
+  z-index: var(--tina-z-index-2);
   height: ${SIDEBAR_HEADER_HEIGHT}px;
   width: 100%;
   padding: 0 var(--tina-padding-big);
@@ -312,7 +312,7 @@ const MenuWrapper = styled.div`
 
 const MenuPanel = styled.div<{ visible: boolean }>`
   background: var(--tina-color-grey-8);
-  z-index: 1000;
+  z-index: var(--tina-z-index-1);
   position: absolute;
   top: 0;
   left: 0;
@@ -420,7 +420,7 @@ const SidebarContainer = styled.div<{ open: boolean }>`
   margin: 0 !important;
   padding: 0 !important;
   border: 0 !important;
-  z-index: ${Z_INDEX} !important;
+  z-index: var(--tina-z-index-2);
   transition: all ${p => (p.open ? 150 : 200)}ms ease-out !important;
   transform: translate3d(
     ${p => (p.open ? '0' : '-' + SIDEBAR_WIDTH + 'px')},


### PR DESCRIPTION
This removes a lot of the aggressive z-index values and instead uses a set of CSS custom properties to set consistent z-index values for components throughout Tina. 

The sidebar will no longer have an incredibly high z-index. Instead, if you find your site has elements that render on top of the sidebar, you can adjust the z-index values used by Tina to compensate. 

Here are the values used: 

```
    --tina-z-index-0: 500;
    --tina-z-index-1: 1000;
    --tina-z-index-2: 1500;
    --tina-z-index-3: 2000;
    --tina-z-index-4: 2500;
```

Some elements will continue to use values like `-1` for local layering. 