### PR TITLE
fix(react-tinacms-inline): Fix ability to clear field selection

### DIFF
--- a/packages/react-tinacms-inline/src/inline-form.tsx
+++ b/packages/react-tinacms-inline/src/inline-form.tsx
@@ -70,18 +70,20 @@ export function InlineForm({ form, children }: InlineFormProps) {
           setFocussedField('')
         }}
       >
-        <FormBuilder form={form}>
-          {({ form, ...formProps }) => {
-            if (typeof children !== 'function') {
-              return children
-            }
+        <div onClick={() => setFocussedField('')}>
+          <FormBuilder form={form}>
+            {({ form, ...formProps }) => {
+              if (typeof children !== 'function') {
+                return children
+              }
 
-            return children({
-              ...formProps,
-              ...inlineFormState,
-            })
-          }}
-        </FormBuilder>
+              return children({
+                ...formProps,
+                ...inlineFormState,
+              })
+            }}
+          </FormBuilder>
+        </div>
       </Dismissible>
     </InlineFormContext.Provider>
   )


### PR DESCRIPTION
Closes #1725

This adds back the `<div onClick={() => setFocussedField('')}>` element that was removed in #1702.

@dwalkr Did this element need to be removed for some reason? I'm guessing it was just forgotten when refactoring?

Thanks!