### PR TITLE
fix: dependend on react-textarea-autosize

### DIFF
--- a/packages/react-tinacms-inline/package.json
+++ b/packages/react-tinacms-inline/package.json
@@ -15,11 +15,13 @@
     "test": "tsdx test --env=jsdom --passWithNoTests",
     "lint": "tsdx lint"
   },
+  "dependencies": {
+    "react-textarea-autosize": ">=7.1"
+  },
   "peerDependencies": {
     "react": ">=16.8",
     "react-dropzone": "10.2.1",
     "react-final-form": "^>=6",
-    "react-textarea-autosize": ">=7.1",
     "react-tinacms-editor": ">=0.0",
     "styled-components": ">=4.1",
     "tinacms": ">=0.13"


### PR DESCRIPTION
Fix #999

react-tinacms-inline should depend directly on react-textarea-autosize

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
