### PR TITLE
fix(Github): fix incorrect property access in PRModal

### DIFF
--- a/packages/react-tinacms-github/src/toolbar-plugins/pull-request/PRModal.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/pull-request/PRModal.tsx
@@ -139,9 +139,9 @@ export const PRModal = () => {
             <TinaButton
               as="a"
               // @ts-ignore
-              href={`https://github.com/${baseRepoFullName}/compare/${baseBranch}...${
-                github.repoFullName.split('/')[0]
-              }:${github.branchName}`}
+              href={`https://github.com/${github.baseRepoFullName}/compare/${
+                github.baseBranch
+              }...${github.repoFullName.split('/')[0]}:${github.branchName}`}
               target="_blank"
             >
               View Diff


### PR DESCRIPTION
Using an undeclared variable name in PRModal (causes screen to blow up). Slipped through with the ts-ignore