### PR TITLE
style: add focus ring height

### DIFF
--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -83,6 +83,7 @@ export const StyledFocusRing = styled.div<StyledFocusRingProps>(p => {
   return css`
     position: relative;
     width: 100%;
+    height: 100%;
 
     ${!p.disableHover &&
       css`


### PR DESCRIPTION
Focus rings weren't working for absolutely positioned elements in some cases, this fixes the issue.