### PR TITLE
Fix Inline Settings Cancel Behaviour

### DIFF
--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -77,7 +77,6 @@ export function SettingsModal({
   const { form } = useInlineForm()
   const { name } = React.useContext(InlineFieldContext)
   const [initialValues] = React.useState(form.values)
-  console.log(form, name)
 
   function handleCancel() {
     form.updateValues(initialValues)

--- a/packages/react-tinacms-inline/src/inline-settings.tsx
+++ b/packages/react-tinacms-inline/src/inline-settings.tsx
@@ -77,10 +77,9 @@ export function SettingsModal({
   const { form } = useInlineForm()
   const { name } = React.useContext(InlineFieldContext)
   const [initialValues] = React.useState(form.values)
+  console.log(form, name)
 
-  function handleCancel(event: any) {
-    event.stopPropagation()
-    event.preventDefault()
+  function handleCancel() {
     form.updateValues(initialValues)
     close()
   }
@@ -110,7 +109,7 @@ export function SettingsModal({
   return (
     <Modal id="tinacms-inline-settings" onClick={e => e.stopPropagation()}>
       <ModalPopup>
-        <ModalHeader close={close}>{title}</ModalHeader>
+        <ModalHeader close={handleCancel}>{title}</ModalHeader>
         <ModalBody>
           <DragDropContext onDragEnd={moveArrayItem}>
             <FormBody>


### PR DESCRIPTION
The inline settings modal 'cancel' button would revert changes, but the 'x' button in the modal header was just closing the modal. Both buttons now trigger the cancel behaviour. 