### PR TITLE
Fix GitHub onlogin

### DIFF
--- a/packages/react-tinacms-github/README.md
+++ b/packages/react-tinacms-github/README.md
@@ -385,6 +385,7 @@ The `GithubClient` defines several events:
 | `github:commit` | A commit has been made to a file. |
 | `github:error` | An error was encountered when interacting with the GitHub API. |
 | `github:branch:checkout` | The client switched to a new branch. |
+| `github:checkout` | The client switched to a new branch, or switched to a fork. |
 | `github:branch:create` | A new branch was created in GitHub. |
 
 ### Alerts
@@ -392,4 +393,4 @@ The `GithubClient` defines several events:
 | Event | Level |  Default Message |
 | --- | --- | --- |
 | `github:commit` | Success | `Saved Successfully: Changes committed to {repo}` |
-| `github:branch:checkout` | Info | `Switched to branch {name}`|
+| `github:checkout` | Info | `Switched to branch {name} [on repo {repo}]`|

--- a/packages/react-tinacms-github/src/events.ts
+++ b/packages/react-tinacms-github/src/events.ts
@@ -19,4 +19,5 @@ limitations under the License.
 export const COMMIT = 'github:commit'
 export const ERROR = 'github:error'
 export const CHECKOUT_BRANCH = 'github:branch:checkout'
+export const CHECKOUT = 'github:checkout'
 export const CREATE_BRANCH = 'github:branch:create'

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -20,7 +20,13 @@ import Cookies from 'js-cookie'
 import { authenticate } from './authenticate'
 import { EventsToAlerts } from '@tinacms/alerts'
 export * from './authenticate'
-import { CHECKOUT_BRANCH, COMMIT, CREATE_BRANCH, ERROR } from '../events'
+import {
+  CHECKOUT,
+  CHECKOUT_BRANCH,
+  COMMIT,
+  CREATE_BRANCH,
+  ERROR,
+} from '../events'
 import { b64EncodeUnicode } from './base64'
 import { EventBus } from '@tinacms/core'
 
@@ -180,6 +186,7 @@ export class GithubClient {
   checkout(branch: string, repo?: string) {
     if (repo) this.setWorkingRepoFullName(repo)
     this.setWorkingBranch(branch)
+    this.events.dispatch({ type: CHECKOUT, branchName: branch, repoName: repo })
   }
 
   /**

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -152,7 +152,7 @@ export class GithubClient {
       method: 'POST',
     })
 
-    this.setCookie(GithubClient.WORKING_REPO_COOKIE_KEY, fork.full_name)
+    this.checkout(fork.full_name)
 
     return fork
   }

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -187,8 +187,18 @@ export class GithubClient {
   }
 
   checkout(branch: string, repo?: string) {
-    if (repo) this.setWorkingRepoFullName(repo)
+    if (
+      this.branchName === branch &&
+      (!repo || this.baseRepoFullName === repo)
+    ) {
+      return
+    }
+
+    if (repo) {
+      this.setWorkingRepoFullName(repo)
+    }
     this.setWorkingBranch(branch)
+
     this.events.dispatch({ type: CHECKOUT, branchName: branch, repoName: repo })
   }
 
@@ -213,8 +223,6 @@ export class GithubClient {
    * @deprecated Call GithubClient#checkout instead
    */
   setWorkingBranch(branch: string) {
-    if (this.branchName === branch) return
-
     this.setCookie(GithubClient.HEAD_BRANCH_COOKIE_KEY, branch)
     this.events.dispatch({
       type: CHECKOUT_BRANCH,

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -200,6 +200,9 @@ export class GithubClient {
     this.setWorkingBranch(branch)
 
     this.events.dispatch({ type: CHECKOUT, branchName: branch, repoName: repo })
+    this.events.dispatch({
+      type: 'unstable:reload-form-data',
+    })
   }
 
   /**
@@ -227,9 +230,6 @@ export class GithubClient {
     this.events.dispatch({
       type: CHECKOUT_BRANCH,
       branchName: branch,
-    })
-    this.events.dispatch({
-      type: 'unstable:reload-form-data',
     })
   }
 

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -65,9 +65,12 @@ export class GithubClient {
       level: 'success',
       message: `Saved Successfully: Changes committed to ${this.workingRepoFullName}`,
     }),
-    [CHECKOUT_BRANCH]: event => ({
+    [CHECKOUT]: event => ({
       level: 'info',
-      message: 'Switched to branch ' + event.branchName,
+      message:
+        'Switched to branch ' + event.branchName + event.repoName
+          ? ' on repo ' + event.repoName
+          : '',
     }),
     [ERROR]: event => ({
       level: 'error',

--- a/packages/react-tinacms-github/src/github-client/github-client.ts
+++ b/packages/react-tinacms-github/src/github-client/github-client.ts
@@ -189,7 +189,7 @@ export class GithubClient {
   checkout(branch: string, repo?: string) {
     if (
       this.branchName === branch &&
-      (!repo || this.baseRepoFullName === repo)
+      (!repo || this.workingRepoFullName === repo)
     ) {
       return
     }

--- a/packages/react-tinacms-github/src/github-editing-context/TinacmsGithubProvider.tsx
+++ b/packages/react-tinacms-github/src/github-editing-context/TinacmsGithubProvider.tsx
@@ -21,7 +21,7 @@ import { TinaCMS, useCMS } from 'tinacms'
 import GithubErrorModal, { GithubError } from '../github-error/GithubErrorModal'
 import { CreateForkModal, GithubAuthenticationModal } from './GithubAuthModal'
 import { GithubClient } from '../github-client'
-import { CHECKOUT_BRANCH, ERROR } from '../events'
+import { ERROR } from '../events'
 import { useCMSEvent } from 'tinacms'
 
 interface ProviderProps {
@@ -63,6 +63,7 @@ export const TinacmsGithubProvider = ({
     if (await github.isAuthorized()) {
       github.checkout(github.branchName, github.baseRepoFullName)
       setActiveModal(null)
+      onLogin()
     } else {
       setActiveModal('createFork')
     }
@@ -70,7 +71,6 @@ export const TinacmsGithubProvider = ({
 
   useCMSEvent(TinaCMS.ENABLED.type, beginAuth, [])
   useCMSEvent(TinaCMS.DISABLED.type, onLogout, [])
-  useCMSEvent(CHECKOUT_BRANCH, onLogin, [])
   useCMSEvent(ERROR, ({ error }: any) => setError(error), [])
 
   return (


### PR DESCRIPTION
fixes #1647 

onLogin being tied to `github:branch:checkout` only makes sense if your onLogin code does certain things (like in the open authoring guide and on tinacms.org, where it activates preview mode and reloads the page.)

This PR removes that subscription and calls it explicitly after authorization instead. We will publish an upgrade guide with this release explaining the change.

If you want to continue using onLogin with the previous behavior, subscribe to `github:branch:checkout` or, more correctly, the new `github:checkout` event instead. Example: https://github.com/tinacms/tinacms.org/pull/763/files?file-filters%5B%5D=.tsx#diff-a9827ce1be32c607c948881a89b99c592f752898f9c49e0dea0b7199eb151029