### PR TITLE
chore(demo-gatsby): media updates

### DIFF
--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -203,7 +203,7 @@ function BlogPostTemplate(props) {
                   return postDirectory
                 },
                 previewSrc(src) {
-                  const formattedSrc = src.replace(/\/public|\/static/, "")
+                  const formattedSrc = src.replace(/^\/public|\/static/, "")
                   return formattedSrc
                 },
               }}

--- a/packages/demo-gatsby/src/templates/blog-post.js
+++ b/packages/demo-gatsby/src/templates/blog-post.js
@@ -18,6 +18,7 @@ limitations under the License.
 
 import React from "react"
 import { Link, graphql } from "gatsby"
+import path from "path"
 
 import Bio from "../components/bio"
 import Layout from "../components/layout"
@@ -194,13 +195,9 @@ function BlogPostTemplate(props) {
 
                 // Decide the file upload directory for the post
                 uploadDir: blogPost => {
-                  const postPathParts = blogPost.fileRelativePath.split("/")
-
-                  const postDirectory = postPathParts
-                    .splice(0, postPathParts.length - 1)
-                    .join("/")
-
-                  return postDirectory
+                  return blogPost.fileRelativePath
+                    ? path.dirname(blogPost.fileRelativePath)
+                    : "/"
                 },
                 previewSrc(src) {
                   const formattedSrc = src.replace(/^\/public|\/static/, "")

--- a/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
@@ -62,8 +62,11 @@ export const ProsemirrorMenu = ({ uploadImages }: MenuProps) => {
     setImageUrl('')
   }
 
-  function onMediaSelect(media?: Media): void {
-    if (media) insertImageInEditor(media.previewSrc || media.id)
+  async function onMediaSelect(media?: Media) {
+    if (media) {
+      const previewSrc = await cms.media.previewSrc(media.id)
+      insertImageInEditor(previewSrc)
+    }
   }
 
   const stopDefault = (evt: React.DragEvent<HTMLSpanElement>) => {

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -215,7 +215,12 @@ export function MediaPicker({
 
 const UploadButton = ({ onClick, uploading }: any) => {
   return (
-    <Button primary busy={uploading} onClick={onClick}>
+    <Button
+      style={{ minWidth: '5.3rem' }}
+      primary
+      busy={uploading}
+      onClick={onClick}
+    >
       {uploading ? <LoadingDots /> : 'Upload'}
     </Button>
   )

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -215,12 +215,7 @@ export function MediaPicker({
 
 const UploadButton = ({ onClick, uploading }: any) => {
   return (
-    <Button
-      style={{ minWidth: '5rem' }}
-      primary
-      busy={uploading}
-      onClick={onClick}
-    >
+    <Button primary busy={uploading} onClick={onClick}>
       {uploading ? <LoadingDots /> : 'Upload'}
     </Button>
   )


### PR DESCRIPTION
Updates the demo to work with latest media changes. I had to adjust the way the selected media preview src was being generated with wysiwyg images...I'm not sure if this is the best way to handle the `previewSrc`. The previous code didn't account for promises. 

Also, a small style fix in the media manager.