### PR TITLE
style: fix font color

### DIFF
--- a/packages/@tinacms/react-toolbar/src/components/DesktopLabel.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/DesktopLabel.tsx
@@ -19,6 +19,8 @@ limitations under the License.
 import styled from 'styled-components'
 
 export const DesktopLabel = styled.span`
+  all: unset;
+  color: inherit;
   display: none;
   @media (min-width: 1030px) {
     display: inline;

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -254,6 +254,9 @@ const BlocksMenu = styled.div<AddMenuProps>`
 `
 
 const BlockOption = styled.button`
+  all: unset;
+  box-sizing: border-box;
+  color: var(--tina-color-grey-8);
   font-family: 'Inter', sans-serif;
   position: relative;
   text-align: center;


### PR DESCRIPTION
Fixing two more cases where global styles were interfering with Tina styles. When a Tina element applies padding or border it relies on the `box-sizing: border-box;` model, which was previously inherited from global Tina styles. Going forward this will have to be applied manually at the component level as needed, after `all: unset;` is used. This still feels like a patchwork solution but any elements updated to include 'all: unset;` should be safe moving forward.