### PR TITLE
build: remove checkForMilestone

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -100,9 +100,9 @@ function runChecksOnPullRequest() {
   listTouchedWorkflows(allFiles)
 
   // Pull Request
-  if (modifiedPackages.length > 0) {
-    checkForMilestone()
-  }
+  // if (modifiedPackages.length > 0) {
+  //   checkForMilestone()
+  // }
 
   checkForDocsChanges(allFiles)
 }


### PR DESCRIPTION
Now that we are automatically generating the root CHANGLOG and the GitHub release, the need to use Milestones has gone. This PR removes that check from the CI
