### PR TITLE
fix: extra paragraphs created while inserting table

### DIFF
--- a/packages/react-tinacms-editor/src/plugins/Image/Popups/Edit.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Popups/Edit.tsx
@@ -285,13 +285,25 @@ const SaveLink = styled.button`
   }
 `
 
-const CancelLink = styled(SaveLink)`
-  background-color: white;
+const CancelLink = styled.button`
+  text-align: center;
   border: 1px solid var(--tina-color-grey-2);
+  border-radius: var(--tina-radius-big);
+  box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.12);
+  background-color: white;
   color: var(--tina-color-primary);
+  font-weight: var(--tina-font-weight-regular);
+  cursor: pointer;
+  transition: all 85ms ease-out;
+  font-size: var(--tina-font-size-0);
+  padding: 8px 20px;
+  margin-left: 8px;
   &:hover {
     background-color: var(--tina-color-grey-1);
     opacity: 1;
+  }
+  &:active {
+    background-color: var(--tina-color-primary-dark);
   }
 `
 

--- a/packages/react-tinacms-editor/src/plugins/Link/Popups/InnerForm.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Link/Popups/InnerForm.tsx
@@ -192,12 +192,24 @@ const SaveLink = styled.button`
   }
 `
 
-const DeleteLink = styled(SaveLink)`
-  background-color: white;
+const DeleteLink = styled.button`
+  text-align: center;
   border: 1px solid var(--tina-color-grey-2);
+  border-radius: var(--tina-radius-big);
+  box-shadow: 0px 2px 3px rgba(0, 0, 0, 0.12);
+  background-color: white;
   color: #0084ff;
+  font-weight: var(--tina-font-weight-regular);
+  cursor: pointer;
+  transition: all 85ms ease-out;
+  font-size: var(--tina-font-size-0);
+  padding: 8px 20px;
+  margin-left: 8px;
   &:hover {
     background-color: #f6f6f9;
     opacity: 1;
+  }
+  &:active {
+    background-color: #0574e4;
   }
 `

--- a/packages/react-tinacms-editor/src/plugins/Table/commands/index.ts
+++ b/packages/react-tinacms-editor/src/plugins/Table/commands/index.ts
@@ -58,6 +58,8 @@ export const insertTable = (
   const newTable = table.createChecked(null, rows)
   const { selection, tr } = state
   const { $from, $to } = selection
-  dispatch(tr.replaceWith($from.pos, $to.pos, newTable).scrollIntoView())
+  dispatch(
+    tr.replaceWith($from.pos - 1, $to.pos + 1, newTable).scrollIntoView()
+  )
   return true
 }


### PR DESCRIPTION
The PR fixes issue with extra paragraphs being inserted when table is created.

May be we can reduce margins also above and below the table:

Currently its `32px`:

---
![Screenshot 2020-06-25 at 7 44 52 PM](https://user-images.githubusercontent.com/2182307/85737269-dba1c200-b71c-11ea-871d-e7ada31bf2c7.png)
---


It can be reduced to `20px` or lesser by moving also icons can be moved closer to table:

---
![Screenshot 2020-06-25 at 7 46 06 PM](https://user-images.githubusercontent.com/2182307/85737344-ee1bfb80-b71c-11ea-86e0-f370e1c74cf2.png)
---

@spbyrne , @DirtyF : plz suggest.