### PR TITLE
Updates package READMEs

### DIFF
--- a/packages/next-tinacms-json/README.md
+++ b/packages/next-tinacms-json/README.md
@@ -1,6 +1,6 @@
-# _next-tinacms-json_
+# next-tinacms-json
 
-The `next-tinacms-json` package provides helpers to make local JSON content editable. This package is intended to be used with a Git-based workflow.
+The `next-tinacms-json` package provides helpers to make local JSON content editable. This package is intended to be used with a [Git-based workflow](https://tinacms.org/guides/nextjs/git/getting-started).
 
 ## Installation
 

--- a/packages/next-tinacms-json/README.md
+++ b/packages/next-tinacms-json/README.md
@@ -10,10 +10,16 @@ yarn add next-tinacms-json
 
 ## Helpers
 
-- `useJsonForm( jsonFile, options? ):[values, form]`: A React Hook that creates a Git form
-- `jsonForm( Component, options? ): Component`: An HOC that creates and registers a Git form
-- `useLocalJsonForm`(deprecated)
-- `useGlobalJsonForm`(deprecated)
+```ts
+useJsonForm( jsonFile, options? ):[values, form]
+```
+`useJsonForm` is a [React Hook](https://reactjs.org/docs/hooks-intro.html) that creates a Git form
+
+```ts
+jsonForm( Component, options? ): Component
+```
+`jsonForm` is a [React Higher-Order Component](https://reactjs.org/docs/higher-order-components.html) that creates and registers a Git form
+
 
 ### _useJsonForm_ hook
 

--- a/packages/next-tinacms-markdown/README.md
+++ b/packages/next-tinacms-markdown/README.md
@@ -10,10 +10,17 @@ yarn add next-tinacms-markdown
 
 ## Helpers
 
-- `useMarkdownForm( markdownFile, options? ):[values, form]` - A [React Hook](https://reactjs.org/docs/hooks-intro.html) for registering local forms with [function components](https://reactjs.org/docs/components-and-props.html#function-and-class-components).
-- `markdownForm( Component, options? ): Component` - A [React Higher-Order Component](https://reactjs.org/docs/higher-order-components.html) for registering local forms with class or function components.
-- `useLocalMarkdownForm`(deprecated)
-- `useGlobalMarkdownForm`(deprecated)
+```ts
+useMarkdownForm( markdownFile, options? ):[values, form]
+```
+A [React Hook](https://reactjs.org/docs/hooks-intro.html) for registering local forms with [function components](https://reactjs.org/docs/components-and-props.html#function-and-class-components).
+
+```ts
+markdownForm( Component, options? ): Component
+```
+
+A [React Higher-Order Component](https://reactjs.org/docs/higher-order-components.html) for registering local forms with class or function components.
+
 
 **Arguments**
 

--- a/packages/next-tinacms-markdown/README.md
+++ b/packages/next-tinacms-markdown/README.md
@@ -1,6 +1,6 @@
-# _next-tinacms-markdown_
+# next-tinacms-markdown
 
-The `next-tinacms-markdown` package provides a set of methods for editing content sourced from Markdown files.
+The `next-tinacms-markdown` package provides a set of methods for editing content sourced from Markdown files in a [Git-based workflow](https://tinacms.org/guides/nextjs/git/getting-started).
 
 ## Installation
 

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -68,6 +68,10 @@ interface InlineFormState {
 
 ### _useInlineForm_
 
+```ts
+useInlineForm(): InlineFormState
+```
+
 The `useInlineForm` [hook](https://reactjs.org/docs/hooks-intro.html) can be used to access the inline editing context. It must be used within a child component of `InlineForm`.
 
 ## Inline Field
@@ -241,6 +245,10 @@ interface InlineBlocksActions {
 ```
 
 ### _useInlineBlocks_
+
+```ts
+useInlineBlocks(): InlineBlocksActions
+```
 
 `useInlineBlocks` is a hook that can be used to access the _Inline Blocks Context_ when creating custom controls.
 

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -296,13 +296,103 @@ interface BlockTemplate {
 }
 ```
 
+**Block Component**
+
+| Key           |                                                                                                                Purpose |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------: |
+| `index`       |                                                                                                Position in the block array. |
+| `data` |                                                                   The source data. |
+
+**Block Template**
+
 | Key           |                                                                                                                Purpose |
 | ------------- | ---------------------------------------------------------------------------------------------------------------------: |
 | `label`       |                                                                                                A human readable label. |
 | `defaultItem` |                                                                   _Optional_ — Populates new blocks with default data. |
 | `fields`      | _Optional_ — Populates fields in the [Settings Modal](/docs/ui/inline-editing/inline-blocks#using-the-settings-modal). |
 
-### Example
+### Examples
+
+Block Components can render _Inline Fields_ to expose the data for editing. When using Inline Fields within a block, the `name` property should be _relative to the block object_ in the source data.
+
+For example: 
+
+```js
+function FeatureList({ index }) {
+  return (
+    <BlocksControls index={index} focusRing={{ offset: 0 }} insetControls>
+      <div className="wrapper">
+        <InlineBlocks name="features_blocks" blocks={FEATURE_BLOCKS} />
+      </div>
+    </BlocksControls>
+  )
+}
+
+function Feature({ index }) {
+  return (
+    <BlocksControls index={index}>
+      <div className="feature">
+        <h3>
+        {/**
+        * The `name` property is relative to individual 
+        * `features_blocks` array items (blocks). The full path
+        * in the source file (example below) would be 
+        *  `features_blocks[index].heading`
+        */}
+          <InlineTextarea name="heading" focusRing={false} />
+        </h3>
+        <p>
+          <InlineTextarea name="supporting_copy" focusRing={false} />
+        </p>
+      </div>
+    </BlocksControls>
+  )
+}
+
+const featureBlock = {
+  Component: Feature,
+  template: {
+    label: 'Feature',
+    defaultItem: {
+      _template: 'feature',
+      heading: 'Marie Skłodowska Curie',
+      supporting_copy:
+        'Muse about vastness.',
+    },
+    fields: [],
+  },
+}
+
+const FEATURE_BLOCKS = {
+    featureBlock
+}
+```
+
+**Example JSON data*
+
+```json
+{
+    "features_blocks": [
+        {
+            "_template": "feature",
+            "heading": "Drake Equation",
+            "supporting_copy": "Light years gathered by gravity Rig Veda.."
+        },
+        {
+            "_template": "feature",
+            "heading": "Jean-François Champollion",
+            "supporting_copy": "Not a sunrise but a galaxyrise."
+        },
+        {
+            "_template": "feature",
+            "heading": "Sea of Tranquility",
+            "supporting_copy": "Bits of moving fluff take root and flourish."
+        }
+    ]
+}
+```
+
+Below is another example using `InlineBlocks` with multiple block definitions:
 
 ```js
 import { useJsonForm } from 'next-tinacms-json'
@@ -342,13 +432,45 @@ const headingBlock = {
     template: heading_template
 }
 
+/**
+ * Example Paragraph Block
+ * Component + template
+*/
+
+function Paragraph({ index }) {
+  return (
+    <BlocksControls index={index} focusRing={{ offset: 0 }} insetControls>
+      <div className="paragraph__background">
+        <div className="wrapper wrapper--narrow">
+          <p className="paragraph__text">
+            <InlineTextarea name="text" focusRing={false} />
+          </p>
+        </div>
+      </div>
+    </BlocksControls>
+  );
+}
+
+const paragraphBlock = {
+  Component: Paragraph,
+  // template defined inline
+  template: {
+    label: 'Paragraph',
+    defaultItem: {
+      text:
+        'Take root and flourish quis nostrum exercitationem ullam',
+    },
+    fields: [],
+  },
+};
+
 /** 
  * Available blocks passed to InlineBlocks to render 
- * Only one defined here, but there can be many blocks
 */
 
 const PAGE_BLOCKS = {
-    headingBlock
+    headingBlock,
+    paragraphBlock
 }
 ```
 

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -326,13 +326,23 @@ Block Components can render _Inline Fields_ to expose the data for editing. When
 For example: 
 
 ```js
-function FeatureList({ index }) {
+import { useForm } from 'tinacms'
+import { InlineForm, InlineBlocks, BlocksControls, InlineTextarea } from 'react-tinacms-inline'
+
+function FeaturePage({ data }) {
+  const [ , form ] = useForm({
+    id: 'my-features-id',
+    label: 'Edit Features',
+    fields: [],
+    initialValues: data,
+  })
+
   return (
-    <BlocksControls index={index} focusRing={{ offset: 0 }} insetControls>
+    <InlineForm form={form}>
       <div className="wrapper">
         <InlineBlocks name="features_blocks" blocks={FEATURE_BLOCKS} />
       </div>
-    </BlocksControls>
+    </InlineForm>
   )
 }
 
@@ -376,7 +386,7 @@ const FEATURE_BLOCKS = {
 }
 ```
 
-**Example JSON data*
+**Example JSON data**
 
 ```json
 {

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -1,1 +1,229 @@
 # react-tinacms-inline
+
+This package provides the components and helpers for [Inline Editing](https://tinacms.org/docs/ui/inline-editing). 
+
+## Install
+
+```bash
+yarn add react-tinacms-inline
+```
+
+> For specific steps on setting up Inline Editing on a page, refer to the [Inline Editing](https://tinacms.org/docs/ui/inline-editing) documentation.
+
+## Inline Form
+
+The `InlineForm` component provides an inline editing [context](https://reactjs.org/docs/context.html). To use, wrap the component where you want to render inline fields and pass the form.
+
+### Usage
+
+```jsx
+export function Page(props) {
+  const [, form] = useForm(props.data)
+  usePlugin(form)
+
+  return (
+    <InlineForm form={form}>
+      <main>
+        {
+            //... 
+        }
+      </main>
+    </InlineForm>
+  )
+}
+```
+
+### Interface 
+
+```ts
+interface InlineFormProps {
+  form: Form
+  children: React.ReactElement | React.ReactElement[] | InlineFormRenderChild
+}
+
+interface InlineFormRenderChild {
+  (props: InlineFormRenderChildOptions):
+    | React.ReactElement
+    | React.ReactElement[]
+}
+
+type InlineFormRenderChildOptions = InlineFormState &
+  Omit<FormRenderProps<any>, 'form'>
+
+/**
+ * This state is available via context
+*/
+interface InlineFormState {
+  form: Form
+  focussedField: string
+  setFocussedField(field: string): void
+}
+```
+
+| Key           | Description                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| `form`        | A [Tina Form](/docs/plugins/forms).                                                          |
+| `children`    | Child components to render — Either [React Elements](https://reactjs.org/docs/rendering-elements.html) or [Render Props](https://reactjs.org/docs/render-props.html) Children that receive the form state and other [Form Render Props](https://final-form.org/docs/react-final-form/types/FormRenderProps)                                                                                   |
+
+
+### _useInlineForm_
+
+The `useInlineForm` [hook](https://reactjs.org/docs/hooks-intro.html) can be used to access the inline editing context. It must be used within a child component of `InlineForm`.
+
+## Inline Field
+
+Inline Fields should provide basic inputs for editing data on the page and account for both [enabled / disabled CMS states](https://tinacms.org/docs/cms#disabling--enabling-the-cms). All Inline Fields must be children of an `InlineForm`. 
+
+### Interface 
+
+```ts
+export interface InlineFieldProps {
+  name: string
+  children(fieldProps: InlineFieldRenderProps): React.ReactElement
+}
+
+export interface InlineFieldRenderProps<V = any>
+  extends FieldRenderProps<V>,
+    InlineFormState {}
+```
+
+| Key           | Description                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| `name`        | The path to the editable data.                                                          |
+| `children`    | Child components to render — [React Elements](https://reactjs.org/docs/rendering-elements.html) that receive the form state and [Field Render Props](https://final-form.org/docs/react-final-form/types/FieldRenderProps).                                                                                  |
+
+### Available Inline Fields
+
+See the full list of [inline fields](https://tinacms.org/docs/ui/inline-editing#all-inline-fields) or learn how to make [custom inline fields](https://tinacms.org/docs/ui/inline-editing#creating-custom-inline-fields).
+
+Below is a list of fields provided by the `react-tinacms-inline` package: 
+- [Inline Text](https://tinacms.org/docs/ui/inline-editing/inline-text)
+- [InlineTextarea](https://tinacms.org/docs/ui/inline-editing/inline-textarea)
+- [Inline Group](https://tinacms.org/docs/ui/inline-editing/inline-group)
+- [Inline Image](https://tinacms.org/docs/ui/inline-editing/inline-image)
+- [Inline Blocks](https://tinacms.org/docs/ui/inline-editing/inline-blocks)
+
+## Inline Field Styles
+
+Styles are stripped as much as possible to prevent interference with base site styling. When toggling between [enabled / disabled states](https://tinacms.org/docs/cms#disabling--enabling-the-cms), the default inline fields will switch between rendering child elements with any additional editing UI and just passing the child elements alone.
+
+For example with `InlineText`:
+
+```tsx
+export function InlineText({
+  name,
+  className,
+  focusRing = true,
+}: InlineTextProps) {
+  const cms: CMS = useCMS()
+
+  return (
+    <InlineField name={name}>
+      {({ input }) => {
+        /**
+        * If the cms is enabled, render the input
+        * with the focus ring
+        */
+        if (cms.enabled) {
+          if (!focusRing) {
+            return <Input type="text" {...input} className={className} />
+          }
+
+          return (
+            <FocusRing name={name} options={focusRing}>
+              <Input type="text" {...input} className={className} />
+            </FocusRing>
+          )
+        }
+        /**
+        * Otherwise, pass the input value
+        */
+        return <>{input.value}</>
+      }}
+    </InlineField>
+  )
+}
+```
+
+`Input` is a styled-component with some [base styling](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-inline/src/fields/inline-text-field.tsx#L64) aimed at making this component mesh well with the surrounding site. If you ever need to override default Inline Field styles, read about this workaround to [extend styles](https://tinacms.org/docs/ui/inline-editing#extending-inline-field-styles). 
+
+### Focus Ring
+
+The common UI element on all Inline Fields is the `FocusRing`. The focus ring provides context to which field is active / available to edit. 
+
+**Interface**
+
+```ts
+interface FocusRingProps {
+  name?: string
+  children?:  React.ReactNode
+  options?: boolean | FocusRingOptions
+}
+
+interface FocusRingOptions {
+  offset?: number | { x: number; y: number }
+  borderRadius?: number
+  nestedFocus?: boolean
+}
+```
+
+**Focus Ring Props**
+
+You would only use these options if you were creating custom inline fields and working with the `FocusRing` directly.
+
+| Key           | Description                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| `children`    | _Optional_: Child elements to render.                                                                    |
+| `name`        | _Optional_: This value is used to set the focused / active field.                            |
+| `options`     | _Optional_: The `FocusRingOptions` outlined below.                                           |
+
+**Focus Ring Options**
+
+These options are passed to default [inline fields](https://tinacms.org/docs/ui/inline-editing#all-inline-fields) or inline block fields via the `focusRing` prop on most default inline fields. The options are configurable by the developer setting up the inline form & fields. Refer to individual [inline field documentation](https://tinacms.org/docs/ui/inline-editing#all-inline-fields) for examples.
+
+| Key           | Description                                                                                                                                    |
+| ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `offset`      | _Optional_: Sets the distance from the focus ring to the edge of the child element(s). It can either be a number (in pixels) for both x & y offsets, or individual x & y offset values passed in an object.|
+| `borderRadius`| _Optional_: Determines (in pixels) the [rounded corners](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) of the focus ring.                                                                |
+| `nestedFocus` | _Optional_:  Disables [pointer-events](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) (clicking) and hides blocks empty state.|
+
+## Inline Blocks
+
+[Inline Blocks](https://tinacms.org/docs/ui/inline-editing/inline-blocks#inlineblocks-interface) consist of an array of [Blocks](https://tinacms.org/blog/what-are-blocks) to render in an Inline Form. Refer to the Inline Blocks Documentation for [code examples]().
+
+### Actions
+
+The Inline Blocks Actions are used by the Inline Blocks Controls. Use these if you are building your own custom Inline Block Field Controls. These actions are avaiable in the _Inline Blocks Context_.
+
+```ts
+interface InlineBlocksActions {
+  count: number
+  insert(index: number, data: any): void
+  move(from: number, to: number): void
+  remove(index: number): void
+  blocks: {
+    [key: string]: Block
+  }
+  activeBlock: number | null
+  setActiveBlock: any
+  direction: 'vertical' | 'horizontal'
+  min?: number
+  max?: number
+}
+```
+
+### _useInlineBlocks_
+
+`useInlineBlocks` is a hook that can be used to access the _Inline Blocks Context_ when creating custom controls.
+
+## Inline Block Field Controls
+
+Editors can add / delete / rearrange blocks with the [blocks controls](https://tinacms.org/docs/ui/inline-editing/inline-blocks#blocks-controls-options). They can also access additional fields in a [Settings Modal](https://tinacms.org/docs/ui/inline-editing/inline-blocks#using-the-settings-modal).
+
+
+## Inline Block Definition
+
+A block is made of two parts: a [component](https://tinacms.org/docs/ui/inline-editing/inline-blocks#part-1-block-component) that renders in edit mode, and a [template](https://tinacms.org/docs/ui/inline-editing/inline-blocks#part-2-block-template) to configure fields, defaults and other required data.
+
+
+> Checkout this guide to learn more on using [Inline Blocks](https://tinacms.org/guides/general/inline-blocks/overview).

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -39,7 +39,7 @@ import { StyledFocusRing } from '../styles'
 import { FocusRingOptions, getOffset, getOffsetX, getOffsetY } from '../styles'
 
 export interface BlocksControlsProps {
-  children: any
+  children: React.ReactNode
   index: number
   insetControls?: boolean
   focusRing?: boolean | FocusRingOptions

--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -26,9 +26,8 @@ export interface FocusRingOptions {
   nestedFocus?: boolean
 }
 
-export interface StyledFocusRingProps {
-  offset?: number | { x: number; y: number }
-  borderRadius?: number
+export interface StyledFocusRingProps
+  extends Omit<FocusRingOptions, 'nestedFocus'> {
   active: boolean
   disableHover?: boolean
   disableChildren?: boolean
@@ -36,7 +35,7 @@ export interface StyledFocusRingProps {
 
 export interface FocusRingProps {
   name?: string
-  children?: any
+  children?: React.ReactNode
   options?: boolean | FocusRingOptions
 }
 
@@ -56,7 +55,7 @@ export const FocusRing = ({ name, options, children }: FocusRingProps) => {
     setChildActive(focussedField.startsWith(name!))
   }, [name, options, focussedField])
 
-  const updateFocusedField = (event: any) => {
+  const updateFocusedField = (event: React.MouseEvent<HTMLElement>) => {
     if (active || !name) return
     setFocussedField(name)
     event.stopPropagation()


### PR DESCRIPTION
## What this does:

- Adds `react-tinacms-inline` package docs 
- Adjusts types on focus ring and blocks controls
- Updates a few small things in `next-tinacms-markdown` & `next-tinacms-json` READMEs

_Note_: Some of the examples and information is duplicated in the docs / inline editing guide. I was having a hard time knowing what to include / exclude from the package docs. IMO, the package docs should provide information on all of the components / functions / helpers that someone may want to use in building their own CMS — with basic interfaces & examples (or links to examples). Or should the interfaces live just in the docs? I think we need some clarity on _what goes in package docs_ versus regular docs.