### PR TITLE
feat: add cms.toggle to make togling the cms.enabled prop easier

### DIFF
--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -175,4 +175,12 @@ export class CMS {
     this._enabled = false
     this.events.dispatch(CMS.DISABLED)
   }
+
+  toggle(): void {
+    if (this.enabled) {
+      this.disable()
+    } else {
+      this.enable()
+    }
+  }
 }


### PR DESCRIPTION
From this [discussion](https://github.com/tinacms/tinacms.org/pull/458#discussion_r440293299). 

Instead of doing this:
```tsx
<button onClick={cms.enabled ? cms.disable() : cms.enable()}>
```
you can now do this:
```tsx
<button onClick={cms.toggle}>
```