### PR TITLE
fix(@tinacms/react-sidebar): fixed site elements relative to SiteWrapper

### DIFF
--- a/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
@@ -138,8 +138,8 @@ const SidebarGlobalStyles = createGlobalStyle`
 
 const SiteWrapper = styled.div<{ open: boolean }>`
   @media (min-width: 840px) {
-    padding-left: ${props => (props.open ? 'var(--tina-sidebar-width)' : '0')};
-    transition: padding-left 150ms ease-out;
+    margin-left: ${props => (props.open ? 'var(--tina-sidebar-width)' : '0')};
+    transition: margin-left 150ms ease-out;
     transform: translate(0);
   }
 `

--- a/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
@@ -140,6 +140,7 @@ const SiteWrapper = styled.div<{ open: boolean }>`
   @media (min-width: 840px) {
     padding-left: ${props => (props.open ? 'var(--tina-sidebar-width)' : '0')};
     transition: padding-left 150ms ease-out;
+    transform: translate(0);
   }
 `
 


### PR DESCRIPTION
Currently, elements in host site that are fixed (like navigation bars) are underneath the Tina sidebar and toolbar when the rest of the site is moved to keep it in view. 

https://user-images.githubusercontent.com/806104/104685494-ca240580-56c0-11eb-96a1-2d6136e20c4b.mp4

Notice the logo is left behind the sidebar. This is because the navigation bar containing the logo is set to `position: fixed; left: 0;`. Because fixed elements are positioned relative to the viewport, this presents a problem when introducing sidebars for sites that may contain elements like this.

Luckily there is a fix to this problem. This is done by putting a transform on the `SiteWrapper`. The transform creates a new local coordinate system, per [W3C spec](https://www.w3.org/TR/css-transforms-1/#transform-rendering):

>In the HTML namespace, any value other than none for the transform results in the creation of both a stacking context and a containing block. The object acts as a containing block for fixed positioned descendants.

https://user-images.githubusercontent.com/806104/104685517-dc9e3f00-56c0-11eb-86ff-58a15a5a788f.mp4

As a result, the fixed element becomes fixed to the transformed element as opposed to the viewport and the underlying content remains visible.

This technique is documented on Eric Meyer's article [Un-fixing Fixed Elements with CSS Transforms](http://meyerweb.com/eric/thoughts/2011/09/12/un-fixing-fixed-elements-with-css-transforms/).