### PR TITLE
feat: drag to resize sidebar

### DIFF
--- a/packages/@tinacms/react-sidebar/src/components/ResizeHandle.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/ResizeHandle.tsx
@@ -1,0 +1,115 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import styled, { createGlobalStyle } from 'styled-components'
+
+export const ResizeHandle = () => {
+  const [mouseDown, setMouseDown] = React.useState(false)
+  /* Only set sidebar width once resized; otherwise default to CSS width */
+  const [sidebarWidth, setSidebarWidth] = React.useState(null)
+
+  const pxToNumber = (string: string) => {
+    return parseInt(string.replace('px', ''), 10)
+  }
+
+  React.useEffect(() => {
+    const handleMouseUp = () => setMouseDown(false)
+
+    window.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      window.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [])
+
+  React.useEffect(() => {
+    const handleMouseMove = (e: any) => {
+      setSidebarWidth(sidebarWidth => {
+        /* Get value from CSS if sidebarWidth isn't set yet */
+        const newWidth = sidebarWidth
+          ? sidebarWidth + e.movementX
+          : pxToNumber(
+              window
+                .getComputedStyle(document.documentElement)
+                .getPropertyValue('--tina-sidebar-width')
+            ) + e.movementX
+        const minWidth = 250
+        const maxWidth = window.innerWidth - 64
+
+        if (newWidth < minWidth) {
+          return minWidth
+        } else if (newWidth > maxWidth) {
+          return maxWidth
+        } else {
+          return newWidth
+        }
+      })
+    }
+
+    if (mouseDown) {
+      window.addEventListener('mousemove', handleMouseMove)
+    }
+
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove)
+    }
+  }, [mouseDown])
+
+  const handleMouseDown = () => setMouseDown(true)
+
+  return (
+    <>
+      <Handle onMouseDown={handleMouseDown}></Handle>
+      <GlobalStyles blockSelect={mouseDown} width={sidebarWidth} />
+    </>
+  )
+}
+
+const Handle = styled.div`
+  position: absolute;
+  top: 0;
+  right: -2px;
+  width: 4px;
+  height: 100%;
+  cursor: ew-resize;
+`
+
+export const GlobalStyles = createGlobalStyle<{
+  width: number | null
+  blockSelect: boolean
+}>`
+  ${({ width }) =>
+    width &&
+    `
+    :root {
+      --tina-sidebar-width: ${width + `px`};
+    }
+  `}
+
+  ${({ blockSelect }) =>
+    blockSelect &&
+    `
+  * {
+  -webkit-user-select: none;  
+  -moz-user-select: none;    
+  -ms-user-select: none;      
+  user-select: none;
+  }
+  `}
+`

--- a/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
+++ b/packages/@tinacms/react-sidebar/src/components/Sidebar.tsx
@@ -30,6 +30,7 @@ import { tina_reset_styles } from '@tinacms/styles'
 import { CreateContentMenu } from './CreateContentMenu'
 import { ScreenPlugin, ScreenPluginModal } from '@tinacms/react-screens'
 import { useSubscribable, useCMS } from '@tinacms/react-core'
+import { ResizeHandle } from './ResizeHandle'
 import { SidebarState, SidebarPosition, SidebarStateOptions } from '../sidebar'
 
 export interface SidebarProviderProps {
@@ -121,6 +122,7 @@ const Sidebar = ({ sidebar }: SidebarProps) => {
               close={() => setActiveView(null)}
             />
           )}
+          <ResizeHandle />
         </SidebarWrapper>
         <SidebarToggle sidebar={sidebar} />
       </SidebarContainer>
@@ -369,7 +371,7 @@ const SidebarToggleButton = styled.button<{ open: boolean }>`
   background-color: var(--tina-color-primary);
   background-repeat: no-repeat;
   background-position: center;
-  transition: all 150ms ease-out;
+  transition: background-color 150ms ease-out;
   cursor: pointer;
   animation: ${SidebarToggleAnimation} 200ms 300ms ease-out 1 both;
   &:hover {


### PR DESCRIPTION
You can now click and drag the right edge of the sidebar to resize it!  🎉

- Sidebar width will still default to `--tina-sidebar-width`, which the user can customize in their CSS.
- There's a 250px minimum width and it can't extend beyond the width of the window viewport. 
- All the logic is contained in a new `ResizeHandle` component.
- There's a 4px clickable area at the right edge of the sidebar instead of a visible handle. Hovering this area will change your cursor.
- Text selection is blocked with a universal selector while dragging.

- [ ] Needs docs 

[Thanks @weibenfalk for your initial work on this](https://github.com/tinacms/tinacms/pull/565)

https://user-images.githubusercontent.com/5075484/114748808-a6587600-9d28-11eb-95d3-b5f7df98c5d8.mp4

Closes #558