### PR TITLE
chore: prevent user from creating PR on base branch

### DIFF
--- a/packages/react-tinacms-github/src/toolbar-plugins/pull-request/PRModal.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/pull-request/PRModal.tsx
@@ -93,6 +93,19 @@ export const PRModal = () => {
     baseBranch = `${baseOwner}:${baseBranch}`
   }
 
+  if (workingBranch === baseBranch) {
+    return (
+      <PrModalBody>
+        <ModalDescription>
+          <p>
+            You are currently on the base branch: <b>{baseBranch}</b>.
+          </p>
+          <p>To create a Pull Request you must first switch to a new branch.</p>
+        </ModalDescription>
+      </PrModalBody>
+    )
+  }
+
   return (
     <>
       <PrModalBody>


### PR DESCRIPTION
<img width="368" alt="image" src="https://user-images.githubusercontent.com/824015/80524464-10380e00-8966-11ea-8a17-bad2c960af29.png">

Note: `baseBranch` and `workingBranch` contain the owner name if they're different?

closes #1069