### PR TITLE
Some options for GlobalFormPlugin can't be passed through useFormScreenPlugin

### DIFF
--- a/packages/tinacms/src/react-tinacms/use-form.ts
+++ b/packages/tinacms/src/react-tinacms/use-form.ts
@@ -46,11 +46,11 @@ export function useGlobalForm<FormShape = any>(
 /**
  * Creates and registers ScreenPlugin that renders the given Form.
  */
-export function useFormScreenPlugin(form: Form, icon?: any) {
+export function useFormScreenPlugin(form: Form, icon?: any, layout?: "fullscreen" | "popup") {
   const GlobalForm = useMemo(() => {
     if (!form) return
 
-    return new GlobalFormPlugin(form, icon)
+    return new GlobalFormPlugin(form, icon, layout)
   }, [form])
 
   usePlugins(GlobalForm)

--- a/packages/tinacms/src/react-tinacms/use-form.ts
+++ b/packages/tinacms/src/react-tinacms/use-form.ts
@@ -51,7 +51,7 @@ export function useFormScreenPlugin(form: Form, icon?: any, layout?: "fullscreen
     if (!form) return
 
     return new GlobalFormPlugin(form, icon, layout)
-  }, [form])
+  }, [form, icon, layout])
 
   usePlugins(GlobalForm)
 }

--- a/packages/tinacms/src/react-tinacms/use-form.ts
+++ b/packages/tinacms/src/react-tinacms/use-form.ts
@@ -46,11 +46,11 @@ export function useGlobalForm<FormShape = any>(
 /**
  * Creates and registers ScreenPlugin that renders the given Form.
  */
-export function useFormScreenPlugin(form: Form) {
+export function useFormScreenPlugin(form: Form, icon?: any) {
   const GlobalForm = useMemo(() => {
     if (!form) return
 
-    return new GlobalFormPlugin(form)
+    return new GlobalFormPlugin(form, icon)
   }, [form])
 
   usePlugins(GlobalForm)


### PR DESCRIPTION
Adds an optional second argument to 'useFormScreenPlugin' to allow an icon to be passed to GlobalFormPlugin when instantiating a new Form Screen.
 
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
