### PR TITLE
fix: close image popup and hitting delete button should delete image

### DIFF
--- a/packages/react-tinacms-editor/src/plugins/Image/Popups/Edit.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Popups/Edit.tsx
@@ -115,6 +115,7 @@ export const ImageEdit: FunctionComponent = () => {
     }).setSelection(new NodeSelection(tr.doc.resolve(pos)))
     dispatch(tr)
     closeImageSettings()
+    view.focus()
   }
 
   const closeImageSettings = () => {
@@ -124,6 +125,7 @@ export const ImageEdit: FunctionComponent = () => {
     setAlt('')
     setLinkTitle('')
     setLinkSrc('')
+    view.focus()
   }
 
   const handleKeyPress = (evt: React.KeyboardEvent) => {


### PR DESCRIPTION
Fix for image not getting deleted when popup over it is closed and delete button is hit.

Ref: https://github.com/tinacms/tinacms/issues/1083