### PR TITLE
fix: uploadDir passes form values

### DIFF
--- a/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/ImageFieldPlugin.tsx
@@ -27,7 +27,7 @@ import { useState, useEffect } from 'react'
 interface ImageProps {
   path: string
   previewSrc?: MediaStore['previewSrc']
-  uploadDir?(form: any): string
+  uploadDir?(formValues: any): string
   clearable?: boolean // defaults to true
 }
 

--- a/packages/react-tinacms-editor/src/components/Wysiwyg/index.tsx
+++ b/packages/react-tinacms-editor/src/components/Wysiwyg/index.tsx
@@ -105,7 +105,7 @@ function useImageProps(
   React.useMemo(() => {
     if (!passedInImageProps) return
     const { uploadDir, parse } = passedInImageProps
-    const directory = uploadDir && form ? uploadDir(form) : ''
+    const directory = uploadDir && form ? uploadDir(form.values) : ''
 
     setImageProps({
       async upload(files: File[]): Promise<string[]> {

--- a/packages/react-tinacms-editor/src/types.ts
+++ b/packages/react-tinacms-editor/src/types.ts
@@ -27,7 +27,7 @@ import { Form, Media } from 'tinacms'
 
 export interface ImageProps {
   parse(media: Media): string
-  uploadDir?(form: Form): string
+  uploadDir?(formValues: any): string
   upload?: (files: File[]) => Promise<string[]>
   previewSrc?: (url: string) => string | Promise<string>
 }

--- a/packages/react-tinacms-inline/src/fields/inline-image/editable-image.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/editable-image.tsx
@@ -48,7 +48,7 @@ export function EditableImage({
   )
 
   async function handleUploadImage([file]: File[]) {
-    const directory = uploadDir ? uploadDir(form) : ''
+    const directory = uploadDir ? uploadDir(form.values) : ''
 
     const [media] = await cms.media.persist([
       {
@@ -71,7 +71,7 @@ export function EditableImage({
         alt={alt}
         onDrop={handleUploadImage}
         onClick={() => {
-          const directory = uploadDir ? uploadDir(form) : ''
+          const directory = uploadDir ? uploadDir(form.values) : ''
           cms.media.open({
             allowDelete: true,
             directory,

--- a/packages/react-tinacms-inline/src/fields/inline-image/inline-image-field.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/inline-image-field.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 
 import * as React from 'react'
 import { InlineField } from '../../inline-field'
-import { useCMS, Form, Media, MediaStore } from 'tinacms'
+import { useCMS, Media, MediaStore } from 'tinacms'
 import { FocusRingOptions } from '../../styles'
 import { NonEditableImage } from './non-editable-image'
 import { EditableImage } from './editable-image'
@@ -26,7 +26,7 @@ import { EditableImage } from './editable-image'
 export interface InlineImageProps {
   name: string
   parse(media: Media): string
-  uploadDir?(form: Form): string
+  uploadDir?(formValues: any): string
   previewSrc?: MediaStore['previewSrc']
   focusRing?: boolean | FocusRingOptions
   className?: string


### PR DESCRIPTION
The wysiwyg images & inline image field was passing the entire `form` as opposed to `form.values`.
