### PR TITLE
style: fix inline add block z-index bug

### DIFF
--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -205,7 +205,7 @@ const AddBlockWrapper = styled.div<AddBlockWrapperProps>(p => {
 
   ${p.isOpen &&
     css`
-      z-index: calc(1 + var(--tina-z-index-2) - ${p.index ? p.index : 0});
+      z-index: calc(1 + var(--tina-z-index-3) - ${p.index ? p.index : 0});
     `}
 `
 })


### PR DESCRIPTION
This fixes the bug where the add block menu was opening below the focus ring and other add block buttons.

<img width="522" alt="Screen Shot 2020-11-18 at 12 57 14 PM" src="https://user-images.githubusercontent.com/5075484/99561668-974de180-299d-11eb-96c4-1a60df5064e7.png">
