### PR TITLE
fix: added string type to sticky prop in WysiwygProps

### DIFF
--- a/packages/react-tinacms-editor/src/components/Editor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/Editor/index.tsx
@@ -32,7 +32,7 @@ import { ProseMirrorCss } from './styles/ProseMirror'
 export interface WysiwygProps {
   input: any
   plugins?: Plugin[]
-  sticky?: boolean
+  sticky?: boolean | string
   format?: Format
   imageProps?: ImageProps
   toggleEditorMode?: () => void


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
added string type to sticky prop as that is what the Menubar component expects. 