### PR TITLE
use experimental flag for changsets

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,5 +6,8 @@
   "access": "restricted",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": []
 }


### PR DESCRIPTION
From [changsets](https://github.com/atlassian/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies) docs:
> Currently, if you list a package as a peerDependency of another package, this causes the package with the peerDependency to be released as a major change. This is because peerDependency changes will not be caught by package installation.

This resulted in an [unwanted major version bump](https://github.com/tinacms/tinacms/pull/1930), while it's likely the more correct behavior, until we're at 1.0 we'll try and hold off on too many major version bumps.

Settings this [option](https://github.com/atlassian/changesets/issues/524) prevents that behavior

