### PR TITLE
Fix main build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,10 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        #  - windows-latest
         node-version: [12.x, 14.x]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
         node-version: [12.x, 14.x]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [10.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
`tsup` doesn't appear to work with Node 10. Since Node 10 is now EOL, we might as well drop it from the matrix.
Additionally, there seem to be some problems with the build on windows. We are disabling windows builds for now and will come back to it later, as noted in #1934 


to test this, I updated the `main` workflow to also run on this branch, but have rebased out that change before merging. I'm attaching a screenshot of the checks to document:

![image](https://user-images.githubusercontent.com/15221702/127387082-0c32254a-9270-4159-9b0f-d9ab654f5ba7.png)