### PR TITLE
Add Block Fixes

### DIFF
--- a/packages/@tinacms/styles/src/Styles.tsx
+++ b/packages/@tinacms/styles/src/Styles.tsx
@@ -76,8 +76,8 @@ const theme = css`
     --tina-font-weight-regular: 400;
     --tina-font-weight-bold: 600;
 
-    --tina-shadow-big: 0px 2px 3px rgba(0, 0, 0, 0.12),
-      0px 4px 8px rgba(48, 48, 48, 0.1);
+    --tina-shadow-big: 0px 2px 3px rgba(0, 0, 0, 0.05),
+      0 4px 12px rgba(0, 0, 0, 0.1);
     --tina-shadow-small: 0px 2px 3px rgba(0, 0, 0, 0.12);
 
     --tina-timing-short: 85ms;

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -50,7 +50,7 @@ export function AddBlockMenu({
       const menuBounding = addBlockButtonElem.getBoundingClientRect()
       const halfWindowHeight =
         (window.innerHeight || document.documentElement.clientHeight) / 2
-      const offsetTop = menuBounding.top - window.scrollY
+      const offsetTop = menuBounding.top
 
       if (offsetTop < halfWindowHeight) {
         setOpenTop(false)

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -209,7 +209,7 @@ const BlocksMenu = styled.div<AddMenuProps>`
   justify-content: flex-start;
   position: absolute;
   z-index: var(--tina-z-index-2);
-  top: 4px;
+  top: 20px;
   left: 50%;
   transform: translate3d(-50%, 0, 0) scale3d(0.5, 0.5, 1);
   opacity: 0;
@@ -225,19 +225,19 @@ const BlocksMenu = styled.div<AddMenuProps>`
     css`
       opacity: 1;
       pointer-events: all;
-      transform: translate3d(-50%, 32px, 0) scale3d(1, 1, 1);
+      transform: translate3d(-50%, 16px, 0) scale3d(1, 1, 1);
     `};
 
   ${props =>
     props.openTop &&
     css`
       top: auto;
-      bottom: 4px;
+      bottom: 20px;
       transform-origin: 50% 100%;
 
       ${props.isOpen &&
         css`
-          transform: translate3d(-50%, -32px, 0) scale3d(1, 1, 1);
+          transform: translate3d(-50%, -16px, 0) scale3d(1, 1, 1);
         `};
     `};
 `
@@ -256,6 +256,8 @@ const BlockOption = styled.button`
   outline: none;
   border: 0;
   transition: all 85ms ease-out;
+  user-select: none;
+
   &:hover {
     color: var(--tina-color-primary);
     background-color: #f6f6f9;

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -185,11 +185,6 @@ const AddBlockWrapper = styled.div<AddBlockWrapperProps>(
   ${p.position == undefined &&
     css`
       position: relative;
-      left: 0;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      width: 100%;
     `}
 
   ${p.isOpen &&

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -152,7 +152,7 @@ interface AddBlockWrapperProps {
 const AddBlockWrapper = styled.div<AddBlockWrapperProps>(
   p => css`
   position: absolute;
-  z-index: calc(var(--tina-z-index-1) - ${p.index !== undefined ? p.index : 0});
+  z-index: calc(var(--tina-z-index-2) - ${p.index !== undefined ? p.index : 0});
 
   ${p.position == 'top' &&
     css`
@@ -194,7 +194,7 @@ const AddBlockWrapper = styled.div<AddBlockWrapperProps>(
 
   ${p.isOpen &&
     css`
-      z-index: calc(1 + var(--tina-z-index-1) - ${p.index ? p.index : 0});
+      z-index: calc(1 + var(--tina-z-index-2) - ${p.index ? p.index : 0});
     `}
 `
 )

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -134,6 +134,8 @@ const AddBlockButton = styled(IconButton)<AddMenuProps>`
   ${props =>
     props.isOpen &&
     css`
+      pointer-events: none;
+
       svg {
         transform: rotate(45deg);
       }

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -242,7 +242,7 @@ export const BlockMenu = styled.div`
   top: 0;
   background-color: white;
   border-radius: var(--tina-radius-small);
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: var(--tina-shadow-big);
   border: 1px solid var(--tina-color-grey-2);
   overflow: hidden;
 `

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -26,7 +26,7 @@ import {
   TrashIcon,
 } from '@tinacms/icons'
 
-import { useInlineBlocks } from './inline-field-blocks'
+import { useInlineBlocks, BlocksEmptyState } from './inline-field-blocks'
 import { useInlineForm } from '../inline-form'
 import { AddBlockMenu } from './add-block-menu'
 import { InlineSettings } from '../inline-settings'
@@ -179,8 +179,16 @@ export function BlocksControls({
 }
 
 const BlockChildren = styled.div<{ disableClick: boolean }>(
-  ({ disableClick }) => css`
-    ${disableClick && `pointer-events: none;`};
+  p => css`
+    ${p.disableClick &&
+      css`
+        pointer-events: none;
+
+        ${BlocksEmptyState} {
+          opacity: 0;
+          pointer-events: none;
+        }
+      `}
   `
 )
 

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -170,7 +170,7 @@ export function InlineBlock({ name, data, block, index }: InlineBlockProps) {
   )
 }
 
-const BlocksEmptyState = styled.div`
+export const BlocksEmptyState = styled.div`
   padding: var(--tina-padding-small);
   position: relative;
   width: 100%;

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -171,6 +171,10 @@ export function InlineBlock({ name, data, block, index }: InlineBlockProps) {
 }
 
 const BlocksEmptyState = styled.div`
-  margin: var(--tina-padding-big) 0;
+  padding: var(--tina-padding-small);
   position: relative;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `

--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -52,7 +52,7 @@ export const FocusRing = styled.div<FocusRingProps>(
       opacity: 0;
       pointer-events: none;
       transition: all var(--tina-timing-medium) ease-out;
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      box-shadow: var(--tina-shadow-big);
     }
 
     ${p.active &&


### PR DESCRIPTION
- Fixes add block menu positioning depending on proximity to the top/bottom of the viewport.
- Fixes close add block menu button.
- Increases z-index of add block button & menu to fix overlap issues.
- Standardize large drop shadow.
- Prevent text selection of add block menu items.
- Centers add block button when no blocks are present for both column and row layouts.
- Hides `BlocksEmptyState` when not selected (add block button when no blocks present).

![Jun-04-2020 12-49-52](https://user-images.githubusercontent.com/5075484/83779115-ec04d680-a661-11ea-8e42-1163adb34fe5.gif)