### PR TITLE
fix(@tinacms/toolkit): Removes onKeyPress from FormBuilder

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
@@ -85,12 +85,7 @@ export const FormBuilder: FC<FormBuilderProps> = ({ form: tinaForm }) => {
         {({ handleSubmit, pristine, invalid, submitting }) => {
           return (
             <DragDropContext onDragEnd={moveArrayItem}>
-              <FormBody
-                className="form-body"
-                onKeyPress={(e) =>
-                  e.charCode === 13 && !submitting ? handleSubmit() : null
-                }
-              >
+              <FormBody className="form-body">
                 <FormPortalProvider>
                   <Wrapper>
                     {tinaForm && tinaForm.fields.length ? (


### PR DESCRIPTION
A lingering difference between our `ContentCreator` (and Modal Forms) vs. Sidebar is that Modal Forms were coded to submit on `Enter`.  While handy, this meant that certain fields - namely `textarea` - would not function properly.

This behavior was carried over to `FormBuilder` as part of the merger, but is better left removed entirely.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
