### PR TITLE
style: add css override

### DIFF
--- a/packages/@tinacms/fields/src/components/Input.tsx
+++ b/packages/@tinacms/fields/src/components/Input.tsx
@@ -26,12 +26,15 @@ export interface InputProps {
 }
 
 export const InputCss = css<InputProps>`
+  all: unset;
+  box-sizing: border-box;
   padding: var(--tina-padding-small);
   border-radius: var(--tina-radius-small);
   background: var(--tina-color-grey-0);
   font-size: var(--tina-font-size-2);
   line-height: 1.35;
   position: relative;
+  color: var(--tina-color-grey-10);
   background-color: var(--tina-color-grey-0);
   transition: all 85ms ease-out;
   border: 1px solid var(--tina-color-grey-2);

--- a/packages/@tinacms/fields/src/components/Select.tsx
+++ b/packages/@tinacms/fields/src/components/Select.tsx
@@ -76,13 +76,17 @@ const SelectElement = styled.div`
   position: relative;
 
   select {
+    all: unset;
+    box-sizing: border-box;
     display: block;
     font-family: inherit;
     max-width: 100%;
+    color: var(--tina-color-grey-10);
     padding: var(--tina-padding-small);
     border-radius: var(--tina-radius-small);
     background: var(--tina-color-grey-0);
     font-size: var(--tina-font-size-2);
+    font-weight: var(--tina-font-weight-regular);
     line-height: 1.35;
     position: relative;
     background-color: var(--tina-color-grey-0);

--- a/packages/@tinacms/react-modals/src/Modal/ModalHeader.tsx
+++ b/packages/@tinacms/react-modals/src/Modal/ModalHeader.tsx
@@ -49,9 +49,13 @@ export const ModalHeader = styled(
 `
 
 const ModalTitle = styled.h2`
+  all: unset;
+  color: var(--tina-color-grey-10);
+  font-weight: var(--tina-font-weight-regular);
+  font-family: var(--tina-font-family);
   font-size: var(--tina-font-size-4);
   font-weight: var(--tina-font-weight-regular);
-  line-height: normal;
+  line-height: 1;
   margin: 0;
 `
 


### PR DESCRIPTION
We're going to have to more aggressively reset CSS at a component level given Tina's UI is no longer isolated. Using `all: unset;` will reset everything for us, but it may nuke defaults we were previously relying on so it can't simply be applied universally. 

This is just a start, I will continue to apply this reset (and compensate for the missing defaults after it's applied) as issues come up.