### PR TITLE
Adjust toggle labels

### DIFF
--- a/packages/@tinacms/fields/src/components/Toggle.tsx
+++ b/packages/@tinacms/fields/src/components/Toggle.tsx
@@ -62,40 +62,43 @@ export const Toggle: FC<ToggleProps> = ({
   }
 
   return (
-    <ToggleElement>
+    <ToggleWrap>
       {labels && <span>{labels.false}</span>}
-      <ToggleInput id={name} type="checkbox" {...input} />
-      <ToggleLabel
-        htmlFor={name}
-        role="switch"
-        disabled={disabled}
-        hasToggleLabels={labels !== null}
-      >
-        <ToggleSwitch checked={checked}>
-          <span></span>
-        </ToggleSwitch>
-      </ToggleLabel>
+      <ToggleElement hasToggleLabels={labels !== null}>
+        <ToggleInput id={name} type="checkbox" {...input} />
+        <ToggleLabel htmlFor={name} role="switch" disabled={disabled}>
+          <ToggleSwitch checked={checked}>
+            <span></span>
+          </ToggleSwitch>
+        </ToggleLabel>
+      </ToggleElement>
       {labels && <span>{labels.true}</span>}
-    </ToggleElement>
+    </ToggleWrap>
   )
 }
 
-const ToggleElement = styled.div`
+const ToggleWrap = styled.div`
   display: flex;
+  align-items: center;
+
+  > span {
+    color: var(--tina-color-grey-8);
+  }
+`
+
+const ToggleElement = styled.div<{ hasToggleLabels?: boolean }>`
   position: relative;
   width: 48px;
   height: 28px;
-  margin: 0;
-  align-items: center;
+  margin: ${props => (props.hasToggleLabels ? '0 10px' : '0')};
 `
 
 const ToggleLabel = styled.label<{
   disabled?: boolean
-  hasToggleLabels?: boolean
 }>`
   background: none;
   color: inherit;
-  padding: ${props => (props.hasToggleLabels ? '0 10px' : '0')};
+  padding: 0;
   opacity: ${props => (props.disabled ? '0.4' : '1')};
   outline: none;
   width: 48px;

--- a/packages/@tinacms/fields/src/components/Toggle.tsx
+++ b/packages/@tinacms/fields/src/components/Toggle.tsx
@@ -19,21 +19,20 @@ limitations under the License.
 import { FC } from 'react'
 import styled from 'styled-components'
 import * as React from 'react'
+import { Field } from '@tinacms/forms'
 
 export interface ToggleProps {
   name: string
   input: any
-  field: ToggleFieldProps
+  field: ToggleFieldDefinition
   disabled?: boolean
   onBlur: <T>(event?: React.FocusEvent<T>) => void
   onChange: <T>(event: React.ChangeEvent<T> | any) => void
   onFocus: <T>(event?: React.FocusEvent<T>) => void
 }
 
-interface ToggleFieldProps {
-  name: string
-  component: string
-  label?: string
+interface ToggleFieldDefinition extends Field {
+  component: 'toggle'
   toggleLabels?: boolean | FieldLabels
 }
 

--- a/packages/@tinacms/fields/src/components/Toggle.tsx
+++ b/packages/@tinacms/fields/src/components/Toggle.tsx
@@ -46,34 +46,36 @@ export const Toggle: FC<ToggleProps> = ({
   disabled = false,
 }) => {
   const checked = !!(input.value || input.checked)
-  const labels = {
-    true: field.toggleLabels === true ? 'Yes' : null,
-    false: field.toggleLabels === true ? 'No' : null,
-  }
+  let labels: null | FieldLabels = null
 
-  if (typeof field.toggleLabels === 'object' && 'true' in field.toggleLabels) {
-    labels.true = field.toggleLabels['true']
-    labels.false = field.toggleLabels['false']
-  }
+  if (field.toggleLabels) {
+    const fieldLabels =
+      typeof field.toggleLabels === 'object' &&
+      'true' in field.toggleLabels &&
+      'false' in field.toggleLabels &&
+      field.toggleLabels
 
-  const hasToggleLabels =
-    typeof labels.true !== null || typeof labels.false !== null
+    labels = {
+      true: fieldLabels ? fieldLabels['true'] : 'Yes',
+      false: fieldLabels ? fieldLabels['false'] : 'No',
+    }
+  }
 
   return (
     <ToggleElement>
-      {labels.false && <span>{labels.false}</span>}
+      {labels && <span>{labels.false}</span>}
       <ToggleInput id={name} type="checkbox" {...input} />
       <ToggleLabel
         htmlFor={name}
         role="switch"
         disabled={disabled}
-        hasToggleLabels={hasToggleLabels}
+        hasToggleLabels={labels !== null}
       >
         <ToggleSwitch checked={checked}>
           <span></span>
         </ToggleSwitch>
       </ToggleLabel>
-      {labels.true && <span>{labels.true}</span>}
+      {labels && <span>{labels.true}</span>}
     </ToggleElement>
   )
 }

--- a/packages/@tinacms/fields/src/components/Toggle.tsx
+++ b/packages/@tinacms/fields/src/components/Toggle.tsx
@@ -22,31 +22,38 @@ import * as React from 'react'
 
 export interface ToggleProps {
   name: string
+  input: any
+  field: ToggleFieldProps
+  disabled?: boolean
   onBlur: <T>(event?: React.FocusEvent<T>) => void
   onChange: <T>(event: React.ChangeEvent<T> | any) => void
   onFocus: <T>(event?: React.FocusEvent<T>) => void
-  value: any
-  input: any
-  checked?: boolean
-  disabled?: boolean
-  toggleLabels?:
-    | boolean
-    | {
-        true: string
-        false: string
-      }
 }
 
-export const Toggle: FC<ToggleProps> = props => {
-  const checked = !!(props.input.value || props.input.checked)
+interface ToggleFieldProps {
+  name: string
+  component: string
+  label?: string
+  toggleLabels?: boolean | FieldLabels
+}
+
+type FieldLabels = { true: string; false: string }
+
+export const Toggle: FC<ToggleProps> = ({
+  input,
+  field,
+  name,
+  disabled = false,
+}) => {
+  const checked = !!(input.value || input.checked)
   const labels = {
-    true: props.toggleLabels === true ? 'Yes' : null,
-    false: props.toggleLabels === true ? 'No' : null,
+    true: field.toggleLabels === true ? 'Yes' : null,
+    false: field.toggleLabels === true ? 'No' : null,
   }
 
-  if (typeof props.toggleLabels === 'object' && 'true' in props.toggleLabels) {
-    labels.true = props.toggleLabels['true']
-    labels.false = props.toggleLabels['false']
+  if (typeof field.toggleLabels === 'object' && 'true' in field.toggleLabels) {
+    labels.true = field.toggleLabels['true']
+    labels.false = field.toggleLabels['false']
   }
 
   const hasToggleLabels =
@@ -55,11 +62,11 @@ export const Toggle: FC<ToggleProps> = props => {
   return (
     <ToggleElement>
       {labels.false && <span>{labels.false}</span>}
-      <ToggleInput id={props.name} type="checkbox" {...props.input} />
+      <ToggleInput id={name} type="checkbox" {...input} />
       <ToggleLabel
-        htmlFor={props.name}
+        htmlFor={name}
         role="switch"
-        disabled={props.disabled}
+        disabled={disabled}
         hasToggleLabels={hasToggleLabels}
       >
         <ToggleSwitch checked={checked}>

--- a/packages/demo-next/pages/nesting.tsx
+++ b/packages/demo-next/pages/nesting.tsx
@@ -99,7 +99,13 @@ export default function Nesting() {
       ],
     },
     label: 'Nesting',
-    fields: [],
+    fields: [
+      {
+        name: 'toggle',
+        component: 'toggle',
+        toggleLabels: true,
+      },
+    ],
     actions: [TestAction, AnotherAction],
     onSubmit() {},
   })


### PR DESCRIPTION
Example to test in `demo-next` on the nesting page in the sidebar form.

Found an issue with the toggle (and select) in the inline settings modal that I think should be addressed in a different PR. I'll create a ticket to describe upon testing further.