### PR TITLE
fix(tinacms): Fixes pagination for any MediaStore

### DIFF
--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -48,8 +48,13 @@ export function PageLinks({ list, setOffset }: MediaPaginatorProps) {
 
   for (let i = 1; i <= numPages; i++) {
     const active = i === currentPageIndex
+    const nextOffset = (i - 1) * limit
     pageLinks.push(
-      <PageNumber active={active} onClick={() => setOffset(i * limit)}>
+      <PageNumber
+        key={`page-${i}`}
+        active={active}
+        onClick={() => setOffset(nextOffset)}
+      >
         {i}
       </PageNumber>
     )


### PR DESCRIPTION
**Fixes #1747**

`offset` was incorrectly being calculated against the page's **display number** rather than the page's **index**.

For example, Page 2 should have an `offset` of `5`, but `setOffset(...)` calculated it to be `10` (`display * limit` or `2 * 5`).

This explains why Page 1 was usually accurate (rarely is `offset` passed in the initial `MediaList` options), but any other page would be incorrect (as `setOffset(...)` would trigger the bug on click).

Note:  I also addressed a React `Warning` regarding `key` missing from the `<PageNumber>` components.

