### PR TITLE
Use form load initial values

### DIFF
--- a/packages/@tinacms/react-core/src/use-form.ts
+++ b/packages/@tinacms/react-core/src/use-form.ts
@@ -19,7 +19,6 @@ limitations under the License.
 import { FormOptions, Form, Field } from '@tinacms/forms'
 import * as React from 'react'
 import { usePlugins } from './use-plugin'
-import { useCMS } from './use-cms'
 
 export interface WatchableFormValue {
   values: any

--- a/packages/@tinacms/react-core/src/use-form.ts
+++ b/packages/@tinacms/react-core/src/use-form.ts
@@ -82,7 +82,7 @@ export function useForm<FormShape = any>(
   )
 
   React.useEffect(() => {
-    if (cms.enabled && loadInitialValues) {
+    if (loadInitialValues) {
       loadInitialValues().then((values: any) => {
         form.updateInitialValues(values)
       })

--- a/packages/@tinacms/react-core/src/use-form.ts
+++ b/packages/@tinacms/react-core/src/use-form.ts
@@ -48,7 +48,6 @@ export function useForm<FormShape = any>(
   { loadInitialValues, ...options }: FormOptions<any>,
   watch: Partial<WatchableFormValue> = {}
 ): [FormShape, Form] {
-  const cms = useCMS()
   /**
    * `initialValues` will be usually be undefined if `loadInitialValues` is used.
    *

--- a/packages/gatsby-tinacms-git/src/use-git-form.ts
+++ b/packages/gatsby-tinacms-git/src/use-git-form.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import { useForm, Form, FormOptions, WatchableFormValue } from 'tinacms'
+import { useForm, Form, FormOptions, WatchableFormValue, useCMS } from 'tinacms'
 import { useGitFile } from '@tinacms/git-client'
 
 export interface GitNode {
@@ -34,13 +34,17 @@ export function useGitForm<N extends GitNode>(
   options: GitFormOptions<N>,
   watch: WatchableFormValue
 ): [N, Form] {
+  const cms = useCMS()
   const { format, parse, ...config } = options
   const gitFile = useGitFile(node.fileRelativePath, format, parse)
 
   const defaultConfig = {
     label: '',
     fields: [],
-    loadInitialValues: gitFile.show,
+    async loadInitialValues() {
+      if (cms.disabled) return watch.values
+      return gitFile.show()
+    },
     onSubmit: gitFile.commit,
     reset: gitFile.reset,
     onChange({ values }: any) {

--- a/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
+++ b/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
@@ -107,7 +107,8 @@ export function useMdxForm(
     {
       label,
       id,
-      loadInitialValues() {
+      async loadInitialValues() {
+        if (cms.disabled) return valuesOnDisk
         return cms.api.git
           .show(id) // Load the contents of this file at HEAD
           .then((git: any) => {

--- a/packages/next-tinacms-json/src/use-json-form.ts
+++ b/packages/next-tinacms-json/src/use-json-form.ts
@@ -55,7 +55,8 @@ export function useJsonForm<T = any>(
       fields,
       actions,
       buttons,
-      loadInitialValues() {
+      async loadInitialValues() {
+        if (cms.disabled) return jsonFile.data
         return cms.api.git
           .show(jsonFile.fileRelativePath) // Load the contents of this file at HEAD
           .then((git: { content: string }) => {

--- a/packages/next-tinacms-markdown/src/use-markdown-form.ts
+++ b/packages/next-tinacms-markdown/src/use-markdown-form.ts
@@ -71,7 +71,8 @@ export function useMarkdownForm(
       fields,
       actions,
       buttons,
-      loadInitialValues() {
+      async loadInitialValues() {
+        if (cms.disabled) return valuesOnDisk
         return cms.api.git
           .show(markdownFile.fileRelativePath) // Load the contents of this file at HEAD
           .then((git: { content: string }) => {


### PR DESCRIPTION
The `useForm` hook was making a weird assumption that `loadInitialValues` should never execute if the CMS is disabled. This PR undoes that assumption and pushes the responsibility to the client. If a developer does not want to make a request in prod, then it's the their responsibility to make sure the `loadInitialValues` they define works that way.