### PR TITLE
fix: Check for $GH_TOKEN when releasing

### DIFF
--- a/scripts/prerelease.sh
+++ b/scripts/prerelease.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Check for $GH_TOKEN
+if [[ -z $GH_TOKEN ]]
+then
+  echo "ENV '\$GH_TOKEN' is required to proceed; learn more at https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type"
+  exit 1
+fi
+
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Check for $GH_TOKEN
+if [[ -z $GH_TOKEN ]]
+then
+  echo "ENV '\$GH_TOKEN' is required to proceed; learn more at https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type"
+  exit 1
+fi
+
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
 


### PR DESCRIPTION
Mentioned by DJ, it might be good to check that `$GH_TOKEN` is set before running either release script.

While `prerelease.sh` is probably fine, running `release.sh` without `$GH_TOKEN` will result in the changelogs getting swallowed and that, in his words, "sucks".

Learn more at https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type
