### PR TITLE
chore(build): run PR build on `pull_request` event

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -1,9 +1,6 @@
 name: Build, Test, Lint for Pull Requests
 
-on:
-  push:
-    branches-ignore:
-      - master
+on: [pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
I think this was working on forked PRs by coincidence before, and due to changes in the dangerjs workflow is not currently running on forked PRs