### PR TITLE
parse media item from within the ImageField itself

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -68,69 +68,69 @@ export function usePreviewSrc(
   return [src, loading]
 }
 
-export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
-  const cms = useCMS()
-  const { form, field } = props
-  const { name, value } = props.input
-  const [src, srcIsLoading] = usePreviewSrc(
-    value,
-    name,
-    form.getState().values,
-    field.previewSrc
-  )
+export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
+  (props) => {
+    const cms = useCMS()
+    const { form, field } = props
+    const { name, value } = props.input
+    const [src, srcIsLoading] = usePreviewSrc(
+      value,
+      name,
+      form.getState().values,
+      field.previewSrc
+    )
 
-  let onClear: any
-  if (props.field.clearable) {
-    onClear = () => props.input.onChange('')
-  }
-
-  function onChange(media?: Media) {
-    if (media) {
-      const mediaParse = cms.media.store
-
-      const parsedValue =
-        // @ts-ignore
-        typeof cms?.media?.store?.parse === 'function'
-          ? // @ts-ignore
-            cms.media.store.parse(media)
-          : // @ts-ignore
-            mediaParse.parse(media)
-      props.input.onChange('')
-      props.input.onChange(parsedValue)
+    let onClear: any
+    if (props.field.clearable) {
+      onClear = () => props.input.onChange('')
     }
-  }
 
-  const uploadDir = props.field.uploadDir || (() => '')
+    function onChange(media?: Media) {
+      if (media) {
+        const parsedValue =
+          // @ts-ignore
+          typeof cms?.media?.store?.parse === 'function'
+            ? // @ts-ignore
+              cms.media.store.parse(media)
+            : media
 
-  return (
-    <ImageUpload
-      value={value}
-      previewSrc={src}
-      loading={srcIsLoading}
-      onClick={() => {
-        const directory = uploadDir(props.form.getState().values)
-        cms.media.open({
-          allowDelete: true,
-          directory,
-          onSelect: onChange,
-        })
-      }}
-      onDrop={async ([file]: File[]) => {
-        const directory = uploadDir(props.form.getState().values)
+        props.input.onChange('')
+        props.input.onChange(parsedValue)
+      }
+    }
 
-        const [media] = await cms.media.persist([
-          {
+    const uploadDir = props.field.uploadDir || (() => '')
+
+    return (
+      <ImageUpload
+        value={value}
+        previewSrc={src}
+        loading={srcIsLoading}
+        onClick={() => {
+          const directory = uploadDir(props.form.getState().values)
+          cms.media.open({
+            allowDelete: true,
             directory,
-            file,
-          },
-        ])
+            onSelect: onChange,
+          })
+        }}
+        onDrop={async ([file]: File[]) => {
+          const directory = uploadDir(props.form.getState().values)
 
-        onChange(media)
-      }}
-      onClear={onClear}
-    />
-  )
-})
+          const [media] = await cms.media.persist([
+            {
+              directory,
+              file,
+            },
+          ])
+
+          onChange(media)
+        }}
+        onClear={onClear}
+      />
+    )
+  }
+)
 
 export const ImageFieldPlugin = {
   name: 'image',

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -68,62 +68,69 @@ export function usePreviewSrc(
   return [src, loading]
 }
 
-export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
-  (props) => {
-    const cms = useCMS()
-    const { form, field } = props
-    const { name, value } = props.input
-    const [src, srcIsLoading] = usePreviewSrc(
-      value,
-      name,
-      form.getState().values,
-      field.previewSrc
-    )
+export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(props => {
+  const cms = useCMS()
+  const { form, field } = props
+  const { name, value } = props.input
+  const [src, srcIsLoading] = usePreviewSrc(
+    value,
+    name,
+    form.getState().values,
+    field.previewSrc
+  )
 
-    let onClear: any
-    if (props.field.clearable) {
-      onClear = () => props.input.onChange('')
-    }
-
-    function onChange(media?: Media) {
-      if (media) {
-        props.input.onChange('')
-        props.input.onChange(media)
-      }
-    }
-
-    const uploadDir = props.field.uploadDir || (() => '')
-
-    return (
-      <ImageUpload
-        value={value}
-        previewSrc={src}
-        loading={srcIsLoading}
-        onClick={() => {
-          const directory = uploadDir(props.form.getState().values)
-          cms.media.open({
-            allowDelete: true,
-            directory,
-            onSelect: onChange,
-          })
-        }}
-        onDrop={async ([file]: File[]) => {
-          const directory = uploadDir(props.form.getState().values)
-
-          const [media] = await cms.media.persist([
-            {
-              directory,
-              file,
-            },
-          ])
-
-          onChange(media)
-        }}
-        onClear={onClear}
-      />
-    )
+  let onClear: any
+  if (props.field.clearable) {
+    onClear = () => props.input.onChange('')
   }
-)
+
+  function onChange(media?: Media) {
+    if (media) {
+      const mediaParse = cms.media.store
+
+      const parsedValue =
+        // @ts-ignore
+        typeof cms?.media?.store?.parse === 'function'
+          ? // @ts-ignore
+            cms.media.store.parse(media)
+          : // @ts-ignore
+            mediaParse.parse(media)
+      props.input.onChange('')
+      props.input.onChange(parsedValue)
+    }
+  }
+
+  const uploadDir = props.field.uploadDir || (() => '')
+
+  return (
+    <ImageUpload
+      value={value}
+      previewSrc={src}
+      loading={srcIsLoading}
+      onClick={() => {
+        const directory = uploadDir(props.form.getState().values)
+        cms.media.open({
+          allowDelete: true,
+          directory,
+          onSelect: onChange,
+        })
+      }}
+      onDrop={async ([file]: File[]) => {
+        const directory = uploadDir(props.form.getState().values)
+
+        const [media] = await cms.media.persist([
+          {
+            directory,
+            file,
+          },
+        ])
+
+        onChange(media)
+      }}
+      onClear={onClear}
+    />
+  )
+})
 
 export const ImageFieldPlugin = {
   name: 'image',


### PR DESCRIPTION
Previously the Cloudinary image parsing happened from a `parse` hook we were hijacking from the `useGraphqlForms` API. This would make it more "core", though I'm admittedly a little lost on what `media` vs `media.store` represents. And we don't have an optional type on the `parse` function from the `MediaStore` interface. Didn't want to add that until I get some more info on how this might be problematic.

EDIT: select "Ignore Whitespace" to see actual diff