### PR TITLE
fix: send json message on succesful preview handling

### DIFF
--- a/packages/next-tinacms-github/src/next/preview.ts
+++ b/packages/next-tinacms-github/src/next/preview.ts
@@ -38,16 +38,14 @@ export const previewHandler = (signingKey: string) => (req: any, res: any) => {
           req.cookies[HEAD_BRANCH_KEY] || process.env.BASE_BRANCH || 'master',
       }
       res.setPreviewData(previewData)
-      res.status(200).end()
+      res.status(200).json({ message: 'Github authentication successful.' })
     } else {
       res.status(401).json({ message: 'Invalid CSRF Token: Please try again' })
     }
   } else {
-    res
-      .status(401)
-      .json({
-        message:
-          'Missing Credentials: see https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github for implementation',
-      })
+    res.status(401).json({
+      message:
+        'Missing Credentials: see https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github for implementation',
+    })
   }
 }

--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -55,10 +55,10 @@ const enterEditMode = async () => {
   }
 
   const response = await fetch(`/api/preview`, { headers })
-  const data = await resp.json()
+  const data = await response.json()
 
   if (response.status === 200) {
-    window.location.href = window.location.pathname
+    window.location.reload()
   } else {
     throw new Error(data.message)
   }


### PR DESCRIPTION
Because `fetch('/preview').then(response => response.json())` doesn't resolve if there's not a json body