### PR TITLE
trigger PR build on pushes to changeset-release branches

### DIFF
--- a/.github/workflows/build-test-lint.yml
+++ b/.github/workflows/build-test-lint.yml
@@ -1,6 +1,10 @@
 name: Build, Test, Lint for Pull Requests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - changeset-release/**
 
 jobs:
   build:


### PR DESCRIPTION
Workflows triggered from PRs do not run when a PR is created by github actions, so the required workflow is not running when changeset bot creates a versioning PR. By also triggering this workflow on pushes to branches prefixed with changeset-release, the expectation is that this workflow will run on pull requests opened by changeset bot.