### PR TITLE
Previewsrc refactor

### DIFF
--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -78,7 +78,7 @@ export interface MediaStore {
    * Given a `src` string it returns a url for previewing that content.
    * This is helpful in cases where the file may not be available in production yet.
    */
-  previewSrc(src: string): Promise<string>
+  previewSrc(src: string, fieldPath: string, formValues: any): Promise<string>
 
   /**
    * Lists all media in a specific directory.
@@ -154,14 +154,35 @@ export class MediaManager implements MediaStore {
     }
   }
 
-  async previewSrc(src: string): Promise<string> {
+  previewSrc = async (
+    src: string,
+    fieldName: string,
+    formValues: any
+  ): Promise<string> => {
     try {
-      this.events.dispatch({ type: 'media:preview:start', src })
-      const url = await this.store.previewSrc(src)
-      this.events.dispatch({ type: 'media:preview:success', src, url })
+      this.events.dispatch({
+        type: 'media:preview:start',
+        src,
+        fieldName,
+        formValues,
+      })
+      const url = await this.store.previewSrc(src, fieldName, formValues)
+      this.events.dispatch({
+        type: 'media:preview:success',
+        src,
+        url,
+        fieldName,
+        formValues,
+      })
       return url
     } catch (error) {
-      this.events.dispatch({ type: 'media:preview:failure', src, error })
+      this.events.dispatch({
+        type: 'media:preview:failure',
+        src,
+        error,
+        fieldName,
+        formValues,
+      })
       throw error
     }
   }

--- a/packages/@tinacms/fields/package.json
+++ b/packages/@tinacms/fields/package.json
@@ -34,6 +34,7 @@
     "@storybook/react": "^5.3.19",
     "@tinacms/form-builder": "^0.29.0",
     "@tinacms/forms": "^0.29.0",
+    "@tinacms/core": "^0.29.0",
     "@tinacms/icons": "^0.29.0",
     "@tinacms/react-core": "^0.29.0",
     "@tinacms/react-forms": "^0.29.0",

--- a/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
@@ -33,37 +33,38 @@ interface ImageProps {
 
 export function usePreviewSrc(
   value: string,
-  name: string,
-  values: any,
-  previewSrc?: MediaStore['previewSrc']
+  fieldName: string,
+  formValues: any,
+  getPreviewSrc?: MediaStore['previewSrc']
 ): [string, boolean] {
   const cms = useCMS()
-  const [srcIsLoading, setSrcIsLoading] = useState(true)
-  const [src, setSrc] = useState('')
+  const getSrc = getPreviewSrc || cms.media.previewSrc
+  const [{ src, loading }, setState] = useState({
+    src: '',
+    loading: true,
+  })
 
   useEffect(() => {
-    let canceled = false
-    ;(async () => {
-      setSrcIsLoading(true)
-      let imageSrc = ''
-      try {
-        const getSrc = previewSrc || cms.media.previewSrc
+    let componentUnmounted = false
+    let tmpSrc = ''
 
-        imageSrc = await getSrc(value, name, values)
-      } catch {}
+    getSrc(value, fieldName, formValues)
+      .then((src: string) => (tmpSrc = src))
+      .finally(() => {
+        if (componentUnmounted) return
 
-      if (!canceled) {
-        setSrc(imageSrc)
-        setSrcIsLoading(false)
-      }
-    })()
+        setState({
+          src: tmpSrc,
+          loading: false,
+        })
+      })
 
     return () => {
-      canceled = true
+      componentUnmounted = true
     }
   }, [value])
 
-  return [src, srcIsLoading]
+  return [src, loading]
 }
 
 export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {

--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -58,7 +58,8 @@ export function InlineWysiwyg({
         })
       },
       previewSrc(src) {
-        return cms.media.previewSrc(src)
+        // TODO: Implement formValues correctly
+        return cms.media.previewSrc(src, name, {})
       },
       ...passedInImageProps,
     }

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -18,16 +18,15 @@ limitations under the License.
 
 import * as React from 'react'
 import { InlineField } from '../inline-field'
-import { useCMS, Form, Media } from 'tinacms'
+import { useCMS, Form, Media, MediaStore, usePreviewSrc } from 'tinacms'
 import { useDropzone } from 'react-dropzone'
 import { FocusRing, FocusRingOptions } from '../styles'
-import { useState, useEffect } from 'react'
 
 export interface InlineImageProps {
   name: string
   parse(media: Media): string
   uploadDir(form: Form): string
-  previewSrc?(formValues: any): string | Promise<string>
+  previewSrc?: MediaStore['previewSrc']
   focusRing?: boolean | FocusRingOptions
   children?: any
 }
@@ -70,34 +69,12 @@ function EditableImage({
 }: EditableImageProps) {
   const cms = useCMS()
 
-  // TODO: Use this
-  const [, setSrcIsLoading] = useState(true)
-  const [_previewSrc, setSrc] = useState('')
-  useEffect(() => {
-    let canceled = false
-    ;(async () => {
-      setSrcIsLoading(true)
-      let imageSrc = ''
-      try {
-        if (previewSrc) {
-          imageSrc = await previewSrc(form.values)
-        } else {
-          imageSrc = await cms.media.previewSrc(input.value)
-        }
-      } catch {
-        if (!canceled) {
-          setSrc('')
-        }
-      }
-      if (!canceled) {
-        setSrc(imageSrc)
-      }
-      setSrcIsLoading(false)
-    })()
-    return () => {
-      canceled = true
-    }
-  }, [input.value])
+  const [_previewSrc] = usePreviewSrc(
+    input.value,
+    name,
+    form.values,
+    previewSrc
+  )
 
   async function handleUploadImage([file]: File[]) {
     const directory = uploadDir(form)


### PR DESCRIPTION
The `previewSrc` signature for `MediaStore`, `InlineImageField`, and `ImageFieldPlugin` are all identical now.