### PR TITLE
useFieldRef: imperative field hover/focus

### DIFF
--- a/packages/react-tinacms-inline/src/inline-form.tsx
+++ b/packages/react-tinacms-inline/src/inline-form.tsx
@@ -21,7 +21,7 @@ import { FormRenderProps } from 'react-final-form'
 import { FormBuilder, Form, Field } from 'tinacms'
 import { Dismissible } from 'react-dismissible'
 import { useMap } from 'react-use'
-import { FieldOverlay, FieldTarget, FieldRefType } from './ref-fields'
+import { FieldOverlay, FieldRefType } from './ref-fields'
 
 type useMapObject<T> = { [key: string]: T }
 
@@ -76,19 +76,27 @@ export function InlineForm({ form, children }: InlineFormProps) {
   React.useEffect(() => {
     let memoOpacity = '1.0'
 
-    const focusRef = fieldRefs[focussedField]
+    const focusRef = fieldRefs[focussedField] as any
 
-    if (focusRef && focusRef.current) {
-      memoOpacity = focusRef.current.style.opacity
-      focusRef.current.style.opacity = '0.0'
+    if (focusRef) {
+      memoOpacity = focusRef.style.opacity
+      focusRef.style.opacity = '0.0'
     }
 
     return () => {
-      if (focusRef && focusRef.current) {
-        focusRef.current.style.opacity = memoOpacity
+      if (focusRef) {
+        focusRef.style.opacity = memoOpacity
       }
     }
   }, [focussedField, fieldRefs])
+
+  const [currentField, setCurrentField] = React.useState(null) as any
+  React.useEffect(() => {
+    const field = inlineFormState.form.fields.find(
+      (formField: Field) => formField.name === focussedField
+    )
+    setCurrentField(field)
+  }, [focussedField])
 
   return (
     <InlineFormContext.Provider value={inlineFormState}>
@@ -121,32 +129,12 @@ export function InlineForm({ form, children }: InlineFormProps) {
                     ...formProps,
                     ...inlineFormState,
                   })}
-                  {Object.entries(fieldRefs).map(([fieldName, ref]) => {
-                    const fieldConfig = inlineFormState.form.fields.find(
-                      (formField: Field) => formField.name === fieldName
-                    )
-                    if (!fieldConfig) return null
-                    return (
-                      <FieldOverlay targetRef={ref}>
-                        {focussedField === fieldName &&
-                        fieldConfig.inlineComponent ? (
-                          <fieldConfig.inlineComponent
-                            name={fieldConfig.name}
-                            // form={inlineFormState.form}
-                            // field={fieldConfig}
-                          />
-                        ) : (
-                          <FieldTarget
-                            onClick={e => {
-                              e.preventDefault()
-                              e.stopPropagation()
-                              setFocussedField(fieldName)
-                            }}
-                          />
-                        )}
-                      </FieldOverlay>
-                    )
-                  })}
+
+                  {currentField && (
+                    <FieldOverlay targetNode={fieldRefs[currentField.name]}>
+                      <currentField.inlineComponent name={currentField.name} />
+                    </FieldOverlay>
+                  )}
                 </>
               )
             }}

--- a/packages/react-tinacms-inline/src/ref-fields/field-overlay.tsx
+++ b/packages/react-tinacms-inline/src/ref-fields/field-overlay.tsx
@@ -17,7 +17,6 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { FieldRefType } from './use-field-ref'
 
 function useWindowResize(handler: () => void) {
   React.useEffect(() => {
@@ -27,22 +26,23 @@ function useWindowResize(handler: () => void) {
 }
 
 export function FieldOverlay({
-  targetRef,
+  targetNode,
   children,
 }: {
-  targetRef: FieldRefType
+  targetNode: any
   children: JSX.Element
 }) {
   const [, setState] = React.useState(0)
   useWindowResize(() => setState(s => s + 1))
+  //if (!targetNode) return null
   return (
     <div
       style={{
         position: 'absolute',
-        top: targetRef?.current?.offsetTop,
-        left: targetRef?.current?.offsetLeft,
-        width: targetRef?.current?.offsetWidth,
-        height: targetRef?.current?.offsetHeight,
+        top: targetNode?.offsetTop,
+        left: targetNode?.offsetLeft,
+        width: targetNode?.offsetWidth,
+        height: targetNode?.offsetHeight,
       }}
     >
       {children}

--- a/packages/react-tinacms-inline/src/ref-fields/use-field-ref.tsx
+++ b/packages/react-tinacms-inline/src/ref-fields/use-field-ref.tsx
@@ -21,12 +21,39 @@ import { useInlineForm } from 'inline-form'
 
 export type FieldRefType = React.RefObject<HTMLElement | null>
 
-export function useFieldRef(fieldName: string) {
-  const ref: FieldRefType = React.useRef(null)
-  const { fieldRefActions } = useInlineForm()
-  React.useEffect(() => {
-    fieldRefActions.set(fieldName, ref)
-  }, [fieldName, ref])
+const outlineCSS = 'solid'
 
-  return ref
+export function useFieldRef(fieldName: string) {
+  const [node, setNode] = React.useState(null) as any
+
+  const { setFocussedField, fieldRefActions } = useInlineForm()
+
+  React.useEffect(() => {
+    fieldRefActions.set(fieldName, node)
+    if (!node) return
+
+    const handleClick = (e: React.MouseEvent<any>) => {
+      e.preventDefault()
+      e.stopPropagation()
+      setFocussedField(fieldName)
+    }
+    const beginHover = () => {
+      node.style.outline = outlineCSS
+    }
+    const endHover = () => {
+      node.style.outline = 'none'
+    }
+    node.addEventListener('click', handleClick)
+    node.addEventListener('mouseover', beginHover)
+    node.addEventListener('mouseout', endHover)
+    return () => {
+      node.removeEventListener('click', handleClick)
+      node.removeEventListener('mouseover', beginHover)
+      node.removeEventListener('mouseout', endHover)
+    }
+  }, [node, fieldRefActions.set])
+
+  return React.useCallback((newNode: HTMLElement | null) => {
+    setNode(newNode)
+  }, [])
 }

--- a/packages/react-tinacms-inline/src/ref-fields/use-field-ref.tsx
+++ b/packages/react-tinacms-inline/src/ref-fields/use-field-ref.tsx
@@ -21,7 +21,7 @@ import { useInlineForm } from 'inline-form'
 
 export type FieldRefType = React.RefObject<HTMLElement | null>
 
-const outlineCSS = 'solid'
+const outlineCSS = '1px solid rgba(34,150,254, 0.5)'
 
 export function useFieldRef(fieldName: string) {
   const [node, setNode] = React.useState(null) as any


### PR DESCRIPTION
This is a different approach to `useFieldRef` that doesn't require every field to have a hover/focus target component placed over it. Instead, it subscribes to DOM events of the element referenced by the ref. The userland API has not changed.

The biggest drawback with this is that we lose a lot of customizability with the hover state. We're now limited by the capabilities of the CSS `outline` property. Since we're indicating the hover state by modifying the DOM element directly, I recommend sticking with `outline` because:
1. It's designed for accessibility
2. it doesn't impact layout flow
3. it is unlikely to be a mission-critical style attribute on the user's component, so it's relatively safe to modify it