### PR TITLE
refactor(github): move authenticate implementation into react-tinacms…

### DIFF
--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -41,7 +41,7 @@ In this case, we will hit our `/api` server functions.
 
 ```ts
 // YourLayout.ts
-import { TinacmsGithubProvider, authenticate } from 'react-tinacms-github';
+import { TinacmsGithubProvider } from 'react-tinacms-github';
 
 const enterEditMode = () =>
   fetch(`/api/preview`).then(() => {
@@ -54,7 +54,8 @@ const exitEditMode = () => {
 }
 const YourLayout = ({ Component, pageProps, children }) => {
   return (<TinacmsGithubProvider
-      authenticate={() => authenticate(process.env.GITHUB_CLIENT_ID, '/api/create-github-access-token')}
+      clientId={process.env.GITHUB_CLIENT_ID}
+      authCallbackRoute: '/api/create-github-access-token'
       enterEditMode={enterEditMode}
       exitEditMode={exitEditMode}
       error={pageProps.error}>

--- a/packages/react-tinacms-github/src/github-editing-context/TinacmsGithubProvider.tsx
+++ b/packages/react-tinacms-github/src/github-editing-context/TinacmsGithubProvider.tsx
@@ -16,17 +16,19 @@ limitations under the License.
 
 */
 
-import React, { useState, useEffect } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import { getForkName, getHeadBranch } from './repository'
 import { useCMS } from 'tinacms'
 import GithubErrorModal from '../github-error/GithubErrorModal'
 import GithubAuthModal from './GithubAuthModal'
 import { GithubEditingContext } from './GithubEditingContext'
 import { useGithubEditing } from './useGithubEditing'
+import { authenticate as githubAuthenticate } from '../github-auth'
 
 interface ProviderProps {
   children: any
-  authenticate: () => Promise<void>
+  clientId: string
+  authCallbackRoute: string
   enterEditMode: () => void
   exitEditMode: () => void
   error?: any
@@ -41,7 +43,8 @@ export const TinacmsGithubProvider = ({
   children,
   enterEditMode,
   exitEditMode,
-  authenticate,
+  authCallbackRoute,
+  clientId,
   error: previewError,
 }: ProviderProps) => {
   const [error, setError] = useState<any>(null)
@@ -66,6 +69,10 @@ export const TinacmsGithubProvider = ({
       })
     }
   }
+
+  const authenticate = useCallback(() => {
+    githubAuthenticate(clientId, authCallbackRoute)
+  }, [clientId, authCallbackRoute])
 
   return (
     <GithubEditingContext.Provider


### PR DESCRIPTION
Move `authenticate` implementation into react-tinacms-github. We already make the assumption at this point that they are using github auth