### PR TITLE
Cms error check

### DIFF
--- a/packages/tinacms/src/components/TinaProvider.test.tsx
+++ b/packages/tinacms/src/components/TinaProvider.test.tsx
@@ -1,0 +1,26 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { TinaProvider, CMS } from '../../build'
+import { TinaCMS } from '..'
+
+describe('TinaProvider', () => {
+  describe('when passed an instance of CMS', () => {
+    it('throws no error', () => {
+      render(<TinaProvider cms={new CMS()} />)
+    })
+  })
+  describe('when passed an instance of TinaCMS', () => {
+    it('throws no error', () => {
+      render(<TinaProvider cms={new TinaCMS()} />)
+    })
+  })
+  describe('when passed an empty object', () => {
+    it('throws an Error', () => {
+      const t = () => {
+        render(<TinaProvider cms={{} as any} />)
+      }
+
+      expect(t).toThrowError('Prop cms is not an instance of CMS.')
+    })
+  })
+})

--- a/packages/tinacms/src/components/TinaProvider.test.tsx
+++ b/packages/tinacms/src/components/TinaProvider.test.tsx
@@ -1,12 +1,17 @@
 import { render } from '@testing-library/react'
 import React from 'react'
-import { TinaProvider, CMS } from '../../build'
-import { TinaCMS } from '..'
+import { TinaProvider, INVALID_CMS_ERROR } from './TinaProvider'
+import { TinaCMS } from '../tina-cms'
+import { CMS } from '@tinacms/core'
 
 describe('TinaProvider', () => {
   describe('when passed an instance of CMS', () => {
     it('throws no error', () => {
-      render(<TinaProvider cms={new CMS()} />)
+      const t = () => {
+        render(<TinaProvider cms={new CMS() as any} />)
+      }
+
+      expect(t).toThrowError(INVALID_CMS_ERROR)
     })
   })
   describe('when passed an instance of TinaCMS', () => {
@@ -20,7 +25,7 @@ describe('TinaProvider', () => {
         render(<TinaProvider cms={{} as any} />)
       }
 
-      expect(t).toThrowError('Prop cms is not an instance of CMS.')
+      expect(t).toThrowError(INVALID_CMS_ERROR)
     })
   })
 })

--- a/packages/tinacms/src/components/TinaProvider.test.tsx
+++ b/packages/tinacms/src/components/TinaProvider.test.tsx
@@ -6,7 +6,7 @@ import { CMS } from '@tinacms/core'
 
 describe('TinaProvider', () => {
   describe('when passed an instance of CMS', () => {
-    it('throws no error', () => {
+    it('throws error', () => {
       const t = () => {
         render(<TinaProvider cms={new CMS() as any} />)
       }

--- a/packages/tinacms/src/components/TinaProvider.test.tsx
+++ b/packages/tinacms/src/components/TinaProvider.test.tsx
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 import { render } from '@testing-library/react'
 import React from 'react'
 import { TinaProvider, INVALID_CMS_ERROR } from './TinaProvider'

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -25,7 +25,6 @@ import { TinaCMS } from '../tina-cms'
 import { CMSContext } from '../react-tinacms'
 import { Alerts } from '@tinacms/react-alerts'
 import { useState, useEffect } from 'react'
-import { CMS } from '@tinacms/core'
 
 export interface TinaProviderProps {
   cms: TinaCMS
@@ -33,6 +32,9 @@ export interface TinaProviderProps {
   position?: SidebarPosition
   styled?: boolean
 }
+
+export const INVALID_CMS_ERROR =
+  'The `cms` prop must be an instance of `TinaCMS`.'
 
 export const TinaProvider: React.FC<TinaProviderProps> = ({
   cms,
@@ -48,8 +50,8 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
     })
   }, [])
 
-  if (!(cms instanceof CMS)) {
-    throw new Error('prop cms is not an instance of CMS')
+  if (!(cms instanceof TinaCMS)) {
+    throw new Error(INVALID_CMS_ERROR)
   }
 
   return (

--- a/packages/tinacms/src/components/TinaProvider.tsx
+++ b/packages/tinacms/src/components/TinaProvider.tsx
@@ -25,6 +25,7 @@ import { TinaCMS } from '../tina-cms'
 import { CMSContext } from '../react-tinacms'
 import { Alerts } from '@tinacms/react-alerts'
 import { useState, useEffect } from 'react'
+import { CMS } from '@tinacms/core'
 
 export interface TinaProviderProps {
   cms: TinaCMS
@@ -46,6 +47,10 @@ export const TinaProvider: React.FC<TinaProviderProps> = ({
       setEnabled(cms.enabled)
     })
   }, [])
+
+  if (!(cms instanceof CMS)) {
+    throw new Error('prop cms is not an instance of CMS')
+  }
 
   return (
     <CMSContext.Provider value={cms}>


### PR DESCRIPTION
Original PR in #1196 by @IronSean 

---

From the discourse topic here: https://community.tinacms.org/t/error-when-trying-to-set-up-tina-for-first-time-cannot-read-property-all-of-undefined/189

When passing an empty object to TinaProvider's `cms` prop, the following error would be thrown:

```
Cannot read property 'all' of undefined
TypeError: Cannot read property 'all' of undefined
    at n.Alerts (C:\Development\TorqIT\TorqIT-next\node_modules\@tinacms\react-alerts\build\index.js:1:5729)
    at processChild (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3043:14)
    at resolve (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:2960:5)
    at ReactDOMServerRenderer.render (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3435:22)
    at ReactDOMServerRenderer.read (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3373:29)
    at renderToString (C:\Development\TorqIT\TorqIT-next\node_modules\react-dom\cjs\react-dom-server.node.development.js:3988:27)
    at render (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\render.js:83:16)
    at Object.renderPage (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\render.js:419:16)
    at Function.getInitialProps (C:\Development\TorqIT\TorqIT-next\.next\server\static\development\pages\_document.js:293:19)
    at Object.loadGetInitialProps (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\lib\utils.js:59:29)
    at Object.renderToHTML (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\render.js:423:36)
    at async DevServer.renderToHTMLWithComponents (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\next-server.js:652:26)
    at async DevServer.renderToHTML (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\next-server.js:799:28)
    at async DevServer.renderToHTML (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\server\next-dev-server.js:19:539)
    at async DevServer.render (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\next-server\server\next-server.js:541:22)
    at async Object.fn (C:\Development\TorqIT\TorqIT-next\node_modules\next\dist\server\next-dev-server.js:9:383)
```

This check verifies that the passed object to `cms` is an instance of CMS or one of it's inheritors and provides a more helpful error message if not.

Note: This doesn't actually prevent the error in my testing (writing a jest test to run the code). It also doesn't work if I change TinaProvider to just immediately `throw new Error()`. Strangely, the above error still seems to throw before the function body gets a change to throw it's own error.

@ncphillips requested this to see what the CI process thinks of it. 