### PR TITLE
feat(github-client): optionally accept scope

### DIFF
--- a/packages/react-tinacms-github/src/github-client/authenticate.ts
+++ b/packages/react-tinacms-github/src/github-client/authenticate.ts
@@ -20,13 +20,14 @@ import popupWindow from './popupWindow'
 export const GITHUB_AUTH_CODE_KEY = 'github_auth_code'
 export const authenticate = (
   clientId: string,
-  codeExchangeRoute: string
+  codeExchangeRoute: string,
+  scope: string = 'public_repo'
 ): Promise<void> => {
   const authState = Math.random()
     .toString(36)
     .substring(7)
 
-  const url = `https://github.com/login/oauth/authorize?scope=public_repo&client_id=${clientId}&state=${authState}`
+  const url = `https://github.com/login/oauth/authorize?scope=${scope}&client_id=${clientId}&state=${authState}`
 
   return new Promise(resolve => {
     // @ts-ignore

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -27,12 +27,15 @@ export interface GithubClientOptions {
   authCallbackRoute: string
   baseRepoFullName: string
   baseBranch?: string
+  authScope?: AuthScope
 }
 
 export interface Branch {
   name: string
   protected: boolean
 }
+
+export type AuthScope = 'public_repo' | 'repo'
 
 export class GithubClient {
   static WORKING_REPO_COOKIE_KEY = 'working_repo_full_name'
@@ -43,6 +46,7 @@ export class GithubClient {
   baseBranch: string
   clientId: string
   authCallbackRoute: string
+  authScope: AuthScope
 
   constructor({
     proxy,
@@ -50,17 +54,19 @@ export class GithubClient {
     authCallbackRoute,
     baseRepoFullName,
     baseBranch = 'master',
+    authScope = 'public_repo',
   }: GithubClientOptions) {
     this.proxy = proxy
     this.baseRepoFullName = baseRepoFullName
     this.baseBranch = baseBranch
     this.clientId = clientId
     this.authCallbackRoute = authCallbackRoute
+    this.authScope = authScope
     this.validate()
   }
 
   authenticate() {
-    return authenticate(this.clientId, this.authCallbackRoute)
+    return authenticate(this.clientId, this.authCallbackRoute, this.authScope)
   }
 
   isAuthenticated() {


### PR DESCRIPTION
allows for access to private repositories if it should be so desired

Co-authored-by: Logan Anderson <logan@forestry.io>

**Example**
```ts
new GitHubClient({
  authScope: 'repo' // defaults to 'public_repo'
})
```