### PR TITLE
1841 - Unify `FormOptions` for `useForm(...)` and its variations

### DIFF
--- a/packages/@tinacms/forms/src/content-creator-plugin.ts
+++ b/packages/@tinacms/forms/src/content-creator-plugin.ts
@@ -18,10 +18,15 @@ limitations under the License.
 
 import { CMS, Plugin } from '@tinacms/core'
 import { Field } from './field'
+import { FormOptions } from './form'
 
 export interface ContentCreatorPlugin<FormShape> extends Plugin {
   __type: 'content-creator'
   fields: Field[]
+  actions?: FormOptions<any>['actions']
+  buttons?: FormOptions<any>['buttons']
   initialValues?: FormShape
   onSubmit(value: FormShape, cms: CMS): Promise<void> | void
+  reset?: FormOptions<any>['reset']
+  onChange?: FormOptions<any>['onChange']
 }

--- a/packages/@tinacms/react-forms/src/CreateContentMenu.tsx
+++ b/packages/@tinacms/react-forms/src/CreateContentMenu.tsx
@@ -101,11 +101,14 @@ const FormModal = ({ plugin, close }: any) => {
   const form: Form = useMemo(
     () =>
       new Form({
-        label: 'create-form',
         id: 'create-form-id',
-        actions: [],
+        label: 'create-form',
         fields: plugin.fields,
+        actions: plugin.actions,
+        buttons: plugin.buttons,
         initialValues: plugin.initialValues || {},
+        reset: plugin.reset,
+        onChange: plugin.onChange,
         onSubmit: async values => {
           await plugin.onSubmit(values, cms).then(() => {
             close()

--- a/packages/gatsby-tinacms-git/src/use-git-form.ts
+++ b/packages/gatsby-tinacms-git/src/use-git-form.ts
@@ -46,8 +46,16 @@ export function useGitForm<N extends GitNode>(
       return gitFile.show()
     },
     onSubmit: gitFile.commit,
-    reset: gitFile.reset,
+    reset: () => {
+      if (options.reset) {
+        options.reset()
+      }
+      return gitFile.reset()
+    },
     onChange({ values }: any) {
+      if (options.onChange) {
+        options.onChange(values)
+      }
       return gitFile.write(values)
     },
   }

--- a/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
+++ b/packages/gatsby-tinacms-mdx/src/useMdxForm.tsx
@@ -38,7 +38,7 @@ const matter = require('gray-matter')
 
 export function useMdxForm(
   _mdx: MdxNode | null | undefined,
-  formOverrrides: Partial<FormOptions<any>> = {}
+  formOverrides: Partial<FormOptions<any>> = {}
 ): [MdxNode | null | undefined, Form | null | undefined] {
   const mdx = usePersistentValue(_mdx)
 
@@ -56,9 +56,9 @@ export function useMdxForm(
 
   /* eslint-disable-next-line react-hooks/rules-of-hooks */
   const cms = useCMS()
-  const label = formOverrrides.label || mdx.frontmatter.title
+  const label = formOverrides.label || mdx.frontmatter.title
   const id = mdx.fileRelativePath
-  const actions = formOverrrides.actions
+  const actions = formOverrides.actions
 
   /**
    * The state of the MdxForm, generated from the contents of the
@@ -81,7 +81,7 @@ export function useMdxForm(
    */
   /* eslint-disable-next-line react-hooks/rules-of-hooks */
   const fields = React.useMemo(() => {
-    let fields = formOverrrides.fields || generateFields(valuesOnDisk)
+    let fields = formOverrides.fields || generateFields(valuesOnDisk)
     fields = fields.map(field => {
       /**
        * Treat the field.name prefix `frontmatter` as an alias to
@@ -100,7 +100,7 @@ export function useMdxForm(
     })
 
     return fields
-  }, [formOverrrides.fields])
+  }, [formOverrides.fields])
 
   /* eslint-disable-next-line react-hooks/rules-of-hooks */
   const [, form] = useForm(
@@ -152,9 +152,9 @@ export function useMdxForm(
 
 export function useLocalMdxForm(
   mdx: MdxNode | null | undefined,
-  formOverrrides: Partial<FormOptions<any>> = {}
+  formOverrides: Partial<FormOptions<any>> = {}
 ): [MdxNode | null | undefined, Form | string | null | undefined] {
-  const [values, form] = useMdxForm(mdx, formOverrrides)
+  const [values, form] = useMdxForm(mdx, formOverrides)
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore form can be `null` and usePlugins doesn't like that.
@@ -165,9 +165,9 @@ export function useLocalMdxForm(
 
 export function useGlobalMdxForm(
   mdx: MdxNode | null | undefined,
-  formOverrrides: Partial<FormOptions<any>> = {}
+  formOverrides: Partial<FormOptions<any>> = {}
 ): [MdxNode | null | undefined, Form | string | null | undefined] {
-  const [values, form] = useMdxForm(mdx, formOverrrides)
+  const [values, form] = useMdxForm(mdx, formOverrides)
 
   usePlugins(
     React.useMemo(() => {

--- a/packages/gatsby-tinacms-remark/src/use-remark-form.tsx
+++ b/packages/gatsby-tinacms-remark/src/use-remark-form.tsx
@@ -121,9 +121,9 @@ function fromMarkdownString(content: string) {
  */
 export function useLocalRemarkForm(
   markdownRemark: RemarkNode | null | undefined,
-  formOverrrides: Partial<FormOptions<any>> = {}
+  formOverrides: Partial<FormOptions<any>> = {}
 ): [RemarkNode | null | undefined, Form | string | null | undefined] {
-  const [values, form] = useRemarkForm(markdownRemark, formOverrrides)
+  const [values, form] = useRemarkForm(markdownRemark, formOverrides)
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
   // @ts-ignore form can be `null` and usePlugins doesn't like that.
@@ -137,9 +137,9 @@ export function useLocalRemarkForm(
  */
 export function useGlobalRemarkForm(
   markdownRemark: RemarkNode | null | undefined,
-  formOverrrides: Partial<FormOptions<any>> = {}
+  formOverrides: Partial<FormOptions<any>> = {}
 ): [RemarkNode | null | undefined, Form | string | null | undefined] {
-  const [values, form] = useRemarkForm(markdownRemark, formOverrrides)
+  const [values, form] = useRemarkForm(markdownRemark, formOverrides)
 
   usePlugins(
     React.useMemo(() => {

--- a/packages/next-tinacms-json/src/use-json-form.ts
+++ b/packages/next-tinacms-json/src/use-json-form.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import { useForm, useCMS, FormOptions, Field, Form } from 'tinacms'
+import { useForm, useCMS, FormOptions, Form } from 'tinacms'
 import { generateFields } from './generate-fields'
 
 /**
@@ -27,19 +27,12 @@ export interface JsonFile<T = any> {
   data: T
 }
 
-export interface Options {
-  id?: string
-  label?: string
-  fields?: Field[]
-  actions?: FormOptions<any>['actions']
-  buttons?: FormOptions<any>['buttons']
-}
 /**
  * Creates a TinaCMS Form for editing a JsonFile in Git
  */
 export function useJsonForm<T = any>(
   jsonFile: JsonFile<T>,
-  options: Options = {}
+  options: Partial<FormOptions<any>> = {}
 ): [T, Form] {
   const cms = useCMS()
 
@@ -72,9 +65,15 @@ export function useJsonForm<T = any>(
         })
       },
       reset() {
+        if (options.reset) {
+          options.reset()
+        }
         return cms.api.git.reset({ files: [id] })
       },
       onChange: formState => {
+        if (options.onChange) {
+          options.onChange(formState.values)
+        }
         cms.api.git.writeToDisk({
           fileRelativePath: jsonFile.fileRelativePath,
           content: JSON.stringify(formState.values, null, 2),

--- a/packages/next-tinacms-markdown/src/use-markdown-form.ts
+++ b/packages/next-tinacms-markdown/src/use-markdown-form.ts
@@ -19,7 +19,7 @@ limitations under the License.
 const matter = require('gray-matter')
 
 import * as yaml from 'js-yaml'
-import { useForm, useCMS, FormOptions, Field } from 'tinacms'
+import { useForm, useCMS, FormOptions } from 'tinacms'
 import { generateFields } from './generate-fields'
 
 /**
@@ -30,14 +30,6 @@ export interface MarkdownFile {
   fileRelativePath: string
   frontmatter: any
   markdownBody: string
-}
-
-export interface Options {
-  id?: string
-  label?: string
-  fields?: Field[]
-  actions?: FormOptions<any>['actions']
-  buttons?: FormOptions<any>['buttons']
 }
 
 export function toMarkdownString(markdownFile: MarkdownFile) {
@@ -53,7 +45,7 @@ export function toMarkdownString(markdownFile: MarkdownFile) {
  */
 export function useMarkdownForm(
   markdownFile: MarkdownFile,
-  options: Options = {}
+  options: Partial<FormOptions<any>> = {}
 ) {
   const cms = useCMS()
 
@@ -90,9 +82,15 @@ export function useMarkdownForm(
         })
       },
       reset() {
+        if (options.reset) {
+          options.reset()
+        }
         return cms.api.git.reset({ files: [id] })
       },
       onChange(formState) {
+        if (options.onChange) {
+          options.onChange(formState.values)
+        }
         cms.api.git.writeToDisk({
           fileRelativePath: markdownFile.fileRelativePath,
           content: toMarkdownString(formState.values),

--- a/packages/react-tinacms-github/src/form/useGithubFileForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubFileForm.ts
@@ -42,6 +42,9 @@ export const useGithubFileForm = <T = any>(
       initialValues: file.data,
       fields: options.fields || [],
       actions: options.actions || [],
+      buttons: options.buttons,
+      reset: options.reset,
+      onChange: options.onChange,
       onSubmit(formData) {
         return githubFile.commit(formData)
       },

--- a/packages/react-tinacms-github/src/form/useGithubJsonForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubJsonForm.ts
@@ -16,16 +16,9 @@ limitations under the License.
 
 */
 
-import { FormOptions, Field, WatchableFormValue } from 'tinacms'
+import { FormOptions, WatchableFormValue } from 'tinacms'
 import { GitFile } from './useGitFileSha'
 import { useGithubFileForm } from './useGithubFileForm'
-
-interface Options<T = any> {
-  id?: string
-  label?: string
-  fields?: Field[]
-  actions?: FormOptions<T>['actions']
-}
 
 const serialize = (formData: any) => {
   return JSON.stringify(formData, null, 2)
@@ -33,7 +26,7 @@ const serialize = (formData: any) => {
 
 export function useGithubJsonForm<T = any>(
   jsonFile: GitFile<T>,
-  formOptions?: Options<T>,
+  formOptions?: FormOptions<T>,
   watch?: Partial<WatchableFormValue>
 ) {
   return useGithubFileForm<T>(

--- a/packages/react-tinacms-github/src/form/useGithubMarkdownForm.ts
+++ b/packages/react-tinacms-github/src/form/useGithubMarkdownForm.ts
@@ -16,20 +16,14 @@ limitations under the License.
 
 */
 
-import { FormOptions, Field, WatchableFormValue } from 'tinacms'
+import { FormOptions, WatchableFormValue } from 'tinacms'
 import { GitFile } from './useGitFileSha'
 import { toMarkdownString } from 'next-tinacms-markdown'
 import { useGithubFileForm } from './useGithubFileForm'
-interface Options<T = any> {
-  id?: string
-  label?: string
-  fields?: Field[]
-  actions?: FormOptions<T>['actions']
-}
 
 export function useGithubMarkdownForm<T = any>(
   markdownFile: GitFile<T>,
-  formOptions?: Options<T>,
+  formOptions?: FormOptions<T>,
   watch?: Partial<WatchableFormValue>
 ) {
   return useGithubFileForm<T>(


### PR DESCRIPTION
**This PR is dependent on #1840 and should be merged afterwards.**

Discovered during research into Form Inconsistencies, our various versions of `useForm(...)` and its wrappers (i.e. `useGitHubFileForm(...), `ContentCreator` Plugin) accepted and respected a certain subset of `FormOptions` - usually identified as `Options` (that sometimes extended `FormOptions`).

This has the unintended consequence of unpredictable behavior when using a `Form`.  Can I provide `reset`?  `onChange`?  `buttons`?  `actions`?  Will `label` actually be used?

This PR seeks to smooth over those rough edges by (to some degree) allow `FormOptions` to be directly passed and each of the options to be respected.  There are still places where `overrides` or `default` options are used (namely, `loadInitialValues()` is defined on most of the `useForm(...)` wrappers, so passing `loadInitialValues(...)` will be ignored).

But _most_ of the other options will, at least, affect the underlying `Form`.

Closes #1841 