### PR TITLE
fix(react-tinacms-editor): fix wysiwyg sticky types

### DIFF
--- a/packages/react-tinacms-editor/src/types.ts
+++ b/packages/react-tinacms-editor/src/types.ts
@@ -71,7 +71,7 @@ export interface Input {
 export interface EditorProps {
   input: Input
   plugins?: Plugin[]
-  sticky?: boolean | string
+  sticky?: string
   format?: Format
   imageProps?: ImageProps
   className?: string


### PR DESCRIPTION
I might be missing some context but this commit didn't remove boolean: https://github.com/tinacms/tinacms/commit/13749e4af46a12d29518a87231f11d26ad1c05bc 

However, a `boolean` values doesn't work in `sticky` prop: https://github.com/tinacms/tinacms/issues/1194#issuecomment-675885043

Tested my change by linking `react-tinacms-editor` locally (Is it possible to add a test case for this?)

![image](https://user-images.githubusercontent.com/746482/90725098-44508980-e2dd-11ea-9f61-29fe884158d8.png)
