### PR TITLE
feat(tinacms): use cursor-based pagination in media manager

### DIFF
--- a/packages/@tinacms/core/src/cms.ts
+++ b/packages/@tinacms/core/src/cms.ts
@@ -75,6 +75,13 @@ export interface CMSConfig {
   plugins?: Array<Plugin>
   apis?: { [key: string]: any }
   media?: MediaStore
+  /**
+   * Might potentially make more sense to consolidate both media.store and mediaOptions.pageSize
+   * under the 'media' config namespace, but that's a breaking change.
+   */
+  mediaOptions?: {
+    pageSize?: number
+  }
 }
 
 export class CMS {
@@ -129,6 +136,9 @@ export class CMS {
 
     if (config.media) {
       this.media.store = config.media
+    }
+    if (config.mediaOptions && config.mediaOptions.pageSize) {
+      this.media.pageSize = config.mediaOptions.pageSize
     }
 
     if (config.plugins) {

--- a/packages/@tinacms/core/src/media-store.default.ts
+++ b/packages/@tinacms/core/src/media-store.default.ts
@@ -35,9 +35,7 @@ export class DummyMediaStore implements MediaStore {
     const items: Media[] = []
     return {
       items,
-      offset: 0,
-      limit: 10,
-      totalCount: 0,
+      nextOffset: 0,
     }
   }
   async delete() {

--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -96,13 +96,14 @@ export interface MediaStore {
   list(options?: MediaListOptions): Promise<MediaList>
 }
 
+export declare type MediaListOffset = string | number
 /**
  * The options available when listing media.
  */
 export interface MediaListOptions {
   directory?: string
   limit?: number
-  offset?: number
+  offset?: MediaListOffset
 }
 
 /**
@@ -110,10 +111,7 @@ export interface MediaListOptions {
  */
 export interface MediaList {
   items: Media[]
-  limit: number
-  offset: number
-  nextOffset?: number
-  totalCount: number
+  nextOffset?: MediaListOffset
 }
 
 /**

--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -129,10 +129,24 @@ export interface MediaList {
  * ```
  */
 export class MediaManager implements MediaStore {
+  private _pageSize: number = 20
+
   constructor(public store: MediaStore, private events: EventBus) {}
 
   get isConfigured() {
     return !(this.store instanceof DummyMediaStore)
+  }
+
+  get pageSize() {
+    return this._pageSize
+  }
+
+  set pageSize(pageSize) {
+    this._pageSize = pageSize
+    this.events.dispatch({
+      type: 'media:pageSize',
+      pageSize: pageSize,
+    })
   }
 
   open(options: SelectMediaOptions = {}) {

--- a/packages/@tinacms/git-client/src/git-media-store.ts
+++ b/packages/@tinacms/git-client/src/git-media-store.ts
@@ -58,15 +58,12 @@ export class GitMediaStore implements MediaStore {
   }
   async list(options?: MediaListOptions): Promise<MediaList> {
     const directory = options?.directory ?? ''
-    const offset = options?.offset ?? 0
+    const offset = (options?.offset as number) ?? 0
     const limit = options?.limit ?? 50
     const { file } = await this.client.getFile(directory)
 
     return {
       items: file.content.slice(offset, offset + limit),
-      totalCount: file.content.length,
-      offset,
-      limit,
       nextOffset: nextOffset(offset, limit, file.content.length),
     }
   }

--- a/packages/react-tinacms-github/src/github-media-store/index.ts
+++ b/packages/react-tinacms-github/src/github-media-store/index.ts
@@ -77,7 +77,7 @@ export class GithubMediaStore implements MediaStore {
 
   async list(options?: MediaListOptions): Promise<MediaList> {
     const directory = options?.directory ?? ''
-    const offset = options?.offset ?? 0
+    const offset = (options?.offset as number) ?? 0
     const limit = options?.limit ?? 50
 
     const unfilteredItems: GithubContent[] = await this.githubClient.fetchFile(
@@ -91,10 +91,7 @@ export class GithubMediaStore implements MediaStore {
 
     return {
       items: items.map(contentToMedia).slice(offset, offset + limit),
-      offset,
-      limit,
       nextOffset: nextOffset(offset, limit, items.length),
-      totalCount: items.length,
     }
   }
 }

--- a/packages/react-tinacms-strapi/README.md
+++ b/packages/react-tinacms-strapi/README.md
@@ -26,9 +26,7 @@ export default function MyApp({ Component, pageProps }) {
         apis: {
           strapi: new StrapiClient("http://localhost:1337/"),
         },
-        media: {
-          store: new StrapiMediaStore("http://localhost:1337/"),
-        },
+        media: new StrapiMediaStore("http://localhost:1337/"),
       }),
     []
   );

--- a/packages/react-tinacms-strapi/src/strapi-media-store.ts
+++ b/packages/react-tinacms-strapi/src/strapi-media-store.ts
@@ -84,7 +84,7 @@ export class StrapiMediaStore {
   }
 
   async list(options: MediaListOptions) {
-    const offset = options?.offset ?? 0
+    const offset = (options?.offset as number) ?? 0
     const limit = options?.limit ?? 50
 
     const authToken = Cookies.get(STRAPI_JWT)
@@ -103,9 +103,6 @@ export class StrapiMediaStore {
 
     return {
       items: mediaData.slice(offset, limit + offset).map(this.strapiToTina),
-      limit,
-      offset,
-      totalCount: mediaData.length,
       nextOffset: nextOffset < mediaData.length ? nextOffset : undefined,
     }
   }

--- a/packages/tinacms/src/components/media/index.ts
+++ b/packages/tinacms/src/components/media/index.ts
@@ -19,9 +19,4 @@ limitations under the License.
 export * from './media-manager'
 export { MediaItem } from './media-item'
 export { Breadcrumb } from './breadcrumb'
-export {
-  CursorPaginator,
-  MediaPaginatorProps,
-  MediaPaginatorPlugin,
-  BaseMediaPaginator,
-} from './pagination'
+export { CursorPaginator, MediaPaginatorProps } from './pagination'

--- a/packages/tinacms/src/components/media/index.ts
+++ b/packages/tinacms/src/components/media/index.ts
@@ -20,7 +20,7 @@ export * from './media-manager'
 export { MediaItem } from './media-item'
 export { Breadcrumb } from './breadcrumb'
 export {
-  PageLinks,
+  CursorPaginator,
   MediaPaginatorProps,
   MediaPaginatorPlugin,
   BaseMediaPaginator,

--- a/packages/tinacms/src/components/media/media-manager.tsx
+++ b/packages/tinacms/src/components/media/media-manager.tsx
@@ -30,7 +30,7 @@ import { MediaList, Media, MediaListOffset } from '@tinacms/core'
 import path from 'path'
 import { Button } from '@tinacms/styles'
 import { useDropzone } from 'react-dropzone'
-import { MediaItem, Breadcrumb, MediaPaginatorPlugin } from './index'
+import { MediaItem, Breadcrumb, CursorPaginator } from './index'
 import { LoadingDots } from '@tinacms/react-forms'
 
 export interface MediaRequest {
@@ -76,9 +76,6 @@ export function MediaPicker({
   ...props
 }: MediaRequest) {
   const cms = useCMS()
-  const Paginator = cms.plugins
-    .getType('media:ui')
-    .find('paginator') as MediaPaginatorPlugin
   const [listState, setListState] = useState<MediaListState>(() => {
     if (cms.media.isConfigured) return 'loading'
     return 'not-configured'
@@ -229,7 +226,7 @@ export function MediaPicker({
         ))}
       </List>
 
-      <Paginator.Component
+      <CursorPaginator
         currentOffset={offset}
         hasNext={hasNext}
         navigateNext={navigateNext}

--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -17,12 +17,15 @@ limitations under the License.
 */
 
 import React from 'react'
-import styled, { css } from 'styled-components'
-import { MediaList, Plugin } from '@tinacms/core'
+import styled from 'styled-components'
+import { MediaListOffset, Plugin } from '@tinacms/core'
 
 export interface MediaPaginatorProps {
-  list: MediaList
-  setOffset: (offset: number) => void
+  currentOffset?: MediaListOffset
+  navigateNext?: () => void
+  navigatePrev?: () => void
+  hasNext: boolean
+  hasPrev: boolean
 }
 
 export interface MediaPaginatorPlugin extends Plugin {
@@ -32,35 +35,25 @@ export interface MediaPaginatorPlugin extends Plugin {
 export const BaseMediaPaginator: MediaPaginatorPlugin = {
   __type: 'media:ui',
   name: 'paginator',
-  Component: PageLinks,
+  Component: CursorPaginator,
 }
 
-export function PageLinks({ list, setOffset }: MediaPaginatorProps) {
-  const limit = list.limit || 10
-  const numPages = Math.ceil(list.totalCount / limit)
-  const lastItemIndexOnPage = list.offset + limit
-  const currentPageIndex = lastItemIndexOnPage / limit
-  let pageLinks = []
-
-  if (numPages <= 1) {
-    return null
-  }
-
-  for (let i = 1; i <= numPages; i++) {
-    const active = i === currentPageIndex
-    const nextOffset = (i - 1) * limit
-    pageLinks.push(
-      <PageNumber
-        key={`page-${i}`}
-        active={active}
-        onClick={() => setOffset(nextOffset)}
-      >
-        {i}
-      </PageNumber>
-    )
-  }
-
-  return <PageLinksWrap>{pageLinks}</PageLinksWrap>
+export function CursorPaginator({
+  navigateNext,
+  navigatePrev,
+  hasNext,
+  hasPrev,
+}: MediaPaginatorProps) {
+  return (
+    <PageLinksWrap>
+      <button disabled={!hasPrev} onClick={navigatePrev}>
+        Previous
+      </button>
+      <button disabled={!hasNext} onClick={navigateNext}>
+        Next
+      </button>
+    </PageLinksWrap>
+  )
 }
 
 const PageLinksWrap = styled.div`
@@ -68,23 +61,4 @@ const PageLinksWrap = styled.div`
   display: flex;
   justify-content: flex-end;
   margin-top: var(--tina-padding-small);
-`
-
-const PageNumber = styled.button<{ active: boolean }>`
-  padding: 0 0.15rem;
-  margin: var(--tina-padding-small);
-  transition: box-shadow 180ms ease;
-  background-color: transparent;
-  border: none;
-
-  :hover {
-    cursor: pointer;
-    box-shadow: 0 1px 0 var(--tina-color-grey-9);
-  }
-
-  ${p =>
-    !p.active &&
-    css`
-      color: var(--tina-color-grey-4);
-    `}
 `

--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -19,6 +19,7 @@ limitations under the License.
 import React from 'react'
 import styled from 'styled-components'
 import { MediaListOffset } from '@tinacms/core'
+import { Button } from '@tinacms/styles'
 
 export interface MediaPaginatorProps {
   currentOffset: MediaListOffset
@@ -36,12 +37,12 @@ export function CursorPaginator({
 }: MediaPaginatorProps) {
   return (
     <PageLinksWrap>
-      <button disabled={!hasPrev} onClick={navigatePrev}>
-        Previous
-      </button>
-      <button disabled={!hasNext} onClick={navigateNext}>
-        Next
-      </button>
+      <Button small disabled={!hasPrev} onClick={navigatePrev}>
+        &laquo; Previous
+      </Button>
+      <Button small disabled={!hasNext} onClick={navigateNext}>
+        Next &raquo;
+      </Button>
     </PageLinksWrap>
   )
 }

--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -21,9 +21,9 @@ import styled from 'styled-components'
 import { MediaListOffset, Plugin } from '@tinacms/core'
 
 export interface MediaPaginatorProps {
-  currentOffset?: MediaListOffset
-  navigateNext?: () => void
-  navigatePrev?: () => void
+  currentOffset: MediaListOffset
+  navigateNext: () => void
+  navigatePrev: () => void
   hasNext: boolean
   hasPrev: boolean
 }

--- a/packages/tinacms/src/components/media/pagination.tsx
+++ b/packages/tinacms/src/components/media/pagination.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 
 import React from 'react'
 import styled from 'styled-components'
-import { MediaListOffset, Plugin } from '@tinacms/core'
+import { MediaListOffset } from '@tinacms/core'
 
 export interface MediaPaginatorProps {
   currentOffset: MediaListOffset
@@ -26,16 +26,6 @@ export interface MediaPaginatorProps {
   navigatePrev: () => void
   hasNext: boolean
   hasPrev: boolean
-}
-
-export interface MediaPaginatorPlugin extends Plugin {
-  Component: React.ComponentType<MediaPaginatorProps>
-}
-
-export const BaseMediaPaginator: MediaPaginatorPlugin = {
-  __type: 'media:ui',
-  name: 'paginator',
-  Component: CursorPaginator,
 }
 
 export function CursorPaginator({

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -53,8 +53,3 @@ export {
   TinaCMSProviderProps,
 } from './components/TinaCMSProvider'
 export { TinaUI, TinaUIProps } from './components/TinaUI'
-export {
-  MediaPaginatorPlugin,
-  BaseMediaPaginator,
-  MediaPaginatorProps,
-} from './components/media'

--- a/packages/tinacms/src/tina-cms.ts
+++ b/packages/tinacms/src/tina-cms.ts
@@ -44,7 +44,6 @@ import {
   HtmlFieldPlaceholder,
 } from './plugins/fields/markdown'
 import { MediaManagerScreenPlugin } from './plugins/screens/media-manager-screen'
-import { BaseMediaPaginator } from './components/media/pagination'
 
 const DEFAULT_FIELDS = [
   TextFieldPlugin,
@@ -112,9 +111,6 @@ export class TinaCMS extends CMS {
       }
     })
     this.plugins.add(MediaManagerScreenPlugin)
-    if (!this.plugins.getType('media:ui').find('paginator')) {
-      this.plugins.add(BaseMediaPaginator)
-    }
   }
 
   get alerts() {


### PR DESCRIPTION
This is essential to support Cloudinary and likely other DAMs in the media manager. The API changes reflect a relaxing of the needed pagination data from Media Stores, moving from a "SQL-style" `limit` + `offset` calculation to a less-opinionated `prevOffset` / `nextOffset` approach.

- [x] Update Media types to support cursor-based pagination
- [x] Update Media Manager UI to use cursor-based pagination instead of numbered
- [x] Update all media stores in monorepo to support new Media API
- [x] Polish pagination styles
- [x] Remove support for custom pagination plugins
    - *This was an experimental feature added to work around UI bugs with page numbers in large media libraries. Existing paginator plugins are expected to break due to the API changes anyway. I think the best course of action is to remove support for these plugins until the needs are better understood.*
- [x] Prepare documentation for release