### PR TITLE
fix(use-github-format-forms): the options are optional

### DIFF
--- a/packages/react-tinacms-github/src/form/useGithubJsonForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubJsonForm.ts
@@ -31,7 +31,7 @@ const serialize = (formData: any) => {
   return JSON.stringify(formData, null, 2)
 }
 
-export function useGithubJsonForm(jsonFile: GitFile, formOptions: Options) {
+export function useGithubJsonForm(jsonFile: GitFile, formOptions?: Options) {
   return useGithubFileForm(jsonFile, {
     ...formOptions,
     serialize,

--- a/packages/react-tinacms-github/src/form/useGithubMarkdownForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubMarkdownForm.ts
@@ -29,7 +29,7 @@ interface Options {
 
 export function useGithubMarkdownForm(
   markdownFile: GitFile,
-  formOptions: Options
+  formOptions?: Options
 ) {
   return useGithubFileForm(markdownFile, {
     ...formOptions,


### PR DESCRIPTION
No need for second argument:
```ts
useGithubJsonForm(file)

// equivalent to

useGithubJsonForm(file, {})
```