### PR TITLE
fix(@tinacms/fields): Fix "type=radio" field warning

### DIFF
--- a/packages/@tinacms/fields/src/components/RadioGroup.tsx
+++ b/packages/@tinacms/fields/src/components/RadioGroup.tsx
@@ -83,7 +83,8 @@ export const RadioGroup: React.FC<RadioGroupProps> = ({
           id={optionId}
           name={input.name}
           value={option.value}
-          onChange={input.onChange}
+          // https://github.com/final-form/react-final-form/issues/392#issuecomment-543118944
+          onChange={event => input.onChange(event.target.value)}
           checked={checked}
         />
         <RadioOption


### PR DESCRIPTION
I noticed that value changes to `RadioGroup` was triggering a warning within `react-final-form` due to how `final-form` handles radios:

> Warning: You must pass `type="radio"` props to your Field component.
> Without it we don't know how to unpack your `value` prop - "undefined".

According to https://github.com/final-form/react-final-form/issues/392, this appears to be an unusual quirk of `react-final-form`'s API (and specific to `type=radio`) and a helpful suggestion (https://github.com/final-form/react-final-form/issues/392#issuecomment-543118944) is to skip the `SyntheticEvent` (`onChange={input.onChange}`) and pass `value` directly:

`onChange={event => input.onChange(event.target.value)}`

This seemingly produces the same result - minus the warning.
