### PR TITLE
fix: prevents empty tag field registering

### DIFF
--- a/packages/@tinacms/fields/src/plugins/TagsFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/TagsFieldPlugin.tsx
@@ -33,6 +33,9 @@ export const TagsField = wrapFieldsWithMeta<
       if (form.getFieldState(field.name)?.value?.includes(tag)) {
         return
       }
+      if (!tag.length) {
+        return
+      }
       form.mutators.insert(field.name, 0, tag)
       setValue('')
     },


### PR DESCRIPTION
Fixes #1201 

Added a simple check to return out of the function if tag field value is an empty string.

(I couldn't find the tests or I would have added one)