### PR TITLE
Fix Editor plugin

### DIFF
--- a/examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -65,7 +65,7 @@
           "name": "body",
           "isBody": true,
           "ui": {
-            "component": "textarea"
+            "component": "markdown"
           },
           "namespace": [
             "posts",

--- a/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
@@ -45,7 +45,7 @@
           "name": "body",
           "isBody": true,
           "ui": {
-            "component": "textarea"
+            "component": "markdown"
           }
         }
       ]

--- a/examples/tina-cloud-starter/.tina/schema.ts
+++ b/examples/tina-cloud-starter/.tina/schema.ts
@@ -58,7 +58,7 @@ export default defineSchema({
           name: 'body',
           isBody: true,
           ui: {
-            component: 'textarea',
+            component: 'markdown',
           },
         },
       ],

--- a/examples/tina-cloud-starter/package.json
+++ b/examples/tina-cloud-starter/package.json
@@ -25,6 +25,7 @@
     "react-dom": "^16.13.1",
     "react-is": "^17.0.2",
     "react-markdown": "^5.0.3",
+    "react-tinacms-editor": "workspace:packages/react-tinacms-editor",
     "styled-components": "^5.1.3",
     "styled-jsx": "^3.2.5",
     "tinacms": "workspace:*",

--- a/packages/react-tinacms-editor/package.json
+++ b/packages/react-tinacms-editor/package.json
@@ -61,6 +61,7 @@
   "dependencies": {
     "@tinacms/toolkit": "workspace:packages/@tinacms/toolkit",
     "codemirror": "^5.42.2",
+    "final-form": ">=4.20.2",
     "lodash.debounce": "^4.0.8",
     "lodash.get": "^4.4.2",
     "markdown-it": "^8.3.1",
@@ -77,15 +78,14 @@
     "prosemirror-transform": "^1.0.0",
     "prosemirror-utils": "^0.9.6",
     "prosemirror-view": "^1.11.3",
-    "react-dismissible": "^1.3.0"
+    "react-dismissible": "^1.3.0",
+    "react-final-form": ">=6",
+    "react-tinacms-inline": "workspace:*"
   },
   "peerDependencies": {
-    "final-form": ">=4.20.2",
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "react-final-form": ">=6",
     "react-is": "^17.0.2",
-    "react-tinacms-inline": ">=0.29",
     "styled-components": ">=4.1",
     "tinacms": ">=0.13"
   },

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/Menubar/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/Menubar/index.tsx
@@ -30,7 +30,7 @@ import { ProsemirrorMenu as LinkMenu } from '../../../plugins/Link'
 
 import { TablePopups } from '../../../plugins/Table/Popup'
 import {
-  ImageEdit as ImageEditPopup,
+  // ImageEdit as ImageEditPopup,
   Loader as ImageLoader,
 } from '../../../plugins/Image'
 import { LinkForm as LinkFormPopup } from '../../../plugins/Link'
@@ -66,7 +66,7 @@ export const Menubar = ({ plugins, imageProps, ...rest }: Props) => {
       ]}
       popups={[
         <TablePopups key="TablePopups" />,
-        <ImageEditPopup key="ImageEditPopup" />,
+        // <ImageEditPopup key="ImageEditPopup" />,
         <LinkFormPopup key="LinkFormPopup" />,
         <ImageLoader key="ImageLoader" />,
       ]}


### PR DESCRIPTION
Closes https://github.com/tinacms/tinacms/issues/1896

This PR is in 2 parts:
1. Get the editor working by commenting out the Image popup, not sure why it's not working
2. Set final-form react-final-form and tinacms-react-inline as direct dependencies so you don't need to add them all when using the editor. It seems to be working for me although I'm not sure if `useField` hooks will get mixed up and if we're using them here.

At the very least part 1 will unblock us