### PR TITLE
Require confirmation before running release

### DIFF
--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -3,6 +3,10 @@
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
 
+# 0. Ensure no uncommitted changes
+source $(dirname $0)/require_clean_work_tree.sh
+require_clean_work_tree
+
 # 1. Checkout Matser
 git checkout master
 git pull

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,6 +3,14 @@
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
 
+# 0. Confirm Action
+read -p "Are you sure you wish to create a new release? Type the word 'release' to confirm: "
+if [[ ! $REPLY =~ ^release$ ]]
+then
+  echo "release canceled."
+  exit 1
+fi
+
 # 1. Update Matser
 git checkout master
 git pull

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -33,10 +33,10 @@ require_clean_work_tree () {
 set -e
 
 # 0.1. Confirm Action
-read -p "Are you sure you wish to create a new release? Type the word 'release' to confirm: "
+read -p "Create a new release? Type the word 'release' to confirm: "
 if [[ ! $REPLY =~ ^release$ ]]
 then
-  echo "release canceled."
+  echo "Release canceled."
   exit 1
 fi
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,36 +1,9 @@
 #!/bin/bash
 
-require_clean_work_tree () {
-    # Update the index
-    git update-index -q --ignore-submodules --refresh
-    err=0
-
-    # Disallow unstaged changes in the working tree
-    if ! git diff-files --quiet --ignore-submodules --
-    then
-        echo >&2 "cannot $1: you have unstaged changes."
-        git diff-files --name-status -r --ignore-submodules -- >&2
-        err=1
-    fi
-
-    # Disallow uncommitted changes in the index
-    if ! git diff-index --cached --quiet HEAD --ignore-submodules --
-    then
-        echo >&2 "cannot $1: your index contains uncommitted changes."
-        git diff-index --cached --name-status -r --ignore-submodules HEAD -- >&2
-        err=1
-    fi
-
-    if [ $err = 1 ]
-    then
-        echo >&2 "Please commit or stash them."
-        exit 1
-    fi
-}
-
-
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
+
+source $(dirname $0)/require_clean_work_tree.sh
 
 # 0.1. Confirm Action
 read -p "Create a new release? Type the word 'release' to confirm: "

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,15 +1,47 @@
 #!/bin/bash
 
+require_clean_work_tree () {
+    # Update the index
+    git update-index -q --ignore-submodules --refresh
+    err=0
+
+    # Disallow unstaged changes in the working tree
+    if ! git diff-files --quiet --ignore-submodules --
+    then
+        echo >&2 "cannot $1: you have unstaged changes."
+        git diff-files --name-status -r --ignore-submodules -- >&2
+        err=1
+    fi
+
+    # Disallow uncommitted changes in the index
+    if ! git diff-index --cached --quiet HEAD --ignore-submodules --
+    then
+        echo >&2 "cannot $1: your index contains uncommitted changes."
+        git diff-index --cached --name-status -r --ignore-submodules HEAD -- >&2
+        err=1
+    fi
+
+    if [ $err = 1 ]
+    then
+        echo >&2 "Please commit or stash them."
+        exit 1
+    fi
+}
+
+
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
 
-# 0. Confirm Action
+# 0.1. Confirm Action
 read -p "Are you sure you wish to create a new release? Type the word 'release' to confirm: "
 if [[ ! $REPLY =~ ^release$ ]]
 then
   echo "release canceled."
   exit 1
 fi
+
+#0.2. Ensure no uncommitted changes
+require_clean_work_tree
 
 # 1. Update Matser
 git checkout master

--- a/scripts/require_clean_work_tree.sh
+++ b/scripts/require_clean_work_tree.sh
@@ -1,0 +1,28 @@
+
+require_clean_work_tree () {
+    # Update the index
+    git update-index -q --ignore-submodules --refresh
+    err=0
+
+    # Disallow unstaged changes in the working tree
+    if ! git diff-files --quiet --ignore-submodules --
+    then
+        echo >&2 "cannot $1: you have unstaged changes."
+        git diff-files --name-status -r --ignore-submodules -- >&2
+        err=1
+    fi
+
+    # Disallow uncommitted changes in the index
+    if ! git diff-index --cached --quiet HEAD --ignore-submodules --
+    then
+        echo >&2 "cannot $1: your index contains uncommitted changes."
+        git diff-index --cached --name-status -r --ignore-submodules HEAD -- >&2
+        err=1
+    fi
+
+    if [ $err = 1 ]
+    then
+        echo >&2 "Please commit or stash them."
+        exit 1
+    fi
+}


### PR DESCRIPTION
Whenever I run a prerelease I panic for 3 seconds and double check to make sure I ran the prerelease script and not the release script.

This PR does two things:

1. ensures there are no uncommitted or unstaged changes in the working tree before running a release or prerelease, and
2. requires a manual confirmation before running a release (to ensure it isn't run by mistake when intending to create a prerelease.)