### PR TITLE
fix(@tinacms/fields): Adds ellipsis to long list selects

### DIFF
--- a/packages/@tinacms/fields/src/components/Select.tsx
+++ b/packages/@tinacms/fields/src/components/Select.tsx
@@ -100,6 +100,9 @@ const SelectElement = styled.div`
     background-repeat: no-repeat;
     background-position: right 0.7em top 50%;
     background-size: 0.65em auto;
+    padding-right: 30px;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &:hover {
       box-shadow: 0 0 0 2px var(--tina-color-grey-3);

--- a/packages/@tinacms/fields/src/components/Select.tsx
+++ b/packages/@tinacms/fields/src/components/Select.tsx
@@ -100,7 +100,7 @@ const SelectElement = styled.div`
     background-repeat: no-repeat;
     background-position: right 0.7em top 50%;
     background-size: 0.65em auto;
-    padding-right: 30px;
+    padding-right: 1.5rem;
     overflow: hidden;
     text-overflow: ellipsis;
 

--- a/packages/@tinacms/fields/src/plugins/ListFieldPlugin.tsx
+++ b/packages/@tinacms/fields/src/plugins/ListFieldPlugin.tsx
@@ -175,7 +175,7 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
 }
 
 const ItemField = styled.div`
-  flex: 1 0 auto;
+  flex: 1;
   display: flex;
   align-items: center;
 
@@ -285,7 +285,7 @@ const ListItem = styled.div<{ isDragging: boolean }>`
 
   ${FieldWrapper} {
     margin: 0;
-    flex: 1 0 auto;
+    flex: 1;
   }
 
   svg {


### PR DESCRIPTION
Something I encountered while working with the `starter`, a `select` inside of a `list` can extend beyond the edge of the sidebar, making it difficult to interact with the `select` and other list members:

https://user-images.githubusercontent.com/1699544/114768222-3220d100-9d2e-11eb-8591-1417ee92b33f.mov

This pure CSS fix will simply add ellipsis (`text-overflow: ellipsis;`) to long `select`s:

https://user-images.githubusercontent.com/1699544/114768353-5b416180-9d2e-11eb-8356-ded9fa811f4c.mov

