### PR TITLE
feat(react-tinacms-editor): Sidebar wysiwyg images, removes media popup

### DIFF
--- a/packages/demo-next/pages/info.js
+++ b/packages/demo-next/pages/info.js
@@ -15,7 +15,7 @@ import matter from 'gray-matter'
 import styled from 'styled-components'
 import { useMarkdownForm } from 'next-tinacms-markdown'
 import ReactMarkdown from 'react-markdown'
-import { useCMS } from 'tinacms'
+import { useCMS, usePlugin } from 'tinacms'
 import {
   InlineForm,
   InlineText,
@@ -31,6 +31,7 @@ import Layout from '../components/Layout'
 function Info(props) {
   const cms = useCMS()
   const [data, form] = useMarkdownForm(props.markdownFile, formOptions)
+  usePlugin(form)
 
   return (
     <InlineForm form={form}>
@@ -101,7 +102,15 @@ function Info(props) {
             >
               {props => <img src={props.src} />}
             </StyledInlineImage>
-            <InlineWysiwyg name="markdownBody">
+            <InlineWysiwyg
+              name="markdownBody"
+              imageProps={{
+                uploadDir: () => '/public/images',
+                parse: media => {
+                  return `/images/${media.filename}`
+                },
+              }}
+            >
               <ReactMarkdown>{data.markdownBody}</ReactMarkdown>
             </InlineWysiwyg>
           </div>
@@ -142,6 +151,10 @@ const formOptions = {
       name: 'markdownBody',
       label: 'Home Page Content',
       component: 'markdown',
+      imageProps: {
+        uploadDir: () => '/public/images',
+        parse: media => `/images/${media.filename}`,
+      },
     },
     { label: 'color', name: 'frontmatter.color', component: 'color' },
     {

--- a/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
@@ -16,16 +16,12 @@ limitations under the License.
 
 */
 
-import React, { useRef, useState } from 'react'
-import styled, { css } from 'styled-components'
-import { Dismissible } from 'react-dismissible'
+import React, { useRef } from 'react'
 
 import { useCMS, Media } from 'tinacms'
-import { Button } from '@tinacms/styles'
-import { Input } from '@tinacms/fields'
-import { MediaIcon, UploadIcon, CloseIcon } from '@tinacms/icons'
+import { MediaIcon } from '@tinacms/icons'
 
-import { MenuButton, MenuDropdown } from '../../../components/MenuHelpers'
+import { MenuButton } from '../../../components/MenuHelpers'
 import { useEditorStateContext } from '../../../context/editorState'
 import { insertImage } from '../commands'
 
@@ -38,29 +34,14 @@ export const ProsemirrorMenu = ({ uploadImages, mediaDir }: MenuProps) => {
   const cms = useCMS()
   const menuButtonRef = useRef()
   const { editorView } = useEditorStateContext()
-  const [displayUrlInput, setDisplayUrlInput] = useState(false)
-  const [imageUrl, setImageUrl] = useState('')
-  const [showImageModal, setShowImageModal] = useState(false)
-  const [uploading, setUploading] = useState(false)
 
   if (!uploadImages) return null
-
-  const uploadImageFile = (file: File) => {
-    setUploading(true)
-    const uploadPromise = uploadImages([file])
-    uploadPromise.then((urls = []) => {
-      setImageUrl(urls[0])
-      setUploading(false)
-    })
-  }
 
   const insertImageInEditor = (src: string) => {
     if (!editorView) return
     const { state, dispatch } = editorView.view
     insertImage(state, dispatch, src)
     editorView.view.focus()
-    setShowImageModal(false)
-    setImageUrl('')
   }
 
   async function onMediaSelect(media?: Media) {
@@ -70,282 +51,20 @@ export const ProsemirrorMenu = ({ uploadImages, mediaDir }: MenuProps) => {
     }
   }
 
-  const stopDefault = (evt: React.DragEvent<HTMLSpanElement>) => {
-    evt.preventDefault()
-    evt.stopPropagation()
-  }
-
-  // Check if property name is files or items
-  // IE uses 'files' instead of 'items'
-  const onImageDrop = (evt: React.DragEvent<HTMLSpanElement>) => {
-    stopDefault(evt)
-    const { items, files } = evt.dataTransfer
-    const data = items || files
-    const dataIsItems = !!items
-    for (let i = 0; i < data.length; i += 1) {
-      if (
-        (!dataIsItems || data[i].kind === 'file') &&
-        data[i].type.match('^image/')
-      ) {
-        const file = (dataIsItems ? data[i].getAsFile() : data[i]) as File
-        if (file) {
-          uploadImageFile(file)
-        }
-      }
-    }
-  }
-
-  const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') setShowImageModal(false)
-  }
-
-  const handleCloseModal = () => {
-    setImageUrl('')
-    setShowImageModal(!showImageModal)
-  }
-
   return (
     <>
-      <MenuButton title="Image" ref={menuButtonRef} onClick={handleCloseModal}>
+      <MenuButton
+        title="Image"
+        ref={menuButtonRef}
+        onClick={() => {
+          cms.media.open({
+            directory: mediaDir || '/',
+            onSelect: onMediaSelect,
+          })
+        }}
+      >
         <MediaIcon />
       </MenuButton>
-      <MenuDropdown
-        triggerRef={menuButtonRef}
-        open={showImageModal}
-        onKeyDown={handleKeyDown}
-      >
-        <Dismissible
-          click
-          escape
-          disabled={!showImageModal}
-          onDismiss={() => {
-            setShowImageModal(false)
-          }}
-        >
-          <ImageModalContent>
-            <UploadSection
-              onClick={() => {
-                cms.media.open({
-                  directory: mediaDir || '/',
-                  onSelect: onMediaSelect,
-                })
-              }}
-              onDragEnter={stopDefault}
-              onDragOver={stopDefault}
-              onDrop={onImageDrop}
-              uploading={uploading}
-              imageUrl={imageUrl}
-            >
-              {imageUrl && (
-                <>
-                  <ClearImageButton
-                    onMouseDown={evt => {
-                      setImageUrl('')
-                      evt.stopPropagation()
-                    }}
-                  >
-                    <CloseIcon />
-                  </ClearImageButton>
-                  <CurrentImage src={imageUrl} alt="uploaded_image" />
-                </>
-              )}
-              {!imageUrl && (
-                <>
-                  <UploadIconWrapper>
-                    <UploadIcon />
-                  </UploadIconWrapper>
-                  <UploadText>
-                    {!uploading && `Drag and drop or click to upload`}
-                    {uploading && 'Image uploading...'}
-                  </UploadText>
-                </>
-              )}
-            </UploadSection>
-            <UrlInputWrapper>
-              {displayUrlInput && (
-                <>
-                  <UrlInput onMouseDown={evt => evt.stopPropagation()}>
-                    <ImageInputLabel
-                      onClick={() => {
-                        setDisplayUrlInput(false)
-                      }}
-                    >
-                      Or Enter Image URL
-                    </ImageInputLabel>
-                    <Input
-                      small
-                      onChange={evt => setImageUrl(evt.target.value)}
-                      value={imageUrl}
-                    ></Input>
-                  </UrlInput>
-                </>
-              )}
-              {!displayUrlInput && (
-                <>
-                  <UrlInputTrigger
-                    onClick={() => {
-                      setDisplayUrlInput(true)
-                    }}
-                  >
-                    Or Enter Image URL
-                  </UrlInputTrigger>
-                </>
-              )}
-            </UrlInputWrapper>
-            <ImageModalActions>
-              <Button small onClick={handleCloseModal}>
-                Cancel
-              </Button>
-              <Button
-                primary
-                small
-                onClick={() => insertImageInEditor(imageUrl)}
-              >
-                Insert
-              </Button>
-            </ImageModalActions>
-          </ImageModalContent>
-        </Dismissible>
-      </MenuDropdown>
     </>
   )
 }
-
-const ClearImageButton = styled.button`
-  background: none;
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  outline: none;
-  width: 32px;
-  height: 32px;
-  padding: 0;
-  position: absolute;
-  top: 18px;
-  right: 18px;
-  border-radius: var(--tina-radius-big);
-  box-shadow: var(--tina-shadow-small);
-  background-color: var(--tina-color-grey-0);
-  border: 1px solid var(--tina-color-grey-2);
-  cursor: pointer;
-  transition: all 85ms ease-out;
-
-  &:hover {
-    background-color: var(--tina-color-grey-1);
-  }
-
-  svg {
-    fill: var(--tina-color-primary);
-    width: 22px;
-    height: 22px;
-  }
-`
-
-const UrlInputWrapper = styled.div`
-  display: flex;
-  margin-bottom: var(--tina-padding-small);
-`
-
-const UrlInputTrigger = styled.button`
-  background: none;
-  border: none;
-  outline: none;
-  color: var(--tina-color-primary);
-  cursor: pointer;
-  transition: all 80ms ease-out;
-  font-size: var(--tina-font-size-1);
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  line-height: 1.35;
-  padding: 0;
-
-  &:hover {
-    text-decoration: underline;
-    text-decoration-color: var(--tina-color-primary-light);
-  }
-`
-
-const UrlInput = styled.div``
-
-const UploadIconWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-top: -7px;
-  svg {
-    width: 50px;
-    height: auto;
-    fill: var(--tina-color-primary);
-  }
-`
-
-const CurrentImage = styled.img`
-  display: block;
-  width: 100%;
-  margin: 0;
-`
-
-const ImageInputLabel = styled.label`
-  display: block;
-  font-size: var(--tina-font-size-1);
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  line-height: 1.35;
-  color: var(--tina-color-grey-8);
-  margin-bottom: 8px;
-  text-overflow: ellipsis;
-  width: 100%;
-  overflow: hidden;
-`
-
-const ImageModalContent = styled.div`
-  background: var(--tina-color-grey-1);
-  padding: var(--tina-padding-small);
-  font-family: var(--tina-font-family);
-
-  * {
-    font-family: inherit;
-  }
-`
-
-const ImageModalActions = styled.div`
-  display: flex;
-  margin: 0 -4px;
-  width: calc(100% + 8px);
-
-  ${Button} {
-    flex: 1 0 auto;
-    margin: 0 4px;
-  }
-`
-
-const UploadText = styled.span`
-  font-size: var(--tina-font-size-2);
-  text-align: center;
-  line-height: 1.2;
-  color: var(--tina-color-grey-10);
-  max-width: 140px;
-  white-space: break-spaces;
-  display: block;
-  margin: 0 auto;
-`
-
-const UploadSection = styled.div<{ uploading: boolean; imageUrl: string }>`
-  display: block;
-  width: 100%;
-  min-width: 200px;
-  padding: var(--tina-padding-big) 0;
-  margin-bottom: var(--tina-padding-small);
-  border-radius: var(--tina-radius-big);
-  border: 3px dashed var(--tina-color-grey-3);
-  cursor: pointer;
-
-  ${props =>
-    props.imageUrl !== '' &&
-    css`
-      padding: 0;
-      border: none;
-      border-radius: var(--tina-radius-small);
-      border: 1px solid var(--tina-color-grey-2);
-    `};
-`

--- a/packages/react-tinacms-editor/src/tinacms-plugins/HtmlFieldPlugin.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-plugins/HtmlFieldPlugin.tsx
@@ -21,7 +21,14 @@ import { Wysiwyg } from '../components/Wysiwyg'
 import { wysiwygStyles } from './wysiwygStyles'
 
 const HTMLField = wysiwygStyles(props => {
-  return <Wysiwyg {...props} sticky={false} format="html" />
+  return (
+    <Wysiwyg
+      {...props}
+      sticky={false}
+      format="html"
+      imageProps={props.field.imageProps}
+    />
+  )
 })
 
 export const HtmlFieldPlugin = {

--- a/packages/react-tinacms-editor/src/tinacms-plugins/MarkdownFieldPlugin.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-plugins/MarkdownFieldPlugin.tsx
@@ -21,7 +21,14 @@ import { Wysiwyg } from '../components/Wysiwyg'
 import { wysiwygStyles } from './wysiwygStyles'
 
 const MarkdownField = wysiwygStyles(props => {
-  return <Wysiwyg {...props} sticky={false} format="markdown" />
+  return (
+    <Wysiwyg
+      {...props}
+      sticky={false}
+      format="markdown"
+      imageProps={props.field.imageProps}
+    />
+  )
 })
 
 export const MarkdownFieldPlugin = {


### PR DESCRIPTION
Enables `imageProps` to be passed to the sidebar wysiwyg. Also removes the image popup from the menu entirely, so when you hit the media icon in the wysiwyg menu, the media manager opens immediately. 

Would love help testing this out to make sure it's all good and see if we actually like it better without the popup. If we want to keep the popup, we'll need to adjust some things in the sidebar.
