### PR TITLE
expose a createGlobalForm function in formify args

### DIFF
--- a/.changeset/giant-badgers-flow.md
+++ b/.changeset/giant-badgers-flow.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+Expose a createGlobalForm function in formifyCallback that creates a screen plugin

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -41,6 +41,13 @@ const App = ({ Component, pageProps }) => {
                 );
               },
             }}
+            formifyCallback={({ formConfig, createForm, createGlobalForm }) => {
+              if (formConfig.id === "getGlobalDocument") {
+                return createGlobalForm(formConfig);
+              }
+
+              return createForm(formConfig);
+            }}
             {...pageProps}
           >
             {(livePageProps) => (

--- a/packages/tinacms/README.md
+++ b/packages/tinacms/README.md
@@ -126,16 +126,13 @@ If you'd like to control the output of those forms, tap into the `formify` callb
 
 ```tsx
 import { useGraphqlForms } from "tinacms";
-import { Form, GlobalFormPlugin, useCMS } from "tinacms";
+import { useCMS } from "tinacms";
 
 const [payload, isLoading] = useGraphqlForms({
   query,
-  formify: ({ formConfig, createForm, skip }) => {
+  formify: ({ formConfig, createForm, createGlobalForm, skip }) => {
     if (formConfig.id === "getSiteNavsDocument") {
-      const form = new Form(formConfig);
-      // The site nav will be a global plugin
-      cms.plugins.add(new GlobalFormPlugin(form));
-      return form;
+      return createGlobalForm(formConfig);
     }
 
     return createForm(formConfig);


### PR DESCRIPTION
the formify API can provide a simple way to create global forms in its callback, similar to the existing createForm