### PR TITLE
fix: on updating editor state when new content is received and editor is not focused, editor history should not be lost

### DIFF
--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
@@ -26,7 +26,7 @@ import { EditorStateProvider } from '../../context/editorState'
 import { useBrowserFocusContext } from '../../context/browserFocus'
 
 import { buildEditor } from './utils/buildEditor'
-import { buildEditorState } from './utils/buildEditorState'
+import { updateEditorState } from './utils/updateEditorState'
 import { Menubar } from './Menubar'
 import { CodeMirrorCss } from './styles/CodeMirror'
 import { ProseMirrorCss } from './styles/ProseMirror'
@@ -70,9 +70,7 @@ export const ProsemirrorEditor = styled(
           browserFocused)
       )
         return
-      view.updateState(
-        buildEditorState(view.state.schema, translator, input.value, imageProps)
-      )
+      updateEditorState(view, translator, input.value)
     }, [input.value])
 
     return (

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/buildEditor.ts
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/buildEditor.ts
@@ -57,7 +57,7 @@ export const buildEditor = (
       view.updateState(nextState as any)
       setEditorView({ view })
 
-      if (tr.docChanged) {
+      if (tr.docChanged && !tr.getMeta('input-update')) {
         input.onChange(translator!.stringFromNode(tr.doc))
       }
     },

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/updateEditorState.ts
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/updateEditorState.ts
@@ -1,0 +1,43 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import { TextSelection } from 'prosemirror-state'
+import { TranslatorClass } from '../../../translator'
+import { EditorView } from 'prosemirror-view'
+
+export function updateEditorState(
+  view: EditorView,
+  translator: TranslatorClass,
+  value: string
+) {
+  const doc = translator.nodeFromString(value)
+  if (!doc) return
+  const { state, dispatch } = view
+  const { tr } = state
+  dispatch(
+    tr
+      .setSelection(
+        new TextSelection(
+          tr.doc.resolve(0),
+          tr.doc.resolve(state.doc.nodeSize - 2)
+        )
+      )
+      .replaceSelectionWith(doc)
+      .setMeta('input-update', true)
+  )
+}


### PR DESCRIPTION
Fixes https://github.com/tinacms/tinacms/issues/1283

When editor is not focused and an update is received its state is re-build from new content this results in history of changes being lost.

PR fixes issue by updating state and not re-creating a new version of state.