### PR TITLE
docs(tinacms): rename tinacms-cli

### DIFF
--- a/packages/@tinacms/cli/CHANGELOG.md
+++ b/packages/@tinacms/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @tinacms/cli
+# tinacms-cli
 
 ## 0.4.0
 

--- a/packages/@tinacms/cli/CHANGELOG.md
+++ b/packages/@tinacms/cli/CHANGELOG.md
@@ -1,4 +1,4 @@
-# tinacms-cli
+# @tinacms/cli
 
 ## 0.4.0
 

--- a/packages/@tinacms/cli/README.md
+++ b/packages/@tinacms/cli/README.md
@@ -7,13 +7,13 @@ The CLI can be installed as a dev dependency in your project.
 Npm:
 
 ```bash
-npm install --save-dev tinacms-cli
+npm install --save-dev @tinacms/cli
 ```
 
 Yarn:
 
 ```bash
-yarn add --dev tinacms-cli
+yarn add --dev @tinacms/cli
 ```
 
 ## Usage
@@ -47,7 +47,7 @@ mkdir .tina && touch .tina/schema.ts
 
 ```ts
 // .tina/schema.ts
-import { defineSchema } from "tinacms-cli";
+import { defineSchema } from "@tinacms/cli";
 
 export default defineSchema({
   collections: [

--- a/packages/@tinacms/cli/package.json
+++ b/packages/@tinacms/cli/package.json
@@ -73,6 +73,6 @@
   },
   "repository": {
     "url": "https://github.com/tinacms/tinacms.git",
-    "directory": "packages/tinacms-cli"
+    "directory": "packages/@tinacms/cli"
   }
 }


### PR DESCRIPTION
Rename tinacms-cli to @tinacms/cli in our docs/examples

(I _think_ this matches our new package naming, but may be off)