### PR TITLE
chore: add error and loading states for media manager

### DIFF
--- a/packages/@tinacms/react-alerts/src/Alerts.tsx
+++ b/packages/@tinacms/react-alerts/src/Alerts.tsx
@@ -73,7 +73,7 @@ const AlertContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  z-index: var(--tina-z-index-3);
+  z-index: 999999;
 `
 
 const AlertEntranceAnimation = keyframes`

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -174,7 +174,7 @@ export function MediaPicker({
   }
 
   if (listState === 'not-configured') {
-    return <DocsLink title="Please Setup a Media Store" />
+    return <DocsLink title="Please Set up a Media Store" />
   }
 
   if (listState === 'error') {

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -143,13 +143,16 @@ export function MediaPicker({
     accept: 'image/*',
 
     onDrop: async ([file]) => {
-      //@ts-ignore
-      await cms.media.persist([
-        {
-          directory: directory || '/',
-          file,
-        },
-      ])
+      try {
+        await cms.media.persist([
+          {
+            directory: directory || '/',
+            file,
+          },
+        ])
+      } catch {
+        // TODO: Events get dispatched already. Does anything else need to happen?
+      }
     },
   })
 

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -171,7 +171,7 @@ export function MediaPicker({
   }
 
   if (listState === 'not-configured') {
-    return <DocsLink title="Please Setup Media" />
+    return <DocsLink title="Please Setup a Media Store" />
   }
 
   if (listState === 'error') {

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -81,7 +81,17 @@ export class TinaCMS extends CMS {
   }: TinaCMSConfig = {}) {
     super(config)
 
-    this.alerts.setMap(alerts)
+    this.alerts.setMap({
+      'media:upload:failure': () => ({
+        level: 'error',
+        message: 'Failed to upload file.',
+      }),
+      'media:delete:failure': () => ({
+        level: 'error',
+        message: 'Failed to delete file.',
+      }),
+      ...alerts,
+    })
 
     if (sidebar) {
       const sidebarConfig = typeof sidebar === 'object' ? sidebar : undefined


### PR DESCRIPTION
Default alerts for media upload and deletion failure

## Loading

<img width="835" alt="image" src="https://user-images.githubusercontent.com/824015/94955006-4a32b080-04c0-11eb-82e8-2c00615722c8.png">

## Error

Not the _most_ helpful error message but still better then no feedback at all.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/824015/94955074-68001580-04c0-11eb-8f98-d79e342a0269.png">

## Not Configured

<img width="836" alt="image" src="https://user-images.githubusercontent.com/824015/94955148-87973e00-04c0-11eb-891a-892d9a399cae.png">
