### PR TITLE
Inline settings — cancel & confirm

### DIFF
--- a/packages/@tinacms/styles/src/Button.tsx
+++ b/packages/@tinacms/styles/src/Button.tsx
@@ -24,6 +24,7 @@ export interface ButtonProps {
   grow?: boolean
   open?: boolean
   busy?: boolean
+  disabled?: boolean
 }
 
 export const Button = styled.button<ButtonProps>`

--- a/packages/demo-next/pages/info.js
+++ b/packages/demo-next/pages/info.js
@@ -133,6 +133,7 @@ function Info(props) {
               flex-direction: column;
               text-align: center;
               padding: 3rem;
+              margin-top: 4rem;
             }
           `}
         </style>

--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -102,6 +102,9 @@ function SettingsModal({ fields, close }: SettingsModalProps) {
           </DragDropContext>
         </ModalBody>
         <ModalActions>
+          {form.values !== initialValues && (
+            <Button onClick={close}>Confirm</Button>
+          )}
           <Button onClick={handleCancel}>Cancel</Button>
         </ModalActions>
       </ModalPopup>

--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -102,9 +102,9 @@ function SettingsModal({ fields, close }: SettingsModalProps) {
           </DragDropContext>
         </ModalBody>
         <ModalActions>
-          {form.values !== initialValues && (
-            <Button onClick={close}>Confirm</Button>
-          )}
+          <Button onClick={close} disabled={form.values === initialValues}>
+            Confirm
+          </Button>
           <Button onClick={handleCancel}>Cancel</Button>
         </ModalActions>
       </ModalPopup>

--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -102,10 +102,14 @@ function SettingsModal({ fields, close }: SettingsModalProps) {
           </DragDropContext>
         </ModalBody>
         <ModalActions>
-          <Button onClick={close} disabled={form.values === initialValues}>
+          <Button onClick={handleCancel}>Cancel</Button>
+          <Button
+            onClick={close}
+            disabled={form.values === initialValues}
+            primary
+          >
             Confirm
           </Button>
-          <Button onClick={handleCancel}>Cancel</Button>
         </ModalActions>
       </ModalPopup>
     </Modal>

--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -65,6 +65,7 @@ interface SettingsModalProps {
 function SettingsModal({ fields, close }: SettingsModalProps) {
   const { form } = useInlineForm()
   const { name } = React.useContext(InlineFieldContext)
+  const [initialValues] = React.useState(form.values)
 
   let formFields = fields
 
@@ -96,7 +97,9 @@ function SettingsModal({ fields, close }: SettingsModalProps) {
           </DragDropContext>
         </ModalBody>
         <ModalActions>
-          <Button onClick={close}>Cancel</Button>
+          <Button onClick={() => form.updateValues(initialValues)}>
+            Cancel
+          </Button>
         </ModalActions>
       </ModalPopup>
     </Modal>

--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -67,6 +67,11 @@ function SettingsModal({ fields, close }: SettingsModalProps) {
   const { name } = React.useContext(InlineFieldContext)
   const [initialValues] = React.useState(form.values)
 
+  function handleCancel() {
+    form.updateValues(initialValues)
+    close()
+  }
+
   let formFields = fields
 
   if (name) {
@@ -97,9 +102,7 @@ function SettingsModal({ fields, close }: SettingsModalProps) {
           </DragDropContext>
         </ModalBody>
         <ModalActions>
-          <Button onClick={() => form.updateValues(initialValues)}>
-            Cancel
-          </Button>
+          <Button onClick={handleCancel}>Cancel</Button>
         </ModalActions>
       </ModalPopup>
     </Modal>


### PR DESCRIPTION
Closes #1003 

## What this does:

- Hitting the 'Cancel' button resets any changes made in the modal form to the initial values when the settings modal was opened
- Adds a confirm button that essentially just closes the modal but makes for better UX. 

<img width="517" alt="Screen Shot 2020-06-02 at 1 29 31 PM" src="https://user-images.githubusercontent.com/36613477/83566590-1c6b3a00-a4d5-11ea-9b86-0dcff8bcba2a.png">

My questions @spbyrne : 

- Do we add an alert or confirmation to this action? - Waiting until it's needed
- Should we call this 'reset' or does 'cancel' feel good? 👉 Cancel
- ~Should the type be red to indicate a delete action?~ Nay
- Should 'cancel' also close the modal? ✅