### PR TITLE
feat(react-tinacms-editor): media mgr opens from mediaDir

### DIFF
--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -103,6 +103,7 @@ interface ImageProps {
   uploadDir?(form: Form): string
   upload?: (files: File[]) => Promise<string[]>
   previewSrc?: (url: string) => string | Promise<string>
+  mediaDir?: string
 }
 
 interface FocusRingProps {
@@ -154,6 +155,7 @@ To upload and manage images in the Wysiwyg, you'll need to configure `imageProps
 | `uploadDir?`    | Defines the upload directory. This function is passed the current form values.                                                                  |
 | `upload?`     | An asynchronous function that handles image upload. By default, this calls the `persist` function on the [media store](https://tinacms.org/docs/media). |
 | `previewSrc?`     | 	An asynchronous function that returns the path or url for the image `src` in preview or edit mode. By default, this calls the `previewSrc` function on the [media store](https://tinacms.org/docs/media)_.                             |
+| `mediaDir?`    | Defines where the media manager opens from. Defaults to the return value from `uploadDir`. If `uploadDir` isn't defined, falls back to the root directory.                                                                  |
 
 ```jsx
 <InlineWysiwyg

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/Menubar/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/Menubar/index.tsx
@@ -42,10 +42,16 @@ import { BaseMenubar } from '../../BaseMenubar'
 interface Props {
   sticky?: boolean | string
   uploadImages?: (files: File[]) => Promise<string[]>
+  mediaDir?: string
   plugins?: Plugin[]
 }
 
-export const Menubar = ({ plugins, uploadImages, ...rest }: Props) => {
+export const Menubar = ({
+  plugins,
+  uploadImages,
+  mediaDir,
+  ...rest
+}: Props) => {
   const { editorView } = useEditorStateContext()
 
   if (!editorView) return null
@@ -57,7 +63,11 @@ export const Menubar = ({ plugins, uploadImages, ...rest }: Props) => {
         <BlockMenu key="BlockMenu" />,
         <InlineMenu key="InlineMenu" />,
         <LinkMenu key="LinkMenu" />,
-        <ImageMenu key="ImageMenu" uploadImages={uploadImages} />,
+        <ImageMenu
+          key="ImageMenu"
+          uploadImages={uploadImages}
+          mediaDir={mediaDir}
+        />,
         <TableMenu key="TableMenu" />,
         <QuoteMenu key="QuoteMenu" />,
         <CodeBlockMenu key="CodeBlockMenu" />,

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
@@ -83,6 +83,7 @@ export const ProsemirrorEditor = styled(
           <Menubar
             sticky={sticky}
             uploadImages={imageProps && imageProps.upload}
+            mediaDir={imageProps?.mediaDir}
             plugins={plugins}
           />
         </EditorStateProvider>

--- a/packages/react-tinacms-editor/src/components/Wysiwyg/index.tsx
+++ b/packages/react-tinacms-editor/src/components/Wysiwyg/index.tsx
@@ -104,13 +104,13 @@ function useImageProps(
 
   React.useMemo(() => {
     if (!passedInImageProps) return
-    const { uploadDir, parse } = passedInImageProps
-    const directory = uploadDir && form ? uploadDir(form.values) : ''
+    const { uploadDir, parse, mediaDir } = passedInImageProps
+    const _uploadDir = uploadDir && form ? uploadDir(form.values) : ''
 
     setImageProps({
       async upload(files: File[]): Promise<string[]> {
         const filesToUpload = files.map(file => ({
-          directory,
+          directory: _uploadDir,
           file,
         }))
 
@@ -127,6 +127,7 @@ function useImageProps(
       previewSrc(src: string) {
         return cms.media.previewSrc(src)
       },
+      mediaDir: mediaDir || _uploadDir,
       ...passedInImageProps,
     })
   }, [

--- a/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
@@ -31,9 +31,10 @@ import { insertImage } from '../commands'
 
 export interface MenuProps {
   uploadImages?: (files: File[]) => Promise<string[]>
+  mediaDir?: string
 }
 
-export const ProsemirrorMenu = ({ uploadImages }: MenuProps) => {
+export const ProsemirrorMenu = ({ uploadImages, mediaDir }: MenuProps) => {
   const cms = useCMS()
   const menuButtonRef = useRef()
   const { editorView } = useEditorStateContext()
@@ -121,10 +122,8 @@ export const ProsemirrorMenu = ({ uploadImages }: MenuProps) => {
           <ImageModalContent>
             <UploadSection
               onClick={() => {
-                // TODO: get uploadDir here
-                const directory = '/'
                 cms.media.open({
-                  directory,
+                  directory: mediaDir || '/',
                   onSelect: onMediaSelect,
                 })
               }}

--- a/packages/react-tinacms-editor/src/types.ts
+++ b/packages/react-tinacms-editor/src/types.ts
@@ -30,6 +30,7 @@ export interface ImageProps {
   uploadDir?(formValues: any): string
   upload?: (files: File[]) => Promise<string[]>
   previewSrc?: (url: string) => string | Promise<string>
+  mediaDir?: string
 }
 
 export interface KeymapPlugin {


### PR DESCRIPTION
A new `mediaDir` prop was added to the imageProps interface; this is where the media manager will open from. It defaults to the return value from `uploadDir` or the root directory if `uploadDir` & `mediaDir` aren't set.