### PR TITLE
Suggested trick for pushing menu below toolbar

### DIFF
--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -191,6 +191,14 @@ Alternatively you can pass a string to set the exact offset of the menu.
 </InlineWysiwyg>
 ```
 
+If you're using Tina's toolbar, you can pass 'var(--tina-toolbar-height)' to ensure the toolbar does not cover the WYSIWYG menu.
+
+```jsx
+<InlineWysiwyg name="markdownBody" format="markdown" sticky="var(--tina-toolbar-height)">
+  <ReactMarkdown source={data.markdownBody} />
+</InlineWysiwyg>
+```
+
 ### Dynamic Imports
 
 The `react-tinacms-editor` is a large package so it is recommended that you make sure it's only being loaded when necessary. The example below will make sure that the editor is only loaded _if_ the CMS is actually enabled, saving the visistors to your website from the extra load time.


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

By default, Tina's toolbar will hide the WYSIWYG menu bar. As the `sticky` prop accepts a string, it also accepts CSS variables, such as the one used by Tina to determine toolbar height.

This means that editors can pass `var(--tina-toolbar-height)` to `sticky` to ensure the WYSIWYG menu is always visible, even in an environment where Tina's toolbar is displaying. It might be worth considering this as default behaviour whenever the toolbar is enabled in case sticky is not set explicitly. If this is seen as a good idea, I can create a PR for it.
