### PR TITLE
Allow custom actions to be added to media manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8210,6 +8210,11 @@
         "@types/react": "*"
       }
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.4.tgz",
+      "integrity": "sha512-rPvqs+1hL/5hbES/0HTdUu4lvNmneiwKwccbWe7HGLWbnsLdqKnQHyWLg4Pj0AMO7PLHCwBM1Cs8orChdkDONg=="
+    },
     "@types/resolve": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz",

--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -61,11 +61,10 @@ export interface MediaUploadOptions {
 export type MediaActionType = 'global' | 'single' | 'multi'
 
 export type MediaAction<Type = MediaActionType> = {
-  label: string
   type: MediaActionType
   action: Type extends 'single'
-    ? (media: Media) => void
-    : (media: Media[]) => void
+    ? React.FC<{ media: Media }>
+    : React.FC<{ media: Media[] }>
 }
 
 /**

--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -58,11 +58,26 @@ export interface MediaUploadOptions {
   file: File
 }
 
+export type MediaActionType = 'global' | 'single' | 'multi'
+
+export type MediaAction<Type = MediaActionType> = {
+  label: string
+  type: MediaActionType
+  action: Type extends 'single'
+    ? (media: Media) => void
+    : (media: Media[]) => void
+}
+
 /**
  * Represents some external service for storing and
  * managing media.
  */
 export interface MediaStore {
+  /**
+   * Specifies custom actions to be displayed in the media manager UI
+   */
+  actions?: MediaAction[]
+
   /**
    * The [input accept string](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#accept)
    * that describes what kind of files the Media Store will accept.
@@ -132,6 +147,10 @@ export interface MediaList {
  */
 export class MediaManager implements MediaStore {
   constructor(public store: MediaStore, private events: EventBus) {}
+
+  get actions() {
+    return this.store.actions ?? []
+  }
 
   get isConfigured() {
     return !(this.store instanceof DummyMediaStore)

--- a/packages/tinacms/src/components/media/media-actions.tsx
+++ b/packages/tinacms/src/components/media/media-actions.tsx
@@ -98,12 +98,13 @@ const ActionsOverlay = styled.div<{ open: boolean }>`
   background-color: white;
   overflow: hidden;
   z-index: var(--tina-z-index-1);
+
   ${props =>
     props.open &&
     css`
       opacity: 1;
       pointer-events: all;
-      transform: translate3d(0, -28px, 0) scale3d(1, 1, 1);
+      transform: translate3d(0, 0.5rem, 0) scale3d(1, 1, 1);
     `};
 `
 

--- a/packages/tinacms/src/components/media/media-actions.tsx
+++ b/packages/tinacms/src/components/media/media-actions.tsx
@@ -1,0 +1,130 @@
+/**
+
+Copyright 2019 Forestry.io Inc
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import styled, { css, StyledComponent } from 'styled-components'
+import { EllipsisVerticalIcon } from '@tinacms/icons'
+import { Media, MediaAction } from '@tinacms/core'
+import { useState, FC } from 'react'
+import { Dismissible } from 'react-dismissible'
+
+export interface MediaActionMenuProps {
+  media: Media | Media[]
+  actions: MediaAction[]
+}
+
+export const MediaActionMenu: FC<MediaActionMenuProps> = ({
+  actions,
+  media,
+}) => {
+  const [actionMenuVisibility, setActionMenuVisibility] = useState(false)
+
+  return (
+    <>
+      <MoreActionsButton onClick={() => setActionMenuVisibility(p => !p)} />
+      <ActionsOverlay open={actionMenuVisibility}>
+        <Dismissible
+          click
+          escape
+          disabled={!actionMenuVisibility}
+          onDismiss={() => {
+            setActionMenuVisibility(p => !p)
+          }}
+        >
+          {actions.map((Action, i) => (
+            <Action.action media={media as Media & Media[]} key={i} />
+          ))}
+        </Dismissible>
+      </ActionsOverlay>
+    </>
+  )
+}
+
+const MoreActionsButton = styled(p => (
+  <button {...p}>
+    <EllipsisVerticalIcon />
+  </button>
+))`
+  height: 64px;
+  width: 40px;
+  align-self: stretch;
+  background-color: transparent;
+  background-position: center;
+  background-size: auto 18px;
+  background-repeat: no-repeat;
+  border: 0;
+  margin: 0 -16px 0 8px;
+  outline: none;
+  cursor: pointer;
+  transition: opacity 85ms ease-out;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  &:hover {
+    background-color: var(--tina-color-grey-1);
+    fill: var(--tina-color-grey-8);
+  }
+`
+
+const ActionsOverlay = styled.div<{ open: boolean }>`
+  min-width: 192px;
+  border-radius: var(--tina-radius-big);
+  border: 1px solid #efefef;
+  display: block;
+  position: absolute;
+  bottom: var(--tina-padding-big);
+  right: var(--tina-padding-big);
+  transform: translate3d(0, 0, 0) scale3d(0.5, 0.5, 1);
+  opacity: 0;
+  pointer-events: none;
+  transition: all 85ms ease-out;
+  transform-origin: 100% 100%;
+  box-shadow: var(--tina-shadow-big);
+  background-color: white;
+  overflow: hidden;
+  z-index: var(--tina-z-index-1);
+  ${props =>
+    props.open &&
+    css`
+      opacity: 1;
+      pointer-events: all;
+      transform: translate3d(0, -28px, 0) scale3d(1, 1, 1);
+    `};
+`
+
+export const ActionButton: StyledComponent<'button', {}, {}> = styled.button`
+  position: relative;
+  text-align: center;
+  font-size: var(--tina-font-size-1);
+  padding: 0 12px;
+  height: 40px;
+  font-weight: var(--tina-font-weight-regular);
+  width: 100%;
+  background: none;
+  cursor: pointer;
+  outline: none;
+  border: 0;
+  transition: all var(--tina-timing-medium) ease-out;
+  &:hover {
+    color: var(--tina-color-primary);
+    background-color: var(--tina-color-grey-1);
+  }
+  &:not(:last-child) {
+    border-bottom: 1px solid var(--tina-color-grey-2);
+  }
+`

--- a/packages/tinacms/src/components/media/media-item.tsx
+++ b/packages/tinacms/src/components/media/media-item.tsx
@@ -144,11 +144,12 @@ const Filename = styled.span`
 `
 
 const ActionButtons = styled.span`
+  position: relative;
   display: flex;
   align-items: center;
   justify-items: center;
 
-  > * {
+  > button {
     margin-left: var(--tina-padding-small);
   }
 `

--- a/packages/tinacms/src/components/media/media-item.tsx
+++ b/packages/tinacms/src/components/media/media-item.tsx
@@ -21,6 +21,7 @@ import { Media, MediaAction } from '@tinacms/core'
 import { Folder, File } from '@tinacms/icons'
 import { Button, IconButton } from '@tinacms/styles'
 import { TrashIcon } from '@tinacms/icons'
+import { MediaActionMenu } from './media-actions'
 
 interface MediaItemProps {
   item: Media
@@ -58,11 +59,9 @@ export function MediaItem({
             <TrashIcon />
           </IconButton>
         )}
-        {actions.map((action, i) => (
-          <Button small onClick={() => action.action(item)} key={i}>
-            {action.label}
-          </Button>
-        ))}
+        {actions.length > 0 && (
+          <MediaActionMenu actions={actions} media={item} />
+        )}
       </ActionButtons>
     </ListItem>
   )
@@ -79,6 +78,7 @@ interface ListItemProps {
 const ListItem = styled.li<ListItemProps>`
   display: flex;
   align-items: center;
+  justify-items: center;
   padding: 1rem;
   background-color: white;
   filter: drop-shadow(0 0 0 transparent);
@@ -145,6 +145,9 @@ const Filename = styled.span`
 
 const ActionButtons = styled.span`
   display: flex;
+  align-items: center;
+  justify-items: center;
+
   > * {
     margin-left: var(--tina-padding-small);
   }

--- a/packages/tinacms/src/components/media/media-item.tsx
+++ b/packages/tinacms/src/components/media/media-item.tsx
@@ -17,13 +17,14 @@ limitations under the License.
 */
 import React from 'react'
 import styled, { css } from 'styled-components'
-import { Media } from '@tinacms/core'
+import { Media, MediaAction } from '@tinacms/core'
 import { Folder, File } from '@tinacms/icons'
 import { Button, IconButton } from '@tinacms/styles'
 import { TrashIcon } from '@tinacms/icons'
 
 interface MediaItemProps {
   item: Media
+  actions: MediaAction<'single'>[]
   onClick(item: Media): void
   onSelect?(item: Media): void
   onDelete?(item: Media): void
@@ -31,6 +32,7 @@ interface MediaItemProps {
 
 export function MediaItem({
   item,
+  actions,
   onClick,
   onSelect,
   onDelete,
@@ -56,6 +58,11 @@ export function MediaItem({
             <TrashIcon />
           </IconButton>
         )}
+        {actions.map((action, i) => (
+          <Button small onClick={() => action.action(item)} key={i}>
+            {action.label}
+          </Button>
+        ))}
       </ActionButtons>
     </ListItem>
   )

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import React from 'react'
+import React, { useMemo } from 'react'
 import { useEffect, useState } from 'react'
 import styled, { css } from 'styled-components'
 import { useCMS } from '../../react-tinacms'
@@ -26,7 +26,7 @@ import {
   ModalBody,
   FullscreenModal,
 } from '@tinacms/react-modals'
-import { MediaList, Media } from '@tinacms/core'
+import { MediaList, Media, MediaAction } from '@tinacms/core'
 import path from 'path'
 import { Button } from '@tinacms/styles'
 import { useDropzone } from 'react-dropzone'
@@ -77,6 +77,20 @@ export function MediaPicker({
   ...props
 }: MediaRequest) {
   const cms = useCMS()
+  const { globalActions, singleActions, multiActions } = useMemo(
+    () => ({
+      globalActions: cms.media.actions.filter(
+        action => action.type === 'global'
+      ) as MediaAction<'global'>[],
+      singleActions: cms.media.actions.filter(
+        action => action.type === 'single'
+      ) as MediaAction<'single'>[],
+      multiActions: cms.media.actions.filter(
+        action => action.type === 'multi'
+      ) as MediaAction<'multi'>[],
+    }),
+    [cms.media.actions]
+  )
   const [listState, setListState] = useState<MediaListState>(() => {
     if (cms.media.isConfigured) return 'loading'
     return 'not-configured'
@@ -191,6 +205,11 @@ export function MediaPicker({
       <Header>
         <Breadcrumb directory={directory} setDirectory={setDirectory} />
         <UploadButton onClick={onClick} uploading={uploading} />
+        {globalActions.map((action, i) => (
+          <Button onClick={() => action.action([])} key={i}>
+            {action.label}
+          </Button>
+        ))}
       </Header>
       <List {...rootProps} dragActive={isDragActive}>
         <input {...getInputProps()} />
@@ -205,6 +224,7 @@ export function MediaPicker({
             onClick={onClickMediaItem}
             onSelect={selectMediaItem}
             onDelete={deleteMediaItem}
+            actions={singleActions}
           />
         ))}
       </List>

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -202,10 +202,12 @@ export function MediaPicker({
     <MediaPickerWrap>
       <Header>
         <Breadcrumb directory={directory} setDirectory={setDirectory} />
-        <UploadButton onClick={onClick} uploading={uploading} />
-        {globalActions.length > 0 && (
-          <MediaActionMenu actions={globalActions} media={list.items} />
-        )}
+        <GlobalActionsWrapper>
+          <UploadButton onClick={onClick} uploading={uploading} />
+          {globalActions.length > 0 && (
+            <MediaActionMenu actions={globalActions} media={list.items} />
+          )}
+        </GlobalActionsWrapper>
       </Header>
       <List {...rootProps} dragActive={isDragActive}>
         <input {...getInputProps()} />
@@ -352,4 +354,11 @@ const DocsLink = styled(({ title, ...props }) => {
     text-decoration: underline;
     font-weight: bold;
   }
+`
+
+const GlobalActionsWrapper = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 `


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
The PR adds the ability to add custom actions to a media store.

It adds a new property to the media store interface and media manager:

```
interface MediaStore {
  ...
  actions: MediaAction[]
  ...
}
```

Actions have the following interface (similar to custom form actions) but with an added `type`:

```
export type MediaAction<Type = MediaActionType> = {
  type: MediaActionType
  action: Type extends 'single'
    ? React.FC<{ media: Media }>
    : React.FC<{ media: Media[] }>
}
```

**Global Actions**

Always display alongside the "upload" button in a dropdown menu, and receives the current media items listed as a prop.

<img width="1498" alt="Screen Shot 2020-11-08 at 4 32 30 PM" src="https://user-images.githubusercontent.com/6855186/98483581-00846680-21e0-11eb-9a45-a51dbd2ff899.png">

**Single Actions**

Display alongside "single" media items, and receives that media item as a prop.

<img width="1486" alt="Screen Shot 2020-11-08 at 4 33 09 PM" src="https://user-images.githubusercontent.com/6855186/98483588-185bea80-21e0-11eb-8f1a-cdeb6f96c37d.png">

**Multi actions**

Currently unimplemented, but these are intended for bulk actions, when we add affordance to select multiple media items and perform an action on them.

