### PR TITLE
chore(react-tinacms-inline): Update block container props

### DIFF
--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -518,6 +518,7 @@ To handle this, you can pass a "render function" as the child of the `InlineBloc
 interface BlocksContainerProps {
   innerRef: React.Ref<any>
   className?: string
+  children?: React.ReactNode
 }
 ```
 

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -49,6 +49,7 @@ export interface InlineBlocksProps {
 export interface BlocksContainerProps {
   innerRef: React.Ref<any>
   className?: string
+  children?: React.ReactNode
 }
 
 const DefaultContainer = (props: BlocksContainerProps) => {


### PR DESCRIPTION
The block container interface didn't explicitly accept `children`. This made the typing awkward when trying to type props with `children` in the wild. 