### PR TITLE
fix: code block breaking heading dropdown

### DIFF
--- a/packages/react-tinacms-editor/src/components/MenuHelpers/MenuDropdown.tsx
+++ b/packages/react-tinacms-editor/src/components/MenuHelpers/MenuDropdown.tsx
@@ -60,6 +60,7 @@ export const MenuDropdown = styled(
   box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.12), 0px 4px 8px rgba(48, 48, 48, 0.1);
   background-color: white;
   overflow: hidden;
+  z-index: 10;
 
   ${props =>
     props.open &&

--- a/packages/react-tinacms-editor/src/plugins/Link/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Link/Menu/ProsemirrorMenu.tsx
@@ -34,10 +34,14 @@ export const ProsemirrorMenu = markControl({
   },
   noMix: ['code'],
   isDisabled: (view: EditorView) => {
-    if (view.state.selection.empty) return true
+    const { schema, selection } = view.state
+    const { marks, nodes } = schema
+    if (selection.empty) return true
+    const selectedNode = selection.$from.node()
     return (
-      isMarkPresent(view.state, view.state.schema.marks.link) ||
-      !!imagePluginKey.getState(view.state).selectedImage
+      isMarkPresent(view.state, marks.link) ||
+      !!imagePluginKey.getState(view.state).selectedImage ||
+      (selectedNode && selectedNode.type === nodes.code_block)
     )
   },
   onClick: (view: EditorView) => {


### PR DESCRIPTION
Fixes https://github.com/tinacms/tinacms/issues/1269

![Screenshot 2020-06-23 at 6 11 07 PM](https://user-images.githubusercontent.com/2182307/85404967-5af88f80-b57d-11ea-88da-037cdc5ee26a.png)

1. Heading dropdown not hidden behind code block.
2 Link menu disabled in code block.