### PR TITLE
fix: wysiwym image modal issues

### DIFF
--- a/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
@@ -120,7 +120,10 @@ export const ProsemirrorMenu = ({ uploadImages }: MenuProps) => {
           }}
         >
           <ImageModalContent>
-            <StyledLabel htmlFor="fileInput">
+            <StyledLabel
+              htmlFor="fileInput"
+              onClick={evt => evt.stopPropagation()}
+            >
               <FileUploadInput
                 id="fileInput"
                 onChange={uploadSelectedImage}
@@ -319,7 +322,8 @@ const UploadText = styled.span`
   text-align: center;
   line-height: 1.2;
   color: var(--tina-color-grey-10);
-  max-width: 120px;
+  max-width: 140px;
+  white-space: break-spaces;
   display: block;
   margin: 0 auto;
 `
@@ -348,4 +352,6 @@ const FileUploadInput = styled.input`
   display: none;
 `
 
-const StyledLabel = styled.label``
+const StyledLabel = styled.label`
+  display: block;
+`


### PR DESCRIPTION
Fix #1405 Upoad image modal issue:

![Screenshot 2020-09-01 at 12 42 41 PM](https://user-images.githubusercontent.com/2182307/91813646-a51e8100-ec50-11ea-9e7d-5992a87875df.png)

Note: there is a broken scenario, probably @spbyrne can check later:

![Screenshot 2020-09-01 at 1 05 26 PM](https://user-images.githubusercontent.com/2182307/91820658-e49a9c80-ec53-11ea-9038-2e0f0862484a.png)
