### PR TITLE
pass remote package data to depcheck when appropriate

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -424,6 +424,7 @@ function checkDeps(tinaPackage: TinaPackage) {
       '@testing-library/react',
       '@testing-library/dom',
     ],
+    package: tinaPackage.packageJson,
   }
   const packagePath = path.resolve(
     tinaPackage.path.replace('/package.json', '')


### PR DESCRIPTION
#1712 changed the context in which our static analysis tools (dangerjs) run, meaning we need to explicitly fetch any code we want to analyze from the appropriate git remote instead of running against the files in the current context.

Left out of that was `depcheck`. This PR aims to fix that.