### PR TITLE
feat(form): values can be passed to constructor

### DIFF
--- a/packages/@tinacms/forms/src/form.test.ts
+++ b/packages/@tinacms/forms/src/form.test.ts
@@ -36,6 +36,46 @@ describe('Form', () => {
         new Form(DEFAULTS)
       })
     })
+    describe('with initialValues', () => {
+      it('has initialValues for form.values', () => {
+        const initialValues = { title: 'Hello World' }
+
+        const form = new Form({
+          ...DEFAULTS,
+          initialValues,
+        })
+
+        expect(form.values).toEqual(initialValues)
+      })
+      describe('with values', () => {
+        it('has the values set for form.values', () => {
+          const initialValues = { title: 'Hello World' }
+          const values = { title: 'The new kid on the block' }
+
+          const form = new Form({
+            ...DEFAULTS,
+            initialValues,
+            values,
+          })
+
+          expect(form.values).toEqual(values)
+        })
+        it('can be reset to the initialValues', () => {
+          const initialValues = { title: 'Hello World' }
+          const values = { title: 'The new kid on the block' }
+
+          const form = new Form({
+            ...DEFAULTS,
+            initialValues,
+            values,
+          })
+
+          form.reset()
+
+          expect(form.values).toEqual(initialValues)
+        })
+      })
+    })
   })
 
   describe('#change', () => {

--- a/packages/@tinacms/forms/src/form.ts
+++ b/packages/@tinacms/forms/src/form.ts
@@ -28,6 +28,7 @@ export interface FormOptions<S, F extends Field = AnyField> extends Config<S> {
   __type?: string
   reset?(): void
   actions?: any[]
+  values?: S
   loadInitialValues?: () => Promise<S>
   onChange?(values: FormState<S>): void
 }
@@ -50,9 +51,10 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
     reset,
     loadInitialValues,
     onChange,
+    values,
     ...options
   }: FormOptions<S, F>) {
-    const initialValues = options.initialValues || ({} as S)
+    const initialValues = options.initialValues || values || ({} as S)
     this.__type = options.__type || 'form'
     this.id = id
     this.label = label
@@ -79,6 +81,10 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
       loadInitialValues().then(initialValues => {
         this.updateInitialValues(initialValues)
       })
+    }
+
+    if (values) {
+      this.updateValues(values)
     }
 
     if (onChange) {


### PR DESCRIPTION
This means a form can be initialized with both it's initialV and it's current values in one step

