### PR TITLE
Add Inset Option For Blocks Controls

### DIFF
--- a/packages/demo-next/pages/nesting.tsx
+++ b/packages/demo-next/pages/nesting.tsx
@@ -115,6 +115,8 @@ export default function Nesting() {
                   templates: { color: COLORS.color.template },
                 },
               ]}
+              offset={24}
+              insetControls={true}
             >
               <h2>Author</h2>
               <InlineText name="name" focusRing={false} />

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -38,6 +38,7 @@ export interface BlocksControlsProps {
   index: number
   offset?: number
   borderRadius?: number
+  insetControls?: boolean
 }
 
 export function BlocksControls({
@@ -45,6 +46,7 @@ export function BlocksControls({
   index,
   offset,
   borderRadius,
+  insetControls,
 }: BlocksControlsProps) {
   const { status, focussedField, setFocussedField } = useInlineForm()
   const { name, template } = React.useContext(InlineFieldContext)
@@ -143,7 +145,13 @@ export function BlocksControls({
           position={addAfterPosition}
         />
       </AddBlockMenuWrapper>
-      <BlockMenuWrapper ref={blockMenuRef} index={index} active={isActive}>
+      <BlockMenuWrapper
+        offset={offset}
+        ref={blockMenuRef}
+        index={index}
+        active={isActive}
+        inset={insetControls}
+      >
         <BlockMenu>
           <BlockAction
             ref={blockMoveUpRef}
@@ -201,6 +209,7 @@ const AddBlockMenuWrapper = styled.div<AddBlockMenuWrapperProps>(
 interface BlockMenuWrapperProps {
   index?: number
   active: boolean
+  inset?: boolean
   offset?: number
 }
 
@@ -214,6 +223,13 @@ export const BlockMenuWrapper = styled.div<BlockMenuWrapperProps>(
     z-index: calc(var(--tina-z-index-1) - ${p.index ? p.index : 0});
     pointer-events: none;
     transform: translate3d(0, -100%, 0);
+
+    ${p.inset &&
+      css`
+        top: calc(14px - ${p.offset !== undefined ? p.offset : `16`}px);
+        right: calc(14px - ${p.offset !== undefined ? p.offset : `16`}px);
+        transform: translate3d(0, 0, 0);
+      `}
 
     ${p.active &&
       css`

--- a/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
@@ -33,6 +33,7 @@ interface InlineGroupControls {
   children: any
   offset?: number
   borderRadius?: number
+  insetControls?: boolean
 }
 
 export function InlineGroupControls({
@@ -40,6 +41,7 @@ export function InlineGroupControls({
   children,
   offset,
   borderRadius,
+  insetControls,
 }: InlineGroupControls) {
   const { status, focussedField, setFocussedField } = useInlineForm()
   const groupRef = React.useRef<HTMLDivElement>(null)
@@ -69,7 +71,12 @@ export function InlineGroupControls({
       borderRadius={borderRadius}
       disableHover={childIsActive}
     >
-      <BlockMenuWrapper ref={groupMenuRef} offset={offset} active={active}>
+      <BlockMenuWrapper
+        ref={groupMenuRef}
+        offset={offset}
+        inset={insetControls}
+        active={active}
+      >
         <BlockMenu>
           <InlineSettings fields={fields} />
         </BlockMenu>

--- a/packages/react-tinacms-inline/src/inline-group/inline-group.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group.tsx
@@ -27,6 +27,7 @@ interface InlineGroupProps {
   fields?: Field[]
   offset?: number
   borderRadius?: number
+  insetControls?: boolean
   children?: any
 }
 
@@ -36,6 +37,7 @@ export function InlineGroup({
   fields = [],
   offset,
   borderRadius,
+  insetControls,
 }: InlineGroupProps) {
   return (
     <InlineFieldContext.Provider value={{ name, fields }}>
@@ -43,6 +45,7 @@ export function InlineGroup({
         name={name}
         offset={offset}
         borderRadius={borderRadius}
+        insetControls={insetControls}
       >
         {children}
       </InlineGroupControls>


### PR DESCRIPTION
This allows you to set `insetControls={true}` on BlocksControls & InlineGroups. I'm not sure if it would make sense to also have the ability to set this at the `InlineBlocks` or not since it depends on how the individual block is set up.

<img width="518" alt="Screen Shot 2020-06-03 at 2 59 39 PM" src="https://user-images.githubusercontent.com/5075484/83671307-dc768680-a5aa-11ea-8815-ca4193df8f87.png">