### PR TITLE
Various UI Logic Corrections

### DIFF
--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -170,7 +170,7 @@ export class CMS {
   }
 
   disable(): void {
-    this._enabled = true
+    this._enabled = false
     this.events.dispatch(CMS.DISABLED)
   }
 }

--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -78,7 +78,7 @@ export class CMS {
   static ENABLED = { type: 'cms:enable' }
   static DISABLED = { type: 'cms:disable' }
 
-  private _enabled: boolean = false
+  private _enabled: boolean = true
 
   /**
    * An object for managing CMSs plugins.
@@ -131,8 +131,10 @@ export class CMS {
       )
     }
 
-    if (config.enabled) {
+    if (config.enabled || typeof config.enabled === 'undefined') {
       this.enable()
+    } else {
+      this.disable()
     }
   }
 

--- a/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
@@ -43,9 +43,10 @@ export function SidebarProvider({
   position,
   sidebar,
 }: SidebarProviderProps) {
+  const cms = useCMS()
   useSubscribable(sidebar)
 
-  if (sidebar.hidden) return children
+  if (cms.disabled || sidebar.hidden) return children
 
   return (
     <>

--- a/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
@@ -36,22 +36,14 @@ export interface SidebarProviderProps {
   children: any
   sidebar: SidebarState
   position?: SidebarStateOptions['position']
-  hidden?: boolean
 }
 
 export function SidebarProvider({
   children,
   position,
-  hidden,
   sidebar,
 }: SidebarProviderProps) {
   useSubscribable(sidebar)
-
-  React.useEffect(() => {
-    if (typeof hidden !== 'undefined') {
-      sidebar.hidden = hidden
-    }
-  }, [hidden])
 
   if (sidebar.hidden) return children
 

--- a/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
@@ -19,6 +19,7 @@ limitations under the License.
 import * as React from 'react'
 import { Toolbar } from './Toolbar'
 import { ToolbarState } from '../toolbar'
+import { useSubscribable } from '@tinacms/react-core'
 
 interface ToolbarProviderProps {
   toolbar: ToolbarState
@@ -26,6 +27,7 @@ interface ToolbarProviderProps {
 }
 
 export function ToolbarProvider({ hidden, toolbar }: ToolbarProviderProps) {
+  useSubscribable(toolbar)
   React.useEffect(() => {
     if (typeof hidden !== 'undefined') {
       toolbar.hidden = hidden

--- a/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/ToolbarProvider.tsx
@@ -23,16 +23,10 @@ import { useSubscribable } from '@tinacms/react-core'
 
 interface ToolbarProviderProps {
   toolbar: ToolbarState
-  hidden?: boolean
 }
 
-export function ToolbarProvider({ hidden, toolbar }: ToolbarProviderProps) {
+export function ToolbarProvider({ toolbar }: ToolbarProviderProps) {
   useSubscribable(toolbar)
-  React.useEffect(() => {
-    if (typeof hidden !== 'undefined') {
-      toolbar.hidden = hidden
-    }
-  }, [hidden])
 
   if (toolbar.hidden) return null
 

--- a/packages/gatsby-plugin-tinacms/gatsby-browser.tsx
+++ b/packages/gatsby-plugin-tinacms/gatsby-browser.tsx
@@ -34,6 +34,7 @@ declare let window: any
 
 exports.onClientEntry = (_: null, options: GatsbyPluginTinacmsOptions) => {
   window.tinacms = new TinaCMS({
+    enabled: options.enabled,
     sidebar: options.sidebar,
     toolbar: options.toolbar,
   })

--- a/packages/gatsby-plugin-tinacms/options.ts
+++ b/packages/gatsby-plugin-tinacms/options.ts
@@ -19,6 +19,7 @@ limitations under the License.
 import { TinaCMSConfig } from 'tinacms'
 
 export interface GatsbyPluginTinacmsOptions {
+  enabled?: boolean
   sidebar: TinaCMSConfig['sidebar']
   toolbar: TinaCMSConfig['toolbar']
   manualInit?: boolean

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -77,10 +77,14 @@ export class GithubClient {
     return this.workingRepoFullName !== this.baseRepoFullName
   }
 
-  async isAuthorized() {
-    const repo = await this.getRepository()
+  async isAuthorized(): Promise<boolean> {
+    try {
+      const repo = await this.getRepository()
 
-    return repo.permissions.push
+      return repo.permissions.push
+    } catch {
+      return false
+    }
   }
 
   async getUser() {

--- a/packages/react-tinacms-github/src/github-editing-context/TinacmsGithubProvider.tsx
+++ b/packages/react-tinacms-github/src/github-editing-context/TinacmsGithubProvider.tsx
@@ -45,11 +45,15 @@ export const TinacmsGithubProvider = ({
   const github: GithubClient = cms.api.github
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
 
-  const onClose = () => {
+  const onClose = async () => {
     setActiveModal(null)
+    if (!(await github.isAuthorized())) {
+      cms.disable()
+    }
   }
 
   const beginAuth = async () => {
+    cms.enable()
     if (await github.isAuthenticated()) {
       onAuthSuccess()
     } else {

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -51,14 +51,10 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
   return (
     <CMSContext.Provider value={cms}>
       <ModalProvider>
-        {enabled && styled && <Theme />}
         <Alerts alerts={cms.alerts} />
-        {enabled && <ToolbarProvider hidden={hidden} toolbar={cms.toolbar} />}
-        <SidebarProvider
-          hidden={hidden}
-          position={position}
-          sidebar={cms.sidebar}
-        >
+        {enabled && styled && <Theme />}
+        {enabled && <ToolbarProvider toolbar={cms.toolbar} />}
+        <SidebarProvider position={position} sidebar={cms.sidebar}>
           {children}
         </SidebarProvider>
       </ModalProvider>

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -24,6 +24,7 @@ import { ToolbarProvider } from '@tinacms/react-toolbar'
 import { TinaCMS } from '../tina-cms'
 import { CMSContext } from '../react-tinacms'
 import { Alerts } from '@tinacms/react-alerts'
+import { useState, useEffect } from 'react'
 
 export interface TinaProviderProps {
   cms: TinaCMS
@@ -39,12 +40,20 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
   position,
   styled = true,
 }) => {
+  const [enabled, setEnabled] = useState(cms.enabled)
+
+  useEffect(() => {
+    return cms.events.subscribe('cms', () => {
+      setEnabled(cms.enabled)
+    })
+  }, [])
+
   return (
     <CMSContext.Provider value={cms}>
       <ModalProvider>
-        {cms.enabled && styled && <Theme />}
+        {enabled && styled && <Theme />}
         <Alerts alerts={cms.alerts} />
-        <ToolbarProvider hidden={hidden} toolbar={cms.toolbar} />
+        {enabled && <ToolbarProvider hidden={hidden} toolbar={cms.toolbar} />}
         <SidebarProvider
           hidden={hidden}
           position={position}

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -36,7 +36,6 @@ export interface TinaProviderProps {
 export const TinaProvider: React.FC<TinaProviderProps> = ({
   cms,
   children,
-  hidden,
   position,
   styled = true,
 }) => {


### PR DESCRIPTION
This PR fixes a few issues with the UI:

* The UI is disabled when `cms.disabled`
* The `TinaProvider` subscribes to cms events i.e. enabling and disabling
* Starting the Github auth flow enables the CMS, thus loading the styles and rendering the sidebar/toolbar
* Exiting the Github auth flow early disables the CMS, thus hiding the sidebar/toolbar
* Toolbar UI subscribes to changes in toolbar state