### PR TITLE
feat(@tinacms/react-core): a new CMS is disabled by default 

### DIFF
--- a/packages/@tinacms/core/src/cms.test.ts
+++ b/packages/@tinacms/core/src/cms.test.ts
@@ -19,33 +19,31 @@ limitations under the License.
 import { CMS } from './cms'
 
 describe('CMS', () => {
-    describe('When instantiated with no arguments', () => {
-        it('instantiates without error', () => {
-            const cms = new CMS()
-            expect(cms).toBeInstanceOf(CMS)
-        })
+  describe('When instantiated with no arguments', () => {
+    it('instantiates without error', () => {
+      const cms = new CMS()
+      expect(cms).toBeInstanceOf(CMS)
     })
-    describe('When configured with a plugin', () => {
-        it('instantiates with the plugin', () => {
-            const p =  { __type: 'test', name: 'Example' }
-            const cms = new CMS({
-                plugins: [
-                   p
-                ]
-            })
-            expect(cms).toBeInstanceOf(CMS)
-            expect(cms.plugins.all('test')).toContain(p)
-        })
+  })
+  describe('When configured with a plugin', () => {
+    it('instantiates with the plugin', () => {
+      const p = { __type: 'test', name: 'Example' }
+      const cms = new CMS({
+        plugins: [p],
+      })
+      expect(cms).toBeInstanceOf(CMS)
+      expect(cms.plugins.all('test')).toContain(p)
     })
-    describe('When configured with an api', () => {
-        it('instantiates with the api', () => {
-            const cms = new CMS({
-                apis: {
-                    test: { foo: 'bar' }
-                }
-            })
-            expect(cms).toBeInstanceOf(CMS)
-            expect(cms.api.test).toHaveProperty('foo')
-        })
+  })
+  describe('When configured with an api', () => {
+    it('instantiates with the api', () => {
+      const cms = new CMS({
+        apis: {
+          test: { foo: 'bar' },
+        },
+      })
+      expect(cms).toBeInstanceOf(CMS)
+      expect(cms.api.test).toHaveProperty('foo')
     })
+  })
 })

--- a/packages/@tinacms/core/src/cms.test.ts
+++ b/packages/@tinacms/core/src/cms.test.ts
@@ -25,8 +25,44 @@ describe('CMS', () => {
 
       expect(cms).toBeInstanceOf(CMS)
     })
+    it('is disabled', () => {
+      const cms = new CMS()
+
+      expect(cms.disabled).toBe(true)
+    })
   })
   describe('when constructed with options', () => {
+    describe('without enabled set', () => {
+      it('is disabled', () => {
+        const options = {}
+
+        const cms = new CMS(options)
+
+        expect(cms.disabled).toBe(true)
+      })
+    })
+    describe('with enabled set to `true`', () => {
+      it('is enabled ', () => {
+        const options = {
+          enabled: true,
+        }
+
+        const cms = new CMS(options)
+
+        expect(cms.enabled).toBe(true)
+      })
+    })
+    describe('with enabled set to `false`', () => {
+      it('is enabled ', () => {
+        const options = {
+          enabled: false,
+        }
+
+        const cms = new CMS(options)
+
+        expect(cms.disabled).toBe(true)
+      })
+    })
     describe('containing a plugin', () => {
       it('will have the plugin', () => {
         const plugin = { __type: 'test', name: 'Example' }

--- a/packages/@tinacms/core/src/cms.test.ts
+++ b/packages/@tinacms/core/src/cms.test.ts
@@ -19,31 +19,37 @@ limitations under the License.
 import { CMS } from './cms'
 
 describe('CMS', () => {
-  describe('When instantiated with no arguments', () => {
+  describe('when constructed without options', () => {
     it('instantiates without error', () => {
       const cms = new CMS()
+
       expect(cms).toBeInstanceOf(CMS)
     })
   })
-  describe('When configured with a plugin', () => {
-    it('instantiates with the plugin', () => {
-      const p = { __type: 'test', name: 'Example' }
-      const cms = new CMS({
-        plugins: [p],
+  describe('when constructed with options', () => {
+    describe('containing a plugin', () => {
+      it('will have the plugin', () => {
+        const plugin = { __type: 'test', name: 'Example' }
+
+        const cms = new CMS({
+          plugins: [plugin],
+        })
+
+        expect(cms.plugins.all('test')).toContain(plugin)
       })
-      expect(cms).toBeInstanceOf(CMS)
-      expect(cms.plugins.all('test')).toContain(p)
     })
-  })
-  describe('When configured with an api', () => {
-    it('instantiates with the api', () => {
-      const cms = new CMS({
-        apis: {
-          test: { foo: 'bar' },
-        },
+    describe('containing an api', () => {
+      it('will have that api', () => {
+        const test = { foo: 'bar' }
+
+        const cms = new CMS({
+          apis: {
+            test,
+          },
+        })
+
+        expect(cms.api.test).toBe(test)
       })
-      expect(cms).toBeInstanceOf(CMS)
-      expect(cms.api.test).toHaveProperty('foo')
     })
   })
 })

--- a/packages/@tinacms/core/src/cms.test.ts
+++ b/packages/@tinacms/core/src/cms.test.ts
@@ -53,7 +53,7 @@ describe('CMS', () => {
       })
     })
     describe('with enabled set to `false`', () => {
-      it('is enabled ', () => {
+      it('is disabled', () => {
         const options = {
           enabled: false,
         }

--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -131,7 +131,7 @@ export class CMS {
       )
     }
 
-    if (config.enabled || typeof config.enabled === 'undefined') {
+    if (config.enabled) {
       this.enable()
     } else {
       this.disable()

--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -78,7 +78,7 @@ export class CMS {
   static ENABLED = { type: 'cms:enable' }
   static DISABLED = { type: 'cms:disable' }
 
-  private _enabled: boolean = true
+  private _enabled: boolean = false
 
   /**
    * An object for managing CMSs plugins.
@@ -133,8 +133,6 @@ export class CMS {
 
     if (config.enabled) {
       this.enable()
-    } else {
-      this.disable()
     }
   }
 


### PR DESCRIPTION
This fixes certain bugs where the CMS will accidentally become enabled because the enabled is set to undefined. It occasionally shows up in in Next.js websites (i.e. tinacms.org)

<img width="477" alt="image" src="https://user-images.githubusercontent.com/824015/88985325-58890400-d2a6-11ea-99fc-d5dffcdf5cd1.png">


- [ ] Updated Docs