### PR TITLE
feat(react-tinacms-github): fire event on branch change

### DIFF
--- a/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
@@ -167,7 +167,7 @@ const BranchSwitcher = ({ onBranchChange }: BranchSwitcherProps) => {
             setConfirmSwitchProps(null)
             setCreateBranchProps(null)
             cms.events.dispatch({
-              type: 'github:branch:select',
+              type: 'github:branch:checkout',
               branchName: confirmSwitchProps.name,
             })
           }}

--- a/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
@@ -166,6 +166,10 @@ const BranchSwitcher = ({ onBranchChange }: BranchSwitcherProps) => {
             }
             setConfirmSwitchProps(null)
             setCreateBranchProps(null)
+            cms.events.dispatch({
+              type: 'github:branch:select',
+              branchName: confirmSwitchProps.name,
+            })
           }}
           close={() => {
             setConfirmSwitchProps(null)


### PR DESCRIPTION
This feels like a **feat** to me but let me know if it should be a **chore** instead.

By firing an event, developers can subscribe to branch change in their form-creating code.

This addresses the problem described in #1264, but we might also want to implement the desired behavior in `useGithubFileForm`