### PR TITLE
chore: update fields doc link

### DIFF
--- a/packages/@tinacms/react-forms/src/FormView.tsx
+++ b/packages/@tinacms/react-forms/src/FormView.tsx
@@ -202,10 +202,7 @@ const NoFieldsPlaceholder = () => (
     <Emoji>🤔</Emoji>
     <h3>Hey, you don't have any fields added to this form.</h3>
     <p>
-      <LinkButton
-        href="https://tinacms.org/docs/gatsby/markdown/#creating-remark-forms"
-        target="_blank"
-      >
+      <LinkButton href="https://tinacms.org/docs/fields" target="_blank">
         <Emoji>📖</Emoji> Field Setup Guide
       </LinkButton>
     </p>


### PR DESCRIPTION
This updates the empty state placeholder link that points to our fields docs. It now points to more generic field docs.

Closes #881