### PR TITLE
style: set current branch name font size

### DIFF
--- a/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
@@ -511,6 +511,7 @@ const SelectCurrent = styled.span`
   display: block;
   text-align: left;
   line-height: 20px;
+  font-size: var(--tina-font-size-3);
   text-overflow: ellipsis;
   max-width: 250px;
   white-space: nowrap;


### PR DESCRIPTION
This explicitly sets a font size for the branch switcher current branch name. It was previously inheriting from site styles, which would only work in some situations. 