### PR TITLE
GitHub: Fire events on branch create

### DIFF
--- a/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
@@ -206,6 +206,10 @@ const CreateBranchModal = ({ current, name, onBranchChange, close }: any) => {
               branchName: name,
             })
             cms.api.github.setWorkingBranch(name)
+            cms.events.dispatch({
+              type: 'github:branch:checkout',
+              branchName: name,
+            })
             if (onBranchChange) {
               onBranchChange(name)
             }

--- a/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
+++ b/packages/react-tinacms-github/src/toolbar-plugins/BranchSwitcherPlugin.tsx
@@ -54,7 +54,8 @@ const BranchSwitcher = ({ onBranchChange }: BranchSwitcherProps) => {
     'pending' | 'loaded' | 'error'
   >('pending')
   const [branches, setBranches] = React.useState<Branch[]>([])
-  React.useEffect(() => {
+
+  const updateBranchList = React.useCallback(() => {
     github
       .getBranchList()
       .then(branches => {
@@ -64,6 +65,11 @@ const BranchSwitcher = ({ onBranchChange }: BranchSwitcherProps) => {
       .catch(() => {
         setBranchStatus('error')
       })
+  }, [github, setBranches, setBranchStatus])
+
+  React.useEffect(() => {
+    updateBranchList()
+    cms.events.subscribe('github:branch:create', updateBranchList)
   }, [])
 
   const closeDropdown = () => {
@@ -195,6 +201,10 @@ const CreateBranchModal = ({ current, name, onBranchChange, close }: any) => {
         async onSubmit({ name }) {
           try {
             await cms.api.github.createBranch(name)
+            cms.events.dispatch({
+              type: 'github:branch:create',
+              branchName: name,
+            })
             cms.api.github.setWorkingBranch(name)
             if (onBranchChange) {
               onBranchChange(name)


### PR DESCRIPTION
Creating a branch now fires `github:branch:create` and `github:branch:checkout`

Branch switcher updates branch listing on `github:branch:create`