### PR TITLE
style: improve z-index

### DIFF
--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -120,7 +120,7 @@ export const Popover = styled.div<{
   transform: translate3d(-50%, 8px, 0) scale3d(1, 1, 1);
   transform-origin: 50% 0;
   animation: ${ColorPopupKeyframes} 85ms ease-out both 1;
-  z-index: var(--tina-z-index-4);
+  z-index: var(--tina-z-index-5);
 
   &:before {
     content: '';

--- a/packages/@tinacms/react-modals/src/Modal/ModalOverlay.tsx
+++ b/packages/@tinacms/react-modals/src/Modal/ModalOverlay.tsx
@@ -29,5 +29,5 @@ export const ModalOverlay = styled.div`
   background: rgba(0, 0, 0, 0.5);
   overflow: auto;
   padding: 0;
-  z-index: var(--tina-z-index-4);
+  z-index: var(--tina-z-index-5);
 `

--- a/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
@@ -433,7 +433,7 @@ const SidebarContainer = styled.div<{ open: boolean }>`
   padding: 0 !important;
   border: 0 !important;
   box-sizing: border-box;
-  z-index: var(--tina-z-index-3);
+  z-index: var(--tina-z-index-4);
   transition: all ${p => (p.open ? 150 : 200)}ms ease-out !important;
   transform: translate3d(
     ${p => (p.open ? '0' : 'calc(var(--tina-sidebar-width) * -1)')},

--- a/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
@@ -236,7 +236,7 @@ const StyledToolbar = styled.div<{ menuIsOpen: boolean }>`
   right: 0;
   padding: 0 12px;
   height: 62px;
-  z-index: var(--tina-z-index-3);
+  z-index: var(--tina-z-index-4);
   box-sizing: border-box;
   display: grid;
   grid-template-areas: 'left right';

--- a/packages/@tinacms/styles/src/Styles.tsx
+++ b/packages/@tinacms/styles/src/Styles.tsx
@@ -89,6 +89,7 @@ const theme = css`
     --tina-z-index-2: 1500;
     --tina-z-index-3: 2000;
     --tina-z-index-4: 2500;
+    --tina-z-index-5: 3000;
 
     --tina-sidebar-width: 340px;
     --tina-sidebar-header-height: 60px;

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -167,7 +167,7 @@ const AddBlockWrapper = styled.div<AddBlockWrapperProps>(p => {
 
   return css`
   position: absolute;
-  z-index: calc(var(--tina-z-index-2) - ${p.index !== undefined ? p.index : 0});
+  z-index: calc(var(--tina-z-index-3) - ${p.index !== undefined ? p.index : 0});
 
 
   ${p.position === 'top' &&

--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -121,6 +121,7 @@ export const StyledFocusRing = styled.div<StyledFocusRingProps>(p => {
       pointer-events: none;
       transition: all var(--tina-timing-medium) ease-out;
       box-shadow: var(--tina-shadow-big);
+      z-index: var(--tina-z-index-2);
     }
 
     ${p.active &&


### PR DESCRIPTION
The focus ring didn't have an explicit z-index set and so was hidden behind absolutely positioned children. We also needed an additional level of z-index available for Tina UI, so `--tina-z-index-5` was added to the existing values. 