### PR TITLE
Fix(react-tinacms-inline): hide AddBlock when form is inactive

### DIFF
--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -96,7 +96,7 @@ export function InlineBlocks({ name, blocks }: InlineBlocksProps) {
               setActiveBlock,
             }}
           >
-            {allData.length < 1 && status === 'inactive' && (
+            {allData.length < 1 && status === 'active' && (
               <BlocksEmptyState>
                 <AddBlockMenu
                   addBlock={block => insert(1, block)}


### PR DESCRIPTION
If there was no block data, the `AddBlock` menu was rendering when the form was inactive.