### PR TITLE
next-tinacms-github: check for signing key and return 500 if it's missing

### DIFF
--- a/packages/next-tinacms-github/src/github/create-auth-handler.test.ts
+++ b/packages/next-tinacms-github/src/github/create-auth-handler.test.ts
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 import { createAuthHandler } from './create-auth-handler'
 import { ResStub } from '../test-helpers'
 

--- a/packages/next-tinacms-github/src/github/create-auth-handler.test.ts
+++ b/packages/next-tinacms-github/src/github/create-auth-handler.test.ts
@@ -1,4 +1,5 @@
 import { createAuthHandler } from './create-auth-handler'
+import { ResStub } from '../test-helpers'
 
 describe('createAuthHandler', () => {
   describe('without a signing key', () => {
@@ -24,8 +25,3 @@ describe('createAuthHandler', () => {
     })
   })
 })
-
-class ResStub {
-  status = jest.fn(() => this)
-  json = jest.fn()
-}

--- a/packages/next-tinacms-github/src/github/create-auth-handler.test.ts
+++ b/packages/next-tinacms-github/src/github/create-auth-handler.test.ts
@@ -1,0 +1,31 @@
+import { createAuthHandler } from './create-auth-handler'
+
+describe('createAuthHandler', () => {
+  describe('without a signing key', () => {
+    it('responds with status 500', async () => {
+      // @ts-ignore That's the point of the test.
+      const handler = createAuthHandler('test', 'test', undefined)
+      const req = {}
+      const res = new ResStub()
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+    it('sends JSON response', async () => {
+      // @ts-ignore That's the point of the test.
+      const handler = createAuthHandler('test', 'test', undefined)
+      const req = {}
+      const res = new ResStub()
+
+      await handler(req, res)
+
+      expect(res.json).toHaveBeenCalled()
+    })
+  })
+})
+
+class ResStub {
+  status = jest.fn(() => this)
+  json = jest.fn()
+}

--- a/packages/next-tinacms-github/src/github/create-auth-handler.ts
+++ b/packages/next-tinacms-github/src/github/create-auth-handler.ts
@@ -28,6 +28,13 @@ export const createAuthHandler = (
   secret: string,
   signingKey: string
 ) => (req: any, res: any) => {
+  if (!signingKey) {
+    return res.status(500).json({
+      message:
+        'next-tinacms-github: createAuthHandler was called without a signing key.',
+    })
+  }
+
   createAccessToken(clientId, secret, req.query.code, req.query.state).then(
     (tokenResp: any) => {
       const { access_token, error } = qs.parse(tokenResp.data)

--- a/packages/next-tinacms-github/src/github/create-auth-handler.ts
+++ b/packages/next-tinacms-github/src/github/create-auth-handler.ts
@@ -29,10 +29,10 @@ export const createAuthHandler = (
   signingKey: string
 ) => (req: any, res: any) => {
   if (!signingKey) {
-    return res.status(500).json({
-      message:
-        'next-tinacms-github: createAuthHandler was called without a signing key.',
-    })
+    const message =
+      'next-tinacms-github: createAuthHandler was called without a signing key.'
+    console.error(message)
+    return res.status(500).json({ message })
   }
 
   createAccessToken(clientId, secret, req.query.code, req.query.state).then(

--- a/packages/next-tinacms-github/src/github/proxy.test.ts
+++ b/packages/next-tinacms-github/src/github/proxy.test.ts
@@ -1,0 +1,31 @@
+import { apiProxy } from './proxy'
+
+describe('apiProxy', () => {
+  describe('without a signing key', () => {
+    it('responds with status 500', async () => {
+      // @ts-ignore That's the point of the test.
+      const handler = apiProxy(undefined)
+      const req = {}
+      const res = new ResStub()
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+    it('sends JSON response', async () => {
+      // @ts-ignore That's the point of the test.
+      const handler = apiProxy(undefined)
+      const req = {}
+      const res = new ResStub()
+
+      await handler(req, res)
+
+      expect(res.json).toHaveBeenCalled()
+    })
+  })
+})
+
+class ResStub {
+  status = jest.fn(() => this)
+  json = jest.fn()
+}

--- a/packages/next-tinacms-github/src/github/proxy.test.ts
+++ b/packages/next-tinacms-github/src/github/proxy.test.ts
@@ -1,4 +1,5 @@
 import { apiProxy } from './proxy'
+import { ReqStub, ResStub } from '../test-helpers'
 
 describe('apiProxy', () => {
   describe('without a signing key', () => {
@@ -23,9 +24,15 @@ describe('apiProxy', () => {
       expect(res.json).toHaveBeenCalled()
     })
   })
-})
+  describe('when CSRF token is not in the request cookies ', () => {
+    it('responds with status 401', async () => {
+      const handler = apiProxy('example-signing-key')
+      const req = new ReqStub()
+      const res = new ResStub()
 
-class ResStub {
-  status = jest.fn(() => this)
-  json = jest.fn()
-}
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+    })
+  })
+})

--- a/packages/next-tinacms-github/src/github/proxy.test.ts
+++ b/packages/next-tinacms-github/src/github/proxy.test.ts
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 import { apiProxy } from './proxy'
 import { ReqStub, ResStub } from '../test-helpers'
 

--- a/packages/next-tinacms-github/src/github/proxy.ts
+++ b/packages/next-tinacms-github/src/github/proxy.ts
@@ -21,10 +21,10 @@ import axios from 'axios'
 
 export const apiProxy = (signingKey: string) => (req: any, res: any) => {
   if (!signingKey) {
-    return res.status(500).json({
-      message:
-        'next-tinacms-github: the apiProxy was created without a signing key.',
-    })
+    const message =
+      'next-tinacms-github: the apiProxy was created without a signing key.'
+    console.error(message)
+    return res.status(500).json({ message })
   }
   const { headers, ...data } = JSON.parse(req.body)
 

--- a/packages/next-tinacms-github/src/github/proxy.ts
+++ b/packages/next-tinacms-github/src/github/proxy.ts
@@ -20,6 +20,12 @@ import { AES, enc } from 'crypto-js'
 import axios from 'axios'
 
 export const apiProxy = (signingKey: string) => (req: any, res: any) => {
+  if (!signingKey) {
+    return res.status(500).json({
+      message:
+        'next-tinacms-github: the apiProxy was created without a signing key.',
+    })
+  }
   const { headers, ...data } = JSON.parse(req.body)
 
   // Parse out the amalgamated token

--- a/packages/next-tinacms-github/src/next/preview.test.ts
+++ b/packages/next-tinacms-github/src/next/preview.test.ts
@@ -24,15 +24,39 @@ describe('previewHandler', () => {
       expect(res.json).toHaveBeenCalled()
     })
   })
-  describe('when CSRF token is not in the request cookies ', () => {
-    it('responds with status 401', async () => {
-      const handler = previewHandler('example-signing-key')
-      const req = new ReqStub()
-      const res = new ResStub()
+  describe('with a signing key', () => {
+    describe('when CSRF token is not in the request cookies ', () => {
+      it('responds with status 401', async () => {
+        const handler = previewHandler('example-signing-key')
+        const req = new ReqStub()
+        const res = new ResStub()
 
-      await handler(req, res)
+        await handler(req, res)
 
-      expect(res.status).toHaveBeenCalledWith(401)
+        expect(res.status).toHaveBeenCalledWith(401)
+      })
+    })
+    describe('when CSRF token is in the request cookies', () => {
+      describe('when "authorization" token is not in headers', () => {
+        it('responds with status 401', async () => {
+          const handler = previewHandler('example-signing-key')
+          const req = new ReqStub()
+          const res = new ResStub()
+
+          await handler(req, res)
+
+          expect(res.status).toHaveBeenCalledWith(401)
+        })
+      })
+      describe('when "authorization" token is in headers', () => {
+        describe('when CSRF token is valid', () => {
+          it.skip('sets preview data', () => {})
+          it.skip('responds with status 200', () => {})
+        })
+        describe('when CSRF token is invalid', () => {
+          it.skip('responds with status 401', () => {})
+        })
+      })
     })
   })
 })

--- a/packages/next-tinacms-github/src/next/preview.test.ts
+++ b/packages/next-tinacms-github/src/next/preview.test.ts
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 import { previewHandler } from './preview'
 import { ReqStub, ResStub } from '../test-helpers'
 

--- a/packages/next-tinacms-github/src/next/preview.test.ts
+++ b/packages/next-tinacms-github/src/next/preview.test.ts
@@ -1,0 +1,31 @@
+import { previewHandler } from './preview'
+
+describe('previewHandler', () => {
+  describe('without a signing key', () => {
+    it('responds with status 500', async () => {
+      // @ts-ignore That's the point of the test.
+      const handler = previewHandler(undefined)
+      const req = {}
+      const res = new ResStub()
+
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(500)
+    })
+    it('sends JSON response', async () => {
+      // @ts-ignore That's the point of the test.
+      const handler = previewHandler(undefined)
+      const req = {}
+      const res = new ResStub()
+
+      await handler(req, res)
+
+      expect(res.json).toHaveBeenCalled()
+    })
+  })
+})
+
+class ResStub {
+  status = jest.fn(() => this)
+  json = jest.fn()
+}

--- a/packages/next-tinacms-github/src/next/preview.test.ts
+++ b/packages/next-tinacms-github/src/next/preview.test.ts
@@ -1,11 +1,12 @@
 import { previewHandler } from './preview'
+import { ReqStub, ResStub } from '../test-helpers'
 
 describe('previewHandler', () => {
   describe('without a signing key', () => {
     it('responds with status 500', async () => {
       // @ts-ignore That's the point of the test.
       const handler = previewHandler(undefined)
-      const req = {}
+      const req = new ReqStub()
       const res = new ResStub()
 
       await handler(req, res)
@@ -15,7 +16,7 @@ describe('previewHandler', () => {
     it('sends JSON response', async () => {
       // @ts-ignore That's the point of the test.
       const handler = previewHandler(undefined)
-      const req = {}
+      const req = new ReqStub()
       const res = new ResStub()
 
       await handler(req, res)
@@ -23,9 +24,15 @@ describe('previewHandler', () => {
       expect(res.json).toHaveBeenCalled()
     })
   })
-})
+  describe('when CSRF token is not in the request cookies ', () => {
+    it('responds with status 401', async () => {
+      const handler = previewHandler('example-signing-key')
+      const req = new ReqStub()
+      const res = new ResStub()
 
-class ResStub {
-  status = jest.fn(() => this)
-  json = jest.fn()
-}
+      await handler(req, res)
+
+      expect(res.status).toHaveBeenCalledWith(401)
+    })
+  })
+})

--- a/packages/next-tinacms-github/src/next/preview.ts
+++ b/packages/next-tinacms-github/src/next/preview.ts
@@ -20,6 +20,12 @@ import { CSRF_TOKEN_KEY, WORKING_REPO_KEY, HEAD_BRANCH_KEY } from '../constants'
 import { AES, enc } from 'crypto-js'
 
 export const previewHandler = (signingKey: string) => (req: any, res: any) => {
+  if (!signingKey) {
+    return res.status(500).json({
+      message:
+        'next-tinacms-github: previewHandler was created without a signing key.',
+    })
+  }
   const expectedCSRFToken = req.cookies[CSRF_TOKEN_KEY]
 
   // Parse out the amalgamated token

--- a/packages/next-tinacms-github/src/next/preview.ts
+++ b/packages/next-tinacms-github/src/next/preview.ts
@@ -21,10 +21,11 @@ import { AES, enc } from 'crypto-js'
 
 export const previewHandler = (signingKey: string) => (req: any, res: any) => {
   if (!signingKey) {
-    return res.status(500).json({
-      message:
-        'next-tinacms-github: previewHandler was created without a signing key.',
-    })
+    const message =
+      'next-tinacms-github: previewHandler was created without a signing key.'
+
+    console.error(message)
+    return res.status(500).json({ message })
   }
   const expectedCSRFToken = req.cookies[CSRF_TOKEN_KEY]
 

--- a/packages/next-tinacms-github/src/test-helpers.ts
+++ b/packages/next-tinacms-github/src/test-helpers.ts
@@ -1,0 +1,13 @@
+export class ReqStub {
+  body: string
+  headers = {}
+  cookies = {}
+  constructor(body: any = {}) {
+    this.body = JSON.stringify(body)
+  }
+}
+
+export class ResStub {
+  status = jest.fn(() => this)
+  json = jest.fn()
+}

--- a/packages/next-tinacms-github/src/test-helpers.ts
+++ b/packages/next-tinacms-github/src/test-helpers.ts
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 export class ReqStub {
   body: string
   headers = {}


### PR DESCRIPTION
This does not fully solve the problem as the frontend does not react appropriately but it's an improvement for #1357