### PR TITLE
Adds focus ring prop to inline groups and blocks controls

### DIFF
--- a/packages/demo-next/pages/info.js
+++ b/packages/demo-next/pages/info.js
@@ -73,8 +73,9 @@ function Info(props) {
                 { label: 'Name', name: 'name', component: 'text' },
                 { label: 'Hometown', name: 'hometown', component: 'text' },
               ]}
-              offset={10}
-              borderRadius={5}
+              focusRing={{
+                offset: 0,
+              }}
             >
               <h1>
                 <InlineText focusRing={false} name="name" />

--- a/packages/demo-next/pages/nesting.tsx
+++ b/packages/demo-next/pages/nesting.tsx
@@ -115,7 +115,9 @@ export default function Nesting() {
                   templates: { color: COLORS.color.template },
                 },
               ]}
-              offset={24}
+              focusRing={{
+                offset: 24,
+              }}
               insetControls={true}
             >
               <h2>Author</h2>
@@ -269,7 +271,10 @@ const COL = {
   Component({ index, data }) {
     return (
       <>
-        <BlocksControls index={index} offset={0} borderRadius={0}>
+        <BlocksControls
+          index={index}
+          focusRing={{ offset: 0, borderRadius: 0 }}
+        >
           <div className="col">
             <InlineBlocks
               name="items"

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -39,6 +39,7 @@ export interface BlocksControlsProps {
   offset?: number
   borderRadius?: number
   insetControls?: boolean
+  focusRing?: boolean
 }
 
 export function BlocksControls({
@@ -47,6 +48,7 @@ export function BlocksControls({
   offset,
   borderRadius,
   insetControls,
+  focusRing = true,
 }: BlocksControlsProps) {
   const { status, focussedField, setFocussedField } = useInlineForm()
   const { name, template } = React.useContext(InlineFieldContext)
@@ -119,11 +121,11 @@ export function BlocksControls({
   return (
     <FocusRing
       ref={blockRef}
-      active={isActive}
+      active={focusRing && isActive}
       onClick={handleSetActiveBlock}
       offset={offset}
       borderRadius={borderRadius}
-      disableHover={childIsActive}
+      disableHover={!focusRing ? true : childIsActive}
     >
       <AddBlockMenuWrapper active={isActive}>
         <AddBlockMenu

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -32,23 +32,20 @@ import { AddBlockMenu } from './add-block-menu'
 import { InlineSettings } from '../inline-settings'
 import { InlineFieldContext } from '../inline-field-context'
 import { FocusRing } from '../styles'
+import { FocusRingProps } from '../inline-group'
 
 export interface BlocksControlsProps {
   children: any
   index: number
-  offset?: number
-  borderRadius?: number
   insetControls?: boolean
-  focusRing?: boolean
+  focusRing?: false | FocusRingProps
 }
 
 export function BlocksControls({
   children,
   index,
-  offset,
-  borderRadius,
   insetControls,
-  focusRing = true,
+  focusRing = {},
 }: BlocksControlsProps) {
   const { status, focussedField, setFocussedField } = useInlineForm()
   const { name, template } = React.useContext(InlineFieldContext)
@@ -118,14 +115,18 @@ export function BlocksControls({
     setFocussedField(name!)
   }
 
+  const offset = typeof focusRing === 'object' ? focusRing.offset : undefined
+
   return (
     <FocusRing
       ref={blockRef}
       active={focusRing && isActive}
       onClick={handleSetActiveBlock}
       offset={offset}
-      borderRadius={borderRadius}
-      disableHover={!focusRing ? true : childIsActive}
+      borderRadius={
+        typeof focusRing === 'object' ? focusRing.borderRadius : undefined
+      }
+      disableHover={focusRing === false ? true : childIsActive}
     >
       <AddBlockMenuWrapper active={isActive}>
         <AddBlockMenu

--- a/packages/react-tinacms-inline/src/inline-group/index.ts
+++ b/packages/react-tinacms-inline/src/inline-group/index.ts
@@ -17,4 +17,4 @@ limitations under the License.
 */
 
 export { InlineGroup } from './inline-group'
-export { InlineGroupControls } from './inline-group-controls'
+export * from './inline-group-controls'

--- a/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
@@ -34,6 +34,7 @@ interface InlineGroupControls {
   offset?: number
   borderRadius?: number
   insetControls?: boolean
+  focusRing?: boolean
 }
 
 export function InlineGroupControls({
@@ -42,6 +43,7 @@ export function InlineGroupControls({
   offset,
   borderRadius,
   insetControls,
+  focusRing = true,
 }: InlineGroupControls) {
   const { status, focussedField, setFocussedField } = useInlineForm()
   const groupRef = React.useRef<HTMLDivElement>(null)
@@ -65,11 +67,11 @@ export function InlineGroupControls({
   return (
     <FocusRing
       ref={groupRef}
-      active={active}
+      active={focusRing && active}
       onClick={handleSetActive}
       offset={offset}
       borderRadius={borderRadius}
-      disableHover={childIsActive}
+      disableHover={!focusRing ? true : childIsActive}
     >
       <BlockMenuWrapper
         ref={groupMenuRef}

--- a/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
@@ -31,19 +31,20 @@ import {
 interface InlineGroupControls {
   name: string
   children: any
+  insetControls?: boolean
+  focusRing?: false | FocusRingProps
+}
+
+export interface FocusRingProps {
   offset?: number
   borderRadius?: number
-  insetControls?: boolean
-  focusRing?: boolean
 }
 
 export function InlineGroupControls({
   name,
   children,
-  offset,
-  borderRadius,
   insetControls,
-  focusRing = true,
+  focusRing = {},
 }: InlineGroupControls) {
   const { status, focussedField, setFocussedField } = useInlineForm()
   const groupRef = React.useRef<HTMLDivElement>(null)
@@ -64,14 +65,18 @@ export function InlineGroupControls({
     event.preventDefault()
   }
 
+  const offset = typeof focusRing === 'object' ? focusRing.offset : undefined
+
   return (
     <FocusRing
       ref={groupRef}
       active={focusRing && active}
       onClick={handleSetActive}
       offset={offset}
-      borderRadius={borderRadius}
-      disableHover={!focusRing ? true : childIsActive}
+      borderRadius={
+        typeof focusRing === 'object' ? focusRing.borderRadius : undefined
+      }
+      disableHover={focusRing === false ? true : childIsActive}
     >
       <BlockMenuWrapper
         ref={groupMenuRef}

--- a/packages/react-tinacms-inline/src/inline-group/inline-group.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group.tsx
@@ -20,15 +20,13 @@ import * as React from 'react'
 import { Field } from 'tinacms'
 
 import { InlineFieldContext } from '../inline-field-context'
-import { InlineGroupControls } from './inline-group-controls'
+import { InlineGroupControls, FocusRingProps } from './inline-group-controls'
 
 interface InlineGroupProps {
   name: string
   fields?: Field[]
-  offset?: number
-  borderRadius?: number
   insetControls?: boolean
-  focusRing?: boolean
+  focusRing?: FocusRingProps
   children?: any
 }
 
@@ -36,8 +34,6 @@ export function InlineGroup({
   name,
   children,
   fields = [],
-  offset,
-  borderRadius,
   insetControls,
   focusRing,
 }: InlineGroupProps) {
@@ -45,8 +41,6 @@ export function InlineGroup({
     <InlineFieldContext.Provider value={{ name, fields }}>
       <InlineGroupControls
         name={name}
-        offset={offset}
-        borderRadius={borderRadius}
         insetControls={insetControls}
         focusRing={focusRing}
       >

--- a/packages/react-tinacms-inline/src/inline-group/inline-group.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group.tsx
@@ -28,6 +28,7 @@ interface InlineGroupProps {
   offset?: number
   borderRadius?: number
   insetControls?: boolean
+  focusRing?: boolean
   children?: any
 }
 
@@ -38,6 +39,7 @@ export function InlineGroup({
   offset,
   borderRadius,
   insetControls,
+  focusRing,
 }: InlineGroupProps) {
   return (
     <InlineFieldContext.Provider value={{ name, fields }}>
@@ -46,6 +48,7 @@ export function InlineGroup({
         offset={offset}
         borderRadius={borderRadius}
         insetControls={insetControls}
+        focusRing={focusRing}
       >
         {children}
       </InlineGroupControls>


### PR DESCRIPTION
```js
<InlineGroup
  name="frontmatter"
  fields={[
    { label: 'Name', name: 'name', component: 'text' },
    { label: 'Hometown', name: 'hometown', component: 'text' },
  ]}
  offset={10}
  borderRadius={5}
  focusRing={false}
>
 ...
</InlineGroup>
```
or 

```js
<BlocksControls index={index} focusRing={false}>
  ...
</BlocksControls>
```
