### PR TITLE
fix(react-tinacms-editor,react-tinacms-inline): Fixes deps

### DIFF
--- a/packages/react-tinacms-editor/package.json
+++ b/packages/react-tinacms-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinacms-editor",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "module": "dist/react-tinacms-editor.esm.js",
@@ -25,6 +25,7 @@
     "@tinacms/react-forms": "^0.43.0",
     "@tinacms/scripts": "^0.42.1",
     "@tinacms/styles": "^0.42.1",
+    "@tinacms/form-builder": ">=0.39",
     "@types/codemirror": "^0.0.71",
     "@types/color-string": "^1.5.0",
     "@types/lodash.debounce": "^4.0.6",
@@ -51,7 +52,6 @@
     "tinacms": "^0.43.0"
   },
   "dependencies": {
-    "@tinacms/form-builder": "^0.39.0",
     "codemirror": "^5.42.2",
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
@@ -76,7 +76,8 @@
     "react-dom": ">=16.8",
     "react-tinacms-inline": ">=0.29",
     "styled-components": ">=4.1",
-    "tinacms": ">=0.13"
+    "tinacms": ">=0.13",
+    "@tinacms/form-builder": ">=0.39"
   },
   "gitHead": "87c8f9a3ca2c5bf41e1a4c54a73759d12a7c5bfd"
 }

--- a/packages/react-tinacms-inline/package.json
+++ b/packages/react-tinacms-inline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-tinacms-inline",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "typings": "dist/src/index.d.ts",
@@ -14,7 +14,6 @@
     "build": "tinacms-scripts build"
   },
   "dependencies": {
-    "@tinacms/form-builder": "^0.39.0",
     "react-dismissible": "^1.3.0",
     "react-textarea-autosize": ">=7.1",
     "react-use": "^17.1.1"
@@ -25,7 +24,8 @@
     "react-final-form": ">=6",
     "react-tinacms-editor": ">=0.0",
     "styled-components": ">=4.1",
-    "tinacms": ">=0.39"
+    "tinacms": ">=0.39",
+    "@tinacms/form-builder": ">=0.39"
   },
   "devDependencies": {
     "@testing-library/react": "^11.1.2",
@@ -33,6 +33,7 @@
     "@tinacms/react-forms": "^0.43.0",
     "@tinacms/scripts": "^0.42.1",
     "@tinacms/styles": "^0.42.1",
+    "@tinacms/form-builder": ">=0.39",
     "jest": "^26.6.3",
     "react-dropzone": "10.1.8",
     "react-tinacms-editor": "^0.4.0",


### PR DESCRIPTION
Like the work on `react-tinacms-github` and `next-tinacms-github`, `@tinacms/form-builder` should no longer be a direct `dependency`, but instead a `peerDependency/devDependency`.  Having it a direct depdendency was causing issues downstream with (I believe) the use of `FormPortalProvider` which would have relied on a shared context.

Can confirm that I was able to using the `MarkdownFieldPlugin` once I made this change using `beta` releases of both packages and the GitHub Backend flow.

Relates to #1865 