### PR TITLE
Fix/date format

### DIFF
--- a/examples/tina-cloud-starter/components/post.tsx
+++ b/examples/tina-cloud-starter/components/post.tsx
@@ -3,6 +3,7 @@ import Markdown from "react-markdown";
 import { Container } from "./container";
 import { Section } from "./section";
 import { ThemeContext } from "./theme";
+import format from 'date-fns/format'
 
 export const Post = ({ data }) => {
   const theme = React.useContext(ThemeContext);
@@ -19,6 +20,8 @@ export const Post = ({ data }) => {
     yellow:
       "from-yellow-400 to-yellow-500 dark:from-yellow-300 dark:to-yellow-500",
   };
+  const date = Date.parse(data.date)
+  const formattedDate = format(date, 'MMM dd, yyyy')
 
   return (
     <Section className="flex-1">
@@ -54,7 +57,7 @@ export const Post = ({ data }) => {
             </>
           )}
           <p className="text-base text-gray-400 group-hover:text-gray-500 dark:text-gray-300 dark:group-hover:text-gray-150">
-            {data.date}
+            {formattedDate}
           </p>
         </div>
       </Container>

--- a/examples/tina-cloud-starter/components/post.tsx
+++ b/examples/tina-cloud-starter/components/post.tsx
@@ -20,8 +20,9 @@ export const Post = ({ data }) => {
     yellow:
       "from-yellow-400 to-yellow-500 dark:from-yellow-300 dark:to-yellow-500",
   };
-  const date = Date.parse(data.date)
-  const formattedDate = format(date, 'MMM dd, yyyy')
+  const date = new Date(data.date)
+  const dateUTC = date.valueOf() + date.getTimezoneOffset() * 60 * 1000
+  const formattedDate = format(dateUTC, 'MMM dd, yyyy')
 
   return (
     <Section className="flex-1">

--- a/examples/tina-cloud-starter/content/posts/voteForPedro.md
+++ b/examples/tina-cloud-starter/content/posts/voteForPedro.md
@@ -1,12 +1,12 @@
 ---
 title: Vote For Pedro
 author: content/authors/pedro.md
-date: April 22 2021
+date: 'Wed, 07 Apr 2021 06:00:00 GMT'
 excerpt: >-
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
   incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo
   vel fringilla est ullamcorper eget. At imperdiet dui accumsan sit amet nulla
   facilities morbi tempus.
-_body: ''
+_body: |+
 ---
 

--- a/examples/tina-cloud-starter/package.json
+++ b/examples/tina-cloud-starter/package.json
@@ -24,6 +24,7 @@
     "@headlessui/react": "^1.3.0",
     "@tailwindcss/typography": "^0.4.1",
     "@tinacms/auth": "workspace:*",
+    "date-fns": "^2.23.0",
     "next": "10.0.5",
     "next-svgr": "^0.0.2",
     "next-tinacms-cloudinary": "workspace:*",

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -656,7 +656,8 @@ const resolveDateInput = (
   const dateUTC = new Date(
     date.valueOf() + date.getTimezoneOffset() * 60 * 1000
   )
-
+  
+  return dateUTC.toUTCString()
   /**
    * Determine dateFormat
    * This involves fixing inconsistencies between `moment.js` (that Tina uses to format dates)

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -201,6 +201,7 @@ export class Resolver {
             await this.database.put(realPath, {
               _template: lastItem(template.namespace),
             })
+            return this.getDocument(realPath)
         }
       }
       const templateInfo =
@@ -529,9 +530,8 @@ export class Resolver {
       case 'string':
         if (field.options) {
           if (field.list) {
-            // FIXME: this is awaiting checkbox suppport
             return {
-              component: 'checkbox',
+              component: 'checkbox-group',
               ...field,
               ...extraFields,
               options: field.options,

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -201,7 +201,6 @@ export class Resolver {
             await this.database.put(realPath, {
               _template: lastItem(template.namespace),
             })
-            return this.getDocument(realPath)
         }
       }
       const templateInfo =
@@ -530,8 +529,9 @@ export class Resolver {
       case 'string':
         if (field.options) {
           if (field.list) {
+            // FIXME: this is awaiting checkbox suppport
             return {
-              component: 'checkbox-group',
+              component: 'checkbox',
               ...field,
               ...extraFields,
               options: field.options,
@@ -636,7 +636,6 @@ export class Resolver {
   }
 }
 
-const DEFAULT_DATE_FORMAT = 'MMM dd, yyyy'
 const resolveDateInput = (
   value: string,
   field: { dateFormat?: string; timeFormat?: string }
@@ -645,40 +644,16 @@ const resolveDateInput = (
    * Convert string to `new Date()`
    */
   const date = parseISO(value)
+  
   if (!isValid(date)) {
     throw 'Invalid Date'
   }
-
-  /**
-   * Remove any local timezone offset (putting the date back in UTC)
-   * https://stackoverflow.com/questions/48172772/time-zone-issue-involving-date-fns-format
-   */
+  
   const dateUTC = new Date(
     date.valueOf() + date.getTimezoneOffset() * 60 * 1000
   )
   
   return dateUTC.toUTCString()
-  /**
-   * Determine dateFormat
-   * This involves fixing inconsistencies between `moment.js` (that Tina uses to format dates)
-   * and `date-fns` (that Gateway uses to format dates).
-   * They are explained here:
-   * https://github.com/date-fns/date-fns/blob/master/docs/unicodeTokens.md
-   */
-  const dateFormat = field.dateFormat || DEFAULT_DATE_FORMAT
-  const fixedDateFormat = dateFormat.replace(/D/g, 'd').replace(/Y/g, 'y')
-
-  /**
-   * Determine timeFormat, if any
-   */
-  const timeFormat = field.timeFormat || false
-
-  /**
-   * Format `date` and `time` parts
-   */
-  const datePart = format(dateUTC, fixedDateFormat)
-  const timePart = timeFormat ? ` ${format(dateUTC, timeFormat)}` : ''
-  return `${datePart}${timePart}`
 }
 
 type FieldParams = {

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -648,7 +648,7 @@ const resolveDateInput = (
   if (!isValid(date)) {
     throw 'Invalid Date'
   }
-  
+
   const dateUTC = new Date(
     date.valueOf() + date.getTimezoneOffset() * 60 * 1000
   )

--- a/packages/@tinacms/graphql/src/primitives/spec/movies/.tina/schema.ts
+++ b/packages/@tinacms/graphql/src/primitives/spec/movies/.tina/schema.ts
@@ -29,7 +29,6 @@ const tinaSchema: TinaCloudSchema<false> = {
           name: 'releaseDate',
           label: 'Release Date',
           type: 'datetime',
-          dateFormat: 'YYYY MM DD',
         },
         {
           name: 'rating',

--- a/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/response.json
+++ b/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/response.json
@@ -3,7 +3,7 @@
     "updateDocument": {
       "id": "content/movies/star-wars.md",
       "data": {
-        "releaseDate": "Tue, 02 Feb 2021 14:00:00 GMT",
+        "releaseDate": "Tue, 02 Feb 2021 00:00:00 GMT",
         "archived": true,
         "genre": "action"
       }

--- a/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/response.json
+++ b/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/response.json
@@ -3,7 +3,7 @@
     "updateDocument": {
       "id": "content/movies/star-wars.md",
       "data": {
-        "releaseDate": "Tue, 02 Feb 2021 00:00:00 GMT",
+        "releaseDate": "Tue, 02 Feb 2021 14:00:00 GMT",
         "archived": true,
         "genre": "action"
       }

--- a/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/response.json
+++ b/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/response.json
@@ -3,7 +3,7 @@
     "updateDocument": {
       "id": "content/movies/star-wars.md",
       "data": {
-        "releaseDate": "2021 02 02",
+        "releaseDate": "Tue, 02 Feb 2021 14:00:00 GMT",
         "archived": true,
         "genre": "action"
       }


### PR DESCRIPTION
Closes #1903 

Discussion surrounding Date and this work covered in this PR, which has become a bit stale.
https://github.com/tinacms/tinacms/pull/1936

Opening a new one for more streamlined review.

Updates the backend to expect and store dates as UTC timestamps. This moves onus to format dates to the developer and outside the concerns of Tina within the sidebar.