### PR TITLE
feat(@tinacms/graphql): Use checkbox-group field

### DIFF
--- a/.changeset/olive-radios-drum.md
+++ b/.changeset/olive-radios-drum.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Uses checkbox-group field

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -529,9 +529,8 @@ export class Resolver {
       case 'string':
         if (field.options) {
           if (field.list) {
-            // FIXME: this is awaiting checkbox suppport
             return {
-              component: 'checkbox',
+              component: 'checkbox-group',
               ...field,
               ...extraFields,
               options: field.options,


### PR DESCRIPTION
Updates the primitives resolver to use `checkbox-group` when field is `type: string`, `options: [...]`, and `list: true`.  This will render as the new `CheckboxGroupField` Plugin and accept multiple `string` values.

Closes #1866 

<img width="1789" alt="Screen Shot 2021-07-28 at 2 54 25 PM" src="https://user-images.githubusercontent.com/1699544/127387124-4591c86c-6dc5-4787-871f-7f3eb75f494c.png">
