### PR TITLE
Feat: Adds ToolbarState & ToolbarProvider

### DIFF
--- a/packages/@tinacms/react-toolbar/package.json
+++ b/packages/@tinacms/react-toolbar/package.json
@@ -40,7 +40,6 @@
     "@tinacms/react-core": "^0.2.9",
     "@tinacms/react-forms": "^0.1.0",
     "@tinacms/react-modals": "^0.1.0",
-    "@tinacms/react-screens": "^0.0.0",
     "@tinacms/styles": "^0.2.9",
     "react-dismissible": "^1.1.5"
   },

--- a/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
@@ -1,12 +1,20 @@
 import * as React from 'react'
 import { Toolbar } from './Toolbar'
+import { ToolbarState } from '../toolbar'
 
 interface ToolbarProviderProps {
+  toolbar: ToolbarState
   hidden?: boolean
 }
 
-export function ToolbarProvider({ hidden }: ToolbarProviderProps) {
-  if (hidden) return null
+export function ToolbarProvider({ hidden, toolbar }: ToolbarProviderProps) {
+  React.useEffect(() => {
+    if (typeof hidden !== 'undefined') {
+      toolbar.hidden = hidden
+    }
+  }, [hidden])
+
+  if (toolbar.hidden) return null
 
   return <Toolbar />
 }

--- a/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react'
+import { Toolbar } from './Toolbar'
+
+interface ToolbarProviderProps {
+  hidden?: boolean
+}
+
+export function ToolbarProvider({ hidden }: ToolbarProviderProps) {
+  if (hidden) return null
+
+  return <Toolbar />
+}

--- a/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 import * as React from 'react'
 import { Toolbar } from './Toolbar'
 import { ToolbarState } from '../toolbar'

--- a/packages/@tinacms/react-toolbar/src/components/index.ts
+++ b/packages/@tinacms/react-toolbar/src/components/index.ts
@@ -1,2 +1,20 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 export * from './ToolbarProvider'
 export * from './Toolbar'

--- a/packages/@tinacms/react-toolbar/src/components/index.ts
+++ b/packages/@tinacms/react-toolbar/src/components/index.ts
@@ -1,0 +1,2 @@
+export * from './ToolbarProvider'
+export * from './Toolbar'

--- a/packages/@tinacms/react-toolbar/src/index.ts
+++ b/packages/@tinacms/react-toolbar/src/index.ts
@@ -16,5 +16,5 @@ limitations under the License.
 
 */
 
-export * from './sidebar'
+export * from './toolbar'
 export * from './components'

--- a/packages/@tinacms/react-toolbar/src/index.ts
+++ b/packages/@tinacms/react-toolbar/src/index.ts
@@ -17,4 +17,4 @@ limitations under the License.
 */
 
 export * from './sidebar'
-export { Toolbar } from './components/Toolbar'
+export * from './components'

--- a/packages/@tinacms/react-toolbar/src/toolbar.ts
+++ b/packages/@tinacms/react-toolbar/src/toolbar.ts
@@ -18,49 +18,38 @@ limitations under the License.
 
 import { Subscribable } from '@tinacms/core'
 
-export interface SidebarStateOptions {
+export interface ToolbarStateOptions {
   hidden?: boolean
-  position?: SidebarPosition
-  buttons?: SidebarButtons
+  buttons?: ToolbarButtons
 }
 
-export interface SidebarButtons {
+export interface ToolbarButtons {
   save: string
   reset: string
 }
 
-export declare type SidebarPosition = 'fixed' | 'float' | 'displace' | 'overlay'
-
-export class SidebarState extends Subscribable {
-  private _isOpen: boolean = false
-
-  position: SidebarPosition = 'displace'
-  _hidden: boolean = false
-  buttons: SidebarButtons = {
+export class ToolbarState extends Subscribable {
+  _hidden: boolean = true
+  buttons: ToolbarButtons = {
     save: 'Save',
     reset: 'Reset',
   }
 
-  constructor(options: SidebarStateOptions = {}) {
+  constructor(options: ToolbarStateOptions = {}) {
     super()
-    this.position = options.position || 'displace'
-    this._hidden = !!options.hidden
+    this._hidden = !options.hidden
 
+    /*
+     ** TODO: Do we want to handle buttons
+     ** the same as sidebar? Or make them plugins?
+     ** maybe remove these
+     */
     if (options.buttons?.save) {
       this.buttons.save = options.buttons.save
     }
     if (options.buttons?.reset) {
       this.buttons.reset = options.buttons.reset
     }
-  }
-
-  get isOpen() {
-    return this._isOpen
-  }
-
-  set isOpen(nextValue: boolean) {
-    this._isOpen = nextValue
-    this.notifiySubscribers()
   }
 
   get hidden() {

--- a/packages/demo-next/pages/_app.js
+++ b/packages/demo-next/pages/_app.js
@@ -20,7 +20,6 @@ import React from 'react'
 import App from 'next/app'
 import { Tina, TinaCMS, withTina } from 'tinacms'
 import { GitClient, GitMediaStore } from '@tinacms/git-client'
-import { Toolbar } from '@tinacms/react-toolbar'
 
 export default class Site extends App {
   constructor() {
@@ -39,8 +38,7 @@ export default class Site extends App {
   render() {
     const { Component, pageProps } = this.props
     return (
-      <Tina cms={this.cms}>
-        <Toolbar />
+      <Tina cms={this.cms} hidden={false}>
         <Component {...pageProps} />
       </Tina>
     )

--- a/packages/demo-next/pages/_app.js
+++ b/packages/demo-next/pages/_app.js
@@ -29,6 +29,9 @@ export default class Site extends App {
         position: 'overlay',
         hidden: process.env.NODE_ENV === 'production',
       },
+      toolbar: {
+        hidden: false,
+      },
     })
     const client = new GitClient('http://localhost:3000/___tina')
     this.cms.registerApi('git', client)
@@ -38,7 +41,7 @@ export default class Site extends App {
   render() {
     const { Component, pageProps } = this.props
     return (
-      <Tina cms={this.cms} hidden={false}>
+      <Tina cms={this.cms}>
         <Component {...pageProps} />
       </Tina>
     )

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -48,6 +48,7 @@
     "@tinacms/react-modals": "^0.1.0",
     "@tinacms/react-screens": "^0.0.0",
     "@tinacms/react-sidebar": "^0.0.0",
+    "@tinacms/react-toolbar": "^0.0.0",
     "@tinacms/styles": "^0.4.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.merge": "^4.6.2",

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -42,7 +42,7 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
       <ModalProvider>
         <GlobalStyles />
         <Alerts alerts={cms.alerts} />
-        <ToolbarProvider hidden={hidden} />
+        <ToolbarProvider hidden={hidden} toolbar={cms.toolbar} />
         <SidebarProvider
           hidden={hidden}
           position={position}

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -20,6 +20,7 @@ import * as React from 'react'
 import { ModalProvider } from '@tinacms/react-modals'
 import { GlobalStyles } from '@tinacms/styles'
 import { SidebarProvider, SidebarPosition } from '@tinacms/react-sidebar'
+import { ToolbarProvider } from '@tinacms/react-toolbar'
 import { TinaCMS } from '../tina-cms'
 import { CMSContext } from '../react-tinacms'
 import { Alerts } from '@tinacms/react-alerts'
@@ -41,6 +42,7 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
       <ModalProvider>
         <GlobalStyles />
         <Alerts alerts={cms.alerts} />
+        <ToolbarProvider hidden={hidden} />
         <SidebarProvider
           hidden={hidden}
           position={position}

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -38,26 +38,30 @@ import { Form } from '@tinacms/forms'
 import { MediaManager, MediaStore, MediaUploadOptions } from '@tinacms/media'
 import { Alerts } from '@tinacms/alerts'
 import { SidebarState, SidebarStateOptions } from '@tinacms/react-sidebar'
+import { ToolbarStateOptions, ToolbarState } from '@tinacms/react-toolbar'
 
 export interface TinaCMSConfig extends CMSConfig {
   sidebar?: SidebarStateOptions
   media?: {
     store: MediaStore
   }
+  toolbar?: ToolbarStateOptions
 }
 
 export class TinaCMS extends CMS {
   sidebar: SidebarState
   media: MediaManager
+  toolbar: ToolbarState
   alerts = new Alerts()
 
-  constructor({ sidebar, media, ...config }: TinaCMSConfig = {}) {
+  constructor({ sidebar, media, toolbar, ...config }: TinaCMSConfig = {}) {
     super(config)
 
     const mediaStore = media?.store || new DummyMediaStore()
     this.media = new MediaManager(mediaStore)
 
     this.sidebar = new SidebarState(sidebar)
+    this.toolbar = new ToolbarState(toolbar)
     this.fields.add(TextFieldPlugin)
     this.fields.add(TextareaFieldPlugin)
     this.fields.add(DateFieldPlugin)


### PR DESCRIPTION
## What this does: 

- Adds `ToolbarState`
- Creates `ToolbarProvider`, adds it to `TinaProvider`
- Instantiates `ToolbarState` class on `tinacms` 

The toolbar's default state is hidden. The toolbar will only mount if the `hidden` property is specified in the config: 

```js
    this.cms = new TinaCMS({
      sidebar: {
        position: 'overlay',
        hidden: true,
      },
      toolbar: {
        hidden: false,
      },
    })
```
Let me know if this is in the ballpark of what you had in mind @ncphillips — I know this isn't a long-term implementation but felt like these are good first steps to let folks opt-in to using the toolbar w/o breaking changes.