### PR TITLE
fix: sticky menu useEffect dep list addition

### DIFF
--- a/packages/react-tinacms-editor/src/state/plugins/Menu/index.tsx
+++ b/packages/react-tinacms-editor/src/state/plugins/Menu/index.tsx
@@ -105,12 +105,13 @@ export const Menu = (props: Props) => {
   const menuRef: any = useRef<HTMLDivElement>(null)
   const [menuBoundingBox, setMenuBoundingBox] = useState<any>(null)
   const menuFixedTopOffset = typeof sticky === 'string' ? sticky : '0'
+  const { editorView } = useEditorStateContext()
 
   useEffect(() => {
     if (menuRef.current && sticky) {
       setMenuBoundingBox(menuRef.current.getBoundingClientRect())
     }
-  }, [menuRef])
+  }, [menuRef, editorView])
 
   useLayoutEffect(() => {
     if (!isBrowser || !menuRef.current || !sticky) {
@@ -156,8 +157,8 @@ export const Menu = (props: Props) => {
     e.preventDefault()
   }, [])
 
-  const { editorView } = useEditorStateContext()
   if (!editorView) return null
+
   return (
     <>
       {menuFixed && (


### PR DESCRIPTION
When not in edit mode, the menu would return null based on editorView. Since the useEffect code that measures the menu (setMenuBoundingBox) relies on menuRef, and menuRef relies on the component rendering, editorView has been added to the useEffect dep list, fixing the issue preventing the sticky menu from working.

Closes #1018