### PR TITLE
chore(examples/tina-cloud-starter): Adds documentCreatorCallback 

### DIFF
--- a/.changeset/healthy-items-unite.md
+++ b/.changeset/healthy-items-unite.md
@@ -1,0 +1,5 @@
+---
+'tina-cloud-starter': patch
+---
+
+Adds documentCreatorCallback to starter

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -23,6 +23,23 @@ const App = ({ Component, pageProps }) => {
                 cms.plugins.add(MarkdownFieldPlugin);
               });
             }}
+            documentCreatorCallback={{
+              /**
+               * After a new document is created, redirect to its location
+               */
+              onNewDocument: ({ collection: { slug }, breadcrumbs }) => {
+                const relativeUrl = `/${slug}/${breadcrumbs.join("/")}`;
+                return (window.location.href = relativeUrl);
+              },
+              /**
+               * Only allows documents to be created to the `Blog Posts` Collection
+               */
+              filterCollections: (options) => {
+                return options.filter(
+                  (option) => option.label === "Blog Posts"
+                );
+              },
+            }}
             {...pageProps}
           >
             {(livePageProps) => (


### PR DESCRIPTION
Uses the `documentCreatorCallback` to set up specific behavior for the `tina-cloud-starter`.  Utilizes `onNewDocument()` to redirect to the new document's relative url after it is successfully created.  Utilizes `filterCollections()` to limit the available Collections to just `Blog Posts`.