### PR TITLE
feat: focus ring on editor

### DIFF
--- a/packages/react-tinacms-editor/src/components/MarkdownEditor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/MarkdownEditor/index.tsx
@@ -100,7 +100,10 @@ const EditingSection = styled.textarea`
   margin: 10px 0;
   resize: none;
   width: 100%;
+  border: 1px solid transparent;
   &:focus {
     outline: none;
+    border: 1px solid #2296fe;
+    border-radius: 10px;
   }
 `

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
@@ -86,7 +86,11 @@ export const ProsemirrorEditor = styled(
             plugins={plugins}
           />
         </EditorStateProvider>
-        <div {...styleProps} ref={editorRef} />
+        <EditingArea
+          {...styleProps}
+          ref={editorRef}
+          focused={!!editorView && browserFocused && editorView.view.hasFocus()}
+        />
       </WysiwygWrapper>
     )
   }
@@ -96,4 +100,10 @@ export const ProsemirrorEditor = styled(
 
 const WysiwygWrapper = styled.div`
   position: relative;
+`
+
+const EditingArea = styled.div<{ focused: boolean }>`
+  border-radius: 10px;
+  padding: 0 4px;
+  border: 1px solid ${({ focused }) => (focused ? '#2296fe' : 'transparent')};
 `


### PR DESCRIPTION
Focus ring works well except the scenario when code block or link modal is focused, I am working to fix those.

Fix #1347 