### PR TITLE
fix: table delete icon should be visible only if whole table is selected

### DIFF
--- a/packages/react-tinacms-editor/src/plugins/Table/Popup/OptionsPopup.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Table/Popup/OptionsPopup.tsx
@@ -36,7 +36,7 @@ export default () => {
     view.focus()
   }
   const markerDivTable = document.getElementsByClassName(
-    'tina_table_header_ext_top_left'
+    'tina_table_header_ext_top_left_selected'
   )
   if (!markerDivTable.length) return null
   const tableElm = markerDivTable[0].closest('table')


### PR DESCRIPTION
Table delete icon should be visible only if whole table is selected.

![Screenshot 2020-07-23 at 12 13 58 AM](https://user-images.githubusercontent.com/2182307/88215550-75578300-cc79-11ea-994a-94842b6575d3.png)
