### PR TITLE
Feat/set image on drag n drop

### DIFF
--- a/.changeset/friendly-bananas-brake.md
+++ b/.changeset/friendly-bananas-brake.md
@@ -2,4 +2,4 @@
 'next-tinacms-cloudinary': patch
 ---
 
-The `persist` method on the Cloudinary Media Store was not returning a properly parsed response from the Cloudinary API. As such, the ImageFieldPlugin could not properly set the image field on drag and drop. The latest changes add new formatting logic to `persist`.
+Fix drag & drop behavior in ImageFieldPlugin

--- a/.changeset/friendly-bananas-brake.md
+++ b/.changeset/friendly-bananas-brake.md
@@ -1,5 +1,5 @@
 ---
-'next-tinacms-cloudinary': minor
+'next-tinacms-cloudinary': patch
 ---
 
 The `persist` method on the Cloudinary Media Store was not returning a properly parsed response from the Cloudinary API. As such, the ImageFieldPlugin could not properly set the image field on drag and drop. The latest changes add new formatting logic to `persist`.

--- a/.changeset/friendly-bananas-brake.md
+++ b/.changeset/friendly-bananas-brake.md
@@ -1,0 +1,5 @@
+---
+'next-tinacms-cloudinary': minor
+---
+
+The `persist` method on the Cloudinary Media Store was not returning a properly parsed response from the Cloudinary API. As such, the ImageFieldPlugin could not properly set the image field on drag and drop. The latest changes add new formatting logic to `persist`.

--- a/examples/tina-cloud-starter/content/posts/voteForPedro.md
+++ b/examples/tina-cloud-starter/content/posts/voteForPedro.md
@@ -1,7 +1,7 @@
 ---
 title: Vote For Pedro
 author: content/authors/pedro.md
-date: 'Wed, 07 Apr 2021 06:00:00 GMT'
+date: 'Thu, 08 Apr 2021 06:00:00 GMT'
 excerpt: >-
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
   incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -3,7 +3,7 @@ import dynamic from "next/dynamic";
 import { TinaEditProvider } from "tinacms/dist/edit-state";
 import { Layout } from "../components/layout";
 const TinaCMS = dynamic(() => import("tinacms"), { ssr: false });
-// import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
+import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
 const NEXT_PUBLIC_USE_LOCAL_CLIENT =
@@ -19,6 +19,7 @@ const App = ({ Component, pageProps }) => {
             branch="main"
             clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
             isLocalClient={Boolean(Number(NEXT_PUBLIC_USE_LOCAL_CLIENT))}
+            mediaStore={TinaCloudCloudinaryMediaStore}
             cmsCallback={(cms) => {
               import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
                 cms.plugins.add(MarkdownFieldPlugin);

--- a/packages/@tinacms/toolkit/src/packages/fields/components/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/ImageUpload/ImageUpload.tsx
@@ -139,11 +139,17 @@ export const ImageUpload = ({
           )}
         </StyledImageContainer>
       ) : (
-        <ImgPlaceholder>
-          Drag 'n' drop some files here,
-          <br />
-          or click to select files
-        </ImgPlaceholder>
+        <StyledImageContainer>
+          {loading ? (
+            <ImageLoadingIndicator />
+          ) : (
+            <ImgPlaceholder>
+            Drag 'n' drop some files here,
+            <br />
+            or click to select files
+          </ImgPlaceholder>
+          )}
+        </StyledImageContainer>
       )}
     </DropArea>
   )

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -79,7 +79,6 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       form.getState().values,
       field.previewSrc
     )
-    const [imgLoading, setImgLoading] = useState(false)
     let onClear: any
     if (props.field.clearable) {
       onClear = () => props.input.onChange('')
@@ -93,7 +92,6 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
             ? // @ts-ignore
               cms.media.store.parse(media)
             : media
-        props.input.onChange('')
         props.input.onChange(parsedValue)
       }
     }
@@ -103,7 +101,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       <ImageUpload
         value={value}
         previewSrc={src}
-        loading={imgLoading}
+        loading={srcIsLoading}
         onClick={() => {
           const directory = uploadDir(props.form.getState().values)
           cms.media.open({
@@ -113,7 +111,6 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
           })
         }}
         onDrop={async ([file]: File[]) => {
-          setImgLoading(true)
           const directory = uploadDir(props.form.getState().values)
           const [media] = await cms.media.persist([
             {
@@ -121,8 +118,8 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
               file,
             },
           ])
+          console.log({media})
           onChange(media)
-          setImgLoading(false)
         }}
         onClear={onClear}
       />

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -118,7 +118,6 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
               file,
             },
           ])
-          console.log({media})
           onChange(media)
         }}
         onClear={onClear}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -79,6 +79,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       form.getState().values,
       field.previewSrc
     )
+    const [isImgUploading, setIsImgUploading] = useState(false)
     let onClear: any
     if (props.field.clearable) {
       onClear = () => props.input.onChange('')
@@ -101,7 +102,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       <ImageUpload
         value={value}
         previewSrc={src}
-        loading={srcIsLoading}
+        loading={isImgUploading || srcIsLoading}
         onClick={() => {
           const directory = uploadDir(props.form.getState().values)
           cms.media.open({
@@ -111,6 +112,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
           })
         }}
         onDrop={async ([file]: File[]) => {
+          setIsImgUploading(true)
           const directory = uploadDir(props.form.getState().values)
           const [media] = await cms.media.persist([
             {
@@ -118,7 +120,10 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
               file,
             },
           ])
-          onChange(media)
+          if (media) {
+            await onChange(media)
+            setIsImgUploading(false)
+          }
         }}
         onClear={onClear}
       />

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -79,7 +79,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       form.getState().values,
       field.previewSrc
     )
-
+    const [imgLoading, setImgLoading] = useState(false)
     let onClear: any
     if (props.field.clearable) {
       onClear = () => props.input.onChange('')
@@ -97,14 +97,13 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
         props.input.onChange(parsedValue)
       }
     }
-
     const uploadDir = props.field.uploadDir || (() => '')
 
     return (
       <ImageUpload
         value={value}
         previewSrc={src}
-        loading={srcIsLoading}
+        loading={imgLoading}
         onClick={() => {
           const directory = uploadDir(props.form.getState().values)
           cms.media.open({
@@ -114,16 +113,16 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
           })
         }}
         onDrop={async ([file]: File[]) => {
+          setImgLoading(true)
           const directory = uploadDir(props.form.getState().values)
-
           const [media] = await cms.media.persist([
             {
               directory,
               file,
             },
           ])
-
           onChange(media)
+          setImgLoading(false)
         }}
         onClear={onClear}
       />

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -125,7 +125,6 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
           if (media) {
             try {
               await onChange(media)
-              setIsImgUploading(false)
             } catch(error) {
               console.error('Error uploading media asset: ', error)
             } finally {

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -85,7 +85,8 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       onClear = () => props.input.onChange('')
     }
 
-    function onChange(media?: Media) {
+    async function onChange(media?: Media) {
+
       if (media) {
         const parsedValue =
           // @ts-ignore
@@ -93,6 +94,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
             ? // @ts-ignore
               cms.media.store.parse(media)
             : media
+        
         props.input.onChange(parsedValue)
       }
     }
@@ -121,8 +123,14 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
             },
           ])
           if (media) {
-            await onChange(media)
-            setIsImgUploading(false)
+            try {
+              await onChange(media)
+              setIsImgUploading(false)
+            } catch(error) {
+              console.error('Error uploading media asset: ', error)
+            } finally {
+              setIsImgUploading(false)
+            }
           }
         }}
         onClear={onClear}

--- a/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
+++ b/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
@@ -44,6 +44,9 @@ export class CloudinaryMediaStore implements MediaStore {
       throw new Error(responseData.message)
     }
     const fileRes = await res.json()
+    await new Promise((resolve) => {
+      setTimeout(resolve, 2000)
+    })
     /**
      * Format the response from Cloudinary to match Media interface
      */

--- a/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
+++ b/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
@@ -44,14 +44,21 @@ export class CloudinaryMediaStore implements MediaStore {
       throw new Error(responseData.message)
     }
     const fileRes = await res.json()
+    /**
+    * Images uploaded to Cloudinary aren't instantly available via the API;
+    * waiting a couple seconds here seems to ensure they show up in the next fetch.
+    */
     await new Promise((resolve) => {
       setTimeout(resolve, 2000)
     })
     /**
      * Format the response from Cloudinary to match Media interface
+     * Valid Cloudinary `resource_type` values: `image`, `video`, `raw` and `auto`
+     * uploading a directory is not supported as such, type is defaulted to `file`
+     * https://cloudinary.com/documentation/upload_images#uploading_with_a_direct_call_to_the_rest_api
      */
     const parsedRes: Media = {
-      type: fileRes.resource_type === 'image' ? 'file' : 'dir',
+      type: 'file',
       id: fileRes.public_id,
       filename: fileRes.original_filename,
       directory: '/',

--- a/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
+++ b/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
@@ -44,14 +44,18 @@ export class CloudinaryMediaStore implements MediaStore {
       throw new Error(responseData.message)
     }
     const fileRes = await res.json()
+    /**
+     * Format the response from Cloudinary to match Media interface
+     */
+    const parsedRes: Media = {
+      type: fileRes.resource_type === 'image' ? 'file' : 'dir',
+      id: fileRes.public_id,
+      filename: fileRes.original_filename,
+      directory: '/',
+      previewSrc: fileRes.url
 
-    // TODO: be programmer
-    // NOTE: why do we need this?
-    await new Promise((resolve) => {
-      setTimeout(resolve, 2000)
-    })
-
-    return []
+    }
+    return [parsedRes]
   }
   async delete(media: Media) {
     await this.fetchFunction(
@@ -90,7 +94,6 @@ export class CloudinaryMediaStore implements MediaStore {
   }
 
   parse = (img) => {
-    console.log({ img })
     return img.previewSrc
   }
 


### PR DESCRIPTION
Closes #1945

This PR addresses the above issue in that when a user drags and drops an image file, it will upload to Cloudinary, but does not set the value of the field properly.

This was due to an issue with the `persist` method in the next-tinacms-cloudinary package not returning an appropriate Media object.
