### PR TITLE
fix(react-tinacms-github): Fix types for form hooks

### DIFF
--- a/packages/react-tinacms-github/src/form/useGithubFileForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubFileForm.ts
@@ -19,21 +19,22 @@ limitations under the License.
 import { GitFile } from './useGitFileSha'
 import { useForm, FormOptions } from 'tinacms'
 import { useGithubFile } from '../github-client'
+import { Form } from '@tinacms/forms'
 
-export interface GithubFormOptions extends Partial<FormOptions<any>> {
+export interface GithubFormOptions <T = any> extends Partial<FormOptions<T>> {
   serialize: (data: any) => string
 }
 
 export const useGithubFileForm = <T = any>(
   file: GitFile<T>,
-  options: GithubFormOptions
-) => {
+  options: GithubFormOptions<T>
+): [T, Form] => {
   const githubFile = useGithubFile({
     path: file.fileRelativePath,
     serialize: options.serialize,
   })
 
-  const [formData, form] = useForm({
+  const [formData, form] = useForm<T>({
     id: file.fileRelativePath,
     label: options.label || file.fileRelativePath,
     initialValues: file.data,

--- a/packages/react-tinacms-github/src/form/useGithubJsonForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubJsonForm.ts
@@ -20,19 +20,19 @@ import { FormOptions, Field } from 'tinacms'
 import { GitFile } from './useGitFileSha'
 import { useGithubFileForm } from './useGithubFileForm'
 
-interface Options {
+interface Options<T = any> {
   id?: string
   label?: string
   fields?: Field[]
-  actions?: FormOptions<any>['actions']
+  actions?: FormOptions<T>['actions']
 }
 
 const serialize = (formData: any) => {
   return JSON.stringify(formData, null, 2)
 }
 
-export function useGithubJsonForm(jsonFile: GitFile, formOptions?: Options) {
-  return useGithubFileForm(jsonFile, {
+export function useGithubJsonForm<T = any>(jsonFile: GitFile<T>, formOptions?: Options<T>) {
+  return useGithubFileForm<T>(jsonFile, {
     ...formOptions,
     serialize,
   })

--- a/packages/react-tinacms-github/src/form/useGithubMarkdownForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubMarkdownForm.ts
@@ -20,18 +20,18 @@ import { FormOptions, Field } from 'tinacms'
 import { GitFile } from './useGitFileSha'
 import { toMarkdownString } from 'next-tinacms-markdown'
 import { useGithubFileForm } from './useGithubFileForm'
-interface Options {
+interface Options<T = any> {
   id?: string
   label?: string
   fields?: Field[]
-  actions?: FormOptions<any>['actions']
+  actions?: FormOptions<T>['actions']
 }
 
-export function useGithubMarkdownForm(
-  markdownFile: GitFile,
-  formOptions?: Options
+export function useGithubMarkdownForm<T = any>(
+  markdownFile: GitFile<T>,
+  formOptions?: Options<T>
 ) {
-  return useGithubFileForm(markdownFile, {
+  return useGithubFileForm<T>(markdownFile, {
     ...formOptions,
     serialize: toMarkdownString,
   })


### PR DESCRIPTION
Before this commit, the return type of `useGithubFileForm` (and transitively of `useGithubJsonForm` & `useGithubMarkdownForm`) was `[any, any]`. 
Now it is `[T, Form]`, where `T` is the generic type parameter describing the shape of the parsed file data.

Also, `useGithubJsonForm` & `useGithubMardownForm` didn't **have** that type parameter `T` (describing the shape of the parsed file data), and where it could be used, an implicit `any` was used instead. 
Now they have that type parameter, defaulted to `any`, so that it may be something more specific than `any`, either by explicit definition, or by inference from argument types.
This same problem existed in options interfaces for all 3 hooks, and I applied the same solution.

Thanks for your work on this awesome project :)
