### PR TITLE
disable create content button via toolbar

### DIFF
--- a/packages/@tinacms/react-toolbar/src/components/CreateContentMenu.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/CreateContentMenu.tsx
@@ -111,23 +111,34 @@ const FormModal = ({ plugin, close }: any) => {
       }),
     [close, cms, plugin]
   )
+
+  const [busy, setBusy] = React.useState(false)
+
   return (
     <Modal>
       <FormBuilder form={form}>
         {({ handleSubmit }) => {
+          const awaitedHandleSubmit = () => {
+            setBusy(true)
+            handleSubmit()?.finally(() => {
+              setBusy(false)
+            })
+          }
           return (
             <ModalPopup>
               <ModalHeader close={close}>{plugin.name}</ModalHeader>
               <ModalBody
                 onKeyPress={e =>
-                  e.charCode === 13 ? (handleSubmit() as any) : null
+                  e.charCode === 13 && !busy
+                    ? (awaitedHandleSubmit() as any)
+                    : null
                 }
               >
                 <FieldsBuilder form={form} fields={form.fields} />
               </ModalBody>
               <ModalActions>
                 <Button onClick={close}>Cancel</Button>
-                <Button onClick={handleSubmit as any} primary>
+                <Button onClick={awaitedHandleSubmit as any} primary>
                   Create
                 </Button>
               </ModalActions>

--- a/packages/@tinacms/react-toolbar/src/components/CreateContentMenu.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/CreateContentMenu.tsx
@@ -103,8 +103,9 @@ const FormModal = ({ plugin, close }: any) => {
         id: 'create-form-id',
         actions: [],
         fields: plugin.fields,
-        onSubmit(values) {
-          plugin.onSubmit(values, cms).then(() => {
+        initialValues: plugin.initialValues || {},
+        onSubmit: async values => {
+          await plugin.onSubmit(values, cms).then(() => {
             close()
           })
         },
@@ -138,7 +139,11 @@ const FormModal = ({ plugin, close }: any) => {
               </ModalBody>
               <ModalActions>
                 <Button onClick={close}>Cancel</Button>
-                <Button onClick={awaitedHandleSubmit as any} primary>
+                <Button
+                  disabled={busy}
+                  onClick={awaitedHandleSubmit as any}
+                  primary
+                >
                   Create
                 </Button>
               </ModalActions>


### PR DESCRIPTION
Prevent rage clicks on when adding new content.

UX: We should convey that the document is currently being created like we do for save.