### PR TITLE
added a better error message for childProcess

### DIFF
--- a/.changeset/mighty-moons-divide.md
+++ b/.changeset/mighty-moons-divide.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': minor
+---
+
+Added better error handleing for childProcess

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -41,6 +41,13 @@ export async function startServer(
       const ps = childProcess.spawn(firstCommand, args, {
         stdio: 'inherit',
       })
+      ps.on("error", (code) =>{
+        logger.error(dangerText(`An error has occured in the Next.js child process. Error message bellow`))
+        logger.error(`name: ${code.name}
+message: ${code.message}
+
+stack: ${code.stack || "No stack was provided"}`)
+      })
       ps.on('close', code => {
         logger.info(`child process exited with code ${code}`)
         process.exit(code)

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -40,6 +40,7 @@ export async function startServer(
       const args = commands.slice(1) || []
       const ps = childProcess.spawn(firstCommand, args, {
         stdio: 'inherit',
+        shell: true,
       })
       ps.on("error", (code) =>{
         logger.error(dangerText(`An error has occured in the Next.js child process. Error message bellow`))

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -43,7 +43,7 @@ export async function startServer(
         shell: true,
       })
       ps.on("error", (code) =>{
-        logger.error(dangerText(`An error has occured in the Next.js child process. Error message bellow`))
+        logger.error(dangerText(`An error has occurred in the Next.js child process. Error message below`))
         logger.error(`name: ${code.name}
 message: ${code.message}
 


### PR DESCRIPTION
The issues we are seeing with windows are only happening when installed from NPM and not happening on the monorepo. This PR is to add a better error message for more context into what is happening. 