### PR TITLE
refactor(blocks): Remove type from block template

### DIFF
--- a/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
@@ -47,7 +47,6 @@ export interface BlocksFieldDefinititon extends Field {
 }
 
 export interface BlockTemplate {
-  type: string
   label: string
   defaultItem?: object | (() => object)
   fields?: Field[]

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -26,14 +26,14 @@ import { getOffset, getOffsetX, getOffsetY } from '../styles'
 
 interface AddBlockMenuProps {
   addBlock(data: any): void
-  templates: BlockTemplate[]
+  blocks: { [key: string]: { template: BlockTemplate } }
   position?: 'top' | 'bottom' | 'left' | 'right'
   index?: number
   offset?: number | { x: number; y: number }
 }
 
 export function AddBlockMenu({
-  templates,
+  blocks,
   addBlock,
   position,
   index,
@@ -61,12 +61,15 @@ export function AddBlockMenu({
       }
     }
 
-    templates.length == 1
-      ? addBlock({
-          _template: templates[0].type,
-          ...templates[0].defaultItem,
-        })
-      : setIsOpen(isOpen => !isOpen)
+    if (Object.keys(blocks).length == 1) {
+      const blockId = Object.keys(blocks)[0]
+      addBlock({
+        _template: blockId,
+        ...blocks[blockId].template.defaultItem,
+      })
+    } else {
+      setIsOpen(isOpen => !isOpen)
+    }
   }
 
   React.useEffect(() => {
@@ -74,8 +77,6 @@ export function AddBlockMenu({
     document.addEventListener('mouseup', inactivateBlockMenu, false)
     return () => document.removeEventListener('mouseup', inactivateBlockMenu)
   }, [])
-
-  templates = templates || []
 
   return (
     <AddBlockWrapper
@@ -94,21 +95,24 @@ export function AddBlockMenu({
         <AddIcon />
       </AddBlockButton>
       <BlocksMenu openTop={openTop} isOpen={isOpen}>
-        {templates.map((template: BlockTemplate) => (
-          <BlockOption
-            key={template.label}
-            onClick={event => {
-              event.stopPropagation()
-              event.preventDefault()
-              addBlock({
-                _template: template.type,
-                ...template.defaultItem,
-              })
-            }}
-          >
-            {template.label}
-          </BlockOption>
-        ))}
+        {Object.keys(blocks).map((key: string) => {
+          const template = blocks[key].template
+          return (
+            <BlockOption
+              key={template.label}
+              onClick={event => {
+                event.stopPropagation()
+                event.preventDefault()
+                addBlock({
+                  _template: key,
+                  ...template.defaultItem,
+                })
+              }}
+            >
+              {template.label}
+            </BlockOption>
+          )
+        })}
       </BlocksMenu>
     </AddBlockWrapper>
   )

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -134,18 +134,14 @@ export function BlocksControls({
             <AddBlockMenuWrapper active={isActive}>
               <AddBlockMenu
                 addBlock={block => insert(index, block)}
-                templates={Object.entries(blocks).map(
-                  ([, block]) => block.template
-                )}
+                blocks={blocks}
                 index={index}
                 offset={offset}
                 position={addBeforePosition}
               />
               <AddBlockMenu
                 addBlock={block => insert(index + 1, block)}
-                templates={Object.entries(blocks).map(
-                  ([, block]) => block.template
-                )}
+                blocks={blocks}
                 index={index}
                 offset={offset}
                 position={addAfterPosition}

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -131,9 +131,7 @@ export function InlineBlocks({
                       <BlocksEmptyState>
                         <AddBlockMenu
                           addBlock={block => insert(0, block)}
-                          templates={Object.entries(blocks).map(
-                            ([, block]) => block.template
-                          )}
+                          blocks={blocks}
                         />
                       </BlocksEmptyState>
                     )}


### PR DESCRIPTION
Blocks require a "type" be set on the template, but the defined blocks that you use, already are key'ed.
```
const PAGE_BLOCKS = {
  hero: {
    Component: HeroBlock,
    template: Hero,
  },
 // ...
```

This PR removed type, and instead uses the key from the blocks definition.

This could be a breaking change if the key differed from the template's type.