### PR TITLE
feat(react-tinacms-inline): Adds Block Label

### DIFF
--- a/packages/demo-next/pages/nesting.tsx
+++ b/packages/demo-next/pages/nesting.tsx
@@ -158,6 +158,9 @@ export default function Nesting() {
               }}
               insetControls={true}
             >
+              <h2>Author</h2>
+              <InlineText name="name" focusRing={false} />
+              <p>{values.author.description}</p>
               <InlineBlocks name="colors" blocks={COLORS} />
             </InlineGroup>
           </div>

--- a/packages/demo-next/pages/nesting.tsx
+++ b/packages/demo-next/pages/nesting.tsx
@@ -158,9 +158,6 @@ export default function Nesting() {
               }}
               insetControls={true}
             >
-              <h2>Author</h2>
-              <InlineText name="name" focusRing={false} />
-              <p>{values.author.description}</p>
               <InlineBlocks name="colors" blocks={COLORS} />
             </InlineGroup>
           </div>
@@ -367,7 +364,7 @@ const HEADING = {
       <>
         <BlocksControls index={index}>
           <h3 className="block-heading">
-            <InlineTextarea name="text" />
+            <InlineTextarea name="text" focusRing={false} />
           </h3>
         </BlocksControls>
         <style jsx>
@@ -397,7 +394,7 @@ const PARAGRAPH = {
       <>
         <BlocksControls index={index}>
           <p className="block-paragraph">
-            <InlineTextarea name="text" />
+            <InlineTextarea name="text" focusRing={false} />
           </p>
         </BlocksControls>
         <style jsx>

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -283,6 +283,7 @@ interface BlocksControlsProps {
   index: number
   insetControls?: boolean
   focusRing?: false | FocusRingProps
+  label?: boolean
   children: React.ReactChild
 }
 
@@ -297,6 +298,7 @@ interface FocusRingProps {
 | `index`         | The index of the block associated with these controls.                                                                                                                                                                                                                                                                             |
 | `insetControls` | A boolean to denote whether the group controls display within or outside the group.                                                                                                                                                                                                                                                |
 | `focusRing`     | Either an object to style the focus ring or `false`, which hides the focus ring entirely. For styles, `offset` (in pixels) controls the distance from the ring to the edge of the group; `borderRadius`(in pixels) controls the [rounding](https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius) edge of the focus ring. |
+| `label`     | A boolean to control whether or not a block label is rendered.              |
 | `children`      | Any child components, typically inline field(s).                                                                                                                                                                                                                                                                                   |
 
 

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -42,6 +42,7 @@ export interface BlocksControlsProps {
   children: React.ReactChild | React.ReactChild[]
   index: number
   insetControls?: boolean
+  label?: boolean
   focusRing?: boolean | FocusRingOptions
 }
 
@@ -49,6 +50,7 @@ export function BlocksControls({
   children,
   index,
   insetControls,
+  label = true,
   focusRing = {},
 }: BlocksControlsProps) {
   const cms = useCMS()
@@ -140,9 +142,15 @@ export function BlocksControls({
             disableHover={focusRing === false ? true : childIsActive}
             disableChildren={!isActive && !childIsActive}
           >
-            <BlockLabel offset={offset} inset={insetControls} active={isActive}>
-              {template.label}
-            </BlockLabel>
+            {label && (
+              <BlockLabel
+                offset={offset}
+                inset={insetControls}
+                active={isActive}
+              >
+                {template.label}
+              </BlockLabel>
+            )}
             {isActive ? (
               <>
                 {withinLimit(max) && (

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -142,15 +142,6 @@ export function BlocksControls({
             disableHover={focusRing === false ? true : childIsActive}
             disableChildren={!isActive && !childIsActive}
           >
-            {label && (
-              <BlockLabel
-                offset={offset}
-                inset={insetControls}
-                active={isActive}
-              >
-                {template.label}
-              </BlockLabel>
-            )}
             {isActive ? (
               <>
                 {withinLimit(max) && (
@@ -178,6 +169,8 @@ export function BlocksControls({
                   active={isActive}
                   inset={insetControls}
                 >
+                  {label && <BlockLabel>{template.label}</BlockLabel>}
+                  <BlockMenuSpacer></BlockMenuSpacer>
                   <BlockMenu>
                     <BlockAction
                       ref={blockMoveUpRef}
@@ -249,8 +242,12 @@ export const BlockMenuWrapper = styled.div<BlockMenuWrapperProps>(p => {
   const offset = getOffset(p.offset)
   return css`
     position: absolute;
+    display: flex;
+    align-items: stretch;
+    justify-content: space-between;
     top: calc(-1 * ${getOffsetY(offset)}px - 16px);
     right: calc(-1 * ${getOffsetX(offset)}px - 1px);
+    left: calc(-1 * ${getOffsetX(offset)}px - 1px);
     opacity: 0;
     transition: all var(--tina-timing-medium) ease-out;
     z-index: calc(var(--tina-z-index-1) - ${p.index ? p.index : 0});
@@ -272,50 +269,25 @@ export const BlockMenuWrapper = styled.div<BlockMenuWrapperProps>(p => {
   `
 })
 
-interface BlockLabelProps {
-  active: boolean
-  inset?: boolean
-  offset?: number | { x: number; y: number }
-}
+export const BlockMenuSpacer = styled.div`
+  flex: 1 1 auto;
+`
 
-export const BlockLabel = styled.div<BlockLabelProps>(p => {
-  const offset = getOffset(p.offset)
-  return css`
-    position: absolute;
-    display: flex;
-    align-items: center;
-    top: calc(-1 * ${getOffsetY(offset)}px - 16px);
-    left: calc(-1 * ${getOffsetX(offset)}px - 1px);
-    opacity: 0;
-    transition: all var(--tina-timing-medium) ease-out;
-    z-index: var(--tina-z-index-1);
-    pointer-events: none;
-    transform: translate3d(0, -100%, 0);
-    font-family: var(--tina-font-family);
-    font-size: var(--tina-font-size-1);
-    background-color: white;
-    border-radius: var(--tina-radius-small);
-    box-shadow: var(--tina-shadow-big);
-    border: 1px solid var(--tina-color-grey-2);
-    padding: 0 var(--tina-padding-small);
-    color: var(--tina-color-grey-8);
-    font-weight: 500;
-    height: 36px;
-
-    ${p.inset &&
-      css`
-        top: calc(14px - ${getOffsetY(offset)}px);
-        right: calc(14px - ${getOffsetX(offset)}px);
-        transform: translate3d(0, 0, 0);
-      `}
-
-    ${p.active &&
-      css`
-        opacity: 1;
-        pointer-events: all;
-      `}
-  `
-})
+export const BlockLabel = styled.div`
+  display: flex;
+  align-items: center;
+  z-index: var(--tina-z-index-1);
+  pointer-events: none;
+  font-family: var(--tina-font-family);
+  font-size: var(--tina-font-size-1);
+  background-color: white;
+  border-radius: var(--tina-radius-small);
+  box-shadow: var(--tina-shadow-big);
+  border: 1px solid var(--tina-color-grey-2);
+  padding: 0 var(--tina-padding-small);
+  color: var(--tina-color-grey-8);
+  font-weight: 500;
+`
 
 export const BlockMenu = styled.div`
   display: flex;

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -270,11 +270,12 @@ export const BlockMenuWrapper = styled.div<BlockMenuWrapperProps>(p => {
 })
 
 export const BlockMenuSpacer = styled.div`
-  flex: 1 1 auto;
+  flex: 1 0 var(--tina-padding-small);
 `
 
 export const BlockLabel = styled.div`
   display: flex;
+  flex: 0 0 auto;
   align-items: center;
   z-index: var(--tina-z-index-1);
   pointer-events: none;
@@ -291,6 +292,7 @@ export const BlockLabel = styled.div`
 
 export const BlockMenu = styled.div`
   display: flex;
+  flex: 0 0 auto;
   flex-direction: row;
   position: relative;
   top: 0;

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -140,6 +140,9 @@ export function BlocksControls({
             disableHover={focusRing === false ? true : childIsActive}
             disableChildren={!isActive && !childIsActive}
           >
+            <BlockLabel offset={offset} inset={insetControls} active={isActive}>
+              {template.label}
+            </BlockLabel>
             {isActive ? (
               <>
                 {withinLimit(max) && (
@@ -216,7 +219,7 @@ interface AddBlockMenuWrapperProps {
 const AddBlockMenuWrapper = styled.div<AddBlockMenuWrapperProps>(
   p => css`
     opacity: 0;
-    transition: all 120ms ease-out;
+    transition: all var(--tina-timing-medium) ease-out;
     pointer-events: none;
 
     ${p.active &&
@@ -238,13 +241,58 @@ export const BlockMenuWrapper = styled.div<BlockMenuWrapperProps>(p => {
   const offset = getOffset(p.offset)
   return css`
     position: absolute;
-    top: calc(-${getOffsetY(offset)}px - 16px);
-    right: calc(-${getOffsetX(offset)}px - 1px);
+    top: calc(-1 * ${getOffsetY(offset)}px - 16px);
+    right: calc(-1 * ${getOffsetX(offset)}px - 1px);
     opacity: 0;
-    transition: all 120ms ease-out;
+    transition: all var(--tina-timing-medium) ease-out;
     z-index: calc(var(--tina-z-index-1) - ${p.index ? p.index : 0});
     pointer-events: none;
     transform: translate3d(0, -100%, 0);
+
+    ${p.inset &&
+      css`
+        top: calc(14px - ${getOffsetY(offset)}px);
+        right: calc(14px - ${getOffsetX(offset)}px);
+        transform: translate3d(0, 0, 0);
+      `}
+
+    ${p.active &&
+      css`
+        opacity: 1;
+        pointer-events: all;
+      `}
+  `
+})
+
+interface BlockLabelProps {
+  active: boolean
+  inset?: boolean
+  offset?: number | { x: number; y: number }
+}
+
+export const BlockLabel = styled.div<BlockLabelProps>(p => {
+  const offset = getOffset(p.offset)
+  return css`
+    position: absolute;
+    display: flex;
+    align-items: center;
+    top: calc(-1 * ${getOffsetY(offset)}px - 16px);
+    left: calc(-1 * ${getOffsetX(offset)}px - 1px);
+    opacity: 0;
+    transition: all var(--tina-timing-medium) ease-out;
+    z-index: var(--tina-z-index-1);
+    pointer-events: none;
+    transform: translate3d(0, -100%, 0);
+    font-family: var(--tina-font-family);
+    font-size: var(--tina-font-size-1);
+    background-color: white;
+    border-radius: var(--tina-radius-small);
+    box-shadow: var(--tina-shadow-big);
+    border: 1px solid var(--tina-color-grey-2);
+    padding: 0 var(--tina-padding-small);
+    color: var(--tina-color-grey-8);
+    font-weight: 500;
+    height: 36px;
 
     ${p.inset &&
       css`

--- a/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
+++ b/packages/react-tinacms-inline/src/inline-group/inline-group-controls.tsx
@@ -24,6 +24,7 @@ import { InlineFieldContext } from '../inline-field-context'
 import {
   BlockMenu,
   BlockMenuWrapper,
+  BlockMenuSpacer,
 } from '../blocks/inline-block-field-controls'
 import { FocusRingOptions, StyledFocusRing } from '../styles'
 import { useInlineForm } from '..'
@@ -85,6 +86,7 @@ export function InlineGroupControls({
         inset={insetControls}
         active={active}
       >
+        <BlockMenuSpacer></BlockMenuSpacer>
         <BlockMenu>
           <InlineSettings fields={fields} />
         </BlockMenu>


### PR DESCRIPTION
Adds a block label for inline blocks which appears opposite the blocks controls. This label uses the 'label' from the block template. `BlocksControls` now accepts a 'label' prop (boolean) to disable the label when it's not needed. The label is displayed by default.

I'd like to see what people think of this label design. I also tried a smaller blue label joined to the focus ring and also putting the label alongside the other blocks controls. This seemed to be the better option. 

It probably makes sense to add this to inline groups but they don't have an easy label option like `template.label` used by inline blocks.

[Docs PR](https://github.com/tinacms/tinacms.org/pull/761)

![Inline Block Label](https://user-images.githubusercontent.com/5075484/100667771-51940000-3331-11eb-9311-7d2d93e5da1f.gif)

Here's what happens on blocks that are smaller than the width of the controls:

<img width="346" alt="Screen Shot 2020-12-01 at 10 45 00 AM" src="https://user-images.githubusercontent.com/5075484/100755172-44732180-33c2-11eb-9457-0d6be1b129d1.png">


Thanks @chrisdmacrae for coming up with and trying out this solution. 