### PR TITLE
fix(react-tinacms-inline): preview src passes form values

### DIFF
--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -81,7 +81,7 @@ function EditableImage({
       let imageSrc = ''
       try {
         if (previewSrc) {
-          imageSrc = await previewSrc(form.getState().values)
+          imageSrc = await previewSrc(form.values)
         } else {
           // @ts-ignore cms.alerts
           imageSrc = await cms.media.store.previewSrc(props.input.value)
@@ -89,6 +89,7 @@ function EditableImage({
       } catch (e) {
         if (!canceled) {
           setSrc('')
+          console.error(e)
           // @ts-ignore cms.alerts
           cms.alerts.error(
             `Failed to generate preview for '${name}': ${e.message}`


### PR DESCRIPTION
When I was trying to test something in`demo-next`, none of the `previewSrc` for inline images were working. In doing some testing, I think I found the issue. There is no `getState` method on `form`, so I updated this to `form.values` which calls on `finalForm.getState().values`

There may be something I am missing because [this line is used](https://github.com/tinacms/tinacms/blob/master/packages/%40tinacms/fields/src/plugins/ImageFieldPlugin.tsx#L47) in the regular `ImageFieldPlugin`: `form.getState().values`. Wondering if there's a different usecase or something with the form config changed.