### PR TITLE
fix: input components are not exported from root

### DIFF
--- a/packages/react-tinacms-inline/src/components/image-upload.tsx
+++ b/packages/react-tinacms-inline/src/components/image-upload.tsx
@@ -1,0 +1,51 @@
+import { useDropzone } from 'react-dropzone'
+
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+import * as React from 'react'
+
+export interface ImageUploadProps {
+  onDrop: (acceptedFiles: any[]) => void
+  value?: string
+  children?: any
+}
+
+export const ImageUpload = ({ onDrop, value, children }: ImageUploadProps) => {
+  const {
+    getRootProps,
+    getInputProps,
+    isDragActive,
+    isDragAccept,
+    isDragReject,
+  } = useDropzone({ accept: 'image/*', onDrop })
+
+  return (
+    <div {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
+      <input {...getInputProps()} />
+      {value ? (
+        <div>{children ? children : <img src={value} />}</div>
+      ) : (
+        <div>
+          Drag 'n' drop some files here,
+          <br />
+          or click to select files
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/react-tinacms-inline/src/components/index.ts
+++ b/packages/react-tinacms-inline/src/components/index.ts
@@ -15,14 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-
-export * from './inline-field-image'
-export * from './inline-field-text'
-export * from './inline-field-textarea'
-export * from './inline-field'
-export * from './inline-form'
-export * from './inline-wysiwyg'
-export * from './blocks'
-export * from './styles'
-import * as components from './components'
-export { components }
+export * from './image-upload'
+export * from './text'
+export { InlineTextarea } from '../inline-field-textarea'

--- a/packages/react-tinacms-inline/src/components/text-area.tsx
+++ b/packages/react-tinacms-inline/src/components/text-area.tsx
@@ -1,0 +1,47 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import styled from 'styled-components'
+import TextareaAutosize from 'react-textarea-autosize'
+
+export const InlineTextarea = styled(TextareaAutosize)`
+  width: 100%;
+  word-wrap: break-word;
+  display: block;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  box-sizing: border-box;
+  color: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  margin: 0 auto;
+  max-width: inherit;
+  background-color: inherit;
+  text-align: inherit;
+  outline: none;
+  resize: none;
+  border: none;
+  overflow: visible;
+  position: relative;
+  -ms-overflow-style: none;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
+`

--- a/packages/react-tinacms-inline/src/components/text.tsx
+++ b/packages/react-tinacms-inline/src/components/text.tsx
@@ -15,14 +15,25 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
+import styled from 'styled-components'
 
-export * from './inline-field-image'
-export * from './inline-field-text'
-export * from './inline-field-textarea'
-export * from './inline-field'
-export * from './inline-form'
-export * from './inline-wysiwyg'
-export * from './blocks'
-export * from './styles'
-import * as components from './components'
-export { components }
+export const InlineText = styled.input`
+  width: 100%;
+  display: block;
+  font-size: inherit;
+  font-family: inherit;
+  font-weight: inherit;
+  box-sizing: border-box;
+  color: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+  max-width: inherit;
+  background-color: inherit;
+  text-align: inherit;
+  outline: none;
+  resize: none;
+  border: none;
+  overflow: visible;
+  position: relative;
+  -ms-overflow-style: none;
+`

--- a/packages/react-tinacms-inline/src/index.tsx
+++ b/packages/react-tinacms-inline/src/index.tsx
@@ -16,11 +16,25 @@ limitations under the License.
 
 */
 
-export * from './inline-form'
+export {
+  InlineImageField,
+  InlineImageProps,
+  ImageUploadProps,
+} from './inline-field-image'
+export { InlineTextField, InlineTextFieldProps } from './inline-field-text'
+export { InlineTextareaField } from './inline-field-textarea'
 export * from './inline-field'
-export * from './inline-field-text'
-export * from './inline-field-textarea'
-export * from './inline-field-image'
+export * from './inline-form'
 export * from './inline-wysiwyg'
 export * from './blocks'
 export * from './styles'
+
+import { ImageUpload } from './inline-field-image'
+import { InlineText } from './inline-field-text'
+import { InlineTextarea } from './inline-field-textarea'
+
+export const inputs = {
+  ImageUpload,
+  InlineText,
+  InlineTextarea,
+}

--- a/packages/react-tinacms-inline/src/inline-field-image.tsx
+++ b/packages/react-tinacms-inline/src/inline-field-image.tsx
@@ -73,7 +73,7 @@ export function InlineImageField({
   )
 }
 
-interface ImageUploadProps {
+export interface ImageUploadProps {
   onDrop: (acceptedFiles: any[]) => void
   value?: string
   children?: any

--- a/packages/react-tinacms-inline/src/inline-field-image.tsx
+++ b/packages/react-tinacms-inline/src/inline-field-image.tsx
@@ -19,8 +19,8 @@ limitations under the License.
 import * as React from 'react'
 import { InlineField } from './inline-field'
 import { useCMS, Form } from 'tinacms'
-import { useDropzone } from 'react-dropzone'
 import { InputFocusWrapper } from './styles'
+import { ImageUpload } from './components/image-upload'
 
 export interface InlineImageProps {
   name: string
@@ -70,36 +70,5 @@ export function InlineImageField({
         return children ? children : <img src={input.value} />
       }}
     </InlineField>
-  )
-}
-
-export interface ImageUploadProps {
-  onDrop: (acceptedFiles: any[]) => void
-  value?: string
-  children?: any
-}
-
-export const ImageUpload = ({ onDrop, value, children }: ImageUploadProps) => {
-  const {
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-  } = useDropzone({ accept: 'image/*', onDrop })
-
-  return (
-    <div {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
-      <input {...getInputProps()} />
-      {value ? (
-        <div>{children ? children : <img src={value} />}</div>
-      ) : (
-        <div>
-          Drag 'n' drop some files here,
-          <br />
-          or click to select files
-        </div>
-      )}
-    </div>
   )
 }

--- a/packages/react-tinacms-inline/src/inline-field-text.tsx
+++ b/packages/react-tinacms-inline/src/inline-field-text.tsx
@@ -17,13 +17,10 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import styled from 'styled-components'
 import { InlineField } from './inline-field'
 import { InputFocusWrapper } from './styles'
+import { InlineText } from './components'
 
-/**
- * InlineTextField
- */
 export interface InlineTextFieldProps {
   name: string
   className?: string
@@ -45,24 +42,3 @@ export function InlineTextField({ name, className }: InlineTextFieldProps) {
     </InlineField>
   )
 }
-
-export const InlineText = styled.input`
-  width: 100%;
-  display: block;
-  font-size: inherit;
-  font-family: inherit;
-  font-weight: inherit;
-  box-sizing: border-box;
-  color: inherit;
-  letter-spacing: inherit;
-  line-height: inherit;
-  max-width: inherit;
-  background-color: inherit;
-  text-align: inherit;
-  outline: none;
-  resize: none;
-  border: none;
-  overflow: visible;
-  position: relative;
-  -ms-overflow-style: none;
-`


### PR DESCRIPTION
    import {
      InlineTextareaField,
      components
    } from "react-tinacms-inline"

    <InlineTextareaField />
    <components.InlineTextarea />

This is to prevent people from accidentally using the wrong component.
