### PR TITLE
feat: Block limits

### DIFF
--- a/packages/demo-next/pages/blocks.tsx
+++ b/packages/demo-next/pages/blocks.tsx
@@ -62,10 +62,8 @@ export default function BlocksExample({ jsonFile }) {
               itemProps={{
                 style: { backgroundColor: 'red' },
               }}
-              limits={{
-                min: 2,
-                max: 4,
-              }}
+              min={2}
+              max={4}
             />
           </Wrap>
         </InlineForm>

--- a/packages/demo-next/pages/blocks.tsx
+++ b/packages/demo-next/pages/blocks.tsx
@@ -62,6 +62,10 @@ export default function BlocksExample({ jsonFile }) {
               itemProps={{
                 style: { backgroundColor: 'red' },
               }}
+              limits={{
+                min: 2,
+                max: 4,
+              }}
             />
           </Wrap>
         </InlineForm>

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -123,20 +123,10 @@ export function BlocksControls({
     .slice(0, -1)
     .join('.')
 
-  function isRangeLimited() {
-    return limits?.max === count && limits?.min === count
-  }
+  function withinLimit(limit: number | undefined) {
+    if (!limit) return true
 
-  function showAddBlock() {
-    if (!limits) return true
-
-    return !(limits.max === count || isRangeLimited())
-  }
-
-  function showTrashIcon() {
-    if (!limits) return true
-
-    return !(limits.min === count || isRangeLimited())
+    return !(limit === count || (max === count && min === count))
   }
 
   return (
@@ -155,7 +145,7 @@ export function BlocksControls({
             {...provider.draggableProps}
             disableChildren={!isActive && !childIsActive}
           >
-            {showAddBlock() && (
+            {withinLimit(max) && (
               <AddBlockMenuWrapper active={isActive}>
                 <AddBlockMenu
                   addBlock={block => insert(index, block)}
@@ -202,7 +192,7 @@ export function BlocksControls({
                   {direction === 'horizontal' && <ReorderRowIcon />}
                 </BlockAction>
                 <InlineSettings fields={template.fields} />
-                {showTrashIcon() && (
+                {withinLimit(min) && (
                   <BlockAction onClick={removeBlock}>
                     <TrashIcon />
                   </BlockAction>

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -59,21 +59,23 @@ export function BlocksControls({
   const cms = useCMS()
   const { focussedField, setFocussedField } = useInlineForm()
   const { name, template } = React.useContext(InlineFieldContext)
-  const { insert, move, remove, blocks, count, direction } = useInlineBlocks()
+  const {
+    insert,
+    move,
+    remove,
+    blocks,
+    count,
+    direction,
+    limits,
+  } = useInlineBlocks()
   const isFirst = index === 0
   const isLast = index === count - 1
   const blockMenuRef = React.useRef<HTMLDivElement>(null)
   const blockMoveUpRef = React.useRef<HTMLButtonElement>(null)
   const blockMoveDownRef = React.useRef<HTMLButtonElement>(null)
 
-  const addBeforePosition =
-    direction === 'horizontal'
-      ? 'left'
-      : 'top'
-  const addAfterPosition =
-    direction === 'horizontal'
-      ? 'right'
-      : 'bottom'
+  const addBeforePosition = direction === 'horizontal' ? 'left' : 'top'
+  const addAfterPosition = direction === 'horizontal' ? 'right' : 'bottom'
 
   if (cms.disabled) {
     return children
@@ -120,6 +122,22 @@ export function BlocksControls({
     .slice(0, -1)
     .join('.')
 
+  function isRangeLimited() {
+    return limits?.max === count && limits?.min === count
+  }
+
+  function showAddBlock() {
+    if (!limits) return true
+
+    return !(limits.max === count || isRangeLimited())
+  }
+
+  function showTrashIcon() {
+    if (!limits) return true
+
+    return !(limits.min === count || isRangeLimited())
+  }
+
   return (
     <Draggable type={parentName} draggableId={name!} index={index}>
       {provider => {
@@ -136,22 +154,24 @@ export function BlocksControls({
             {...provider.draggableProps}
             disableChildren={!isActive && !childIsActive}
           >
-            <AddBlockMenuWrapper active={isActive}>
-              <AddBlockMenu
-                addBlock={block => insert(index, block)}
-                blocks={blocks}
-                index={index}
-                offset={offset}
-                position={addBeforePosition}
-              />
-              <AddBlockMenu
-                addBlock={block => insert(index + 1, block)}
-                blocks={blocks}
-                index={index}
-                offset={offset}
-                position={addAfterPosition}
-              />
-            </AddBlockMenuWrapper>
+            {showAddBlock() && (
+              <AddBlockMenuWrapper active={isActive}>
+                <AddBlockMenu
+                  addBlock={block => insert(index, block)}
+                  blocks={blocks}
+                  index={index}
+                  offset={offset}
+                  position={addBeforePosition}
+                />
+                <AddBlockMenu
+                  addBlock={block => insert(index + 1, block)}
+                  blocks={blocks}
+                  index={index}
+                  offset={offset}
+                  position={addAfterPosition}
+                />
+              </AddBlockMenuWrapper>
+            )}
             <BlockMenuWrapper
               offset={offset}
               ref={blockMenuRef}
@@ -181,9 +201,11 @@ export function BlocksControls({
                   {direction === 'horizontal' && <ReorderRowIcon />}
                 </BlockAction>
                 <InlineSettings fields={template.fields} />
-                <BlockAction onClick={removeBlock}>
-                  <TrashIcon />
-                </BlockAction>
+                {showTrashIcon() && (
+                  <BlockAction onClick={removeBlock}>
+                    <TrashIcon />
+                  </BlockAction>
+                )}
               </BlockMenu>
             </BlockMenuWrapper>
             {children}

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -66,7 +66,8 @@ export function BlocksControls({
     blocks,
     count,
     direction,
-    limits,
+    min,
+    max,
   } = useInlineBlocks()
   const isFirst = index === 0
   const isLast = index === count - 1

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -40,6 +40,10 @@ export interface InlineBlocksProps {
   itemProps?: {
     [key: string]: any
   }
+  limits?: {
+    min: number
+    max: number
+  }
 }
 
 export interface InlineBlocksActions {
@@ -53,6 +57,10 @@ export interface InlineBlocksActions {
   activeBlock: number | null
   setActiveBlock: any
   direction: 'vertical' | 'horizontal'
+  limits?: {
+    min: number
+    max: number
+  }
 }
 
 export const InlineBlocksContext = React.createContext<InlineBlocksActions | null>(
@@ -75,6 +83,7 @@ export function InlineBlocks({
   className,
   direction = 'vertical',
   itemProps,
+  limits,
 }: InlineBlocksProps) {
   const cms = useCMS()
   const [activeBlock, setActiveBlock] = useState(-1)
@@ -128,6 +137,7 @@ export function InlineBlocks({
                       activeBlock,
                       setActiveBlock,
                       direction,
+                      limits,
                     }}
                   >
                     {allData.length < 1 && cms.enabled && (

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -41,8 +41,8 @@ export interface InlineBlocksProps {
     [key: string]: any
   }
   limits?: {
-    min: number
-    max: number
+    min?: number
+    max?: number
   }
 }
 
@@ -58,8 +58,8 @@ export interface InlineBlocksActions {
   setActiveBlock: any
   direction: 'vertical' | 'horizontal'
   limits?: {
-    min: number
-    max: number
+    min?: number
+    max?: number
   }
 }
 

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -40,10 +40,8 @@ export interface InlineBlocksProps {
   itemProps?: {
     [key: string]: any
   }
-  limits?: {
-    min?: number
-    max?: number
-  }
+  min?: number
+  max?: number
 }
 
 export interface InlineBlocksActions {
@@ -57,10 +55,8 @@ export interface InlineBlocksActions {
   activeBlock: number | null
   setActiveBlock: any
   direction: 'vertical' | 'horizontal'
-  limits?: {
-    min?: number
-    max?: number
-  }
+  min?: number
+  max?: number
 }
 
 export const InlineBlocksContext = React.createContext<InlineBlocksActions | null>(
@@ -83,7 +79,8 @@ export function InlineBlocks({
   className,
   direction = 'vertical',
   itemProps,
-  limits,
+  min,
+  max,
 }: InlineBlocksProps) {
   const cms = useCMS()
   const [activeBlock, setActiveBlock] = useState(-1)
@@ -137,7 +134,8 @@ export function InlineBlocks({
                       activeBlock,
                       setActiveBlock,
                       direction,
-                      limits,
+                      min,
+                      max,
                     }}
                   >
                     {allData.length < 1 && cms.enabled && (


### PR DESCRIPTION
Pretty simple implementation. The add block and trash icons are hidden / shown based on the limits. Checkout the blocks page in `demo-next` for an example. When the range is limited (i.e. min === max), neither add block or trash icon will show. 

**Example**
```jsx
<InlineBlocks
  name="blocks"
  blocks={PAGE_BUILDER_BLOCKS}
  min= {1}
  max={4}
/>
```

---
- [x] Docs updates PR approved

_Note: I will write docs if we like this API_