### PR TITLE
style: add z-index to alerts container

### DIFF
--- a/packages/@tinacms/react-alerts/src/Alerts.tsx
+++ b/packages/@tinacms/react-alerts/src/Alerts.tsx
@@ -73,6 +73,7 @@ const AlertContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  z-index: var(--tina-z-index-3);
 `
 
 const AlertEntranceAnimation = keyframes`


### PR DESCRIPTION
The alerts container was rendering under site elements. This applies the second highest z-index available in Tina to the container. 