### PR TITLE
Performance improvements for inline blocks

### DIFF
--- a/packages/demo-next/pages/blocks.tsx
+++ b/packages/demo-next/pages/blocks.tsx
@@ -29,6 +29,7 @@ import {
   useInlineForm,
   InlineTextarea,
 } from 'react-tinacms-inline'
+import { InlineWysiwyg } from 'react-tinacms-editor'
 
 import Layout from '../components/Layout'
 
@@ -184,6 +185,14 @@ const image_template: BlockTemplate = {
   fields: [{ name: 'alt', label: 'Image Alt', component: 'text' }],
 }
 
+const wysi_template: BlockTemplate = {
+  label: 'Content',
+  defaultItem: {
+    _template: 'wysiwyg',
+    content: '# Hello World',
+  },
+}
+
 // Testing the block styled component override
 
 const StyledBlockText = styled(InlineTextarea)`
@@ -207,6 +216,12 @@ const PAGE_BUILDER_BLOCKS = {
   image: {
     Component: ImageBlock,
     template: image_template,
+  },
+  wysiwyg: {
+    Component: ({ data }) => {
+      return <InlineWysiwyg name="content">{data.content}</InlineWysiwyg>
+    },
+    template: wysi_template,
   },
 }
 

--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -57,12 +57,19 @@ export function InlineWysiwyg({
       {({ input, form }: InlineWysiwygRenderProps) => {
         return (
           <FocusRing name={input.name} options={focusRing}>
-            <Wysiwyg
-              input={input}
-              imageProps={imageProps}
-              form={form}
-              {...wysiwygProps}
-            />
+            {active => {
+              if (active) {
+                return (
+                  <Wysiwyg
+                    input={input}
+                    imageProps={imageProps}
+                    form={form}
+                    {...wysiwygProps}
+                  />
+                )
+              }
+              return children
+            }}
           </FocusRing>
         )
       }}

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -160,7 +160,7 @@ The common UI element on all Inline Fields is the `FocusRing`. The focus ring pr
 ```ts
 interface FocusRingProps {
   name?: string
-  children?:  React.ReactChild
+  children: React.ReactNode | ((active: boolean) => React.ReactNode)
   options?: boolean | FocusRingOptions
 }
 
@@ -180,6 +180,23 @@ You would only use these options if you were creating custom inline fields and w
 | `children`    | _Optional_: Child elements to render.                                                                    |
 | `name`        | _Optional_: This value is used to set the focused / active field.                            |
 | `options`     | _Optional_: The `FocusRingOptions` outlined below.                                           |
+
+<br />
+
+> **Focus Ring Children**
+>
+> `FocusRing` optionally accepts [render prop](https://reactjs.org/docs/render-props.html#using-props-other-than-render) patterned children, which receive the `active` state and can be used to conditionally render elements based on whether the `FocusRing` currently has focus.
+>
+> ```jsx
+><FocusRing>
+>  {active => {
+>    if (active) {
+>      return <ComplicatedEditableComponent />
+>    }
+>    return <SimpleDisplayComponent />
+>  }}
+></FocusRing>
+> ```
 
 **Focus Ring Options**
 

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -99,6 +99,8 @@ export function BlocksControls({
   const childIsActive = focussedField.startsWith(name!)
 
   const focusOnBlock = (event: any) => {
+    event.stopPropagation()
+    event.preventDefault()
     if (
       blockMenuRef.current?.contains(event.target) ||
       blockMoveUpRef.current?.contains(event.target) ||
@@ -106,8 +108,6 @@ export function BlocksControls({
     ) {
       return
     }
-    event.stopPropagation()
-    event.preventDefault()
     setFocussedField(name!)
   }
 

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -140,60 +140,67 @@ export function BlocksControls({
             disableHover={focusRing === false ? true : childIsActive}
             disableChildren={!isActive && !childIsActive}
           >
-            {withinLimit(max) && (
-              <AddBlockMenuWrapper active={isActive}>
-                <AddBlockMenu
-                  addBlock={block => insert(index, block)}
-                  blocks={blocks}
-                  index={index}
-                  offset={offset}
-                  position={addBeforePosition}
-                />
-                <AddBlockMenu
-                  addBlock={block => insert(index + 1, block)}
-                  blocks={blocks}
-                  index={index}
-                  offset={offset}
-                  position={addAfterPosition}
-                />
-              </AddBlockMenuWrapper>
-            )}
-            <BlockMenuWrapper
-              offset={offset}
-              ref={blockMenuRef}
-              index={index}
-              active={isActive}
-              inset={insetControls}
-            >
-              <BlockMenu>
-                <BlockAction
-                  ref={blockMoveUpRef}
-                  onClick={moveBlockUp}
-                  disabled={isFirst}
-                >
-                  {direction === 'vertical' && <ChevronUpIcon />}
-                  {direction === 'horizontal' && <ChevronLeftIcon />}
-                </BlockAction>
-                <BlockAction
-                  ref={blockMoveDownRef}
-                  onClick={moveBlockDown}
-                  disabled={isLast}
-                >
-                  {direction === 'vertical' && <ChevronDownIcon />}
-                  {direction === 'horizontal' && <ChevronRightIcon />}
-                </BlockAction>
-                <BlockAction {...provider.dragHandleProps}>
-                  {direction === 'vertical' && <ReorderIcon />}
-                  {direction === 'horizontal' && <ReorderRowIcon />}
-                </BlockAction>
-                <InlineSettings fields={template.fields} />
-                {withinLimit(min) && (
-                  <BlockAction onClick={removeBlock}>
-                    <TrashIcon />
-                  </BlockAction>
+            {isActive ? (
+              <>
+                {withinLimit(max) && (
+                  <AddBlockMenuWrapper active={isActive}>
+                    <AddBlockMenu
+                      addBlock={block => insert(index, block)}
+                      blocks={blocks}
+                      index={index}
+                      offset={offset}
+                      position={addBeforePosition}
+                    />
+                    <AddBlockMenu
+                      addBlock={block => insert(index + 1, block)}
+                      blocks={blocks}
+                      index={index}
+                      offset={offset}
+                      position={addAfterPosition}
+                    />
+                  </AddBlockMenuWrapper>
                 )}
-              </BlockMenu>
-            </BlockMenuWrapper>
+                <BlockMenuWrapper
+                  offset={offset}
+                  ref={blockMenuRef}
+                  index={index}
+                  active={isActive}
+                  inset={insetControls}
+                >
+                  <BlockMenu>
+                    <BlockAction
+                      ref={blockMoveUpRef}
+                      onClick={moveBlockUp}
+                      disabled={isFirst}
+                    >
+                      {direction === 'vertical' && <ChevronUpIcon />}
+                      {direction === 'horizontal' && <ChevronLeftIcon />}
+                    </BlockAction>
+                    <BlockAction
+                      ref={blockMoveDownRef}
+                      onClick={moveBlockDown}
+                      disabled={isLast}
+                    >
+                      {direction === 'vertical' && <ChevronDownIcon />}
+                      {direction === 'horizontal' && <ChevronRightIcon />}
+                    </BlockAction>
+                    <BlockAction {...provider.dragHandleProps}>
+                      {direction === 'vertical' && <ReorderIcon />}
+                      {direction === 'horizontal' && <ReorderRowIcon />}
+                    </BlockAction>
+                    <InlineSettings fields={template.fields} />
+                    {withinLimit(min) && (
+                      <BlockAction onClick={removeBlock}>
+                        <TrashIcon />
+                      </BlockAction>
+                    )}
+                  </BlockMenu>
+                </BlockMenuWrapper>
+              </>
+            ) : (
+              // dummy element; react-beautiful-dnd complains when dragHandleProps isn't present
+              <div {...provider.dragHandleProps}></div>
+            )}
             {children}
           </StyledFocusRing>
         )

--- a/packages/react-tinacms-inline/src/inline-form.tsx
+++ b/packages/react-tinacms-inline/src/inline-form.tsx
@@ -51,7 +51,7 @@ export function InlineForm({ form, children }: InlineFormProps) {
       focussedField,
       setFocussedField,
     }
-  }, [form, focussedField])
+  }, [form, focussedField, setFocussedField])
 
   const moveArrayItem = React.useCallback(
     (result: DropResult) => {

--- a/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
@@ -59,10 +59,10 @@ export function InlineGroupControls({
   }, [name, focusRing, focussedField])
 
   const updateFocusedField = (event: any) => {
-    if (active || !name) return
-    setFocussedField(name)
     event.stopPropagation()
     event.preventDefault()
+    if (active || !name) return
+    setFocussedField(name)
   }
 
   if (cms.disabled) {

--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -59,10 +59,10 @@ export const FocusRing = ({ name, options, children }: FocusRingProps) => {
   }, [name, options, focussedField])
 
   const updateFocusedField = (event: React.MouseEvent<HTMLElement>) => {
-    if (active || !name) return
-    setFocussedField(name)
     event.stopPropagation()
     event.preventDefault()
+    if (active || !name) return
+    setFocussedField(name)
   }
 
   return (

--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -35,10 +35,7 @@ export interface StyledFocusRingProps
 
 export interface FocusRingProps {
   name?: string
-  children:
-    | React.ReactChild
-    | React.ReactChild[]
-    | ((active: boolean) => React.ReactChildren)
+  children: React.ReactNode | ((active: boolean) => React.ReactNode)
   options?: boolean | FocusRingOptions
 }
 

--- a/packages/react-tinacms-inline/src/styles/focus-ring.tsx
+++ b/packages/react-tinacms-inline/src/styles/focus-ring.tsx
@@ -35,7 +35,10 @@ export interface StyledFocusRingProps
 
 export interface FocusRingProps {
   name?: string
-  children: React.ReactChild | React.ReactChild[]
+  children:
+    | React.ReactChild
+    | React.ReactChild[]
+    | ((active: boolean) => React.ReactChildren)
   options?: boolean | FocusRingOptions
 }
 
@@ -72,7 +75,7 @@ export const FocusRing = ({ name, options, children }: FocusRingProps) => {
       disableHover={!options || childActive}
       disableChildren={nestedFocus && !active && !childActive}
     >
-      {children}
+      {typeof children === 'function' ? children(active) : children}
     </StyledFocusRing>
   )
 }


### PR DESCRIPTION

![inline-block-perf](https://user-images.githubusercontent.com/15221702/98567903-7c34f080-227e-11eb-870e-66f595a8da55.gif)
_Left: v0.32.0; Right: build of this branch_

### 1. Fixes an event bubbling bug causing WYSIWYG editor to lose focus when nested inside of a block
When an inline field is active, the focus-setting callback would return before `event.stopPropagation` is called, yielding to the parent element which would assign itself focus. This led to a state where focus was constantly toggling back and forth between parent and child fields.

### 2. Skips rendering block menu for blocks that don't have focus
This seems to give a pretty significant performance boost when there are many blocks in a single inline blocks field.

### 3. **Skips rendering ProseMirror editor for `InlineWysiwyg` fields that don't currently have focus**

This PR adds a render-child option to `FocusRing`, enabling conditional rendering of children depending on if the focus ring is currently focused.

```jsx
<FocusRing>
  {active => {
    if (active) {
      return <ComplicatedEditableComponent />
    }
    return <SimpleDisplayComponent />
  }}
</FocusRing>
```

This feature is now used by `InlineWysiwyg` to only render the `Wysiwyg` component when its `FocusRing` is focused, falling back to the component's children when not. In addition to boosting runtime performance when multiple `InlineWysiwyg` components are used on a page, this gives editors a way to preview their content without the WYSIWYG chrome by clicking off of the field to remove focus.