### PR TITLE
improvement: add type check on cms property of TinaProvider

### DIFF
--- a/packages/tinacms/src/components/TinaProvider.test.tsx
+++ b/packages/tinacms/src/components/TinaProvider.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { TinaProvider, CMS } from '../../build'
+import { TinaCMS } from '..'
+
+describe('TinaProvider', () => {
+  describe('when passed an instance of CMS', () => {
+    it('throws no error', () => {
+      render(<TinaProvider cms={new CMS()} />)
+    })
+  })
+  describe('when passed an instance of TinaCMS', () => {
+    it('throws no error', () => {
+      render(<TinaProvider cms={new TinaCMS()} />)
+    })
+  })
+  describe('when passed an empty object', () => {
+    it('throws an Error', () => {
+      const t = () => {
+        render(<TinaProvider cms={{} as any} />)
+      }
+
+      expect(t).toThrowError('Prop cms is not an instance of CMS.')
+    })
+  })
+})

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -25,6 +25,7 @@ import { TinaCMS } from '../tina-cms'
 import { CMSContext } from '../react-tinacms'
 import { Alerts } from '@tinacms/react-alerts'
 import { useState, useEffect } from 'react'
+import { CMS } from '@tinacms/core'
 
 export interface TinaProviderProps {
   cms: TinaCMS
@@ -46,6 +47,10 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
       setEnabled(cms.enabled)
     })
   }, [])
+
+  if (!(cms instanceof CMS)) {
+    throw new Error('prop cms is not an instance of CMS')
+  }
 
   return (
     <CMSContext.Provider value={cms}>


### PR DESCRIPTION
From the discourse topic here: https://community.tinacms.org/t/error-when-trying-to-set-up-tina-for-first-time-cannot-read-property-all-of-undefined/189

When passing an empty object to TinaProvider's `cms` prop, the following error would be thrown:

```
Cannot read property 'all' of undefined
TypeError: Cannot read property 'all' of undefined
    at n.Alerts (C:\Development\TorqIT\TorqIT-next\node_modules\@tinacms\react-alerts\build\index.js:1:5729)
    at processChild (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3043:14)
    at resolve (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3373:29)
    at renderToString (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3988:27)
    at render (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\render.js:83:16)
    at Object.renderPage (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\render.js:419:16)
    at Function.getInitialProps (C:\Development\TorqIT\TorqIT-next\.next\server\static\development\pages\_document.js:293:19)
    at Object.loadGetInitialProps (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\lib\utils.js:59:29)
    at Object.renderToHTML (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\render.js:423:36)
    at async DevServer.renderToHTMLWithComponents (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\next-server.js:652:26)
    at async DevServer.renderToHTML (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\next-server.js:799:28)
    at async DevServer.renderToHTML (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\server\next-dev-server.js:19:539)
    at async DevServer.render (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\next-server.js:541:22)
    at async Object.fn (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\server\next-dev-server.js:9:383)
```

This check verifies that the passed object to `cms` is an instance of CMS or one of it's inheritors and provides a more helpful error message if not.

Note: This doesn't actually prevent the error in my testing (writing a jest test to run the code). It also doesn't work if I change TinaProvider to just immediately `throw new Error()`. Strangely, the above error still seems to throw before the function body gets a change to throw it's own error.

@ncphillips requested this to see what the CI process thinks of it. 