### PR TITLE
chore: use Tina Styles for the Edit Button

### DIFF
--- a/packages/demo-gatsby/src/components/edit-toggle.js
+++ b/packages/demo-gatsby/src/components/edit-toggle.js
@@ -18,21 +18,24 @@ limitations under the License.
 
 import React from "react"
 import styled from "styled-components"
-import {
-  Button as TinaButton,
-  TinaResetStyles as TinaStyles,
-} from "@tinacms/styles"
+import { Button as TinaButton } from "@tinacms/styles"
 import { EditIcon } from "@tinacms/icons"
+import { useInlineForm } from "react-tinacms-inline"
 
-export const EditToggle = styled(
-  ({ isEditing, setIsEditing, ...styleProps }) => {
-    return (
-      <TinaButton onClick={() => setIsEditing(p => !p)} primary {...styleProps}>
-        <EditIcon /> {isEditing ? "Preview" : "Edit"}
-      </TinaButton>
-    )
-  }
-)`
+export const EditToggle = styled(({ ...styleProps }) => {
+  const { status, deactivate, activate } = useInlineForm()
+  return (
+    <TinaButton
+      onClick={() => {
+        status === "active" ? deactivate() : activate()
+      }}
+      primary
+      {...styleProps}
+    >
+      {status === "active" ? "Preview" : "Edit"}
+    </TinaButton>
+  )
+})`
   position: fixed;
   bottom: 46px;
   margin-left: 64px;

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -27,6 +27,7 @@ import { rhythm } from "../utils/typography"
 import { useLocalRemarkForm, DeleteAction } from "gatsby-tinacms-remark"
 import Img from "gatsby-image"
 import { ModalProvider } from "tinacms"
+import { EditToggle } from "../components/edit-toggle"
 
 import {
   InlineForm,
@@ -57,7 +58,6 @@ function BlogPostTemplate(props) {
     <ModalProvider>
       <InlineForm form={form}>
         <Layout location={props.location} title={siteTitle}>
-          <EditToggle />
           <SEO
             title={post.frontmatter.title}
             description={post.frontmatter.description || post.excerpt}
@@ -188,6 +188,7 @@ function BlogPostTemplate(props) {
               />
             </InlineWysiwyg>
           </div>
+          <EditToggle />
           <div
             style={{
               marginBottom: rhythm(1),
@@ -363,23 +364,6 @@ const BlogPostForm = {
     //   },
     // },
   ],
-}
-
-/**
- * Toggle -------------------------------------------------------
- */
-export function EditToggle() {
-  const { status, deactivate, activate } = useInlineForm()
-
-  return (
-    <button
-      onClick={() => {
-        status === "active" ? deactivate() : activate()
-      }}
-    >
-      {status === "active" ? "Preview" : "Edit"}
-    </button>
-  )
 }
 
 export function DiscardChanges() {


### PR DESCRIPTION
The Edit button was unstyled and aligned to left.

The PR updates `EditToggle` to inherit from @tinacms/styles

<img width="784" alt="Edit-demo" src="https://user-images.githubusercontent.com/103008/78790136-64c31b80-79ae-11ea-812d-58145a439fcf.png">

Co-authored-by: Scott Byrne  <scott.byrne@forestry.io>
