### PR TITLE
Run DangerJS workflow on pull_request_target instead of pull_request

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -4,7 +4,6 @@ on: [pull_request]
 jobs:
   danger:
     runs-on: ubuntu-latest
-    environment: test
 
     steps:
       - uses: actions/checkout@v1
@@ -14,4 +13,3 @@ jobs:
         uses: danger/danger-js@10.5.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.DANGER_GITHUB_API_TOKEN }}

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,5 +1,5 @@
 name: 'Danger JS'
-on: [pull_request]
+on: [pull_request_target]
 
 jobs:
   danger:

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -273,11 +273,24 @@ function fileNeedsLicense(filepath: string) {
 /**
  *
  */
-function checkFileForLicenseHeader(filepath: string) {
+async function checkFileForLicenseHeader(filepath: string) {
   try {
-    const content = fs.readFileSync(path.resolve(`./${filepath}`), {
-      encoding: 'utf8',
-    })
+    let content
+    if (!danger.github) {
+      content = fs.readFileSync(path.resolve(`./${filepath}`), {
+        encoding: 'utf8',
+      })
+    } else {
+      const octokit = danger.github.api
+      const { owner, repo } = danger.github.thisPR
+      const { data }: any = await octokit.repos.getContents({
+        owner,
+        repo,
+        path: filepath,
+        ref: 'tbd',
+      })
+      content = atob(data.content)
+    }
 
     if (isMissingHeader(content)) {
       fail(`${filepath} is missing the license header`)

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -286,7 +286,7 @@ async function checkFileForLicenseHeader(filepath: string) {
         owner: 'tinacms',
         repo: 'tinacms',
         path: filepath,
-        ref: `refs/pull/${danger.github.thisPR.number}/head`,
+        ref: `refs/pull/${danger.github.thisPR.number}/merge`,
       })
       content = atob(data.content)
     }
@@ -294,7 +294,8 @@ async function checkFileForLicenseHeader(filepath: string) {
     if (isMissingHeader(content)) {
       fail(`${filepath} is missing the license header`)
     }
-  } catch {
+  } catch (e) {
+    fail(e.message)
     // The file was deleted. That's okay.
   }
 }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -282,12 +282,11 @@ async function checkFileForLicenseHeader(filepath: string) {
       })
     } else {
       const octokit = danger.github.api
-      const { owner, repo } = danger.github.thisPR
       const { data }: any = await octokit.repos.getContents({
-        owner,
-        repo,
+        owner: 'tinacms',
+        repo: 'tinacms',
         path: filepath,
-        ref: 'tbd',
+        ref: `refs/pull/${danger.github.thisPR.number}/head`,
       })
       content = atob(data.content)
     }

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -106,9 +106,15 @@ async function runChecksOnPullRequest() {
     ...danger.git.deleted_files,
     ...danger.git.modified_files,
   ]
+  const existingFiles = [
+    ...danger.git.created_files,
+    ...danger.git.modified_files,
+  ]
 
   // Files
-  await allFiles.filter(fileNeedsLicense).forEach(checkFileForLicenseHeader)
+  await existingFiles
+    .filter(fileNeedsLicense)
+    .forEach(checkFileForLicenseHeader)
 
   // Packages
   const modifiedPackages = await getModifiedPackages(allFiles)
@@ -308,7 +314,6 @@ async function checkFileForLicenseHeader(filepath: string) {
     }
   } catch (e) {
     fail(e.message)
-    // The file was deleted. That's okay.
   }
 }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -100,7 +100,7 @@ interface TinaPackage {
 /**
  * Executes all checks for the Pull Request.
  */
-function runChecksOnPullRequest() {
+async function runChecksOnPullRequest() {
   const allFiles = [
     ...danger.git.created_files,
     ...danger.git.deleted_files,
@@ -108,10 +108,10 @@ function runChecksOnPullRequest() {
   ]
 
   // Files
-  allFiles.filter(fileNeedsLicense).forEach(checkFileForLicenseHeader)
+  await allFiles.filter(fileNeedsLicense).forEach(checkFileForLicenseHeader)
 
   // Packages
-  const modifiedPackages = getModifiedPackages(allFiles)
+  const modifiedPackages = await getModifiedPackages(allFiles)
 
   modifiedPackages.forEach(checkForNpmScripts)
   modifiedPackages.forEach(checkForLicense)
@@ -343,7 +343,7 @@ The following packages were modified by this pull request:
 /**
  * Lists all packages modified by this PR.
  */
-function getModifiedPackages(allFiles: string[]) {
+async function getModifiedPackages(allFiles: string[]) {
   const packageList: TinaPackage[] = []
   const paths = new Set(
     allFiles
@@ -375,18 +375,23 @@ function getModifiedPackages(allFiles: string[]) {
       })
   )
 
-  paths.forEach(path => {
+  const pathArray = Array.from(paths) // typescript doesn't like iterables
+  for (let path of pathArray) {
     try {
-      const packageJson = require(`./${path}/package.json`)
-
-      packageList.push({
-        path,
-        packageJson,
-      })
+      // get file contents + JSON decode
+      await getFileContents(`./${path}/package.json`)
+        .then(JSON.parse)
+        .then(packageJson => {
+          packageList.push({
+            path,
+            packageJson,
+          })
+        })
     } catch (e) {
       warn(`Could not find package: ${path}`)
     }
-  })
+  }
+
   return packageList
 }
 

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -379,7 +379,7 @@ async function getModifiedPackages(allFiles: string[]) {
   for (let path of pathArray) {
     try {
       // get file contents + JSON decode
-      await getFileContents(`./${path}/package.json`)
+      await getFileContents(`${path}/package.json`)
         .then(JSON.parse)
         .then(packageJson => {
           packageList.push({
@@ -388,7 +388,7 @@ async function getModifiedPackages(allFiles: string[]) {
           })
         })
     } catch (e) {
-      warn(`Could not find package: ${path}`)
+      warn(`Could not find package: ${path}: ${e.message}`)
     }
   }
 


### PR DESCRIPTION
## The Problem

We've been wrangling with the problem of how to run DangerJS against PRs that originate from forks. DangerJS works by leaving comments on PRs with warnings/errors triggered by the script, and the read-only `GITHUB_TOKEN` provided to GItHub actions that run against forks can't comment on PRs.

Previously, I attempted to resolve this by using a machine user and generating a personal access token for them, which we then send to the script. The idea is that this user can comment on PRs, but doesn't have access to anything important since there is potential for this access token to be extracted by a malicious PR. Creating a build environment to provide this token, and requiring builds to first be approved before running, seemed like adequate mitigation against this threat. Unfortunately, I misunderstood the documentation around secrets provided to GitHub actions, as even when a build is authorized to run, environment secrets are still not provided to fork PRs. Presumably, using a machine user with DangerJS on fork PRs would require the access token to be hard-coded into the script. For a public repo, that means publishing this token. Even if the machine user has no important access, that solution is not one I am OK with.

## The pull_request_target event

The only practical solution, then, is to use the `pull_request_target` event instead of `pull_request`. Per the [GitHub docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target):

> This event runs in the context of the base of the pull request, rather than in the merge commit as the pull_request event does. This prevents executing unsafe workflow code from the head of the pull request that could alter your repository or steal any secrets you use in your workflow. This event allows you to do things like create workflows that label and comment on pull requests based on the contents of the event payload.

Since `pull_request_target` will run in the context of `tinacms/tinacms`, even when executed on behalf of a fork PR, its provided `GITHUB_TOKEN` will be able to insert Danger's comments on PRs.

## Caveat

There is a caveat to this, which the DangerJS maintainer points out in [this issue](https://github.com/danger/danger-js/issues/1060): performing static analysis on code files fetched via the local file system will end up examining that code as it exists on the _target_ branch, and not the new code being proposed in the pull request. Thus, any static analysis needs to first fetch the file contents over the GItHub API, against the appropriate ref.

## Solution

Since this duality between locally-sourced content and content fetched from remotes is something we've frequently grappled with ourselves working on TinaCMS, I wasn't that intimidated by the problem. There are only two static analysis routines we perform in our danger script, and it seemed reasonable to swap out the local file access for API access. 

The results of these changes (running on `pull_request`, not `pull_request_target`) can be seen in [this PR](https://github.com/tinacms/tinacms/pull/1711), where I've removed a couple licenses to verify that danger will fail the build correctly