### PR TITLE
Fix references for empty documents

### DIFF
--- a/.changeset/silver-icons-guess.md
+++ b/.changeset/silver-icons-guess.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': minor
+---
+
+When working with a new document that queries for a reference, we were not properly building the path information required to update that reference, resulting in an error until the page was refreshed.


### PR DESCRIPTION
When using the starter, if you add a new document, and then go and add an author to that document - we don't know how to properly build the path for that request, so it just gets the `id: path/to/author.md` instead of the node itself. 

When GraphQL gets a `null` value, it doesn't continue to resolve the fields:

```graphql
{
  getPostsDocument(relativePath: $relativePath) {
    data { # when this is null
      author { # this resolver function doesn't run
        name  
      }
    }
  }
}
```
If `data` is null (as it is after creating a new document), `author` is never resolved. And that's where we set up the information to tell the form how to update when a reference is changed [here](https://github.com/tinacms/tinacms/compare/fix-null-document-reference-error?expand=1#diff-275a3281b2f1deff910cd6e4496be5abf14160c8ea92d1113c9ce95c280288cbL140). So instead we're doing it as the request comes in

None of this work would be necessary if we had a reference field, and I think that would totally remove the need to sync `data` and `values` keys. I think we should prioritize this work soon.