### PR TITLE
feat: add a blockProps prop which spreads props to child elements

### DIFF
--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -34,6 +34,12 @@ export interface InlineBlocksProps {
   }
   className?: string
   direction?: 'column' | 'row'
+  /**
+   * object will be spread to every block child element
+   */
+  blockProps?: {
+    [key: string]: any
+  }
 }
 
 export interface InlineBlocksActions {
@@ -68,6 +74,7 @@ export function InlineBlocks({
   blocks,
   className,
   direction = 'column',
+  blockProps,
 }: InlineBlocksProps) {
   const cms = useCMS()
   const [activeBlock, setActiveBlock] = useState(-1)
@@ -151,6 +158,7 @@ export function InlineBlocks({
 
                       return (
                         <InlineBlock
+                          {...blockProps}
                           key={index}
                           index={index}
                           name={blockName}

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -37,7 +37,7 @@ export interface InlineBlocksProps {
   /**
    * object will be spread to every block child element
    */
-  blockProps?: {
+  itemProps?: {
     [key: string]: any
   }
 }
@@ -74,7 +74,7 @@ export function InlineBlocks({
   blocks,
   className,
   direction = 'column',
-  blockProps,
+  itemProps,
 }: InlineBlocksProps) {
   const cms = useCMS()
   const [activeBlock, setActiveBlock] = useState(-1)
@@ -158,7 +158,7 @@ export function InlineBlocks({
 
                       return (
                         <InlineBlock
-                          {...blockProps}
+                          {...itemProps}
                           key={index}
                           index={index}
                           name={blockName}


### PR DESCRIPTION
this allows passing trough dynamic props

---

I've just gave tina-cms a spin after reading the next.js blogpost about it.
When experimenting a bit with the incredible cool inline features I faced some problems.

I wanted to make a collapsible list which roughly works like that:
```js
function InteractiveBlocks() {
  // ensure a single collapsible is open at a time
  const [expanded, setExpanded] = React.useState<number | false>(false);

  const handleChange = (panel: number) => (
    event: React.ChangeEvent<{}>,
    newExpanded: boolean
  ) => {
    setExpanded(newExpanded ? panel : false);
  };
  return (
   <InlineBlocks name="faqs" blocks={FAQ_BLOCKS} blockProps={{onChange: handleChange, expanded}} />
  )
}

const faq_item_template = {
  type: "faq_item",
  label: "Selling Point",
  defaultItem: {
    title: "How much is the fish",
    body: "8000 mark",
  },
};

const FAQ_BLOCKS = {
  faq_item: {
    Component: FaqItem,
    template: faq_item_template,
  },
};
```