### PR TITLE
Fix/form portal zindex management

### DIFF
--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -109,7 +109,6 @@ const ColorPopupOpenTopKeyframes = keyframes`
 export const Popover = styled.div<{
   triggerBoundingBox: any
   openTop: boolean
-  zIndex: number
 }>`
   position: fixed;
   top: ${props =>
@@ -121,7 +120,7 @@ export const Popover = styled.div<{
   transform: translate3d(-50%, 8px, 0) scale3d(1, 1, 1);
   transform-origin: 50% 0;
   animation: ${ColorPopupKeyframes} 85ms ease-out both 1;
-  z-index: ${zIndex + 3000};
+  z-index: var(--tina-z-index-5);
 
   &:before {
     content: '';
@@ -336,11 +335,11 @@ export const ColorPicker: React.FC<Props> = ({
       />
       {displayColorPicker && (
         <FormPortal>
-          {({ zIndex }) => (
+          {({ zIndexShift }) => (
             <Popover
               openTop={openTop}
               triggerBoundingBox={triggerBoundingBox}
-              zIndex={zIndex}
+              style={{ zIndex: 5000 + zIndexShift }}
             >
               <Dismissible
                 click
@@ -358,6 +357,7 @@ export const ColorPicker: React.FC<Props> = ({
               </Dismissible>
             </Popover>
           )}
+        </FormPortal>
       )}
     </ColorPickerWrapper>
   )

--- a/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/@tinacms/fields/src/components/ColorPicker/ColorPicker.tsx
@@ -109,6 +109,7 @@ const ColorPopupOpenTopKeyframes = keyframes`
 export const Popover = styled.div<{
   triggerBoundingBox: any
   openTop: boolean
+  zIndex: number
 }>`
   position: fixed;
   top: ${props =>
@@ -120,7 +121,7 @@ export const Popover = styled.div<{
   transform: translate3d(-50%, 8px, 0) scale3d(1, 1, 1);
   transform-origin: 50% 0;
   animation: ${ColorPopupKeyframes} 85ms ease-out both 1;
-  z-index: var(--tina-z-index-5);
+  z-index: ${zIndex + 3000};
 
   &:before {
     content: '';
@@ -335,23 +336,28 @@ export const ColorPicker: React.FC<Props> = ({
       />
       {displayColorPicker && (
         <FormPortal>
-          <Popover openTop={openTop} triggerBoundingBox={triggerBoundingBox}>
-            <Dismissible
-              click
-              escape
-              disabled={!displayColorPicker}
-              onDismiss={toggleColorPicker}
+          {({ zIndex }) => (
+            <Popover
+              openTop={openTop}
+              triggerBoundingBox={triggerBoundingBox}
+              zIndex={zIndex}
             >
-              <Widget
-                presetColors={[...userColors, nullColor]}
-                color={getColorRGBA || { r: 0, g: 0, b: 0, a: 0 }}
-                onChange={handleChange}
-                disableAlpha={true}
-                width={'240px'}
-              />
-            </Dismissible>
-          </Popover>
-        </FormPortal>
+              <Dismissible
+                click
+                escape
+                disabled={!displayColorPicker}
+                onDismiss={toggleColorPicker}
+              >
+                <Widget
+                  presetColors={[...userColors, nullColor]}
+                  color={getColorRGBA || { r: 0, g: 0, b: 0, a: 0 }}
+                  onChange={handleChange}
+                  disableAlpha={true}
+                  width={'240px'}
+                />
+              </Dismissible>
+            </Popover>
+          )}
       )}
     </ColorPickerWrapper>
   )

--- a/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
@@ -243,9 +243,9 @@ const BlockListItem = ({
             </DeleteButton>
           </ItemHeader>
           <FormPortal>
-            {({ zIndex }) => (
+            {({ zIndexShift }) => (
               <Panel
-                zIndex={zIndex}
+                zIndexShift={zIndexShift}
                 isExpanded={isExpanded}
                 setExpanded={setExpanded}
                 field={field}
@@ -523,7 +523,7 @@ interface PanelProps {
   item: any
   label: string
   template: BlockTemplate
-  zIndex: number
+  zIndexShift: number
 }
 
 const Panel = function Panel({
@@ -534,7 +534,7 @@ const Panel = function Panel({
   index,
   label,
   template,
-  zIndex,
+  zIndexShift,
 }: PanelProps) {
   const fields: any[] = React.useMemo(() => {
     if (!template.fields) return []
@@ -546,7 +546,7 @@ const Panel = function Panel({
   }, [field.name, index, template.fields])
 
   return (
-    <GroupPanel isExpanded={isExpanded} zIndex={zIndex}>
+    <GroupPanel isExpanded={isExpanded} style={{ zIndex: zIndexShift + 1000 }}>
       <PanelHeader onClick={() => setExpanded(false)}>
         <LeftArrowIcon />
         <GroupLabel>{label}</GroupLabel>

--- a/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/BlocksFieldPlugin.tsx
@@ -243,16 +243,19 @@ const BlockListItem = ({
             </DeleteButton>
           </ItemHeader>
           <FormPortal>
-            <Panel
-              isExpanded={isExpanded}
-              setExpanded={setExpanded}
-              field={field}
-              item={block}
-              index={index}
-              tinaForm={tinaForm}
-              label={label || template.label}
-              template={template}
-            />
+            {({ zIndex }) => (
+              <Panel
+                zIndex={zIndex}
+                isExpanded={isExpanded}
+                setExpanded={setExpanded}
+                field={field}
+                item={block}
+                index={index}
+                tinaForm={tinaForm}
+                label={label || template.label}
+                template={template}
+              />
+            )}
           </FormPortal>
         </>
       )}
@@ -520,6 +523,7 @@ interface PanelProps {
   item: any
   label: string
   template: BlockTemplate
+  zIndex: number
 }
 
 const Panel = function Panel({
@@ -530,6 +534,7 @@ const Panel = function Panel({
   index,
   label,
   template,
+  zIndex,
 }: PanelProps) {
   const fields: any[] = React.useMemo(() => {
     if (!template.fields) return []
@@ -541,7 +546,7 @@ const Panel = function Panel({
   }, [field.name, index, template.fields])
 
   return (
-    <GroupPanel isExpanded={isExpanded}>
+    <GroupPanel isExpanded={isExpanded} zIndex={zIndex}>
       <PanelHeader onClick={() => setExpanded(false)}>
         <LeftArrowIcon />
         <GroupLabel>{label}</GroupLabel>

--- a/packages/@tinacms/fields/src/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupFieldPlugin.tsx
@@ -78,8 +78,11 @@ const Panel = function Panel({
 
   return (
     <FormPortal>
-      {({ zIndex }) => (
-        <GroupPanel isExpanded={isExpanded} zIndex={zIndex}>
+      {({ zIndexShift }) => (
+        <GroupPanel
+          isExpanded={isExpanded}
+          style={{ zIndex: zIndexShift + 1000 }}
+        >
           <PanelHeader onClick={() => setExpanded(false)}>
             <LeftArrowIcon /> <span>{field.label || field.name}</span>
           </PanelHeader>
@@ -180,10 +183,7 @@ const GroupPanelKeyframes = keyframes`
   }
 `
 
-export const GroupPanel = styled.div<{
-  isExpanded: boolean
-  zIndex: number
-}>`
+export const GroupPanel = styled.div<{ isExpanded: boolean }>`
   position: absolute;
   width: 100%;
   top: 0;
@@ -193,7 +193,7 @@ export const GroupPanel = styled.div<{
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
-  z-index: ${zIndex};
+  z-index: var(--tina-z-index-1);
   pointer-events: ${p => (p.isExpanded ? 'all' : 'none')};
 
   > * {

--- a/packages/@tinacms/fields/src/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupFieldPlugin.tsx
@@ -78,16 +78,18 @@ const Panel = function Panel({
 
   return (
     <FormPortal>
-      <GroupPanel isExpanded={isExpanded}>
-        <PanelHeader onClick={() => setExpanded(false)}>
-          <LeftArrowIcon /> <span>{field.label || field.name}</span>
-        </PanelHeader>
-        <PanelBody>
-          {isExpanded ? (
-            <FieldsBuilder form={tinaForm} fields={fields} />
-          ) : null}
-        </PanelBody>
-      </GroupPanel>
+      {({ zIndex }) => (
+        <GroupPanel isExpanded={isExpanded} zIndex={zIndex}>
+          <PanelHeader onClick={() => setExpanded(false)}>
+            <LeftArrowIcon /> <span>{field.label || field.name}</span>
+          </PanelHeader>
+          <PanelBody>
+            {isExpanded ? (
+              <FieldsBuilder form={tinaForm} fields={fields} />
+            ) : null}
+          </PanelBody>
+        </GroupPanel>
+      )}
     </FormPortal>
   )
 }
@@ -178,7 +180,10 @@ const GroupPanelKeyframes = keyframes`
   }
 `
 
-export const GroupPanel = styled.div<{ isExpanded: boolean }>`
+export const GroupPanel = styled.div<{
+  isExpanded: boolean
+  zIndex: number
+}>`
   position: absolute;
   width: 100%;
   top: 0;
@@ -188,7 +193,7 @@ export const GroupPanel = styled.div<{ isExpanded: boolean }>`
   flex-direction: column;
   justify-content: space-between;
   overflow: hidden;
-  z-index: var(--tina-z-index-1);
+  z-index: ${zIndex};
   pointer-events: ${p => (p.isExpanded ? 'all' : 'none')};
 
   > * {

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -170,14 +170,17 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
             </DeleteButton>
           </ItemHeader>
           <FormPortal>
-            <Panel
-              isExpanded={isExpanded}
-              setExpanded={setExpanded}
-              field={field}
-              index={index}
-              tinaForm={tinaForm}
-              itemTitle={title}
-            />
+            {({ zIndex }) => (
+              <Panel
+                isExpanded={isExpanded}
+                setExpanded={setExpanded}
+                field={field}
+                index={index}
+                tinaForm={tinaForm}
+                itemTitle={title}
+                zIndex={zIndex}
+              />
+            )}
           </FormPortal>
         </>
       )}
@@ -393,6 +396,7 @@ interface PanelProps {
   index: number
   field: GroupFieldDefinititon
   itemTitle: string
+  zIndex: number
 }
 
 const Panel = function Panel({
@@ -402,6 +406,7 @@ const Panel = function Panel({
   field,
   index,
   itemTitle,
+  zIndex,
 }: PanelProps) {
   const fields: any[] = React.useMemo(() => {
     return field.fields.map((subField: any) => ({
@@ -411,7 +416,7 @@ const Panel = function Panel({
   }, [field.fields, field.name, index])
 
   return (
-    <GroupPanel isExpanded={isExpanded}>
+    <GroupPanel isExpanded={isExpanded} zIndex={zIndex}>
       <PanelHeader onClick={() => setExpanded(false)}>
         <LeftArrowIcon />
         <GroupLabel>{itemTitle}</GroupLabel>

--- a/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/GroupListFieldPlugin.tsx
@@ -170,7 +170,7 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
             </DeleteButton>
           </ItemHeader>
           <FormPortal>
-            {({ zIndex }) => (
+            {({ zIndexShift }) => (
               <Panel
                 isExpanded={isExpanded}
                 setExpanded={setExpanded}
@@ -178,7 +178,7 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
                 index={index}
                 tinaForm={tinaForm}
                 itemTitle={title}
-                zIndex={zIndex}
+                zIndexShift={zIndexShift}
               />
             )}
           </FormPortal>
@@ -396,7 +396,7 @@ interface PanelProps {
   index: number
   field: GroupFieldDefinititon
   itemTitle: string
-  zIndex: number
+  zIndexShift: number
 }
 
 const Panel = function Panel({
@@ -406,7 +406,7 @@ const Panel = function Panel({
   field,
   index,
   itemTitle,
-  zIndex,
+  zIndexShift,
 }: PanelProps) {
   const fields: any[] = React.useMemo(() => {
     return field.fields.map((subField: any) => ({
@@ -416,7 +416,7 @@ const Panel = function Panel({
   }, [field.fields, field.name, index])
 
   return (
-    <GroupPanel isExpanded={isExpanded} zIndex={zIndex}>
+    <GroupPanel isExpanded={isExpanded} style={{ zIndex: zIndexShift + 1000 }}>
       <PanelHeader onClick={() => setExpanded(false)}>
         <LeftArrowIcon />
         <GroupLabel>{itemTitle}</GroupLabel>

--- a/packages/@tinacms/react-forms/src/FormPortal.tsx
+++ b/packages/@tinacms/react-forms/src/FormPortal.tsx
@@ -21,7 +21,9 @@ import { useContext } from 'react'
 import { createPortal } from 'react-dom'
 import styled from 'styled-components'
 
-export type FormPortal = React.FC<{}>
+export type FormPortal = React.FC<{
+  children(props: { zIndexShift: number }): React.ReactNode | null
+}>
 
 const FormPortalContext = React.createContext<FormPortal>(() => {
   return null
@@ -34,7 +36,7 @@ export function useFormPortal() {
 export const FormPortalProvider: React.FC = styled(
   ({ children, ...styleProps }) => {
     const wrapperRef = React.useRef<HTMLDivElement | null>(null)
-    const zIndexRef = React.useRef<number>(1000)
+    const zIndexRef = React.useRef<number>(0)
 
     const FormPortal = React.useCallback(
       (props: any) => {
@@ -45,7 +47,11 @@ export const FormPortalProvider: React.FC = styled(
         }, [])
 
         if (!wrapperRef.current) return null
-        return createPortal(props.children(portalZIndex), wrapperRef.current)
+
+        return createPortal(
+          props.children({ zIndexShift: portalZIndex }),
+          wrapperRef.current
+        )
       },
       [wrapperRef, zIndexRef]
     )

--- a/packages/@tinacms/react-forms/src/FormPortal.tsx
+++ b/packages/@tinacms/react-forms/src/FormPortal.tsx
@@ -34,13 +34,20 @@ export function useFormPortal() {
 export const FormPortalProvider: React.FC = styled(
   ({ children, ...styleProps }) => {
     const wrapperRef = React.useRef<HTMLDivElement | null>(null)
+    const zIndexRef = React.useRef<number>(1000)
 
     const FormPortal = React.useCallback(
       (props: any) => {
+        const portalZIndex = React.useMemo<number>(() => {
+          const value = zIndexRef.current
+          zIndexRef.current += 1
+          return value
+        }, [])
+
         if (!wrapperRef.current) return null
-        return createPortal(props.children, wrapperRef.current)
+        return createPortal(props.children(portalZIndex), wrapperRef.current)
       },
-      [wrapperRef.current]
+      [wrapperRef, zIndexRef]
     )
 
     return (


### PR DESCRIPTION
Connects to #1780

### What changed
In one FormPortal might be rendered multiple panels. Each new panel should be shown on screen above the previous one, no matter in what order they was rendered in the DOM. This PR adds zindex management to the FormPortal by switching children prop to a function that accepts an object with zIndexShift. The value of that shift can be used to set a final zIndex of a panel or whatever wants to be rendered inside the portal