### PR TITLE
 Added advanced pagination UI for media stores that return dozens, hundreds, or thousands of pages

### DIFF
--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -16,10 +16,9 @@ limitations under the License.
 
 */
 
-import React from 'react'
+import React, { ChangeEvent } from 'react'
 import styled, { css } from 'styled-components'
 import { MediaList } from '@tinacms/core'
-import { Media } from 'tinacms'
 
 interface PageLinksProps {
   list: MediaList
@@ -114,21 +113,10 @@ const AdvancedPageLinks = ({
 
   if (pages.length !== numPages) {
     let i = 0
-    while (pages.length < numPages) {
+    while (pages.length <= numPages) {
       pages.push(i++)
     }
   }
-
-  console.log({
-    offset: list.offset,
-    limit,
-    numPages,
-    currentPageIndex,
-    previousOffset,
-    nextOffset,
-    lastOffset,
-    total: list.totalCount,
-  })
 
   return (
     <>
@@ -143,10 +131,14 @@ const AdvancedPageLinks = ({
       </PageButton>
       <PageLinksText>
         Showing page
-        <PageSelector onChange={(val: any) => console.log(val)}>
+        <PageSelector
+          onChange={(event: ChangeEvent<any>) =>
+            event?.target?.value ? setOffset(event.target.value * limit) : null
+          }
+        >
           {pages.map(page => (
             <option
-              value={page + 1}
+              value={page}
               selected={page + 1 === currentPageIndex}
               key={page}
             >

--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -19,6 +19,7 @@ limitations under the License.
 import React from 'react'
 import styled, { css } from 'styled-components'
 import { MediaList } from '@tinacms/core'
+import { Media } from 'tinacms'
 
 interface PageLinksProps {
   list: MediaList
@@ -29,42 +30,232 @@ export function PageLinks({ list, setOffset }: PageLinksProps) {
   const limit = list.limit || 10
   const numPages = Math.ceil(list.totalCount / limit)
   const lastItemIndexOnPage = list.offset + limit
-  const currentPageIndex = lastItemIndexOnPage / limit
-  let pageLinks = []
+  const currentPageIndex = Math.ceil(lastItemIndexOnPage / limit)
+  const shouldUseAdvanced = numPages + 1 > 10
 
   if (numPages <= 1) {
     return null
   }
 
-  for (let i = 1; i <= numPages; i++) {
-    const active = i === currentPageIndex
-    pageLinks.push(
-      <PageNumber active={active} onClick={() => setOffset(i * limit)}>
-        {i}
-      </PageNumber>
+  if (shouldUseAdvanced) {
+    return (
+      <PageLinksWrap>
+        <AdvancedPageLinks
+          list={list}
+          setOffset={setOffset}
+          numPages={numPages}
+          limit={limit}
+          currentPageIndex={currentPageIndex}
+        />
+      </PageLinksWrap>
     )
   }
 
-  return <PageLinksWrap>{pageLinks}</PageLinksWrap>
+  return (
+    <PageLinksWrap>
+      <SimplePageLinks
+        list={list}
+        setOffset={setOffset}
+        numPages={numPages}
+        limit={limit}
+        currentPageIndex={currentPageIndex}
+      />
+    </PageLinksWrap>
+  )
+}
+
+export interface PaginationProps {
+  list: MediaList
+  setOffset: Function
+  numPages: number
+  limit: number
+  currentPageIndex: number
+}
+
+const SimplePageLinks = ({
+  setOffset,
+  numPages,
+  limit,
+  currentPageIndex,
+}: PaginationProps) => {
+  let pageLinks = []
+
+  for (let i = 1; i <= numPages; i++) {
+    const active = i === currentPageIndex
+    pageLinks.push(
+      <PageButton active={active} onClick={() => setOffset(i * limit)}>
+        {i}
+      </PageButton>
+    )
+  }
+
+  return <>{pageLinks}</>
+}
+
+const AdvancedPageLinks = ({
+  list,
+  setOffset,
+  limit,
+  numPages,
+  currentPageIndex,
+}: PaginationProps) => {
+  const shouldAllowFirst = currentPageIndex > 1
+  const shouldAllowPrev = list.offset - limit >= 0
+  const shouldAllowNext = list?.nextOffset
+    ? list.nextOffset <= list.totalCount
+    : false
+  const shouldAllowLast = list?.nextOffset
+    ? list.nextOffset < list.totalCount
+    : false
+  const previousOffset = shouldAllowPrev ? list.offset - limit : list.offset
+  const nextOffset = shouldAllowNext ? list.nextOffset : list.offset
+  const lastOffset = list.totalCount - list.limit
+  let pages = []
+
+  if (pages.length !== numPages) {
+    let i = 0
+    while (pages.length < numPages) {
+      pages.push(i++)
+    }
+  }
+
+  console.log({
+    offset: list.offset,
+    limit,
+    numPages,
+    currentPageIndex,
+    previousOffset,
+    nextOffset,
+    lastOffset,
+    total: list.totalCount,
+  })
+
+  return (
+    <>
+      <PageButton onClick={() => setOffset(0)} disabled={!shouldAllowFirst}>
+        First
+      </PageButton>
+      <PageButton
+        onClick={() => setOffset(previousOffset)}
+        disabled={!shouldAllowPrev}
+      >
+        Prev
+      </PageButton>
+      <PageLinksText>
+        Showing page
+        <PageSelector onChange={(val: any) => console.log(val)}>
+          {pages.map(page => (
+            <option
+              value={page + 1}
+              selected={page + 1 === currentPageIndex}
+              key={page}
+            >
+              {page + 1}
+            </option>
+          ))}
+        </PageSelector>
+        of {numPages + 1}
+      </PageLinksText>
+      <PageButton
+        onClick={() => setOffset(nextOffset)}
+        disabled={!shouldAllowNext}
+      >
+        Next
+      </PageButton>
+      <PageButton
+        onClick={() => setOffset(lastOffset)}
+        disabled={!shouldAllowLast}
+      >
+        Last
+      </PageButton>
+    </>
+  )
 }
 
 const PageLinksWrap = styled.div`
   width: 100%;
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: center;
 `
 
-const PageNumber = styled.button<{ active: boolean }>`
+const PageButton = styled.button<{ active?: boolean }>`
   padding: 0 0.15rem;
   margin: var(--tina-padding-small);
   transition: border 180ms ease;
+  border-radius: var(--tina-radius-small);
+  box-shadow: var(--tina-shadow-small);
+  background-color: var(--tina-color-grey-0);
+  border: 1px solid var(--tina-color-grey-2);
+  color: var(--tina-color-primary);
+  fill: var(--tina-color-primary);
+  font-weight: var(--tina-font-weight-regular);
+  cursor: pointer;
+  font-size: var(--tina-font-size-1);
+  transition: all 85ms ease-out;
+
+  &:hover {
+    background-color: var(--tina-color-grey-1);
+  }
+
+  &:active, &:disabled {
+    background-color: var(--tina-color-grey-2);
+    outline: none;
+  }
+
+  &:disabled {
+    color: var(--tina-color-grey-5);
+    cursor: initial;
+  }
 
   ${p =>
-      !p.active &&
-      css`
-        color: var(--tina-color-grey-4);
-      `}
-    :hover {
-    border-bottom: 1px solid var(--tina-color-grey-9);
+    p.active &&
+    css`
+      background-color: var(--tina-color-primary);
+      color: var(--tina-color-grey-0);
+      fill: var(--tina-color-grey-0);
+      border: none;
+      &:hover {
+        background-color: var(--tina-color-primary-light);
+      }
+      &:active {
+        background-color: var(--tina-color-primary-dark);
+      }
+    `}
   }
+`
+
+const PageSelector = styled.select`
+  border: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -ms-appearance: none;
+  padding: 0 0.15rem;
+  margin: var(--tina-padding-small);
+  transition: border 180ms ease;
+  border-radius: var(--tina-radius-small);
+  box-shadow: var(--tina-shadow-small);
+  background-color: var(--tina-color-grey-0);
+  border: 1px solid var(--tina-color-grey-2);
+  color: var(--tina-color-primary);
+  fill: var(--tina-color-primary);
+  font-weight: var(--tina-font-weight-regular);
+  cursor: pointer;
+  font-size: var(--tina-font-size-1);
+  transition: all 85ms ease-out;
+
+  &:hover {
+    background-color: var(--tina-color-grey-1);
+  }
+
+  &:active {
+    background-color: var(--tina-color-grey-2);
+    outline: none;
+  }
+`
+
+const PageLinksText = styled.p`
+  font-size: var(--tina-font-size-1);
+  color: var(--tina-color-grey-5);
 `


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

Improves the media manager pagination UI, as it is currently totally unstyled, and for media stores that return dozens of pages, it looks terrible (and breaks).

In fact, listing pages doesn't work passed around 10 pages, and feels ineffective. Considering, the media manager has been updated to have two behaviours...

For media stores that return 10 pages or less, it renders this:

<img width="423" alt="Screen Shot 2020-11-08 at 6 50 21 PM" src="https://user-images.githubusercontent.com/6855186/98486392-68907800-21f3-11eb-946f-c3d43f32b4df.png">

For media stores that render more than 10 pages, it renders this:

<img width="385" alt="Screen Shot 2020-11-08 at 6 49 23 PM" src="https://user-images.githubusercontent.com/6855186/98486399-72b27680-21f3-11eb-8ec5-a0ca5a836bd5.png">

Which allows the user to quickly jump to a specific page as follows:

<img width="1499" alt="Screen Shot 2020-11-08 at 6 52 32 PM" src="https://user-images.githubusercontent.com/6855186/98486421-91187200-21f3-11eb-8be7-f58baedf8390.png">

The behaviour is as follows:

- The first button is disabled on the first page
  - It goes back to page 1
- The prev button is disabled on the first page
  - It goes back 1 page
- The next button is disabled on the last page
  - It goes forward 1 page
- The last button is disabled on the last page
  - It goes to the last page
- On change of the page dropdown, the media manager changes to that page
