### PR TITLE
remove unused danger scripts

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Install
-        run: npm ci
+        run: yarn install
       - name: Danger
         uses: danger/danger-js@10.6.4
         env:


### PR DESCRIPTION
- consumers metadata on tina.io is not maintained
- global dep check will no longer be necessary with migration to PNP