### PR TITLE
Inline Image Updates

### DIFF
--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -83,7 +83,11 @@ export interface MediaStore {
    * Given a `src` string it returns a url for previewing that content.
    * This is helpful in cases where the file may not be available in production yet.
    */
-  previewSrc(src: string, fieldPath?: string, formValues?: any): Promise<string>
+  previewSrc(
+    src: string,
+    fieldPath?: string,
+    formValues?: any
+  ): Promise<string> | string
 
   /**
    * Lists all media in a specific directory.

--- a/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
@@ -47,17 +47,18 @@ export function usePreviewSrc(
   useEffect(() => {
     let componentUnmounted = false
     let tmpSrc = ''
+    ;(async () => {
+      try {
+        tmpSrc = await getSrc(value, fieldName, formValues)
+      } catch {}
 
-    getSrc(value, fieldName, formValues)
-      .then((src: string) => (tmpSrc = src))
-      .finally(() => {
-        if (componentUnmounted) return
+      if (componentUnmounted) return
 
-        setState({
-          src: tmpSrc,
-          loading: false,
-        })
+      setState({
+        src: tmpSrc,
+        loading: false,
       })
+    })()
 
     return () => {
       componentUnmounted = true

--- a/packages/demo-next/pages/blocks.tsx
+++ b/packages/demo-next/pages/blocks.tsx
@@ -48,7 +48,6 @@ export default function BlocksExample({ jsonFile }) {
           </h1>
           <InlineImage
             name="hero_image"
-            previewSrc={formValues => formValues.hero_image}
             parse={filename => `/images/${filename}`}
             uploadDir={() => '/public/images/'}
           >
@@ -159,9 +158,6 @@ function ImageBlock({ index, data }) {
       <BlocksControls index={index}>
         <InlineImage
           name="src"
-          previewSrc={formValues => {
-            return formValues.blocks[index].src
-          }}
           parse={filename => `/images/${filename}`}
           uploadDir={() => '/public/images/'}
           focusRing={false}

--- a/packages/demo-next/pages/info.js
+++ b/packages/demo-next/pages/info.js
@@ -87,13 +87,17 @@ function Info(props) {
           <div className="group">
             <InlineImage
               name="frontmatter.image"
-              previewSrc={formValues => {
-                return formValues.frontmatter.image
-              }}
               uploadDir={() => '/public/images/'}
-              parse={filename => `/images/${filename}`}
+              parse={media => media.id}
             />
-
+            <h1>INLINE IMAGE WITH CHILDREN</h1>
+            <InlineImage
+              name="frontmatter.image"
+              uploadDir={() => '/public/images/'}
+              parse={media => media.id}
+            >
+              {props => <img src={props.src} />}
+            </InlineImage>
             <InlineWysiwyg name="markdownBody">
               <ReactMarkdown>{data.markdownBody}</ReactMarkdown>
             </InlineWysiwyg>

--- a/packages/demo-next/pages/info.js
+++ b/packages/demo-next/pages/info.js
@@ -91,6 +91,7 @@ function Info(props) {
               uploadDir={() => '/public/images/'}
               parse={media => media.id}
               className="inline-img"
+              alt="blue-orange"
             />
             <h1>INLINE IMAGE WITH CHILDREN</h1>
             <StyledInlineImage

--- a/packages/demo-next/pages/info.js
+++ b/packages/demo-next/pages/info.js
@@ -12,6 +12,7 @@ limitations under the License.
 */
 
 import matter from 'gray-matter'
+import styled from 'styled-components'
 import { useMarkdownForm } from 'next-tinacms-markdown'
 import ReactMarkdown from 'react-markdown'
 import { useCMS } from 'tinacms'
@@ -89,15 +90,16 @@ function Info(props) {
               name="frontmatter.image"
               uploadDir={() => '/public/images/'}
               parse={media => media.id}
+              className="inline-img"
             />
             <h1>INLINE IMAGE WITH CHILDREN</h1>
-            <InlineImage
+            <StyledInlineImage
               name="frontmatter.image"
               uploadDir={() => '/public/images/'}
               parse={media => media.id}
             >
               {props => <img src={props.src} />}
-            </InlineImage>
+            </StyledInlineImage>
             <InlineWysiwyg name="markdownBody">
               <ReactMarkdown>{data.markdownBody}</ReactMarkdown>
             </InlineWysiwyg>
@@ -119,6 +121,10 @@ function Info(props) {
             div.group {
               margin-top: 2rem;
               padding: 1rem;
+            }
+
+            .inline-img {
+              background: pink;
             }
           `}
         </style>
@@ -168,3 +174,7 @@ Info.getInitialProps = async function() {
     },
   }
 }
+
+const StyledInlineImage = styled(InlineImage)`
+  background-color: red;
+`

--- a/packages/react-tinacms-inline/src/blocks/inline-block-image.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-image.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { InlineImageProps, InlineImage } from '../fields/inline-image-field'
+import { InlineImageProps, InlineImage } from '../fields/inline-image'
 
 /**
  * @deprecated

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -28,7 +28,11 @@ export interface InlineImageProps {
   uploadDir?(form: Form): string
   previewSrc?: MediaStore['previewSrc']
   focusRing?: boolean | FocusRingOptions
-  children?: any
+  children?(props: InlineImageRenderProps): React.ReactNode
+}
+
+interface InlineImageRenderProps {
+  src: string
 }
 
 /**
@@ -47,7 +51,11 @@ export function InlineImage(props: InlineImageProps) {
           return <EditableImage {...props} input={input} form={form} />
         }
 
-        return props.children ? props.children() : <img src={input.value} />
+        return props.children ? (
+          props.children({ src: input.value })
+        ) : (
+          <img src={input.value} />
+        )
       }}
     </InlineField>
   )
@@ -96,8 +104,7 @@ function EditableImage({
   return (
     <FocusRing name={name} options={focusRing}>
       <InlineImageUpload
-        value={input.value}
-        previewSrc={_previewSrc}
+        src={_previewSrc}
         onDrop={handleUploadImage}
         onClick={() =>
           cms.media.open({
@@ -111,28 +118,24 @@ function EditableImage({
         }
         {...input}
       >
-        {/** If children, pass previewSrc to children */}
-        {children &&
-          ((props: any) => children({ previewSrc: _previewSrc }, ...props))}
+        {children}
       </InlineImageUpload>
     </FocusRing>
   )
 }
 
 interface InlineImageUploadProps {
-  onDrop: (acceptedFiles: any[]) => void
-  value?: string
-  children?: any
-  previewSrc?: string
-  onClick: () => void
+  src?: string
+  onClick(): void
+  onDrop(acceptedFiles: any[]): void
+  children?(props: InlineImageRenderProps): React.ReactNode
 }
 
 function InlineImageUpload({
-  onDrop,
-  value,
-  previewSrc,
-  children,
+  src,
   onClick,
+  onDrop,
+  children,
 }: InlineImageUploadProps) {
   const { getRootProps, getInputProps } = useDropzone({
     accept: 'image/*',
@@ -140,12 +143,12 @@ function InlineImageUpload({
     noClick: !!onClick,
   })
 
-  if (!value) return <ImagePlaceholder />
+  if (!src) return <ImagePlaceholder />
 
   return (
     <div {...getRootProps()} onClick={onClick}>
       <input {...getInputProps()} />
-      <div>{children ? children(previewSrc) : <img src={previewSrc} />}</div>
+      {children ? children({ src }) : <img src={src} />}
     </div>
   )
 }

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -30,6 +30,7 @@ export interface InlineImageProps {
   previewSrc?: MediaStore['previewSrc']
   focusRing?: boolean | FocusRingOptions
   className?: string
+  alt?: string
   children?: ImageRenderChildren
 }
 
@@ -53,6 +54,7 @@ export function InlineImage(props: InlineImageProps) {
           <NonEditableImage
             children={props.children}
             src={input.value}
+            alt={props.alt}
             className={props.className}
           />
         )
@@ -74,6 +76,7 @@ function EditableImage({
   uploadDir,
   children,
   focusRing = true,
+  alt = '',
   className,
 }: EditableImageProps) {
   const cms = useCMS()
@@ -106,6 +109,7 @@ function EditableImage({
     <FocusRing name={name} options={focusRing}>
       <InlineImageUpload
         src={_previewSrc}
+        alt={alt}
         onDrop={handleUploadImage}
         onClick={() =>
           cms.media.open({
@@ -133,6 +137,7 @@ type ImageRenderChildren = (props: ImageRenderChildrenProps) => React.ReactNode
 
 interface InlineImageUploadProps {
   src?: string
+  alt?: string
   className?: string
   onClick(): void
   onDrop(acceptedFiles: any[]): void
@@ -141,6 +146,7 @@ interface InlineImageUploadProps {
 
 function InlineImageUpload({
   src,
+  alt,
   className,
   onClick,
   onDrop,
@@ -157,21 +163,27 @@ function InlineImageUpload({
   return (
     <Container {...getRootProps()} onClick={onClick} className={className}>
       <input {...getInputProps()} />
-      {children ? children({ src }) : <img src={src} />}
+      {children ? children({ src }) : <img src={src} alt={alt} />}
     </Container>
   )
 }
 
 interface NonEditableImageProps {
   src?: string
+  alt?: string
   className?: string
   children?: ImageRenderChildren
 }
 
-function NonEditableImage({ children, src, className }: NonEditableImageProps) {
+function NonEditableImage({
+  src,
+  alt,
+  className,
+  children,
+}: NonEditableImageProps) {
   return (
     <Container className={className}>
-      {children ? children({ src }) : <img src={src} />}
+      {children ? children({ src }) : <img src={src} alt={alt} />}
     </Container>
   )
 }

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -28,11 +28,7 @@ export interface InlineImageProps {
   uploadDir?(form: Form): string
   previewSrc?: MediaStore['previewSrc']
   focusRing?: boolean | FocusRingOptions
-  children?(props: InlineImageRenderProps): React.ReactNode
-}
-
-interface InlineImageRenderProps {
-  src: string
+  children?: ImageRenderChildren
 }
 
 /**
@@ -51,11 +47,7 @@ export function InlineImage(props: InlineImageProps) {
           return <EditableImage {...props} input={input} form={form} />
         }
 
-        return props.children ? (
-          props.children({ src: input.value })
-        ) : (
-          <img src={input.value} />
-        )
+        return <NonEditableImage children={props.children} src={input.value} />
       }}
     </InlineField>
   )
@@ -63,7 +55,7 @@ export function InlineImage(props: InlineImageProps) {
 
 interface EditableImageProps extends InlineImageProps {
   input: any
-  form: any
+  form: Form
 }
 
 function EditableImage({
@@ -124,11 +116,17 @@ function EditableImage({
   )
 }
 
+interface ImageRenderChildrenProps {
+  src?: string
+}
+
+type ImageRenderChildren = (props: ImageRenderChildrenProps) => React.ReactNode
+
 interface InlineImageUploadProps {
   src?: string
   onClick(): void
   onDrop(acceptedFiles: any[]): void
-  children?(props: InlineImageRenderProps): React.ReactNode
+  children?: ImageRenderChildren
 }
 
 function InlineImageUpload({
@@ -151,6 +149,15 @@ function InlineImageUpload({
       {children ? children({ src }) : <img src={src} />}
     </div>
   )
+}
+
+interface NonEditableImageProps {
+  src?: string
+  children?: ImageRenderChildren
+}
+
+function NonEditableImage({ children, src }: NonEditableImageProps) {
+  return <div>{children ? children({ src }) : <img src={src} />}</div>
 }
 
 function ImagePlaceholder() {

--- a/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image-field.tsx
@@ -17,6 +17,7 @@ limitations under the License.
 */
 
 import * as React from 'react'
+import styled from 'styled-components'
 import { InlineField } from '../inline-field'
 import { useCMS, Form, Media, MediaStore, usePreviewSrc } from 'tinacms'
 import { useDropzone } from 'react-dropzone'
@@ -28,6 +29,7 @@ export interface InlineImageProps {
   uploadDir?(form: Form): string
   previewSrc?: MediaStore['previewSrc']
   focusRing?: boolean | FocusRingOptions
+  className?: string
   children?: ImageRenderChildren
 }
 
@@ -47,7 +49,13 @@ export function InlineImage(props: InlineImageProps) {
           return <EditableImage {...props} input={input} form={form} />
         }
 
-        return <NonEditableImage children={props.children} src={input.value} />
+        return (
+          <NonEditableImage
+            children={props.children}
+            src={input.value}
+            className={props.className}
+          />
+        )
       }}
     </InlineField>
   )
@@ -66,6 +74,7 @@ function EditableImage({
   uploadDir,
   children,
   focusRing = true,
+  className,
 }: EditableImageProps) {
   const cms = useCMS()
 
@@ -108,7 +117,7 @@ function EditableImage({
             },
           })
         }
-        {...input}
+        className={className}
       >
         {children}
       </InlineImageUpload>
@@ -124,6 +133,7 @@ type ImageRenderChildren = (props: ImageRenderChildrenProps) => React.ReactNode
 
 interface InlineImageUploadProps {
   src?: string
+  className?: string
   onClick(): void
   onDrop(acceptedFiles: any[]): void
   children?: ImageRenderChildren
@@ -131,6 +141,7 @@ interface InlineImageUploadProps {
 
 function InlineImageUpload({
   src,
+  className,
   onClick,
   onDrop,
   children,
@@ -144,20 +155,25 @@ function InlineImageUpload({
   if (!src) return <ImagePlaceholder />
 
   return (
-    <div {...getRootProps()} onClick={onClick}>
+    <Container {...getRootProps()} onClick={onClick} className={className}>
       <input {...getInputProps()} />
       {children ? children({ src }) : <img src={src} />}
-    </div>
+    </Container>
   )
 }
 
 interface NonEditableImageProps {
   src?: string
+  className?: string
   children?: ImageRenderChildren
 }
 
-function NonEditableImage({ children, src }: NonEditableImageProps) {
-  return <div>{children ? children({ src }) : <img src={src} />}</div>
+function NonEditableImage({ children, src, className }: NonEditableImageProps) {
+  return (
+    <Container className={className}>
+      {children ? children({ src }) : <img src={src} />}
+    </Container>
+  )
 }
 
 function ImagePlaceholder() {
@@ -170,3 +186,8 @@ function ImagePlaceholder() {
     </div>
   )
 }
+
+const Container = styled.div`
+  width: inherit;
+  height: inherit;
+`

--- a/packages/react-tinacms-inline/src/fields/inline-image/editable-image.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/editable-image.tsx
@@ -1,0 +1,89 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import { usePreviewSrc, Form, useCMS } from 'tinacms'
+import { FocusRing } from '../../styles'
+import { InlineImageProps } from './inline-image-field'
+import { InlineImageUpload } from './inline-image-upload'
+
+interface EditableImageProps extends InlineImageProps {
+  input: any
+  form: Form
+}
+
+export function EditableImage({
+  form,
+  input,
+  name,
+  previewSrc,
+  uploadDir,
+  children,
+  focusRing = true,
+  alt = '',
+  className,
+}: EditableImageProps) {
+  const cms = useCMS()
+
+  const [_previewSrc] = usePreviewSrc(
+    input.value,
+    name,
+    form.values,
+    previewSrc
+  )
+
+  async function handleUploadImage([file]: File[]) {
+    const directory = uploadDir ? uploadDir(form) : ''
+
+    const [media] = await cms.media.persist([
+      {
+        directory,
+        file,
+      },
+    ])
+
+    if (media) {
+      input.onChange(media)
+    }
+
+    return null
+  }
+
+  return (
+    <FocusRing name={name} options={focusRing}>
+      <InlineImageUpload
+        src={_previewSrc}
+        alt={alt}
+        onDrop={handleUploadImage}
+        onClick={() =>
+          cms.media.open({
+            onSelect(media: any) {
+              if (media.filename == input.value) {
+                input.onChange('') // trigger rerender
+              }
+              input.onChange(media)
+            },
+          })
+        }
+        className={className}
+      >
+        {children}
+      </InlineImageUpload>
+    </FocusRing>
+  )
+}

--- a/packages/react-tinacms-inline/src/fields/inline-image/index.ts
+++ b/packages/react-tinacms-inline/src/fields/inline-image/index.ts
@@ -16,20 +16,8 @@ limitations under the License.
 
 */
 
-export * from './inline-form'
-export * from './inline-field'
-export * from './inline-field-context'
 export {
-  InlineText,
-  InlineTextField,
-  InlineTextProps,
-} from './fields/inline-text-field'
-export {
-  InlineTextarea,
-  InlineTextareaField,
-} from './fields/inline-textarea-field'
-export * from './fields/inline-image'
-export * from './inline-group'
-export { InlineSettings } from './inline-settings'
-export * from './blocks'
-export * from './styles'
+  InlineImage,
+  InlineImageField,
+  InlineImageProps,
+} from './inline-image-field'

--- a/packages/react-tinacms-inline/src/fields/inline-image/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/inline-image-field.tsx
@@ -18,10 +18,10 @@ limitations under the License.
 
 import * as React from 'react'
 import styled from 'styled-components'
-import { InlineField } from '../inline-field'
+import { InlineField } from '../../inline-field'
 import { useCMS, Form, Media, MediaStore, usePreviewSrc } from 'tinacms'
 import { useDropzone } from 'react-dropzone'
-import { FocusRing, FocusRingOptions } from '../styles'
+import { FocusRing, FocusRingOptions } from '../../styles'
 
 export interface InlineImageProps {
   name: string

--- a/packages/react-tinacms-inline/src/fields/inline-image/inline-image-upload.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/inline-image-upload.tsx
@@ -1,0 +1,71 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import styled from 'styled-components'
+import { useDropzone } from 'react-dropzone'
+import { ImageRenderChildren } from './inline-image-field'
+
+interface InlineImageUploadProps {
+  src?: string
+  alt?: string
+  className?: string
+  onClick(): void
+  onDrop(acceptedFiles: any[]): void
+  children?: ImageRenderChildren
+}
+
+export function InlineImageUpload({
+  src,
+  alt,
+  className,
+  onClick,
+  onDrop,
+  children,
+}: InlineImageUploadProps) {
+  const { getRootProps, getInputProps } = useDropzone({
+    accept: 'image/*',
+    onDrop,
+    noClick: !!onClick,
+  })
+
+  if (!src) return <ImagePlaceholder />
+
+  return (
+    <Container {...getRootProps()} onClick={onClick} className={className}>
+      <input {...getInputProps()} />
+      {children ? children({ src }) : <img src={src} alt={alt} />}
+    </Container>
+  )
+}
+
+function ImagePlaceholder() {
+  // TODO: style this component
+  return (
+    <div>
+      Drag 'n' drop some files here,
+      <br />
+      or click to select files
+    </div>
+  )
+}
+
+export const Container = styled.div`
+  width: inherit;
+  height: inherit;
+`

--- a/packages/react-tinacms-inline/src/fields/inline-image/non-editable-image.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/non-editable-image.tsx
@@ -1,0 +1,41 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import { ImageRenderChildren } from './inline-image-field'
+import { Container } from './inline-image-upload'
+
+interface NonEditableImageProps {
+  src?: string
+  alt?: string
+  className?: string
+  children?: ImageRenderChildren
+}
+
+export function NonEditableImage({
+  src,
+  alt,
+  className,
+  children,
+}: NonEditableImageProps) {
+  return (
+    <Container className={className}>
+      {children ? children({ src }) : <img src={src} alt={alt} />}
+    </Container>
+  )
+}

--- a/packages/react-tinacms-inline/src/inline-field.tsx
+++ b/packages/react-tinacms-inline/src/inline-field.tsx
@@ -26,7 +26,7 @@ export interface InlineFieldProps {
   name: string
   parse?(value: any): any
   format?(value: any): any
-  children(fieldProps: InlineFieldRenderProps): React.ReactElement
+  children(fieldProps: InlineFieldRenderProps): React.ReactNode
 }
 
 export interface InlineFieldRenderProps<V = any>


### PR DESCRIPTION
## What this does

- **Feat**: Allows the extension of styles on the `InlineImage` container div via styled components or by passing a `className` directly. 
```js
// via styled components
<StyledInlineImage
  name="frontmatter.image"
  uploadDir={() => '/public/images/'}
  parse={media => media.id}
>
  {props => <img src={props.src} />}
</StyledInlineImage>

const StyledInlineImage = styled(InlineImage)`
  background-color: red;
`

// or directly via className
<InlineImage
  name="frontmatter.image"
  uploadDir={() => '/public/images/'}
  parse={media => media.id}
  className="inline-img"
/>
```
- **Feat**: `InlineImage` accepts an `alt` prop, so if one doesn't use the render props pattern, they can still set the alt on the image element. 
```js
<InlineImage
  name="frontmatter.image"
  parse={media => media.id}
  alt="RAD-ALT-TAG"
/>
```
- **Breaking Change**: Render children are always passed a `src`, as opposed to conditionally passing `previewSrc`, depending on `cms.enabled`
```js
/** Previous: handling the src swap depending on whether the cms was enabled. 
* When the cms wasn't enabled, props weren't being passed at all
*/
<InlineImage
  name="frontmatter.image"
  uploadDir={() => '/public/images/'}
  parse={media => media.id}
>
  {props => <img src={props?.previewSrc || data.frontmatter.image} alt={data.frontmatter.alt} />}
</InlineImage>

/** Current: render child always passed `src`, the image field handles whether
* that should be previewSrc or input.value
*/
<InlineImage
  name="frontmatter.image"
  uploadDir={() => '/public/images/'}
  parse={media => media.id}
>
  {props => <img src={props.src} alt={data.frontmatter.alt} />}
</InlineImage>
```
- Refactors so that the DOM structure is closer aligned between edit and non-edit mode — removed an extra wrapper div.
- Refactored so `inline-image` has its own directory, with components extracted into their own files. 
- Updates `MediaStore#previewSrc` to expect either a Promise _or_ a string, refactors `usePreviewSrc` to async / await to accommodate.
- Updates `InlineField`'s `children` type to be `React.ReactNode`... we're thinking this should be the convention for typing children...maybe, need to do more research.
- Updates `demo-next` to play nice with the latest media API changes.

## Next Steps

We talked about inline image accepting a `Container`, similar to the [inline blocks](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx#L45-L47) field. This would replace the `Container` styled component and allow for very finite control over refs, layout, etc. 

---
- [ ] Docs PR approved
