### PR TITLE
Async form improvements

### DIFF
--- a/packages/@tinacms/react-core/src/use-form.ts
+++ b/packages/@tinacms/react-core/src/use-form.ts
@@ -46,7 +46,7 @@ export function useLocalForm<FormShape = any>(
 export function useForm<FormShape = any>(
   { loadInitialValues, ...options }: FormOptions<any>,
   watch: Partial<WatchableFormValue> = {}
-): [FormShape, Form] {
+): [FormShape, Form, boolean] {
   /**
    * `initialValues` will be usually be undefined if `loadInitialValues` is used.
    *
@@ -79,11 +79,19 @@ export function useForm<FormShape = any>(
     [options.id]
   )
 
+  const [formIsLoading, setFormIsLoading] = React.useState(() =>
+    loadInitialValues ? true : false
+  )
   React.useEffect(() => {
     if (loadInitialValues) {
-      loadInitialValues().then((values: any) => {
-        form.updateInitialValues(values)
-      })
+      setFormIsLoading(true)
+      loadInitialValues()
+        .then((values: any) => {
+          form.updateInitialValues(values)
+        })
+        .finally(() => {
+          setFormIsLoading(false)
+        })
     }
   }, [form])
 
@@ -91,7 +99,7 @@ export function useForm<FormShape = any>(
   useUpdateFormLabel(form, watch.label)
   useUpdateFormValues(form, watch.values)
 
-  return [form ? form.values : options.initialValues, form]
+  return [form ? form.values : options.initialValues, form, formIsLoading]
 }
 
 function createForm(options: FormOptions<any>, handleChange: any): Form {

--- a/packages/gatsby-tinacms-git/src/use-git-form.ts
+++ b/packages/gatsby-tinacms-git/src/use-git-form.ts
@@ -33,7 +33,7 @@ export function useGitForm<N extends GitNode>(
   node: N,
   options: GitFormOptions<N>,
   watch: WatchableFormValue
-): [N, Form] {
+): [N, Form, boolean] {
   const cms = useCMS()
   const { format, parse, ...config } = options
   const gitFile = useGitFile(node.fileRelativePath, format, parse)

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -208,6 +208,9 @@ export class GithubClient {
       type: CHECKOUT_BRANCH,
       branchName: branch,
     })
+    this.events.dispatch({
+      type: 'unstable:reload-form-data',
+    })
   }
 
   async fetchExistingPR() {

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -203,6 +203,8 @@ export class GithubClient {
    * @deprecated Call GithubClient#checkout instead
    */
   setWorkingBranch(branch: string) {
+    if (this.branchName === branch) return
+
     this.setCookie(GithubClient.HEAD_BRANCH_COOKIE_KEY, branch)
     this.events.dispatch({
       type: CHECKOUT_BRANCH,

--- a/packages/react-tinacms-inline/src/inline-group/inline-group.test.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group.test.tsx
@@ -20,39 +20,36 @@ import { render, screen } from '@testing-library/react'
 import * as React from 'react'
 import { InlineGroup } from '.'
 import { InlineForm, InlineText } from '../'
-import { TinaProvider, TinaCMS, useForm } from 'tinacms'
+import { withTina, useForm } from 'tinacms'
 
 describe('Inline Group', () => {
-  const cms = new TinaCMS({
-    enabled: true,
-    toolbar: {
-      buttons: {
-        save: 'inline-group-test-save',
-        reset: 'reset',
-      },
-    },
-  })
-
-  const Wrapper = ({ children }: { children: React.ReactElement }) => {
-    const [, form] = useForm({
-      id: 'test-inline-group',
-      label: 'inline group',
-      initialValues: {
-        parent: {
-          child: {
-            child_text: 'inline group text test',
+  const Wrapper = withTina(
+    ({ children }: { children: React.ReactElement }) => {
+      const [, form] = useForm({
+        id: 'test-inline-group',
+        label: 'inline group',
+        initialValues: {
+          parent: {
+            child: {
+              child_text: 'inline group text test',
+            },
           },
         },
-      },
-      onSubmit: () => {},
-    })
+        onSubmit: () => {},
+      })
 
-    return (
-      <TinaProvider cms={cms}>
-        <InlineForm form={form}>{children}</InlineForm>
-      </TinaProvider>
-    )
-  }
+      return <InlineForm form={form}>{children}</InlineForm>
+    },
+    {
+      enabled: true,
+      toolbar: {
+        buttons: {
+          save: 'inline-group-test-save',
+          reset: 'reset',
+        },
+      },
+    }
+  )
 
   it('renders children', () => {
     render(


### PR DESCRIPTION
before:

```js
const [data, form] = useForm({
  //...
  loadInitialValues: async () => { await doSomething() },
})

return form.loading ? <Spinner /> : <Page data={data} />
```

This wouldn't correctly subscribe to the form loading state. With this PR, `useForm` has been updated to track its loading state in a `useState` under the hood, which is more idiomatic:

```js
const [data, form, formIsLoading] = useForm({
  //...
  loadInitialValues: async () => { await doSomething() },
})

return formIsLoading ? <Spinner /> : <Page data={data} />
```

also includes some other fixes involving workflows with loadInitialValues

potential fix for #1551 

Note this also **creates a new event** — `unstable:reload-form-data` that fires on branch switch. This is helpful for pages that fetch data client-side or don't fully refresh when switching branches. In `useForm`, the form is reloaded & reset when this event dispatches. 


---
- [x] Docs