### PR TITLE
feat: keyboard shortcut for toggle editor mode

### DIFF
--- a/packages/react-tinacms-editor/src/context/editorMode.tsx
+++ b/packages/react-tinacms-editor/src/context/editorMode.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { createContext, useContext } from 'react'
 
 const EditorModeContext = createContext<{
@@ -30,6 +30,18 @@ const EditorModeContext = createContext<{
 
 export const EditorModeProvider = ({ children }: any) => {
   const [mode, setMode] = useState('wysiwyg')
+
+  useEffect(() => {
+    document.addEventListener('keydown', event => {
+      if (
+        event.altKey &&
+        event.shiftKey &&
+        event.metaKey &&
+        event.keyCode === 77
+      )
+        setMode(mode === 'wysiwyg' ? 'markdown' : 'wysiwyg')
+    })
+  })
 
   return (
     <EditorModeContext.Provider value={{ mode, setMode }}>


### PR DESCRIPTION
Adding keyboard shortcut `Cmd-/` or `Ctrl-/` for mode toggling in editor.