### PR TITLE
fix: github client fetch file works on any branch

### DIFF
--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -257,7 +257,7 @@ export class GithubClient {
     const repo = this.workingRepoFullName
     const branch = this.branchName
     const request = await this.req({
-      url: `https://api.github.com/repos/${repo}/contents/${filePath}`,
+      url: `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${branch}`,
       method: 'GET',
       data: {
         sha,

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -259,10 +259,6 @@ export class GithubClient {
     const request = await this.req({
       url: `https://api.github.com/repos/${repo}/contents/${filePath}?ref=${branch}`,
       method: 'GET',
-      data: {
-        sha,
-        branch: branch,
-      },
     })
 
     // decode using base64 decoding (https://developer.mozilla.org/en-US/docs/Glossary/Base64)

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -253,7 +253,7 @@ export class GithubClient {
       },
     })
   }
-  async fetchFile(filePath: string, sha: string, decoded: boolean = true) {
+  async fetchFile(filePath: string, decoded: boolean = true) {
     const repo = this.workingRepoFullName
     const branch = this.branchName
     const request = await this.req({


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

Added ref to the fetch file method in the github client. before this it would only fetch from the default branch.
