### PR TITLE
chore: export ToolbarWidgetPlugin interface

### DIFF
--- a/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
+++ b/packages/@tinacms/react-toolbar/src/components/Toolbar.tsx
@@ -41,7 +41,7 @@ const useFormState = (form: Form | null, subscription: any): any => {
   return state
 }
 
-interface ToolbarWidgetPlugin<Props = any> extends Plugin {
+export interface ToolbarWidgetPlugin<Props = any> extends Plugin {
   weight: number
   props?: Props
   component(): React.ReactElement


### PR DESCRIPTION
3rd-party toolbar widgets should implement this interface to ensure interop, so we need to export it