### PR TITLE
fix: table row add delete icons overlapping

### DIFF
--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/styles/ProseMirror.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/styles/ProseMirror.tsx
@@ -61,6 +61,9 @@ const proseMirrorTableStyles = `
   .ProseMirror:focus {
     outline: 0px solid transparent;
   }
+  .ProseMirror p {
+    min-height: 18px;
+  }
   .ProseMirror table {
     border-collapse: collapse;
     table-layout: fixed;
@@ -71,6 +74,9 @@ const proseMirrorTableStyles = `
   }
   .ProseMirror th {
     background-color: #F6F6F9;
+  }
+  .ProseMirror tr {
+    height: 40px;
   }
   .ProseMirror table td,
   .ProseMirror table th {


### PR DESCRIPTION
The PR addresses issue of table add and delete row icons overlapping:

![Screenshot 2020-07-23 at 6 51 57 PM](https://user-images.githubusercontent.com/2182307/88293189-4c39ff80-cd18-11ea-9e9c-96e78219c5d1.png)

It might also address the issue of cursor not visible in empty document but I could not replicate or text that.