### PR TITLE
fix: sticky menu useEffect dep list addition

### DIFF
--- a/packages/react-tinacms-editor/src/components/Menubar/index.tsx
+++ b/packages/react-tinacms-editor/src/components/Menubar/index.tsx
@@ -50,12 +50,13 @@ export const Menubar = ({ sticky = true, uploadImages }: Props) => {
   const menuRef = useRef<HTMLDivElement>(null)
   const [menuBoundingBox, setMenuBoundingBox] = useState<any>(null)
   const menuFixedTopOffset = typeof sticky === 'string' ? sticky : '0'
+  const { editorView } = useEditorStateContext()
 
   useEffect(() => {
     if (menuRef.current && sticky) {
       setMenuBoundingBox(menuRef.current.getBoundingClientRect())
     }
-  }, [menuRef])
+  }, [menuRef, editorView])
 
   useLayoutEffect(() => {
     if (!isBrowser || !menuRef.current || !sticky) {
@@ -99,8 +100,8 @@ export const Menubar = ({ sticky = true, uploadImages }: Props) => {
     e.preventDefault()
   }, [])
 
-  const { editorView } = useEditorStateContext()
   if (!editorView) return null
+
   return (
     <>
       {menuFixed && (


### PR DESCRIPTION
When not in edit mode, the menu would return null based on editorView. Since the useEffect code that measures the menu (setMenuBoundingBox) relies on menuRef, and menuRef relies on the component rendering, editorView has been added to the useEffect dep list, fixing the issue preventing the sticky menu from working.

Closes #1018

I'm feeling some strong déjà vu... 😆 