### PR TITLE
Don't allow users to set cookie schema in api handlers

### DIFF
--- a/packages/next-tinacms-github/README.md
+++ b/packages/next-tinacms-github/README.md
@@ -19,8 +19,8 @@ export default createCreateAccessTokenFn(
 )
 ```
 
-# `createProxy`
-Helper for creating a proxy which attaches this Github access token to the request
+# `apiProxy`
+Proxies requests to GitHub, attaching the GitHub access token in the process
 
 ## Implementation
 
@@ -32,8 +32,8 @@ import { apiProxy } from 'next-tinacms-github'
 export default apiProxy
 ```
 
-# `createPreviewFn`
-Helper for creating a preview function which will set the preview data from Github cookies
+# `previewHandler`
+Handles setting the preview data from Github cookies
 
 ## Implementation
 

--- a/packages/next-tinacms-github/README.md
+++ b/packages/next-tinacms-github/README.md
@@ -27,10 +27,9 @@ Helper for creating a proxy which attaches this Github access token to the reque
 ```
 // pages/api/proxy-github.ts
 
-import { createProxy } from 'next-tinacms-github'
-import { GITHUB_ACCESS_TOKEN_COOKIE_KEY } from './constants'
+import { apiProxy } from 'next-tinacms-github'
 
-export default createProxy(GITHUB_ACCESS_TOKEN_COOKIE_KEY)
+export default apiProxy
 ```
 
 # `createPreviewFn`
@@ -41,12 +40,8 @@ Helper for creating a preview function which will set the preview data from Gith
 ```
 // pages/api/preview.ts
 
-import { createPreviewFn } from 'next-tinacms-github'
+import { previewHandler } from 'next-tinacms-github'
 
-export default createPreviewFn(
-  'fork_full_name',
-  'head_branch',
-  'github_access_token'
-)
+export default previewHandler
 
 ```

--- a/packages/next-tinacms-github/src/constants.ts
+++ b/packages/next-tinacms-github/src/constants.ts
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 export const ACCESS_TOKEN_KEY = 'github_access_token'
 export const FORK_KEY = 'fork_full_name'
 export const HEAD_BRANCH_KEY = 'head_branch'

--- a/packages/next-tinacms-github/src/constants.ts
+++ b/packages/next-tinacms-github/src/constants.ts
@@ -1,0 +1,3 @@
+export const ACCESS_TOKEN_KEY = 'github_access_token'
+export const FORK_KEY = 'fork_full_name'
+export const HEAD_BRANCH_KEY = 'head_branch'

--- a/packages/next-tinacms-github/src/github/create-access-token.ts
+++ b/packages/next-tinacms-github/src/github/create-access-token.ts
@@ -16,6 +16,8 @@ limitations under the License.
 
 */
 
+import { ACCESS_TOKEN_KEY } from '../constants'
+
 const qs = require('qs')
 const axios = require('axios')
 import { serialize } from 'cookie'
@@ -32,7 +34,7 @@ export const createCreateAccessTokenFn = (clientId: string, secret: string) => (
       } else {
         res.setHeader(
           'Set-Cookie',
-          serialize('github_access_token', access_token, {
+          serialize(ACCESS_TOKEN_KEY, access_token, {
             path: '/',
             httpOnly: true,
           })

--- a/packages/next-tinacms-github/src/github/proxy.ts
+++ b/packages/next-tinacms-github/src/github/proxy.ts
@@ -19,7 +19,7 @@ import { ACCESS_TOKEN_KEY } from '../constants'
 
 const axios = require('axios')
 
-export const createProxy = () => (req: any, res: any) => {
+export const apiProxy = (req: any, res: any) => {
   const { headers, ...data } = JSON.parse(req.body)
 
   axios({

--- a/packages/next-tinacms-github/src/github/proxy.ts
+++ b/packages/next-tinacms-github/src/github/proxy.ts
@@ -15,17 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+import { ACCESS_TOKEN_KEY } from '../constants'
 
 const axios = require('axios')
 
-export const createProxy = (authTokenKey: string) => (req: any, res: any) => {
+export const createProxy = () => (req: any, res: any) => {
   const { headers, ...data } = JSON.parse(req.body)
 
   axios({
     ...data,
     headers: {
       ...headers,
-      Authorization: 'token ' + req.cookies[authTokenKey],
+      Authorization: 'token ' + req.cookies[ACCESS_TOKEN_KEY],
     },
   })
     .then((resp: any) => {

--- a/packages/next-tinacms-github/src/next/preview.ts
+++ b/packages/next-tinacms-github/src/next/preview.ts
@@ -18,7 +18,7 @@ limitations under the License.
 
 import { ACCESS_TOKEN_KEY, FORK_KEY, HEAD_BRANCH_KEY } from '../constants'
 
-export const createPreviewFn = () => (req: any, res: any) => {
+export const previewHandler = (req: any, res: any) => {
   const previewData = {
     fork_full_name: req.cookies[FORK_KEY],
     github_access_token: req.cookies[ACCESS_TOKEN_KEY],

--- a/packages/next-tinacms-github/src/next/preview.ts
+++ b/packages/next-tinacms-github/src/next/preview.ts
@@ -16,15 +16,13 @@ limitations under the License.
 
 */
 
-export const createPreviewFn = (
-  forkCookieKey: string,
-  headBranchCookieKey: string,
-  githubAccessTokenCookieKey: string
-) => (req: any, res: any) => {
+import { ACCESS_TOKEN_KEY, FORK_KEY, HEAD_BRANCH_KEY } from '../constants'
+
+export const createPreviewFn = () => (req: any, res: any) => {
   const previewData = {
-    fork_full_name: req.cookies[forkCookieKey],
-    github_access_token: req.cookies[githubAccessTokenCookieKey],
-    head_branch: req.cookies[headBranchCookieKey] || 'master',
+    fork_full_name: req.cookies[FORK_KEY],
+    github_access_token: req.cookies[ACCESS_TOKEN_KEY],
+    head_branch: req.cookies[HEAD_BRANCH_KEY] || 'master',
   }
   res.setPreviewData(previewData)
   res.status(200).end()


### PR DESCRIPTION
Cookie schema was user-specified, perhaps to ensure interoperability with `react-tinacms-github` which contains the code that sets these cookies. After discussing with @jamespohalloran,  we determined that this degree of configuration was unnecessary and may even be a detriment down the line. This schema is now a hard-coded concern within the package, which has the benefit of simplifying userland implementation for these API routes