### PR TITLE
fix ref forwarding in InlineBlocks

### DIFF
--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -514,7 +514,7 @@ To handle this, you can pass a "render function" as the child of the `InlineBloc
 
 ```ts
 interface BlocksContainerProps {
-  ref: React.Ref<any>
+  innerRef: React.Ref<any>
   className?: string
 }
 ```
@@ -525,8 +525,8 @@ interface BlocksContainerProps {
 import { useJsonForm } from 'next-tinacms-json'
 import { InlineForm, InlineBlocks, BlocksControls, InlineTextarea } from 'react-tinacms-inline'
 
-const MyBlocksContainer = ({ref, children}) => (
-  <div ref={ref}>
+const MyBlocksContainer = ({innerRef, children}) => (
+  <div ref={innerRef}>
     {children}
   </div>
 )

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -48,11 +48,14 @@ export interface InlineBlocksProps {
 }
 
 export interface BlocksContainerProps {
-  ref: React.Ref<any>
+  innerRef: React.Ref<any>
   className?: string
 }
 
-const DefaultContainer = (props: BlocksContainerProps) => <div {...props} />
+const DefaultContainer = (props: BlocksContainerProps) => {
+  const { innerRef, ...otherProps } = props
+  return <div ref={innerRef} {...otherProps} />
+}
 
 export interface InlineBlocksActions {
   count: number
@@ -135,7 +138,7 @@ export function InlineBlocks({
         return (
           <Droppable droppableId={name} type={name} direction={direction}>
             {provider => (
-              <Container ref={provider.innerRef} className={className}>
+              <Container innerRef={provider.innerRef} className={className}>
                 {
                   <InlineBlocksContext.Provider
                     value={{


### PR DESCRIPTION
https://reactjs.org/docs/forwarding-refs.html

We can either pass the ref in a different prop (`innerRef`, as is done here) or we could require consumers to use `React.forwardRef` when creating their custom container component