### PR TITLE
feat(tinacms): customize list error message by throwing a MediaListError

### DIFF
--- a/packages/@tinacms/core/src/media.ts
+++ b/packages/@tinacms/core/src/media.ts
@@ -249,3 +249,21 @@ export interface SelectMediaOptions {
   directory?: string
   onSelect?(media: Media): void
 }
+
+interface MediaListErrorConfig {
+  title: string
+  message: string
+  docsLink: string
+}
+
+export class MediaListError extends Error {
+  public ERR_TYPE = 'MediaListError'
+  public title: string
+  public docsLink: string
+
+  constructor(config: MediaListErrorConfig) {
+    super(config.message)
+    this.title = config.title
+    this.docsLink = config.docsLink
+  }
+}

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -27,6 +27,7 @@ export {
   MediaListOptions,
   MediaList,
   MediaManager,
+  MediaListError,
 } from '@tinacms/core'
 export { ScreenPlugin, useScreenPlugin } from '@tinacms/react-screens'
 export * from '@tinacms/fields'


### PR DESCRIPTION
alternative to https://github.com/tinacms/tinacms/pull/1868

this enables customizing error feedback by throwing an instance of `MediaListError` which enables you to customize the title, explanation message, and link to documentation.

This feels simpler, and allows Media Stores to include troubleshooting instructions directly.

```
import { MediaListError } from 'tinacms'

class MyCustomMediaStore {
  // ...
  async list(options) {
    // ...
    throw new MediaListError({
      title: 'Missing API Key'
      message: 'We couldn't find the API key',
      docsLink: 'https://example.com/my-media-store-docs',
    })
  }
}
```