### PR TITLE
feat(github): Show error message when github fork fails

### DIFF
--- a/packages/next-tinacms-github/package.json
+++ b/packages/next-tinacms-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-tinacms-github",
-  "version": "0.0.2-canary4.1",
+  "version": "0.0.2-canary4.2",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/react-tinacms-github/package.json
+++ b/packages/react-tinacms-github/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinacms-github",
-  "version": "0.0.1-canary3.1",
+  "version": "0.0.1-canary3.2",
   "description": "",
   "main": "dist/index.js",
   "scripts": {

--- a/packages/react-tinacms-github/src/components/AsyncButton.tsx
+++ b/packages/react-tinacms-github/src/components/AsyncButton.tsx
@@ -31,8 +31,12 @@ export const AsyncButton = ({ name, primary, action }: ButtonProps) => {
 
   const onClick = useCallback(async () => {
     setSubmitting(true)
-    await action()
-    setSubmitting(false)
+    try {
+      await action()
+    } catch (e) {
+      setSubmitting(false)
+      throw e
+    }
   }, [action, setSubmitting])
 
   return (

--- a/packages/react-tinacms-github/src/components/AsyncButton.tsx
+++ b/packages/react-tinacms-github/src/components/AsyncButton.tsx
@@ -33,6 +33,7 @@ export const AsyncButton = ({ name, primary, action }: ButtonProps) => {
     setSubmitting(true)
     try {
       await action()
+      setSubmitting(false)
     } catch (e) {
       setSubmitting(false)
       throw e

--- a/packages/react-tinacms-github/src/github-editing-context/GithubAuthModal.tsx
+++ b/packages/react-tinacms-github/src/github-editing-context/GithubAuthModal.tsx
@@ -27,7 +27,8 @@ import {
 } from 'tinacms'
 import { TinaReset } from '@tinacms/styles'
 import { AsyncButton } from '../components/AsyncButton'
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import styled from 'styled-components'
 
 const GithubAuthModal = ({
   onUpdateAuthState,
@@ -38,6 +39,15 @@ const GithubAuthModal = ({
   let modalProps
 
   const cms = useCMS()
+
+  const [error, setError] = useState<string | undefined>()
+
+  useEffect(() => {
+    //clear error when authState changes
+    if (error) {
+      setError(undefined)
+    }
+  }, [authState])
 
   if (!authState.authenticated) {
     modalProps = {
@@ -71,7 +81,15 @@ const GithubAuthModal = ({
         {
           name: 'Create Fork',
           action: async () => {
-            const { full_name } = await cms.api.github.createFork()
+            let full_name: string = ''
+            try {
+              full_name = (await cms.api.github.createFork()).full_name
+            } catch (e) {
+              setError(
+                'Forking repository failed. Are you sure you have access?'
+              )
+              throw e
+            }
             setForkName(full_name)
             onUpdateAuthState()
           },
@@ -90,6 +108,7 @@ const GithubAuthModal = ({
           <ModalHeader close={close}>{modalProps.title}</ModalHeader>
           <ModalBody padded>
             <p>{modalProps.message}</p>
+            {error && <ErrorLabel>{error}</ErrorLabel>}
           </ModalBody>
           <ModalActions>
             {modalProps.actions.map((action: any) => (
@@ -101,5 +120,9 @@ const GithubAuthModal = ({
     </TinaReset>
   )
 }
+
+export const ErrorLabel = styled.p`
+  color: var(--tina-color-error) !important;
+`
 
 export default GithubAuthModal

--- a/packages/react-tinacms-github/src/github-editing-context/GithubAuthModal.tsx
+++ b/packages/react-tinacms-github/src/github-editing-context/GithubAuthModal.tsx
@@ -81,17 +81,17 @@ const GithubAuthModal = ({
         {
           name: 'Create Fork',
           action: async () => {
-            let full_name: string = ''
             try {
-              full_name = (await cms.api.github.createFork()).full_name
+              const full_name = (await cms.api.github.createFork()).full_name
+              setForkName(full_name)
+              onUpdateAuthState()
             } catch (e) {
               setError(
                 'Forking repository failed. Are you sure you have access?'
               )
               throw e
             }
-            setForkName(full_name)
-            onUpdateAuthState()
+
           },
           primary: true,
         },

--- a/packages/react-tinacms-github/src/github-editing-context/GithubAuthModal.tsx
+++ b/packages/react-tinacms-github/src/github-editing-context/GithubAuthModal.tsx
@@ -87,11 +87,10 @@ const GithubAuthModal = ({
               onUpdateAuthState()
             } catch (e) {
               setError(
-                'Forking repository failed. Are you sure you have access?'
+                'Forking repository failed. Are you sure the repository is public?'
               )
               throw e
             }
-
           },
           primary: true,
         },


### PR DESCRIPTION
Show error message when GitHub fork fails. This might occur is the repo url is incorrect or private.
<img width="510" alt="Screen Shot 2020-04-17 at 10 53 00 AM" src="https://user-images.githubusercontent.com/3323181/79577381-05929480-809b-11ea-9b57-499f18af1f2a.png">
