### PR TITLE
fix: inline group click event  bug

### DIFF
--- a/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
+++ b/packages/react-tinacms-inline/src/blocks/inline-block-field-controls.tsx
@@ -267,6 +267,7 @@ export const BlockMenuWrapper = styled.div<BlockMenuWrapperProps>(p => {
     ${p.active &&
       css`
         opacity: 1;
+        pointer-events: all;
       `}
   `
 })
@@ -305,7 +306,6 @@ export const BlockMenu = styled.div`
   box-shadow: var(--tina-shadow-big);
   border: 1px solid var(--tina-color-grey-2);
   overflow: hidden;
-  pointer-events: all;
 `
 
 interface BlockActionProps {


### PR DESCRIPTION
This prevents block and group actions from being clicked when the block or group isn't active.

