### PR TITLE
chore: Excludes examples folder when determining files needing license

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -198,7 +198,7 @@ function checkForLicense({ packageJson }: TinaPackage) {
  *
  */
 function fileNeedsLicense(filepath: string) {
-  return new RegExp(/^(?!examples\/).+\.(js|tsx?)$/).test(filepath)
+  return new RegExp(/^(?!examples\/).+\.(jsx?|tsx?)$/).test(filepath)
 }
 
 /**

--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -198,7 +198,7 @@ function checkForLicense({ packageJson }: TinaPackage) {
  *
  */
 function fileNeedsLicense(filepath: string) {
-  return new RegExp(/\.(js|tsx?)$/).test(filepath)
+  return new RegExp(/^(?!examples\/).+\.(js|tsx?)$/).test(filepath)
 }
 
 /**


### PR DESCRIPTION
Trying to change the dangerfile to exclude files in the `examples/` folder.  I believe it needs to be a separate PR to work.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
