### PR TITLE
react-tinacms-github: Allow creating new file by saving form

### DIFF
--- a/packages/react-tinacms-github/src/github-client/GithubFile.ts
+++ b/packages/react-tinacms-github/src/github-client/GithubFile.ts
@@ -45,11 +45,20 @@ export class GithubFile {
     retryOnConflict = true
   ) => {
     const serializedContent = this.serialize ? this.serialize(data) : data
-    try {
-      if (!this.sha) {
+    if (!this.sha) {
+      try {
         const res = await this.cms.api.github.fetchFile(this.path)
         this.sha = res.sha
+      } catch (error) {
+        if (error.status === 404) {
+          this.sha = ''
+        } else {
+          this.cms.events.dispatch({ type: ERROR, error })
+          throw error
+        }
       }
+    }
+    try {
       const response = await this.cms.api.github.commit(
         this.path,
         this.sha,

--- a/packages/react-tinacms-github/src/github-error/github-interpeter.ts
+++ b/packages/react-tinacms-github/src/github-error/github-interpeter.ts
@@ -90,7 +90,7 @@ export const getModalProps = async (
       }
 
       // Does the branch exist?
-      if (await githubClient.getBranch()) {
+      if (!(await githubClient.getBranch())) {
         return {
           title: 'Missing Branch ',
           message: 'The branch that you were editing has been deleted. Press.',


### PR DESCRIPTION
I want to be able to save a new file to GitHub with a form plugin.
I figured I should be able to initialize the form (i.e. use `useGithubJsonForm`) with an empty `GitFile` (e.g. `{ fileRelativePath: "content/offerings/${slug}.json", data: {}, sha: "" }` when the file doesn't exist yet, and clicking "Save" in that form should make a commit **creating** that file (instead of updating a preexisting file).

The first part works.. I can initialize the form with an empty file.
The problem comes when trying to save the form:

First off, I received a wrong error message in the browser, saying I was on a branch that doesn't exist. (I was on a branch that did in fact exist). With my first commit 7e3ba86 I fixed this, to show the [more] correct error message, "Content Not Found". 
I think that commit is self-explanatory, so if I didn't explain well, please just look at it.

Second, I traced what was actually causing the error, and I found that it was a 404 not found error when trying to _retrieve_ that file (which didn't exist yet) from GitHub.
This request (to _retrieve_ the file from Github) happens when no `sha` is present, since the `sha` is required by GitHub API _when updating an existing file_. The request is just to get the `sha` of the file.
When the file is not found, instead of erroring, we should just continue with no `sha`, since in this case we know we must be **creating** (not updating) a file, and a `sha` does not apply (and is not expected by GitHub API) when creating a file.
I made this change with my second commit d13eb76.

With these changes was able to accomplish what I described in the first paragraph. I tested by publishing forked versions of react-tinacms-github and next-tinacms-github as [@zen_flow/react-tinacms-github](https://www.npmjs.com/package/@zen_flow/react-tinacms-github) and [@zen_flow/next-tinacms-github](https://www.npmjs.com/package/@zen_flow/react-tinacms-github).

Thanks!
 