### PR TITLE
gatsby-plugin-tinacms: pass enabled option

### DIFF
--- a/packages/gatsby-plugin-tinacms/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-tinacms/gatsby-ssr.tsx
@@ -25,7 +25,7 @@ exports.wrapRootElement = (
   options: GatsbyPluginTinacmsOptions
 ) => {
   const cms = new TinaCMS({
-    enabled: true,
+    enabled: options.enabled,
     sidebar: options.sidebar,
     toolbar: options.toolbar,
   })

--- a/packages/gatsby-plugin-tinacms/gatsby-ssr.tsx
+++ b/packages/gatsby-plugin-tinacms/gatsby-ssr.tsx
@@ -25,6 +25,7 @@ exports.wrapRootElement = (
   options: GatsbyPluginTinacmsOptions
 ) => {
   const cms = new TinaCMS({
+    enabled: true,
     sidebar: options.sidebar,
     toolbar: options.toolbar,
   })


### PR DESCRIPTION
According to the docs: https://tinacms.org/docs/releases/2020-08-03#upgrading-from-v0250,  you have to pass `enabled` since 0.26.0.

Context: being able to upgrade tina-starter-grande to latest Tina 