### PR TITLE
Minor Style Fixes

### DIFF
--- a/packages/@tinacms/fields/src/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/fields/src/plugins/wrapFieldWithMeta.tsx
@@ -83,6 +83,8 @@ const FieldWrapper = styled.div<{ margin: boolean }>`
 `
 
 const FieldLabel = styled.label`
+  all: unset;
+  font-family: 'Inter', sans-serif;
   display: block;
   font-size: var(--tina-font-size-1);
   font-weight: 600;
@@ -95,11 +97,14 @@ const FieldLabel = styled.label`
   overflow: hidden;
 `
 
-export const FieldDescription = styled.p`
-  color: var(--tina-color-grey-6);
+export const FieldDescription = styled.span`
+  all: unset;
+  display: block;
+  font-family: 'Inter', sans-serif;
   font-size: var(--tina-font-size-0);
   font-style: italic;
   font-weight: lighter;
+  color: var(--tina-color-grey-6);
   padding-top: 4px;
   white-space: normal;
   margin: 0;

--- a/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
@@ -485,7 +485,9 @@ const MenuWrapper = styled.div`
 `
 
 const MenuPanel = styled.div<{ visible: boolean }>`
+  all: unset;
   ${tina_reset_styles}
+  box-sizing: border-box;
   background: var(--tina-color-grey-8);
   position: fixed;
   top: 0;

--- a/packages/@tinacms/styles/src/Styles.tsx
+++ b/packages/@tinacms/styles/src/Styles.tsx
@@ -61,7 +61,7 @@ const theme = css`
     --tina-padding-small: 12px;
     --tina-padding-big: 20px;
 
-    --tina-font-size-0: 11px;
+    --tina-font-size-0: 12px;
     --tina-font-size-1: 13px;
     --tina-font-size-2: 15px;
     --tina-font-size-3: 16px;


### PR DESCRIPTION
* Fixes toolbar menu panel styles. On sites where a box sizing reset wasn't used the padding was being added to the calculated width.
* Bumps minimum Tina font size from 11 to 12px. This size is used for field descriptions.
* Prevents field description text from inheriting site <p> styles.
