### PR TITLE
fix(react-tinacms-github): Makes form-builder a peerDependency

### DIFF
--- a/packages/react-tinacms-github/package.json
+++ b/packages/react-tinacms-github/package.json
@@ -35,6 +35,7 @@
     "@tinacms/react-core": "^0.43.0",
     "@tinacms/react-forms": "^0.43.0",
     "@tinacms/react-modals": "^0.39.0",
+    "@tinacms/form-builder": ">=0.39",
     "@tinacms/scripts": "^0.42.1",
     "@tinacms/styles": "^0.42.1",
     "@types/js-cookie": "^2.2.5",

--- a/packages/react-tinacms-github/package.json
+++ b/packages/react-tinacms-github/package.json
@@ -19,6 +19,7 @@
     "@tinacms/icons": ">=0.7.0",
     "@tinacms/react-core": ">=0.39",
     "@tinacms/react-modals": ">=0.39",
+    "@tinacms/form-builder": ">=0.39",
     "@tinacms/styles": ">=0.4",
     "final-form": ">=4.18.0",
     "react": ">=16.8",
@@ -42,7 +43,6 @@
     "tinacms": "^0.43.0"
   },
   "dependencies": {
-    "@tinacms/form-builder": "^0.39.0",
     "btoa": "^1.2.1",
     "js-cookie": "^2.2.1",
     "next-tinacms-markdown": "^0.43.0"


### PR DESCRIPTION
... rather than a direct dependency.  Should resolve issues where `useCMS()` could not locate a `cms` context and maybe other issues downstream.

Could be a fix for issues encountered here:
https://github.com/tinacms/tinacms/issues/1865
