### PR TITLE
fix(@tinacms/react-sidebar): Allows initialValues for ContentCreator Plugins

### DIFF
--- a/packages/@tinacms/forms/src/content-creator-plugin.ts
+++ b/packages/@tinacms/forms/src/content-creator-plugin.ts
@@ -22,5 +22,6 @@ import { Field } from './field'
 export interface ContentCreatorPlugin<FormShape> extends Plugin {
   __type: 'content-creator'
   fields: Field[]
+  initialValues?: FormShape
   onSubmit(value: FormShape, cms: CMS): Promise<void> | void
 }

--- a/packages/@tinacms/react-sidebar/src/components/CreateContentMenu.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/CreateContentMenu.tsx
@@ -98,6 +98,7 @@ const FormModal = ({ plugin, close }: any) => {
         id: 'create-form-id',
         actions: [],
         fields: plugin.fields,
+        initialValues: plugin.initialValues || {},
         onSubmit(values) {
           plugin.onSubmit(values, cms).then(() => {
             close()


### PR DESCRIPTION
Fixes #1715 

Behind the scenes, a custom `ContentCreator` plugin is a `Form` wrapped in `Modal` functionality.  Because of this, `initialValues` can be passed in the same way as defining a `Form` config and then used when creating the `Form` (via the `plugin.initialValues`).
