### PR TITLE
simplify installation for `react-tinacms-editor`

### DIFF
--- a/.changeset/hungry-lies-shave.md
+++ b/.changeset/hungry-lies-shave.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-editor': minor
+---
+
+Remove unused peer dependencies

--- a/examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -66,7 +66,7 @@
           "type": "string",
           "label": "Body",
           "ui": {
-            "component": "textarea"
+            "component": "markdown"
           },
           "name": "_body",
           "isBody": true,
@@ -628,7 +628,7 @@
                   "label": "Text",
                   "name": "text",
                   "ui": {
-                    "component": "textarea"
+                    "component": "markdown"
                   },
                   "namespace": [
                     "pages",

--- a/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
@@ -46,7 +46,7 @@
           "type": "string",
           "label": "Body",
           "ui": {
-            "component": "textarea"
+            "component": "markdown"
           },
           "name": "_body",
           "isBody": true
@@ -464,7 +464,7 @@
                   "label": "Text",
                   "name": "text",
                   "ui": {
-                    "component": "textarea"
+                    "component": "markdown"
                   }
                 },
                 {

--- a/examples/tina-cloud-starter/.tina/schema.ts
+++ b/examples/tina-cloud-starter/.tina/schema.ts
@@ -307,7 +307,7 @@ const heroBlockSchema = {
       label: "Text",
       name: "text",
       ui: {
-        component: "textarea",
+        component: "markdown",
       },
     },
     {
@@ -426,7 +426,7 @@ export default defineSchema({
           type: "string",
           label: "Body",
           ui: {
-            component: "textarea",
+            component: "markdown",
           },
           name: "_body",
           isBody: true,

--- a/examples/tina-cloud-starter/package.json
+++ b/examples/tina-cloud-starter/package.json
@@ -32,6 +32,7 @@
     "react-icons": "^4.2.0",
     "react-is": "^17.0.2",
     "react-markdown": "^5.0.3",
+    "react-tinacms-editor": "workspace:*",
     "styled-components": "^5.1.3",
     "styled-jsx": "^3.2.5",
     "tinacms": "workspace:*",

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -3,7 +3,6 @@ import dynamic from "next/dynamic";
 import { TinaEditProvider } from "tinacms/dist/edit-state";
 import { Layout } from "../components/layout";
 const TinaCMS = dynamic(() => import("tinacms"), { ssr: false });
-import { MarkdownFieldPlugin } from "react-tinacms-editor";
 // import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
@@ -20,7 +19,9 @@ const App = ({ Component, pageProps }) => {
             clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
             isLocalClient={Boolean(Number(NEXT_PUBLIC_USE_LOCAL_CLIENT))}
             cmsCallback={(cms) => {
-              cms.plugins.add(MarkdownFieldPlugin);
+              import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
+                cms.plugins.add(MarkdownFieldPlugin);
+              });
             }}
             {...pageProps}
           >

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -3,6 +3,7 @@ import dynamic from "next/dynamic";
 import { TinaEditProvider } from "tinacms/dist/edit-state";
 import { Layout } from "../components/layout";
 const TinaCMS = dynamic(() => import("tinacms"), { ssr: false });
+import { MarkdownFieldPlugin } from "react-tinacms-editor";
 // import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
@@ -18,6 +19,9 @@ const App = ({ Component, pageProps }) => {
             branch="main"
             clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
             isLocalClient={Boolean(Number(NEXT_PUBLIC_USE_LOCAL_CLIENT))}
+            cmsCallback={(cms) => {
+              cms.plugins.add(MarkdownFieldPlugin);
+            }}
             {...pageProps}
           >
             {(livePageProps) => (

--- a/packages/react-tinacms-editor/package.json
+++ b/packages/react-tinacms-editor/package.json
@@ -52,7 +52,6 @@
     "react-docgen-typescript-webpack-plugin": "^1.1.0",
     "react-dom": "16.12.0",
     "react-is": "^17.0.2",
-    "react-tinacms-inline": "^0.43.2-alpha.0",
     "styled-components": ">=4.1",
     "tinacms": "workspace:*",
     "ts-jest": "^24.0.3",
@@ -77,12 +76,12 @@
     "prosemirror-transform": "^1.0.0",
     "prosemirror-utils": "^0.9.6",
     "prosemirror-view": "^1.11.3",
-    "react-dismissible": "^1.3.0"
+    "react-dismissible": "^1.3.0",
+    "react-tinacms-inline": "workspace:*"
   },
   "peerDependencies": {
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "react-tinacms-inline": ">=0.29",
     "styled-components": ">=4.1",
     "tinacms": ">=0.13"
   },

--- a/packages/react-tinacms-editor/package.json
+++ b/packages/react-tinacms-editor/package.json
@@ -80,11 +80,8 @@
     "react-dismissible": "^1.3.0"
   },
   "peerDependencies": {
-    "final-form": ">=4.20.2",
     "react": ">=16.8",
     "react-dom": ">=16.8",
-    "react-final-form": ">=6",
-    "react-is": "^17.0.2",
     "react-tinacms-inline": ">=0.29",
     "styled-components": ">=4.1",
     "tinacms": ">=0.13"


### PR DESCRIPTION
![](https://media2.giphy.com/media/3zFcbgHoIXzykQc7vU/200.gif)

`react-tinacms-editor` wasn't actually using any APIs in `final-form` or `react-final-form` so they don't need to be in the dependency tree at all.