### PR TITLE
chore: removes unused dropzone variables from image upload

### DIFF
--- a/packages/@tinacms/fields/src/components/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/fields/src/components/ImageUpload/ImageUpload.tsx
@@ -107,16 +107,13 @@ export const ImageUpload = ({
   previewSrc,
   loading,
 }: ImageUploadProps) => {
-  const {
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-  } = useDropzone({ accept: 'image/*', onDrop })
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: 'image/*',
+    onDrop,
+  })
 
   return (
-    <DropArea {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
+    <DropArea {...getRootProps()}>
       <input {...getInputProps()} />
       {value ? (
         <StyledImageContainer>

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -121,18 +121,15 @@ function InlineImageUpload({
   previewSrc,
   children,
 }: InlineImageUploadProps) {
-  const {
-    getRootProps,
-    getInputProps,
-    isDragActive,
-    isDragAccept,
-    isDragReject,
-  } = useDropzone({ accept: 'image/*', onDrop })
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: 'image/*',
+    onDrop,
+  })
 
   if (!value) return <ImagePlaceholder />
 
   return (
-    <div {...getRootProps({ isDragActive, isDragAccept, isDragReject })}>
+    <div {...getRootProps()}>
       <input {...getInputProps()} />
       <div>{children ? children(previewSrc) : <img src={previewSrc} />}</div>
     </div>


### PR DESCRIPTION
Resolves the warnings for image upload by removing unused variables: `isDragActive`, `isDragAccept` & `isDragReject`. Typically these are passed to styled components to add various style states depending on the drag, but we weren't doing that.

<img width="873" alt="drag-warnings" src="https://user-images.githubusercontent.com/36613477/84168558-651e7800-aa2c-11ea-8bb0-be49c951e1fa.png">

