### PR TITLE
git-media-store#list calls previewSrc

### DIFF
--- a/packages/@tinacms/git-client/src/git-media-store.ts
+++ b/packages/@tinacms/git-client/src/git-media-store.ts
@@ -63,7 +63,11 @@ export class GitMediaStore implements MediaStore {
     const { file } = await this.client.getFile(directory)
 
     return {
-      items: file.content.slice(offset, offset + limit),
+      items: file.content.slice(offset, offset + limit).map((media: Media) => ({
+        ...media,
+        previewSrc:
+          media.type === 'file' ? this.previewSrc(media.id) : undefined,
+      })),
       totalCount: file.content.length,
       offset,
       limit,

--- a/packages/demo-next/next-git-media-store.js
+++ b/packages/demo-next/next-git-media-store.js
@@ -1,0 +1,7 @@
+import { GitMediaStore } from '@tinacms/git-client'
+
+export class NextGitMediaStore extends GitMediaStore {
+  previewSrc(src) {
+    return /jpg|png$/.test(src) ? src.replace('/public', '') : null
+  }
+}

--- a/packages/demo-next/next-git-media-store.js
+++ b/packages/demo-next/next-git-media-store.js
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 import { GitMediaStore } from '@tinacms/git-client'
 
 export class NextGitMediaStore extends GitMediaStore {

--- a/packages/demo-next/pages/_app.js
+++ b/packages/demo-next/pages/_app.js
@@ -21,6 +21,7 @@ import App from 'next/app'
 import { TinaProvider, TinaCMS, withTina } from 'tinacms'
 import { GitClient, GitMediaStore } from '@tinacms/git-client'
 import { GlobalStyles as TinaCustomStyles } from '@tinacms/styles'
+import { NextGitMediaStore } from '../next-git-media-store'
 
 function Empty() {
   return <span>Hello from a custom empty state Component</span>
@@ -48,7 +49,7 @@ export default class Site extends App {
     })
     const client = new GitClient('http://localhost:3000/___tina')
     this.cms.registerApi('git', client)
-    this.cms.media.store = new GitMediaStore(client)
+    this.cms.media.store = new NextGitMediaStore(client)
   }
 
   render() {


### PR DESCRIPTION
This allows folks to provide a custom `previewSrc` function by extending `GitMediaStore` so the proper src urls can render in the media manager list. 

Note that if the `type` is `file`, then `previewSrc` will be called. This can result in broken image paths for non-image files. One can account for this in their custom function, and I'm assuming the filtering or additional media types will help mitigate this.