### PR TITLE
Updates `react-tinacms-editor` docs 

### DIFF
--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -95,6 +95,7 @@ interface InlineWysiwygProps {
   sticky?: boolean | string
   format?: 'markdown' | 'html'
   imageProps?: ImageProps
+  focusRing?: boolean | FocusRingProps
 }
 
 interface ImageProps {
@@ -102,6 +103,11 @@ interface ImageProps {
   directory?: string
   upload?: (files: File[]) => Promise<string[]>
   previewSrc?: (url: string) => string | Promise<string>
+}
+
+interface FocusRingProps {
+  offset?: number | { x: number; y: number }
+  borderRadius?: number
 }
 ```
 
@@ -111,7 +117,8 @@ interface ImageProps {
 | `children`    | Child components to render.                                                                  |
 | `sticky?`     | A boolean determining whether the Wysiwyg Toolbar 'sticks' to the top of the page on scroll. |
 | `format?`     | This value denotes whether Markdown or HTML will be rendered.                                |
-| `imageProps?` | Configures how images in the Wysiwyg are uploaded and rendered. Images are disabled when undefined.|
+| `imageProps?` | An object that configures how images in the Wysiwyg are uploaded and rendered. Images are disabled when undefined.|
+| `focusRing?`   | Either an object to style the focus ring or a boolean to show/hide the focus ring. Defaults to `true` which displays the focus ring with default styles. For style options, `offset` (in pixels) sets the distance from the ring to the edge of the component, and `borderRadius` (in pixels) controls the [rounded corners](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) of the focus ring. |
 
 ### Basic Usage
 

--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -144,6 +144,33 @@ export function Page(props) {
 }
 ```
 
+### With _imageProps_
+
+To upload and manage images in the Wysiwyg, you'll need to configure `imageProps`. 
+
+| Key           | Description                                                                                  |
+| ------------- | -------------------------------------------------------------------------------------------- |
+| `parse`        | Defines how the actual front matter or data value gets populated on upload. The name of the file gets passed as an argument. _Defaults to `filename`_.                                           |
+| `directory?`    | Defines the upload directory.                                                                 |
+| `upload?`     | An asynchronous function that handles image upload. By default, this calls the `persist` function on the [media store](https://tinacms.org/docs/media). |
+| `previewSrc?`     | 	An asynchronous function that returns the path or url for the image `src` in preview or edit mode. By default, this calls the `previewSrc` function on the [media store](https://tinacms.org/docs/media)_.                             |
+
+```jsx
+<InlineWysiwyg
+  name="rawMarkdownBody"
+  imageProps={{
+    parse: (filename) => `images/about/${filename}`
+    directory: 'public/images/about/',
+  }}
+>
+  <div
+    dangerouslySetInnerHTML={{
+      __html: props.data.markdownRemark.html,
+    }}
+  />
+</InlineWysiwyg>
+```
+
 ### Sticky Menu
 
 When editing long content it is likely that the editor will scroll past the wysiwyg menu.


### PR DESCRIPTION
- adds focus ring info
- adds table and example on `imageProps`...could use a second eye here as I know this has changed recently.