### PR TITLE
feat: form({ onChange })

### DIFF
--- a/packages/@tinacms/forms/src/form.ts
+++ b/packages/@tinacms/forms/src/form.ts
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import arrayMutators from 'final-form-arrays'
-import { FormApi, createForm, Config } from 'final-form'
+import { FormApi, createForm, Config, FormState } from 'final-form'
 import { Plugin } from '@tinacms/core'
 import { Field, AnyField } from './field'
 
@@ -29,6 +29,7 @@ export interface FormOptions<S, F extends Field = AnyField> extends Config<S> {
   reset?(): void
   actions?: any[]
   loadInitialValues?: () => Promise<S>
+  onChange(values: FormState<S>): void
 }
 
 export class Form<S = any, F extends Field = AnyField> implements Plugin {
@@ -48,6 +49,7 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
     actions,
     reset,
     loadInitialValues,
+    onChange,
     ...options
   }: FormOptions<S, F>) {
     const initialValues = options.initialValues || ({} as S)
@@ -77,6 +79,20 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
       loadInitialValues().then(initialValues => {
         this.updateInitialValues(initialValues)
       })
+    }
+
+    if (onChange) {
+      let firstUpdate = true
+      this.subscribe(
+        formState => {
+          if (firstUpdate) {
+            firstUpdate = false
+          } else {
+            onChange(formState)
+          }
+        },
+        { values: true }
+      )
     }
   }
 

--- a/packages/@tinacms/forms/src/form.ts
+++ b/packages/@tinacms/forms/src/form.ts
@@ -29,7 +29,7 @@ export interface FormOptions<S, F extends Field = AnyField> extends Config<S> {
   reset?(): void
   actions?: any[]
   loadInitialValues?: () => Promise<S>
-  onChange(values: FormState<S>): void
+  onChange?(values: FormState<S>): void
 }
 
 export class Form<S = any, F extends Field = AnyField> implements Plugin {

--- a/packages/gatsby-tinacms-git/src/use-git-form.ts
+++ b/packages/gatsby-tinacms-git/src/use-git-form.ts
@@ -16,15 +16,7 @@ limitations under the License.
 
 */
 
-import {
-  useCMS,
-  useForm,
-  Form,
-  useWatchFormValues,
-  FormOptions,
-  WatchableFormValue,
-} from 'tinacms'
-import React from 'react'
+import { useCMS, useForm, Form, FormOptions, WatchableFormValue } from 'tinacms'
 
 export interface GitNode {
   fileRelativePath: string
@@ -56,7 +48,7 @@ export function useGitForm<N extends GitNode>(
       })
   }
 
-  const [values, form] = useForm(
+  return useForm(
     {
       label: formOptions.label || '',
       fields: formOptions.fields || [],
@@ -72,20 +64,15 @@ export function useGitForm<N extends GitNode>(
       reset() {
         return cms.api.git.reset({ files: [node.fileRelativePath] })
       },
+      onChange({ values }) {
+        cms.api.git.onChange!({
+          fileRelativePath: values.fileRelativePath,
+          content: format(values),
+        })
+      },
       ...formOptions,
       id: node.fileRelativePath,
     },
     watch
   )
-
-  const writeToDisk = React.useCallback(({ values }) => {
-    cms.api.git.onChange!({
-      fileRelativePath: values.fileRelativePath,
-      content: format(values),
-    })
-  }, [])
-
-  useWatchFormValues(form, writeToDisk)
-
-  return [values, form]
 }

--- a/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
+++ b/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
@@ -131,6 +131,12 @@ export function useMdxForm(
       reset() {
         return cms.api.git.reset({ files: [id] })
       },
+      onChange(formState) {
+        cms.api.git.onChange!({
+          fileRelativePath: formState.values.fileRelativePath,
+          content: toMdxString(formState.values),
+        })
+      },
       actions,
     },
     // The Form will be updated if these values change.
@@ -140,17 +146,6 @@ export function useMdxForm(
       values: valuesOnDisk,
     }
   )
-
-  /* eslint-disable-next-line react-hooks/rules-of-hooks */
-  const writeToDisk = React.useCallback(formState => {
-    cms.api.git.onChange!({
-      fileRelativePath: formState.values.fileRelativePath,
-      content: toMdxString(formState.values),
-    })
-  }, [])
-
-  /* eslint-disable-next-line react-hooks/rules-of-hooks */
-  useWatchFormValues(form, writeToDisk)
 
   return [mdx, form]
 }

--- a/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
+++ b/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
@@ -21,7 +21,6 @@ import {
   Form,
   GlobalFormPlugin,
   useCMS,
-  useWatchFormValues,
   useForm,
   usePlugins,
 } from 'tinacms'

--- a/packages/next-tinacms-json/src/use-json-form.ts
+++ b/packages/next-tinacms-json/src/use-json-form.ts
@@ -16,15 +16,7 @@ limitations under the License.
 
 */
 
-import { useCallback } from 'react'
-import {
-  useWatchFormValues,
-  useForm,
-  useCMS,
-  FormOptions,
-  Field,
-  Form,
-} from 'tinacms'
+import { useForm, useCMS, FormOptions, Field, Form } from 'tinacms'
 import { generateFields } from './generate-fields'
 
 /**
@@ -78,21 +70,15 @@ export function useJsonForm<T = any>(
       reset() {
         return cms.api.git.reset({ files: [id] })
       },
+      onChange: formState => {
+        cms.api.git.writeToDisk({
+          fileRelativePath: jsonFile.fileRelativePath,
+          content: JSON.stringify(formState.values, null, 2),
+        })
+      },
     },
     { values: jsonFile.data, label }
   )
-
-  const writeToDisk = useCallback(
-    formState => {
-      cms.api.git.writeToDisk({
-        fileRelativePath: jsonFile.fileRelativePath,
-        content: JSON.stringify(formState.values, null, 2),
-      })
-    },
-    [jsonFile.fileRelativePath]
-  )
-
-  useWatchFormValues(form, writeToDisk)
 
   return [values || jsonFile.data, form]
 }

--- a/packages/next-tinacms-markdown/src/use-markdown-form.ts
+++ b/packages/next-tinacms-markdown/src/use-markdown-form.ts
@@ -16,17 +16,10 @@ limitations under the License.
 
 */
 
-import { useCallback } from 'react'
 const matter = require('gray-matter')
-import * as yaml from 'js-yaml'
 
-import {
-  useWatchFormValues,
-  useForm,
-  useCMS,
-  FormOptions,
-  Field,
-} from 'tinacms'
+import * as yaml from 'js-yaml'
+import { useForm, useCMS, FormOptions, Field } from 'tinacms'
 import { generateFields } from './generate-fields'
 
 /**
@@ -95,21 +88,18 @@ export function useMarkdownForm(
       reset() {
         return cms.api.git.reset({ files: [id] })
       },
+      onChange(formState) {
+        cms.api.git.writeToDisk({
+          fileRelativePath: formState.values.fileRelativePath,
+          content: toMarkdownString(formState.values),
+        })
+      },
     },
     {
       values: valuesOnDisk,
       label,
     }
   )
-
-  const writeToDisk = useCallback(formState => {
-    cms.api.git.writeToDisk({
-      fileRelativePath: formState.values.fileRelativePath,
-      content: toMarkdownString(formState.values),
-    })
-  }, [])
-
-  useWatchFormValues(form, writeToDisk)
 
   return [values || markdownFile, form]
 }


### PR DESCRIPTION
This PR makes it possible to pass an `onChange` callback to a form construction.

This change makes it possible to override default behaviour of `useGitForm`:

```js
const cms = useCMS()

useRemarkForm(node, {
  onSubmit(data) {
    return cms.api.git.writeToDisk({
      fileRelativePath: values.fileRelativePath,
      content: toMarkdown(values),
    })
  }, 
  onChange: null,
})
```

This makes it so:

1. The form does not write to disk `onChange` 
1. Pressing `Save` writes to disk

Effectively disabling the "live" preview mode which causes problems for users with slow builds.