### PR TITLE
fix: close on click outside

### DIFF
--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -102,9 +102,7 @@ export function AddBlockMenu({
     >
       <AddBlockButton
         ref={addBlockButtonRef}
-        onClick={(event: any) => {
-          isOpen ? setIsOpen(false) : handleOpenBlockMenu(event)
-        }}
+        onClick={handleOpenBlockMenu}
         isOpen={isOpen}
         primary
         small
@@ -191,6 +189,8 @@ const AddBlockButton = styled(IconButton)<AddMenuProps>`
   ${props =>
     props.isOpen &&
     css`
+      pointer-events: none;
+
       svg {
         transform: rotate(45deg);
       }

--- a/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
+++ b/packages/react-tinacms-inline/src/blocks/add-block-menu.tsx
@@ -42,6 +42,7 @@ export function AddBlockMenu({
 }: AddBlockMenuProps) {
   const [isOpen, setIsOpen] = React.useState(false)
   const addBlockButtonRef = React.useRef<HTMLButtonElement>(null)
+  const addBlockMenuRef = React.useRef<HTMLDivElement>(null)
   const [openTop, setOpenTop] = React.useState(false)
   const [filterValue, setFilterValue] = React.useState('')
 
@@ -79,6 +80,19 @@ export function AddBlockMenu({
     }
   }
 
+  React.useEffect(() => {
+    const inactivateBlockMenu = (event: any) => {
+      if (
+        addBlockMenuRef.current &&
+        !addBlockMenuRef.current.contains(event.target)
+      ) {
+        setIsOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', inactivateBlockMenu)
+    return () => document.removeEventListener('mousedown', inactivateBlockMenu)
+  }, [addBlockButtonRef])
+
   return (
     <AddBlockWrapper
       index={index}
@@ -97,7 +111,7 @@ export function AddBlockMenu({
       >
         <AddIcon />
       </AddBlockButton>
-      <BlocksMenu openTop={openTop} isOpen={isOpen}>
+      <BlocksMenu openTop={openTop} isOpen={isOpen} ref={addBlockMenuRef}>
         {Object.keys(blocks).length > 9 && (
           <DropdownHeader>
             <SelectFilter


### PR DESCRIPTION
This reintroduces the 'click outside' code removed in #1772 but with added logic to handle the filter input. 