### PR TITLE
Update README for react-tinacms-github

### DIFF
--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -162,15 +162,15 @@ function BlogTemplate({ jsonFile }) {
 ## Next steps
 
 Now that we have configured our front-end to use Github, we will need to setup some backend functions to handle authentication.
-If you are using Nextjs, you may want to use the [next-tinacms-github](https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github) package.
+If you are using Next.js, you may want to use the [next-tinacms-github](https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github) package.
 
 
 
 ## Toolbar and form plugins
 
-### Github Delete Action
+### GitHub Delete Action
 
-This is a delete action for [the github client](https://tinacms.org/docs/packages/github-client).
+This is a delete action for the GitHub client.
 
 It will **delete the entire form file**. So the primary use case would be dynamic pages like blog pages or docs pages. (Commonly used with markdown files but could be any file format)
 

--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -266,19 +266,7 @@ The `GithubFile` class is a helper class to provide methods for manipulating a s
 
 ### Signature
 
-```ts
-type parseFn = (content: string) => any
-type serializeFn = (data: any) => string
-
-interface GithubFileArgs {
-  private cms: TinaCMS
-  private path: string
-  private parse?: parseFn
-  private serialize?: serializeFn
-}
-
-const file = new GithubFile(args: GithubFileArgs)
-```
+The `GithubFile` constructor takes four parameters: `cms`, `path`, `parse`, and `serialize`.
 
 | argument | description |
 | --- | --- |

--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -126,11 +126,11 @@ export const EditLink = () => {
 }
 ```
 
-### Github Oauth App:
+### Github OAuth App:
 
-In GitHub, within your account Settings, click [Oauth Apps](https://github.com/settings/developers) under Developer Settings.
+In GitHub, within your account Settings, click [OAuth Apps](https://github.com/settings/developers) under Developer Settings.
 
-click "New Oauth App".
+click "New OAuth App".
 
 For the **Authorization callback URL**, enter the url for the "authorizing" page that [you created above](#auth-redirects) (e.g https://your-url/github/authorizing). Fill out the other fields with your custom values.
 

--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -119,7 +119,7 @@ const cms = new TinaCMS({
 
 The `TinacmsGithubProvider` component controls edit access to your site and will send unauthenticated users through the authentication flow.
 
-`TinacmsGithubProvider` can be configured with custom handlers that run after a user has logged in / logged out successfully. The below example uses cust `onLogin` / `onLogout` handlers to hit custom API routes that trigger Next.js Preview Mode:
+`TinacmsGithubProvider` can be configured with custom handlers that run after a user has logged in / logged out successfully. The below example uses custom `onLogin` / `onLogout` handlers to hit custom API routes that trigger Next.js Preview Mode:
 
 ```tsx
 import { TinacmsGithubProvider } from 'react-tinacms-github';

--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -174,7 +174,7 @@ This is a delete action for [the github client](https://tinacms.org/docs/package
 
 It will **delete the entire form file**. So the primary use case would be dynamic pages like blog pages or docs pages. (Commonly used with markdown files but could be any file format)
 
-![](https://tinacms.org/img/delete-action-ex.png)
+![Form Actions panel with Delete button](https://tinacms.org/img/delete-action-ex.png)
 
 
 #### Options
@@ -313,7 +313,7 @@ import { useGithubFile } from 'react-tinacms-github'
 import { useForm, usePlugin } from 'tinacms'
 
 export function Page(props) => {
-  
+
   const { fetchFile, commit } = useGithubFile({
     path: 'content/home-page.json',
     parse: JSON.parse,

--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -228,3 +228,111 @@ const formOptions = {
      //...
 }
 ```
+
+## _GithubFile_ and _useGithubFile_
+
+The `GithubFile` class is a helper class to provide methods for manipulating a single file in your GitHub repo.
+
+### Signature
+
+```ts
+type parseFn = (content: string) => any
+type serializeFn = (data: any) => string
+
+interface GithubFileArgs {
+  private cms: TinaCMS
+  private path: string
+  private parse?: parseFn
+  private serialize?: serializeFn
+}
+
+const file = new GithubFile(args: GithubFileArgs)
+```
+
+| argument | description |
+| --- | --- |
+| cms | An instance of TinaCMS |
+| path | Filepath, relative to repository root |
+| parse | Function to deserialize file contents into an object |
+| serialize | Function to serialize data object into a string |
+
+### Methods
+
+The `GithubFile` class has two public methods:
+
+| method | description |
+| --- | --- |
+| fetchFile | Wraps `GithubClient#fetchFile`; async function to retrieve file contents from GitHub API |
+| commit | Wraps `GithubClient#commit`; async function to commit changes to a file |
+
+
+
+### Usage Example
+
+```ts
+import { GithubFile } from 'react-tinacms-github'
+
+async function example() {
+  const navigationFile = new GithubFile(
+    cms,
+    'content/navigation.json',
+    JSON.parse,
+    JSON.stringify
+  )
+
+  // get file contents from GitHub
+  const navigation = await navigationFile.fetchFile()
+
+  // modify the file data
+  navigation.push({ url: 'https://tinacms.org', title: 'TinaCMS' })
+
+  // commit the updated file data
+  await navigationFile.commit(navigation, 'Update navigation')
+}
+
+```
+
+### _useGithubFile_
+
+`useGithubFile` wraps the `GithubFile` class and is designed to be used from inside a Function Component.
+
+```ts
+interface UseGithubFileArgs {
+  path: string
+  parse?: parseFn
+  serialize?: serializeFn
+}
+
+function useGithubFile(args: UseGithubFileArgs): GithubFile
+```
+
+`useGithubFile` is intended to provide a more flexible abstraction than the form helpers, giving you file manipulation methods that you can use in conjunction with `useForm`.
+
+```ts
+import { useGithubFile } from 'react-tinacms-github'
+import { useForm, usePlugin } from 'tinacms'
+
+export function Page(props) => {
+  
+  const { fetchFile, commit } = useGithubFile({
+    path: 'content/home-page.json',
+    parse: JSON.parse,
+    stringify: JSON.stringify
+  })
+
+  const [homepageData, homepageForm] = useForm({
+    loadInitialValues: fetchFile,
+    onSubmit: commit,
+
+    id: 'home-page',
+    label: 'Home Page',
+    fields: [
+      //...
+    ],
+  })
+  usePlugin(homepageForm)
+
+  //...
+}
+```
+


### PR DESCRIPTION
[View README](https://github.com/tinacms/tinacms/blob/58eebf59e5e6f3c42c00e5625baac7e07703b663/packages/react-tinacms-github/README.md)

- Reorganizes README
- delegates step-by-step content to the Next.js + GitHub guide
- documents `GithubFile` and `useGithubFile`
- documents `GithubClient` public methods

The API reference for `GithubClient` is a bit big and clunky and would likely be better served by Typedoc annotations.