### PR TITLE
fix(react-tinacms-editor): Fixing FocusRingOptions import path

### DIFF
--- a/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-inline/inline-wysiwyg.tsx
@@ -18,8 +18,8 @@ limitations under the License.
 
 import * as React from 'react'
 import { useCMS, Form } from 'tinacms'
-import { InlineField, FocusRing } from 'react-tinacms-inline'
-import { FocusRingOptions } from 'react-tinacms-inline/src/styles'
+import { InlineField, FocusRing, FocusRingOptions } from 'react-tinacms-inline'
+import { FocusRingOptions } from 'react-tinacms-inline'
 import { Wysiwyg } from '../components/Wysiwyg'
 import { EditorProps } from '../types'
 


### PR DESCRIPTION
using relative path to import `FocusRingOptions` fails when using webpack and node as the path becomes  `react-tinacms-inline/dist/src/styles`
