### PR TITLE
(@tinacms/git-client): git-media-store#list doesn't set previewSrc

### DIFF
--- a/packages/@tinacms/git-client/src/git-media-store.ts
+++ b/packages/@tinacms/git-client/src/git-media-store.ts
@@ -63,11 +63,7 @@ export class GitMediaStore implements MediaStore {
     const { file } = await this.client.getFile(directory)
 
     return {
-      items: file.content.slice(offset, offset + limit).map((media: Media) => ({
-        ...media,
-        previewSrc:
-          media.type === 'file' ? this.previewSrc(media.id) : undefined,
-      })),
+      items: file.content.slice(offset, offset + limit),
       totalCount: file.content.length,
       offset,
       limit,
@@ -81,7 +77,7 @@ export class GitMediaStore implements MediaStore {
   }
 }
 
-const nextOffset = (offset: number, limit: number, count: number) => {
+export const nextOffset = (offset: number, limit: number, count: number) => {
   if (offset + limit < count) return offset + limit
   return undefined
 }

--- a/packages/demo-next/next-git-media-store.js
+++ b/packages/demo-next/next-git-media-store.js
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import { GitMediaStore, nextOffset } from '@tinacms/git-client'
+import { GitMediaStore } from '@tinacms/git-client'
 
 export class NextGitMediaStore extends GitMediaStore {
   previewSrc(src) {
@@ -25,21 +25,14 @@ export class NextGitMediaStore extends GitMediaStore {
       : null
   }
   async list(options) {
-    const directory = options.directory ?? ''
-    const offset = options.offset ?? 0
-    const limit = options.limit ?? 50
-    const { file } = await this.client.getFile(directory)
-
+    const listItems = await super.list(options)
     return {
-      items: file.content.slice(offset, offset + limit).map(media => ({
+      ...listItems,
+      items: listItems.items.map(media => ({
         ...media,
         previewSrc:
           media.type === 'file' ? this.previewSrc(media.id) : undefined,
       })),
-      totalCount: file.content.length,
-      offset,
-      limit,
-      nextOffset: nextOffset(offset, limit, file.content.length),
     }
   }
 }

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -102,7 +102,8 @@ export function MediaPicker({
           setList(list)
           setListState('loaded')
         })
-        .catch(() => {
+        .catch(e => {
+          console.error(e)
           setListState('error')
         })
     }


### PR DESCRIPTION
With this change, all media files will render with the `File` icon in the media manager list. This default prevents broken preview src states for media files. 

The assumption is that for preview src's to work in the media manager with any project using the git-client, they will need to extend the media store to tailor the `previewSrc` and `list` methods according to their project / framework. 
