### PR TITLE
fix: alert container click blocking

### DIFF
--- a/packages/@tinacms/react-alerts/src/Alerts.tsx
+++ b/packages/@tinacms/react-alerts/src/Alerts.tsx
@@ -74,6 +74,7 @@ const AlertContainer = styled.div`
   flex-direction: column;
   align-items: center;
   z-index: 999999;
+  pointer-events: none;
 `
 
 const AlertEntranceAnimation = keyframes`
@@ -97,6 +98,7 @@ const Alert = styled.div<{ level: AlertLevel; index: number }>`
   color: var(--tina-color-grey-9);
   fill: var(--tina-color-primary);
   font-weight: var(--tina-font-weight-regular);
+  pointer-events: all;
   cursor: pointer;
   font-size: var(--tina-font-size-2);
   padding: 8px 4px 8px 12px;


### PR DESCRIPTION
The container alerts pop up in was blocking click events, so in order to open the sidebar you had to wait for any alerts to go away given the toggle is underneath this container. This is now fixed so that the container itself doesn't capture any click events, just the alerts. 