### PR TITLE
feat: update inline text with child render prop

### DIFF
--- a/packages/react-tinacms-inline/src/fields/inline-text-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-text-field.tsx
@@ -21,11 +21,13 @@ import styled from 'styled-components'
 import { useCMS, CMS } from 'tinacms'
 import { FocusRing, FocusRingOptions } from '../styles'
 import { InlineField } from '..'
+import { InlineFieldProps } from '../inline-field'
 
 export interface InlineTextProps {
   name: string
   className?: string
   focusRing?: boolean | FocusRingOptions
+  children?: InlineFieldProps['children']
 }
 
 /**
@@ -55,7 +57,7 @@ export function InlineText({
             </FocusRing>
           )
         }
-        return <>{input.value}</>
+        return <>{children ?? input.value}</>
       }}
     </InlineField>
   )


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
This PR allows `InlineBlocks` to take a renderChild that allows you to configure the `<div>` with `react-dnd`s `providedRef`.

This is because a WIP inline field we're using requires two instances of InlineBlocks to be direct DOM dependencies of each other, and currently `InlineBlocks` places a div between them.