### PR TITLE
MediaStore#previewSrc

### DIFF
--- a/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
@@ -26,7 +26,7 @@ import { useState, useEffect } from 'react'
 type FieldProps = any
 interface ImageProps {
   path: string
-  previewSrc(form: any, field: FieldProps): string | Promise<string>
+  previewSrc?(form: any, field: FieldProps): string | Promise<string>
   uploadDir(form: any): string
   clearable?: boolean // defaults to true
 }
@@ -42,10 +42,15 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
       setSrcIsLoading(true)
       let imageSrc = ''
       try {
-        imageSrc = await props.field.previewSrc(
-          props.form.getState().values,
-          props
-        )
+        if (props.field.previewSrc) {
+          imageSrc = await props.field.previewSrc(
+            props.form.getState().values,
+            props
+          )
+        } else {
+          // @ts-ignore cms.alerts
+          imageSrc = await cms.media.store.previewSrc(props.input.value)
+        }
       } catch (e) {
         if (!canceled) {
           setSrc('')

--- a/packages/@tinacms/git-client/src/git-media-store.ts
+++ b/packages/@tinacms/git-client/src/git-media-store.ts
@@ -44,4 +44,7 @@ export class GitMediaStore implements MediaStore {
 
     return uploaded
   }
+  async previewSrc(src: string) {
+    return src
+  }
 }

--- a/packages/@tinacms/media/src/media.ts
+++ b/packages/@tinacms/media/src/media.ts
@@ -57,6 +57,12 @@ export interface MediaStore {
    * for those files.
    */
   persist(files: MediaUploadOptions[]): Promise<Media[]>
+
+  /**
+   * Given a `src` string it returns a url for previewing that content.
+   * This is helpful in cases where the file may not be available in production yet.
+   */
+  previewSrc?(src: string): Promise<string>
 }
 
 /**

--- a/packages/@tinacms/media/src/media.ts
+++ b/packages/@tinacms/media/src/media.ts
@@ -62,7 +62,7 @@ export interface MediaStore {
    * Given a `src` string it returns a url for previewing that content.
    * This is helpful in cases where the file may not be available in production yet.
    */
-  previewSrc?(src: string): Promise<string>
+  previewSrc(src: string): Promise<string>
 }
 
 /**

--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -98,6 +98,7 @@ interface InlineWysiwygProps {
 }
 
 interface ImageProps {
+  parse: (filename: string) => string
   directory?: string
   upload?: (files: File[]) => Promise<string[]>
   previewUrl?: (url: string) => string | Promise<string>
@@ -110,7 +111,7 @@ interface ImageProps {
 | `children`    | Child components to render.                                                                  |
 | `sticky?`     | A boolean determining whether the Wysiwyg Toolbar 'sticks' to the top of the page on scroll. |
 | `format?`     | This value denotes whether Markdown or HTML will be rendered.                                |
-| `imageProps?` | Configures how images in the Wysiwyg are uploaded and rendered.
+| `imageProps?` | Configures how images in the Wysiwyg are uploaded and rendered. Images are disabled when undefined.|
 
 ### Basic Usage
 

--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -101,7 +101,7 @@ interface ImageProps {
   parse: (filename: string) => string
   directory?: string
   upload?: (files: File[]) => Promise<string[]>
-  previewUrl?: (url: string) => string | Promise<string>
+  previewSrc?: (url: string) => string | Promise<string>
 }
 ```
 

--- a/packages/react-tinacms-editor/src/components/MarkdownEditor/index.test.tsx
+++ b/packages/react-tinacms-editor/src/components/MarkdownEditor/index.test.tsx
@@ -39,7 +39,7 @@ describe('MarkdownEditor', () => {
       <MarkdownEditor
         onChange={() => {}}
         value=""
-        imageProps={{ upload: (() => {}) as any }}
+        imageProps={{ parse: filename => filename, upload: (() => {}) as any }}
       />
     )
     expect(getByTestId('image-menu')).toBeDefined()

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
@@ -50,8 +50,8 @@ export const ProsemirrorEditor = styled(
       const { translator: translatorObj } = buildEditor(
         input,
         editorRef.current,
-        imageProps,
         setEditorView,
+        imageProps,
         format
       )
       setTranslator(translatorObj)

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/buildEditor.ts
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/buildEditor.ts
@@ -29,8 +29,8 @@ import { TextSelection } from 'prosemirror-state'
 export const buildEditor = (
   input: Input,
   el: HTMLDivElement | undefined | null,
-  imageProps: ImageProps = {},
   setEditorView: ({ view }: { view: EditorView }) => void,
+  imageProps?: ImageProps,
   format?: Format
 ): { translator?: any } => {
   const schema = buildSchema()

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/buildEditorState.ts
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/buildEditorState.ts
@@ -41,22 +41,27 @@ export function buildEditorState(
   value: string,
   imageProps?: ImageProps
 ) {
+  const plugins = [
+    commonPlugin,
+    inlinePlugin,
+    inputRules(schema),
+    keymap(buildKeymap(schema)),
+    history(),
+    linkPlugin(),
+    dropCursor({ width: 2, color: 'rgb(0, 132, 255)' }),
+    gapCursor(),
+    tableEditing(),
+    tablePlugin,
+    codeBlockPlugin,
+  ]
+
+  if (imageProps) {
+    plugins.push(imagePlugin(imageProps))
+  }
+
   return EditorState.create({
     schema,
     doc: translator.nodeFromString(value),
-    plugins: [
-      commonPlugin,
-      inlinePlugin,
-      inputRules(schema),
-      keymap(buildKeymap(schema)),
-      history(),
-      linkPlugin(),
-      dropCursor({ width: 2, color: 'rgb(0, 132, 255)' }),
-      gapCursor(),
-      tableEditing(),
-      tablePlugin,
-      imagePlugin(imageProps || {}),
-      codeBlockPlugin,
-    ],
+    plugins,
   })
 }

--- a/packages/react-tinacms-editor/src/plugins/Image/Popups/Edit.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Popups/Edit.tsx
@@ -31,9 +31,9 @@ import { imagePluginKey } from '../plugin'
 export const ImageEdit: FunctionComponent = () => {
   const { editorView } = useEditorStateContext()
   const view = editorView!.view
-  const { selectedImage } = imagePluginKey.getState(view.state)
-  if (!selectedImage) return null
-  const { node, pos } = selectedImage
+  const imagePluginState = imagePluginKey.getState(view.state)
+  if (!imagePluginState || !imagePluginState.selectedImage) return null
+  const { node, pos } = imagePluginState.selectedImage
   const { link } = view.state.schema.marks
   const linkMark = node.marks.find((mark: Mark) => mark.type === link)
   const [title, setTitle] = useState(node.attrs.title)
@@ -88,7 +88,7 @@ export const ImageEdit: FunctionComponent = () => {
   useEffect(() => {
     setTitle(node.attrs.title)
     setAlt(node.attrs.alt)
-  }, [selectedImage.node])
+  }, [imagePluginState.selectedImage.node])
 
   useEffect(() => {
     setTimeout(() => {

--- a/packages/react-tinacms-editor/src/plugins/Image/nodeView.ts
+++ b/packages/react-tinacms-editor/src/plugins/Image/nodeView.ts
@@ -31,7 +31,7 @@ export class ImageView implements NodeView {
   constructor(
     node: Node,
     view: EditorView,
-    private previewSrc: ImageProps['previewUrl'] = Identity
+    private previewSrc: ImageProps['previewSrc'] = Identity
   ) {
     this.node = node
     this.view = view

--- a/packages/react-tinacms-editor/src/plugins/Image/plugin.ts
+++ b/packages/react-tinacms-editor/src/plugins/Image/plugin.ts
@@ -30,7 +30,7 @@ import { insertImageList } from './commands'
 import { ImageView } from './nodeView'
 import { ImageProps } from '../../types'
 
-export const imagePluginKey = new PluginKey('image')
+export const imagePluginKey = new PluginKey<{ selectedImage: any }>('image')
 
 const setSelectionAtPos = (
   state: EditorState,

--- a/packages/react-tinacms-editor/src/plugins/Image/plugin.ts
+++ b/packages/react-tinacms-editor/src/plugins/Image/plugin.ts
@@ -64,7 +64,7 @@ const insertImageFiles = (
   return false
 }
 
-export const imagePlugin = ({ previewUrl, upload: uploadImages }: ImageProps) =>
+export const imagePlugin = ({ previewSrc, upload: uploadImages }: ImageProps) =>
   new Plugin({
     key: imagePluginKey,
 
@@ -112,7 +112,7 @@ export const imagePlugin = ({ previewUrl, upload: uploadImages }: ImageProps) =>
     props: {
       nodeViews: {
         image(node, view) {
-          return new ImageView(node, view, previewUrl)
+          return new ImageView(node, view, previewSrc)
         },
       },
       decorations(state) {

--- a/packages/react-tinacms-editor/src/plugins/Link/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Link/Menu/ProsemirrorMenu.tsx
@@ -38,9 +38,10 @@ export const ProsemirrorMenu = markControl({
     const { marks, nodes } = schema
     if (selection.empty) return true
     const selectedNode = selection.$from.node()
+    const imagePluginState = imagePluginKey.getState(view.state)
     return (
       isMarkPresent(view.state, marks.link) ||
-      !!imagePluginKey.getState(view.state).selectedImage ||
+      !!imagePluginState!.selectedImage ||
       (selectedNode && selectedNode.type === nodes.code_block)
     )
   },

--- a/packages/react-tinacms-editor/src/plugins/Link/Popups/Form.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Link/Popups/Form.tsx
@@ -78,7 +78,7 @@ export const LinkForm = () => {
     setPosition({ arrowOffset, left, top })
   }, [linkPluginState])
 
-  if (!linkPluginState.show_link_toolbar) {
+  if (!linkPluginState!.show_link_toolbar) {
     return null
   }
 

--- a/packages/react-tinacms-editor/src/plugins/Link/plugin.ts
+++ b/packages/react-tinacms-editor/src/plugins/Link/plugin.ts
@@ -28,7 +28,7 @@ interface LinkPluginState {
   showLinkForm: boolean
 }
 
-export const linkPluginKey = new PluginKey('image')
+export const linkPluginKey = new PluginKey<LinkPluginState>('image')
 
 export function linkPlugin(): Plugin {
   let shiftKey: boolean

--- a/packages/react-tinacms-editor/src/plugins/Link/plugin.ts
+++ b/packages/react-tinacms-editor/src/plugins/Link/plugin.ts
@@ -26,6 +26,7 @@ import { linkify } from './util'
 
 interface LinkPluginState {
   showLinkForm: boolean
+  show_link_toolbar: boolean
 }
 
 export const linkPluginKey = new PluginKey<LinkPluginState>('image')

--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -51,7 +51,7 @@ export function InlineWysiwyg({
 
         return allMedia.map(media => passedInImageProps.parse(media.filename))
       },
-      previewUrl(src) {
+      previewSrc(src) {
         return cms.media.store.previewSrc(src)
       },
       ...passedInImageProps,
@@ -59,7 +59,7 @@ export function InlineWysiwyg({
   }, [
     cms.media.store,
     passedInImageProps?.directory,
-    passedInImageProps?.previewUrl,
+    passedInImageProps?.previewSrc,
     passedInImageProps?.upload,
   ])
 

--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -50,6 +50,9 @@ export function InlineWysiwyg({
 
         return allMedia.map(media => `${media.directory}${media.filename}`)
       },
+      previewUrl(src) {
+        return cms.media.store.previewSrc(src)
+      },
       ...passedInImageProps,
     }
   }, [

--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -29,11 +29,12 @@ export interface InlineWysiwygFieldProps extends Omit<EditorProps, 'input'> {
   focusRing?: boolean | FocusRingOptions
 }
 
+const parse = (filename: string) => filename
 export function InlineWysiwyg({
   name,
   children,
   focusRing = true,
-  imageProps: passedInImageProps = {},
+  imageProps: passedInImageProps = { parse },
   ...wysiwygProps
 }: InlineWysiwygFieldProps) {
   const cms = useCMS()
@@ -48,7 +49,7 @@ export function InlineWysiwyg({
           }))
         )
 
-        return allMedia.map(media => `${media.directory}${media.filename}`)
+        return allMedia.map(media => passedInImageProps.parse(media.filename))
       },
       previewUrl(src) {
         return cms.media.store.previewSrc(src)

--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -29,17 +29,17 @@ export interface InlineWysiwygFieldProps extends Omit<EditorProps, 'input'> {
   focusRing?: boolean | FocusRingOptions
 }
 
-const parse = (filename: string) => filename
 export function InlineWysiwyg({
   name,
   children,
   focusRing = true,
-  imageProps: passedInImageProps = { parse },
+  imageProps: passedInImageProps,
   ...wysiwygProps
 }: InlineWysiwygFieldProps) {
   const cms = useCMS()
 
-  const imageProps: ImageProps = React.useMemo(() => {
+  const imageProps: ImageProps | undefined = React.useMemo(() => {
+    if (!passedInImageProps) return
     return {
       async upload(files: File[]) {
         const allMedia = await cms.media.store.persist(
@@ -58,9 +58,9 @@ export function InlineWysiwyg({
     }
   }, [
     cms.media.store,
-    passedInImageProps.directory,
-    passedInImageProps.previewUrl,
-    passedInImageProps.upload,
+    passedInImageProps?.directory,
+    passedInImageProps?.previewUrl,
+    passedInImageProps?.upload,
   ])
 
   if (cms.disabled) {

--- a/packages/react-tinacms-editor/src/types.ts
+++ b/packages/react-tinacms-editor/src/types.ts
@@ -28,7 +28,7 @@ export interface ImageProps {
   parse(filename: string): string
   directory?: string
   upload?: (files: File[]) => Promise<string[]>
-  previewUrl?: (url: string) => string | Promise<string>
+  previewSrc?: (url: string) => string | Promise<string>
 }
 
 export interface KeymapPlugin {

--- a/packages/react-tinacms-editor/src/types.ts
+++ b/packages/react-tinacms-editor/src/types.ts
@@ -25,6 +25,7 @@ import { Schema } from 'prosemirror-model'
 import { Format } from './translator'
 
 export interface ImageProps {
+  parse(filename: string): string
   directory?: string
   upload?: (files: File[]) => Promise<string[]>
   previewUrl?: (url: string) => string | Promise<string>

--- a/packages/react-tinacms-editor/stories/wysiwyg.stories.tsx
+++ b/packages/react-tinacms-editor/stories/wysiwyg.stories.tsx
@@ -79,7 +79,7 @@ const WithImage = () => {
             }, 250)
           })
         },
-        previewUrl: (str: string) => str,
+        previewSrc: (str: string) => str,
       }}
     />
   )

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -263,7 +263,7 @@ export class GithubClient {
     })
   }
 
-  async getDownloadUrl(path: string) {
+  async getDownloadUrl(path: string): Promise<string> {
     const res = await this.fetchFile(path, false)
     return res.download_url
   }

--- a/packages/react-tinacms-github/src/github-media-store/index.ts
+++ b/packages/react-tinacms-github/src/github-media-store/index.ts
@@ -50,4 +50,12 @@ export class GithubMediaStore implements MediaStore {
 
     return uploaded
   }
+
+  async previewSrc(src: string) {
+    try {
+      return this.githubClient.getDownloadUrl(src)
+    } catch {
+      return src
+    }
+  }
 }

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -25,9 +25,9 @@ import { useState, useEffect } from 'react'
 
 export interface InlineImageProps {
   name: string
-  previewSrc(formValues: any): string
   parse(filename: string): string
   uploadDir(form: Form): string
+  previewSrc?(formValues: any): string
   focusRing?: boolean | FocusRingOptions
   children?: any
 }

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -27,7 +27,7 @@ export interface InlineImageProps {
   name: string
   parse(filename: string): string
   uploadDir(form: Form): string
-  previewSrc?(formValues: any): string
+  previewSrc?(formValues: any): string | Promise<string>
   focusRing?: boolean | FocusRingOptions
   children?: any
 }

--- a/packages/react-tinacms-strapi/src/strapi-media-store.ts
+++ b/packages/react-tinacms-strapi/src/strapi-media-store.ts
@@ -63,6 +63,10 @@ export class StrapiMediaStore {
     return uploadResponse.json()
   }
 
+  async previewSrc(src: string) {
+    return this.strapiUrl + this.getFilePath(src)
+  }
+
   getFilePath(fileUrl: string): string {
     return fileUrl.split('?')[0]
   }

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -122,4 +122,7 @@ class DummyMediaStore implements MediaStore {
       filename: file.name,
     }))
   }
+  async previewSrc(filename: string) {
+    return filename
+  }
 }


### PR DESCRIPTION
This RFC introduces `MediaStore#previewSrc`. This allows `MediaStores` to provide a default method that can be overridden on a field-by-field basis

Todo:


Done
- [x] Implement `StrapiMediaStore#previewSrc`
- [x] `InlineWysiwyg` should expect `imageProps.parse` 
- [x] `InlineImage`
  - Needs to work with async previewSrc
- [x] Introduces `MediaStore#previewSrc`
- [x] `InlineWysiwyg` 
- [x] `ImageFieldPlugin`
- [x] Implement `GithubMediaStore#previewSrc`
- [x] Implement `GitMediaStore#previewSrc`

Note: READMEs don't really require any updates from this PR

## Ways to Test

### Test with GithubMediaStore on Tinacms.org
Setup
* Add the `parse` function to the `InlineWysiwyg` wrapper.
* Run with local TINA version
* Turn on the sidebar and add a dummy `image` field to the sidebar
* Make sure to create a new testing branch
* Add an Inline Image Field somewhere

Tests
- [ ] Dragging images onto the Editor
- [ ] Using the image menu in the Editor 
- [ ] Sidebar image field
- [ ] Inline Image field

### Test GitMediaStore in `demo-gatsby`

- [x] Editor on a Blog
- [x] Inline Image on above and right of the blog body
- [x] Sidebar image

### Test StrapiMediaStore a site built by going through the guide
- [ ] Setup images on the wysiwyg
- [ ] Remove `previewSrc` from the InlineImage example