### PR TITLE
Inline text children

### DIFF
--- a/packages/react-tinacms-inline/src/fields/inline-text-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-text-field.tsx
@@ -27,6 +27,7 @@ export interface InlineTextProps {
   className?: string
   focusRing?: boolean | FocusRingOptions
   placeholder?: string
+  children?: React.ReactChild
 }
 
 /**
@@ -40,6 +41,7 @@ export function InlineText({
   className,
   focusRing = true,
   placeholder,
+  children,
 }: InlineTextProps) {
   const cms: CMS = useCMS()
 
@@ -69,7 +71,7 @@ export function InlineText({
             </FocusRing>
           )
         }
-        return <>{input.value || placeholder}</>
+        return <>{children || input.value}</>
       }}
     </InlineField>
   )

--- a/packages/react-tinacms-inline/src/fields/inline-textarea-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-textarea-field.tsx
@@ -34,6 +34,7 @@ export function InlineTextarea({
   name,
   className,
   placeholder,
+  children,
   focusRing = true,
 }: InlineTextProps) {
   const cms = useCMS()
@@ -64,7 +65,7 @@ export function InlineTextarea({
             </FocusRing>
           )
         }
-        return <>{input.value}</>
+        return <>{children || input.value}</>
       }}
     </InlineField>
   )

--- a/packages/react-tinacms-inline/src/fields/inline-textarea-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-textarea-field.tsx
@@ -33,6 +33,7 @@ export const InlineTextareaField = InlineTextarea
 export function InlineTextarea({
   name,
   className,
+  placeholder,
   focusRing = true,
 }: InlineTextProps) {
   const cms = useCMS()
@@ -42,12 +43,24 @@ export function InlineTextarea({
       {({ input }) => {
         if (cms.enabled) {
           if (!focusRing) {
-            return <Textarea className={className} {...input} rows={1} />
+            return (
+              <Textarea
+                className={className}
+                {...input}
+                rows={1}
+                placeholder={placeholder}
+              />
+            )
           }
 
           return (
             <FocusRing name={name} options={focusRing}>
-              <Textarea className={className} {...input} rows={1} />
+              <Textarea
+                className={className}
+                {...input}
+                rows={1}
+                placeholder={placeholder}
+              />
             </FocusRing>
           )
         }


### PR DESCRIPTION
Backwards compatible change.

When inside a form with `title = "Hello World"`

**Default Usage**

```jsx
<InlineText name="title" />
```

Output when `cms.disabled` will be:
```html
Hello World
```

**With Children**

```jsx
<InlineText name="title">
  Not Editing
</InlineText>
```

Output when `cms.disabled` will be:

```html
Not Editing
```
---
- [ ] Docs
