### PR TITLE
chore(release): ensure access token can create a release before starting

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,15 +1,9 @@
 #!/bin/bash
 
-# Check for $GH_TOKEN
-if [[ -z $GH_TOKEN ]]
-then
-  echo "ENV '\$GH_TOKEN' is required to proceed; learn more at https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type"
-  exit 1
-fi
-
 # Terminate after the first line that fails (returns nonzero exit code)
 set -e
 
+source $(dirname $0)/require_gh_token.sh
 source $(dirname $0)/require_clean_work_tree.sh
 
 # 0.1. Confirm Action
@@ -22,6 +16,9 @@ fi
 
 #0.2. Ensure no uncommitted changes
 require_clean_work_tree
+
+#0.3 Check if GH_TOKEN present and has correct permissions
+require_gh_token
 
 # 1. Update Matser
 git checkout master

--- a/scripts/require_gh_token.sh
+++ b/scripts/require_gh_token.sh
@@ -1,0 +1,30 @@
+
+require_gh_token () {
+  #  Ensure that $GH_TOKEN is in env
+  echo "Checking for GH_TOKEN..."
+  if [[ -z $GH_TOKEN ]]
+  then
+  echo "ENV '\$GH_TOKEN' is required to proceed; learn more at https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type"
+  exit 1
+  fi
+
+  # Check if token can create a relese
+  echo "Checking GH_TOKEN permissions..."
+  set -e
+
+  # create a dummy release
+  # this is the capability that we will need so let's just check it by trying it
+  RELEASE_ID=$(curl --silent --show-error --fail \
+  -u :$GH_TOKEN \
+  -X POST \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/tinacms/tinacms/releases \
+  -d '{"tag_name": "permission_check", "draft": true}' | jq '.id')
+
+  # cleanup the dummy release
+  curl --silent --show-error --fail \
+  -u :$GH_TOKEN \
+  -X DELETE \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/tinacms/tinacms/releases/$RELEASE_ID
+}


### PR DESCRIPTION
Automatically creating a GitHub release is one of the last steps in the release script, and can cause some minor havoc for the entire release if the script runner's credentials are misconfigured. This PR updates the release script to check this capability by creating and deleting a dummy release before kicking off the rest of the process.