### PR TITLE
chore: fix client.createFork request

### DIFF
--- a/packages/react-tinacms-github/src/github-client/index.ts
+++ b/packages/react-tinacms-github/src/github-client/index.ts
@@ -44,7 +44,7 @@ export class GithubClient {
 
   createFork() {
     return this.req({
-      url: `https://api.github.com/repos/${process.env.REPO_FULL_NAME}/forks`,
+      url: `https://api.github.com/repos/${this.baseRepoFullName}/forks`,
       method: 'POST',
     })
   }


### PR DESCRIPTION
Was using an env, now uses this.baseRepoFullName.
