### PR TITLE
feat: Use custom actions in BlocksControls

### DIFF
--- a/packages/demo-next/pages/nesting.tsx
+++ b/packages/demo-next/pages/nesting.tsx
@@ -24,6 +24,7 @@ import {
   InlineBlocks,
   BlocksControls,
 } from 'react-tinacms-inline'
+import { TinaIcon } from '@tinacms/icons'
 import styled from 'styled-components'
 
 import Layout from '../components/Layout'
@@ -256,7 +257,15 @@ const COLORS = {
     },
     Component({ index, data }) {
       return (
-        <BlocksControls index={index}>
+        <BlocksControls
+          index={index}
+          customActions={[
+            {
+              icon: <TinaIcon />,
+              onClick: () => alert('Hello from a custom Block Action!'),
+            },
+          ]}
+        >
           <InlineTextarea name="name" />
           <p>{data.color}</p>
         </BlocksControls>

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -38,11 +38,17 @@ import { InlineFieldContext } from '../inline-field-context'
 import { StyledFocusRing } from '../styles'
 import { FocusRingOptions, getOffset, getOffsetX, getOffsetY } from '../styles'
 
+export interface BlocksControlActionItem {
+  icon: React.ReactNode
+  onClick: React.MouseEventHandler<HTMLElement>
+}
+
 export interface BlocksControlsProps {
   children: React.ReactChild | React.ReactChild[]
   index: number
   insetControls?: boolean
   focusRing?: boolean | FocusRingOptions
+  customActions?: BlocksControlActionItem[]
 }
 
 export function BlocksControls({
@@ -50,6 +56,7 @@ export function BlocksControls({
   index,
   insetControls,
   focusRing = {},
+  customActions = [],
 }: BlocksControlsProps) {
   const cms = useCMS()
   const { focussedField, setFocussedField } = useInlineForm()
@@ -188,6 +195,11 @@ export function BlocksControls({
                       {direction === 'vertical' && <ReorderIcon />}
                       {direction === 'horizontal' && <ReorderRowIcon />}
                     </BlockAction>
+                    {customActions.map((x, i) => (
+                      <BlockAction key={i} onClick={x.onClick}>
+                        {x.icon}
+                      </BlockAction>
+                    ))}
                     <InlineSettings fields={template.fields} />
                     {withinLimit(min) && (
                       <BlockAction onClick={removeBlock}>


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

## Description
Make it possible to use custom Actions in BlocksControls. Usage looks like this:

``` typescript
<BlocksControls
  index={index}
  customActions={[
    {
      icon: <TinaIcon />,
      onClick: () => alert('Hello from a custom Block Action!'),
    },
  ]}
/>
``` 

## Use Cases
This opens a variety of use cases, such as:
- Opening a custom Screen when a custom action is clicked.
- Toggle a `boolean` field value when clicked.