### PR TITLE
fix(bug): disables form save button if field fails validation

### DIFF
--- a/packages/@tinacms/react-forms/src/FormView.tsx
+++ b/packages/@tinacms/react-forms/src/FormView.tsx
@@ -51,7 +51,7 @@ export function FormView({ activeForm }: FormViewProps) {
 
   return (
     <FormBuilder form={activeForm as any}>
-      {({ handleSubmit, pristine, form, submitting }) => {
+      {({ handleSubmit, pristine, invalid, form, submitting }) => {
         return (
           <DragDropContext onDragEnd={moveArrayItem}>
             <FormBody>
@@ -84,7 +84,7 @@ export function FormView({ activeForm }: FormViewProps) {
                 )}
                 <Button
                   onClick={() => handleSubmit()}
-                  disabled={pristine}
+                  disabled={pristine || invalid}
                   busy={submitting}
                   primary
                   grow

--- a/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
@@ -60,6 +60,7 @@ export const Toolbar = () => {
   const formState = useFormState(form, {
     pristine: true,
     submitting: true,
+    invalid: true,
   })
 
   // this is used to refreshe the discard button to fix it not updating when pressed after the page loads
@@ -113,6 +114,7 @@ export const Toolbar = () => {
   const submitting = disabled
     ? false
     : !!(formState && currentState?.submitting)
+  const invalid = formState && currentState?.invalid
 
   return (
     <>
@@ -159,7 +161,7 @@ export const Toolbar = () => {
               //@ts-ignore
               onClick={submit}
               busy={submitting}
-              disabled={disabled || pristine}
+              disabled={disabled || pristine || invalid}
             >
               {submitting && <LoadingDots />}
               {!submitting && (

--- a/packages/demo-next/data/blog/apple.md
+++ b/packages/demo-next/data/blog/apple.md
@@ -1,5 +1,5 @@
 ---
-title: Apple
+title: 'apple'
 ---
 ![](/images/pup.jpeg)
 

--- a/packages/demo-next/pages/blog/[slug].tsx
+++ b/packages/demo-next/pages/blog/[slug].tsx
@@ -57,7 +57,17 @@ const Post: NextPage<{ post: MarkdownFile }> = props => {
 
   const [post, form] = useMarkdownForm(props.post, {
     fields: [
-      { name: 'frontmatter.title', component: 'text' },
+      {
+        name: 'frontmatter.title',
+        component: 'text',
+        validate: value => {
+          if (!value) {
+            return 'required'
+          } else {
+            return undefined
+          }
+        },
+      },
       { name: 'markdownBody', component: 'markdown' },
     ],
   })


### PR DESCRIPTION
This PR will disable the save button in the sidebar and toolbar if a field fails a validation check.

Big thanks to @Enigmatical who did the heavy lifting to track down the source.