### PR TITLE
Stop event propagation

### DIFF
--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import * as React from 'react'
+import * as React, { SyntheticEvent } from 'react'
 import { useState } from 'react'
 import { Dismissible } from 'react-dismissible'
 import { SketchPicker, BlockPicker } from 'react-color'
@@ -317,7 +317,8 @@ export const ColorPicker: React.FC<Props> = ({
     )
   }
 
-  const toggleColorPicker = () => {
+  const toggleColorPicker = (event: SyntheticEvent) => {
+    event.stopPropagation()
     const display = !displayColorPicker
     setDisplayColorPicker(display)
     if (display) {

--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import * as React, { SyntheticEvent } from 'react'
+import * as React from 'react'
 import { useState } from 'react'
 import { Dismissible } from 'react-dismissible'
 import { SketchPicker, BlockPicker } from 'react-color'

--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -317,7 +317,7 @@ export const ColorPicker: React.FC<Props> = ({
     )
   }
 
-  const toggleColorPicker = (event: SyntheticEvent) => {
+  const toggleColorPicker = (event: React.SyntheticEvent) => {
     event.stopPropagation()
     const display = !displayColorPicker
     setDisplayColorPicker(display)


### PR DESCRIPTION
This fixes a bug, when color picker is nested inside form and does not open up. The problem is that the click event is fired twice (one for Swatch and one for SwatchInner) and the color picker then stays always closed.

Example field configuration:
```
const formOptions = {
    label: 'Header',
    fields: [
      {
        label: 'Banner',
        name: 'banner',
        component: 'group',
        fields: [
          {
            label: 'Background color',
            name: 'backgroundColor',
            component: 'color',
          },
          {
            label: 'Text',
            name: 'text',
            component: 'text',
          },
          {
            label: 'Text color',
            name: 'textColor',
            component: 'color',
          },
        ],
      },
    ],
  }

  const [data, form] = useGithubJsonForm(file, formOptions)
  useFormScreenPlugin(form)

...
```

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
