### PR TITLE
fix: github-client branch name should default to base branch

### DIFF
--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -138,8 +138,16 @@ export class GithubClient {
     return this.baseRepoFullName
   }
 
-  get branchName() {
-    return this.getCookie(GithubClient.HEAD_BRANCH_COOKIE_KEY) || 'master'
+  get branchName(): string {
+    const branchName = this.getCookie(GithubClient.HEAD_BRANCH_COOKIE_KEY)
+
+    if (branchName) {
+      return branchName
+    }
+
+    this.setCookie(GithubClient.HEAD_BRANCH_COOKIE_KEY, this.baseBranch)
+
+    return this.branchName
   }
 
   setWorkingBranch(branch: string) {


### PR DESCRIPTION
It was defaulting to 'master' even if that wasn't the base

Discovered this while trying to turn the tinacms/rfcs repo into a Next+Github site.