### PR TITLE
fix: wysiwym UX issues fixes in table, heading, link modals

### DIFF
--- a/packages/react-tinacms-editor/src/plugins/Block/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Block/Menu/ProsemirrorMenu.tsx
@@ -44,6 +44,7 @@ export const ProsemirrorMenu: FunctionComponent = () => {
       <MenuButton
         ref={menuButtonRef}
         data-tooltip="Heading"
+        title="Heading"
         onClick={toggle}
         active={active}
       >

--- a/packages/react-tinacms-editor/src/plugins/Link/Popups/InnerForm.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Link/Popups/InnerForm.tsx
@@ -43,8 +43,11 @@ export class InnerForm extends React.Component<Props, State> {
     // title: this.props.title || '',
   }
 
+  inputRef = React.createRef<HTMLInputElement>()
+
   componentDidMount() {
     document.addEventListener('keydown', this.onEscapeCancel)
+    if (this.inputRef.current) this.inputRef.current.focus()
   }
 
   componentWillUnmount() {
@@ -54,6 +57,13 @@ export class InnerForm extends React.Component<Props, State> {
   componentDidUpdate(prevProps: Props) {
     const { href } = this.props
     if (href !== prevProps.href) this.setState(() => ({ href }))
+  }
+
+  closeModal() {
+    const { href } = this.state
+    const { cancel, removeLink, href: originalHref } = this.props
+    if (!href && !originalHref) removeLink()
+    cancel()
   }
 
   setHref = ({ target: { value } }: E) => this.setState(() => ({ href: value }))
@@ -70,7 +80,7 @@ export class InnerForm extends React.Component<Props, State> {
 
   onEscapeCancel = (e: KeyboardEvent) => {
     if (e.keyCode === 27) {
-      this.props.cancel()
+      this.closeModal()
     }
   }
 
@@ -93,6 +103,7 @@ export class InnerForm extends React.Component<Props, State> {
         /> */}
         <LinkLabel>URL</LinkLabel>
         <LinkInput
+          ref={this.inputRef}
           placeholder="Enter URL"
           type={'text'}
           value={href}
@@ -101,7 +112,9 @@ export class InnerForm extends React.Component<Props, State> {
         />
         <LinkActions>
           <DeleteLink onClick={removeLink}>Delete</DeleteLink>
-          <SaveLink onClick={this.save}>Save</SaveLink>
+          <SaveLink onClick={this.save} disabled={!href}>
+            Save
+          </SaveLink>
         </LinkActions>
       </LinkPopup>
     )
@@ -193,6 +206,10 @@ const SaveLink = styled.button`
   }
   &:active {
     background-color: #0574e4;
+  }
+  &:disabled {
+    background-color: #d1d1d1;
+    box-shadow: none;
   }
 `
 

--- a/packages/react-tinacms-editor/src/plugins/Table/commands/index.ts
+++ b/packages/react-tinacms-editor/src/plugins/Table/commands/index.ts
@@ -58,8 +58,8 @@ export const insertTable = (
   const newTable = table.createChecked(null, rows)
   const { selection, tr } = state
   const { $from, $to } = selection
-  dispatch(
-    tr.replaceWith($from.pos - 1, $to.pos + 1, newTable).scrollIntoView()
-  )
+  const start = $from.pos - 1
+  const end = $to.pos < state.doc.content.size ? $to.pos + 1 : $to.pos
+  dispatch(tr.replaceWith(start, end, newTable).scrollIntoView())
   return true
 }


### PR DESCRIPTION
@DirtyF: PR fixes the issues in editor we discussed last week:

1. I added tooltip to heading icon in menubar
2. Link URL input to get focus as modal opens
3. In link modal disable Save until URL is entered
4. In an edge case table creation was failing, that is fixed

In addition I also checked in heading dropdown to ensure that current heading get highlighted correctly and it seems to work well for all heading types.