### PR TITLE
docs: link rfc repo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 - [Contributing](./CONTRIBUTING.md)
   - [Troubleshooting in Development](./CONTRIBUTING.md#Troubleshooting-in-Development)
 - [Projects](https://github.com/orgs/tinacms/projects)
+- [Change proposals(RFCs)](https://github.com/tinacms/rfcs)
 
 ## Development
 


### PR DESCRIPTION
found this repo by accident via google and think it should be more prominently linked as it's quite interesting 

---

When being at it: would you consider enabling github discussions?

This is an obviously super subjective observation of myself so feel free to ignore that request:
Working with tina is fun, troubleshooting not so much :)
The "problem" i'm facing is that information is not at all centralized. Some is in `1) issues`, some in `2) readmes`, some in the `3) rfc repo`, some on `4) tinacms.org`, some on `5) https://community.tinacms.org/`.

Github search covers `1,2,~3`, via google i frequently land on `4`. `5` i only found by accident via the readme - never via google, but contains a lot of valuable information. I'd personally prefer `5` to be on github as well like e.g. on https://github.com/vercel/next.js/discussions - it's well indexed, you find stuff via github search and you don't need an extra account.