### PR TITLE
fix(tinacms): Test if currentFields is an Array

### DIFF
--- a/.changeset/stale-tables-heal.md
+++ b/.changeset/stale-tables-heal.md
@@ -1,0 +1,6 @@
+---
+'tina-cloud-starter': patch
+'tinacms': patch
+---
+
+Handles situations where `currentFields` is not an Array

--- a/examples/tina-cloud-starter/components/header.tsx
+++ b/examples/tina-cloud-starter/components/header.tsx
@@ -86,7 +86,7 @@ export const Header = ({ data }) => {
                     : windowUrl.includes(item.href);
                 return (
                   <li
-                    key={item.label}
+                    key={`${item.label}-${i}`}
                     className={activeItem ? activeItemClasses[theme.color] : ""}
                   >
                     <Link href={`${prefix}/${item.href}`} passHref>

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -346,8 +346,9 @@ const getFieldUpdate = (newUpdate, activeForm, formValues) => {
       [newUpdate.queryName, 'values', lookupName].join('.')
     )
     if (isNaN(Number(item))) {
-      const field = currentFields.find((field) => field.name === item)
-      currentFields = field
+      if (Array.isArray(currentFields)) {
+        currentFields = currentFields.find((field) => field.name === item)
+      }
     } else {
       // Get templatable for polymorphic or homogenous
       const template = currentFields.templates


### PR DESCRIPTION
This cropped up when adding a new NavItem to the Starter.  The error message:

`currentFields.find() is not a function.`

Debugging this, it appears that `currentFields` is not always a function of `fields` and can sometimes be a singular `field`.

The fix appears to be simply to test if `currentFields` is an Array, otherwise, the value of `currentFields` is already a singular `field`.

Fixes https://github.com/tinacms/tina-cloud-starter/issues/141
Fixes https://github.com/tinacms/tina-cloud-starter/issues/143 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
