### PR TITLE
refactor(react-tinacms-inline): remove drag + drop for blocks

### DIFF
--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -238,7 +238,7 @@ export interface InlineBlocksProps {
 | `name`      |                                                                                            The path to the **source data** for the blocks. |
 | `blocks`    |                                         An object composed of individual [Blocks](/docs/ui/inline-editing/inline-blocks#creating-a-block). |
 | `className` | _Optional_ — To set styles directly on the input or extend via [styled components](/docs/ui/inline-editing#extending-inline-field-styles). |
-| `direction` |                                                    _Optional_ — Sets the orientation of the drag direction and `AddBlock` button position. |
+| `direction` |                                                    _Optional_ — Sets the orientation of the `AddBlock` button position. |
 | `itemProps` |                                                          _Optional_ — An object that passes additional props to every block child element. |
 | `min`       |                         _Optional_ — Controls the minimum number of blocks. Once reached, blocks won't be able to be removed. _(Optional)_ |
 | `max`       |                   _Optional_ — Controls the maximum number of blocks allowed. Once reached, blocks won't be able to be added. _(Optional)_ |
@@ -523,11 +523,9 @@ const PAGE_BLOCKS = {
 }
 ```
 
-**Configuring the drag and drop Container**
+**Configuring the Container**
 
-`InlineBlocks` wraps your blocks with a `<div>` element that informs the drag and drop functionality of what can be dragged and dropped.
-
-This can be an issue if your styles require direct inheritance, such as a flexbox grid:
+`InlineBlocks` wraps your blocks with a `<div>` element by default. This can be an issue if your styles require direct inheritance, such as a flexbox grid:
 
 ```html
 <div class="row">
@@ -536,13 +534,12 @@ This can be an issue if your styles require direct inheritance, such as a flexbo
 </div>
 ```
 
-To handle this, you can pass a "render function" as the child of the `InlineBlocks` component to control the container that renders the the child blocks. 
+To handle this, you can pass a custom container component to `InlineBlocks`.
 
 **Interface**
 
 ```ts
-interface BlocksContainerProps {
-  innerRef: React.Ref<any>
+interface BlocksContainerProps {s
   className?: string
   children?: React.ReactNode
 }
@@ -554,8 +551,8 @@ interface BlocksContainerProps {
 import { useJsonForm } from 'next-tinacms-json'
 import { InlineForm, InlineBlocks, BlocksControls, InlineTextarea } from 'react-tinacms-inline'
 
-const MyBlocksContainer = ({innerRef, children}) => (
-  <div ref={innerRef}>
+const MyBlocksContainer = (children}) => (
+  <div>
     {children}
   </div>
 )

--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -25,11 +25,8 @@ import {
   ChevronRightIcon,
   DuplicateIcon,
   TrashIcon,
-  ReorderIcon,
-  ReorderRowIcon,
 } from '@tinacms/icons'
 import { useCMS } from 'tinacms'
-import { Draggable } from 'react-beautiful-dnd'
 
 import { useInlineBlocks } from './inline-field-blocks'
 import { useInlineForm } from '../inline-form'
@@ -132,11 +129,6 @@ export function BlocksControls({
   const borderRadius =
     typeof focusRing === 'object' ? focusRing.borderRadius : undefined
 
-  const parentName = name!
-    .split('.')
-    .slice(0, -1)
-    .join('.')
-
   function withinLimit(limit: number | undefined) {
     if (!limit) return true
 
@@ -144,97 +136,82 @@ export function BlocksControls({
   }
 
   return (
-    <Draggable type={parentName} draggableId={name!} index={index}>
-      {provider => {
-        return (
-          <StyledFocusRing
-            ref={provider.innerRef}
-            active={focusRing && isActive}
-            onClick={focusOnBlock}
+    <StyledFocusRing
+      active={focusRing && isActive}
+      onClick={focusOnBlock}
+      offset={offset}
+      borderRadius={borderRadius}
+      disableHover={focusRing === false ? true : childIsActive}
+      disableChildren={!isActive && !childIsActive}
+    >
+      {isActive && (
+        <>
+          {withinLimit(max) && (
+            <AddBlockMenuWrapper active={isActive}>
+              <AddBlockMenu
+                addBlock={block => insert(index, block)}
+                blocks={blocks}
+                index={index}
+                offset={offset}
+                position={addBeforePosition}
+              />
+              <AddBlockMenu
+                addBlock={block => insert(index + 1, block)}
+                blocks={blocks}
+                index={index}
+                offset={offset}
+                position={addAfterPosition}
+              />
+            </AddBlockMenuWrapper>
+          )}
+          <BlockMenuWrapper
             offset={offset}
-            borderRadius={borderRadius}
-            {...provider.draggableProps}
-            disableHover={focusRing === false ? true : childIsActive}
-            disableChildren={!isActive && !childIsActive}
+            ref={blockMenuRef}
+            index={index}
+            active={isActive}
+            inset={insetControls}
           >
-            {isActive ? (
-              <>
-                {withinLimit(max) && (
-                  <AddBlockMenuWrapper active={isActive}>
-                    <AddBlockMenu
-                      addBlock={block => insert(index, block)}
-                      blocks={blocks}
-                      index={index}
-                      offset={offset}
-                      position={addBeforePosition}
-                    />
-                    <AddBlockMenu
-                      addBlock={block => insert(index + 1, block)}
-                      blocks={blocks}
-                      index={index}
-                      offset={offset}
-                      position={addAfterPosition}
-                    />
-                  </AddBlockMenuWrapper>
-                )}
-                <BlockMenuWrapper
-                  offset={offset}
-                  ref={blockMenuRef}
-                  index={index}
-                  active={isActive}
-                  inset={insetControls}
-                >
-                  {label && <BlockLabel>{template.label}</BlockLabel>}
-                  <BlockMenuSpacer></BlockMenuSpacer>
-                  <BlockMenu>
-                    <BlockAction
-                      ref={blockMoveUpRef}
-                      onClick={moveBlockUp}
-                      disabled={isFirst}
-                    >
-                      {direction === 'vertical' && <ChevronUpIcon />}
-                      {direction === 'horizontal' && <ChevronLeftIcon />}
-                    </BlockAction>
-                    <BlockAction
-                      ref={blockMoveDownRef}
-                      onClick={moveBlockDown}
-                      disabled={isLast}
-                    >
-                      {direction === 'vertical' && <ChevronDownIcon />}
-                      {direction === 'horizontal' && <ChevronRightIcon />}
-                    </BlockAction>
-                    <BlockAction {...provider.dragHandleProps}>
-                      {direction === 'vertical' && <ReorderIcon />}
-                      {direction === 'horizontal' && <ReorderRowIcon />}
-                    </BlockAction>
-                    {customActions.map((x, i) => (
-                      <BlockAction key={i} onClick={() => x.onClick()}>
-                        {x.icon}
-                      </BlockAction>
-                    ))}
-                    {withinLimit(max) && (
-                      <BlockAction onClick={duplicateBlock}>
-                        <DuplicateIcon />
-                      </BlockAction>
-                    )}
-                    <InlineSettings fields={template.fields} />
-                    {withinLimit(min) && (
-                      <BlockAction onClick={removeBlock}>
-                        <TrashIcon />
-                      </BlockAction>
-                    )}
-                  </BlockMenu>
-                </BlockMenuWrapper>
-              </>
-            ) : (
-              // dummy element; react-beautiful-dnd complains when dragHandleProps isn't present
-              <div {...provider.dragHandleProps}></div>
-            )}
-            {children}
-          </StyledFocusRing>
-        )
-      }}
-    </Draggable>
+            {label && <BlockLabel>{template.label}</BlockLabel>}
+            <BlockMenuSpacer></BlockMenuSpacer>
+            <BlockMenu>
+              <BlockAction
+                ref={blockMoveUpRef}
+                onClick={moveBlockUp}
+                disabled={isFirst}
+              >
+                {direction === 'vertical' && <ChevronUpIcon />}
+                {direction === 'horizontal' && <ChevronLeftIcon />}
+              </BlockAction>
+              <BlockAction
+                ref={blockMoveDownRef}
+                onClick={moveBlockDown}
+                disabled={isLast}
+              >
+                {direction === 'vertical' && <ChevronDownIcon />}
+                {direction === 'horizontal' && <ChevronRightIcon />}
+              </BlockAction>
+              {customActions.map((x, i) => (
+                <BlockAction key={i} onClick={() => x.onClick()}>
+                  {x.icon}
+                </BlockAction>
+              ))}
+              {withinLimit(max) && (
+                <BlockAction onClick={duplicateBlock}>
+                  <DuplicateIcon />
+                </BlockAction>
+              )}
+              <InlineSettings fields={template.fields} />
+              {withinLimit(min) && (
+                <BlockAction onClick={removeBlock}>
+                  <TrashIcon />
+                </BlockAction>
+              )}
+            </BlockMenu>
+          </BlockMenuWrapper>
+        </>
+      )}
+      {children}
+    </StyledFocusRing>
   )
 }
 

--- a/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-field-blocks.tsx
@@ -24,7 +24,6 @@ import { useInlineForm } from '../inline-form'
 import styled from 'styled-components'
 import { InlineFieldContext } from '../inline-field-context'
 import { useCMS } from 'tinacms'
-import { Droppable } from 'react-beautiful-dnd'
 
 export interface InlineBlocksProps {
   name: string
@@ -47,14 +46,12 @@ export interface InlineBlocksProps {
 }
 
 export interface BlocksContainerProps {
-  innerRef: React.Ref<any>
   className?: string
   children?: React.ReactNode
 }
 
 const DefaultContainer = (props: BlocksContainerProps) => {
-  const { innerRef, ...otherProps } = props
-  return <div ref={innerRef} {...otherProps} />
+  return <div {...props} />
 }
 
 export interface InlineBlocksActions {
@@ -137,62 +134,52 @@ export function InlineBlocks({
         const Container = components.Container || DefaultContainer
 
         return (
-          <Droppable droppableId={name} type={name} direction={direction}>
-            {provider => (
-              <Container innerRef={provider.innerRef} className={className}>
-                {
-                  <InlineBlocksContext.Provider
-                    value={{
-                      insert,
-                      duplicate,
-                      move,
-                      remove,
-                      blocks,
-                      count: allData.length,
-                      direction,
-                      min,
-                      max,
-                    }}
-                  >
-                    {allData.length < 1 && cms.enabled && (
-                      <BlocksEmptyState>
-                        <AddBlockMenu
-                          addBlock={block => insert(0, block)}
-                          blocks={blocks}
-                        />
-                      </BlocksEmptyState>
-                    )}
+          <Container className={className}>
+            <InlineBlocksContext.Provider
+              value={{
+                insert,
+                duplicate,
+                move,
+                remove,
+                blocks,
+                count: allData.length,
+                direction,
+                min,
+                max,
+              }}
+            >
+              {allData.length < 1 && cms.enabled && (
+                <BlocksEmptyState>
+                  <AddBlockMenu
+                    addBlock={block => insert(0, block)}
+                    blocks={blocks}
+                  />
+                </BlocksEmptyState>
+              )}
 
-                    {allData.map((data, index) => {
-                      const Block = blocks[data._template]
+              {allData.map((data, index) => {
+                const Block = blocks[data._template]
 
-                      if (!Block) {
-                        console.warn(
-                          'Unrecognized Block of type:',
-                          data._template
-                        )
-                        return null
-                      }
-
-                      const blockName = `${input.name}.${index}`
-
-                      return (
-                        <InlineBlock
-                          itemProps={itemProps}
-                          key={index}
-                          index={index}
-                          name={blockName}
-                          data={data}
-                          block={Block}
-                        />
-                      )
-                    })}
-                    {provider.placeholder}
-                  </InlineBlocksContext.Provider>
+                if (!Block) {
+                  console.warn('Unrecognized Block of type:', data._template)
+                  return null
                 }
-              </Container>
-            )}
-          </Droppable>
+
+                const blockName = `${input.name}.${index}`
+
+                return (
+                  <InlineBlock
+                    itemProps={itemProps}
+                    key={index}
+                    index={index}
+                    name={blockName}
+                    data={data}
+                    block={Block}
+                  />
+                )
+              })}
+            </InlineBlocksContext.Provider>
+          </Container>
         )
       }}
     </InlineField>

--- a/packages/react-tinacms-inline/src/inline-form.tsx
+++ b/packages/react-tinacms-inline/src/inline-form.tsx
@@ -20,7 +20,6 @@ import * as React from 'react'
 import { FormRenderProps } from 'react-final-form'
 import { FormBuilder, Form } from 'tinacms'
 import { Dismissible } from 'react-dismissible'
-import { DragDropContext, DropResult } from 'react-beautiful-dnd'
 
 export interface InlineFormProps {
   form: Form
@@ -53,19 +52,6 @@ export function InlineForm({ form, children }: InlineFormProps) {
     }
   }, [form, focussedField, setFocussedField])
 
-  const moveArrayItem = React.useCallback(
-    (result: DropResult) => {
-      if (!result.destination || !form) return
-      const name = result.type
-      const from = result.source.index
-      const to = result.destination.index
-
-      setFocussedField(`${name}.${to}`)
-      form.mutators.move(name, from, to)
-    },
-    [form]
-  )
-
   return (
     <InlineFormContext.Provider value={inlineFormState}>
       <Dismissible
@@ -84,22 +70,18 @@ export function InlineForm({ form, children }: InlineFormProps) {
           setFocussedField('')
         }}
       >
-        <DragDropContext onDragEnd={moveArrayItem}>
-          <div onClick={() => setFocussedField('')}>
-            <FormBuilder form={form}>
-              {({ form, ...formProps }) => {
-                if (typeof children !== 'function') {
-                  return children
-                }
+        <FormBuilder form={form}>
+          {({ form, ...formProps }) => {
+            if (typeof children !== 'function') {
+              return children
+            }
 
-                return children({
-                  ...formProps,
-                  ...inlineFormState,
-                })
-              }}
-            </FormBuilder>
-          </div>
-        </DragDropContext>
+            return children({
+              ...formProps,
+              ...inlineFormState,
+            })
+          }}
+        </FormBuilder>
       </Dismissible>
     </InlineFormContext.Provider>
   )


### PR DESCRIPTION
The drag + drop feature of inline blocks adds a lot of complexity to the code. The incoming [planned changes to inline editing](https://tina.io/blog/more-changes-coming-to-inline-editing/) do not yet have a plan for working with drag + drop functionality.

The feature doesn't work in all cases (https://github.com/tinacms/tinacms/issues/1610), and even at its best, it is of limited utility when the layout is composed of tall, full-width blocks (our most common pattern right now.)

Because of this, we believe that, at least for now, it makes sense to remove drag + drop capabilities for inline blocks. Blocks can still be reordered using the chevron buttons on block controls. This UI is simpler and less buggy than drag + drop.