### PR TITLE
feat(@tinacms/core): events from APIs are dispatched to the entire CMS

### DIFF
--- a/packages/@tinacms/core/src/cms.test.ts
+++ b/packages/@tinacms/core/src/cms.test.ts
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 import { CMS } from './cms'
+import { CMSEvent, EventBus } from './event'
 
 describe('CMS', () => {
   describe('when constructed without options', () => {
@@ -85,6 +86,22 @@ describe('CMS', () => {
         })
 
         expect(cms.api.test).toBe(test)
+      })
+    })
+  })
+
+  describe('#registerApi', () => {
+    describe('when the API has `events` of type EventBus', () => {
+      it('events dispatched to the API are also sent through the CMS', () => {
+        const listener = jest.fn()
+        const event: CMSEvent = { type: 'api:example' }
+        const example = { events: new EventBus() }
+        const cms = new CMS({ apis: { example } })
+        cms.events.subscribe('*', listener)
+
+        cms.api.example.events.dispatch(event)
+
+        expect(listener).toHaveBeenCalledWith(event)
       })
     })
   })

--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -141,7 +141,6 @@ export class CMS {
    *
    * #### Example
    *
-   *
    * ```ts
    * import { CoolApi } from "cool-api"
    *
@@ -150,9 +149,15 @@ export class CMS {
    *
    * @param name The name used to lookup the external API.
    * @param api An object for interacting with an external API.
+   *
+   * ### Additional Resources
+   *
+   * * https://github.com/tinacms/rfcs/blob/master/0010-api-events.md
    */
   registerApi(name: string, api: any): void {
-    // TODO: Make sure we're not overwriting an existing API.
+    if (api.events instanceof EventBus) {
+      ;(api.events as EventBus).subscribe('*', this.events.dispatch)
+    }
     this.api[name] = api
   }
 


### PR DESCRIPTION
See [RFC 0010](https://github.com/tinacms/rfcs/blob/master/0010-api-events.md) for more information.