### PR TITLE
fix: remove missing-clientId error

### DIFF
--- a/packages/tinacms/src/utils/index.ts
+++ b/packages/tinacms/src/utils/index.ts
@@ -26,29 +26,11 @@ export const createClient = ({
 }: CreateClientProps) => {
   return isLocalClient
     ? new LocalClient()
-    : createCloudClient({ clientId, branch })
-}
-
-export const createCloudClient = (
-  props: Omit<CreateClientProps, 'isLocalClient'>
-) => {
-  const clientId = props.clientId
-
-  const missingProps: string[] = []
-  if (!clientId) {
-    missingProps.push('clientId')
-  }
-
-  if (missingProps.length) {
-    throw new Error(`The following props are required when using the Tina Cloud Client, please make sure they are being passed to TinaCloudAuthWall:
-     ${missingProps.join(', ')}`)
-  }
-
-  return new Client({
-    clientId,
-    branch: props.branch || 'main',
-    tokenStorage: 'LOCAL_STORAGE',
-  })
+    : new Client({
+      clientId: clientId || '',
+      branch: branch || 'main',
+      tokenStorage: 'LOCAL_STORAGE',
+    })
 }
 
 export function assertShape<T extends unknown>(


### PR DESCRIPTION
Before, we were throwing an error when a site was missing its clientId. This flags things for the user on local development, but when you run into this on a hosted environment, e.g, when trying to edit on our [hosted starter](https://tina-cloud-starter-orcin.vercel.app/), things blow up, without a helpful message.

With a recent up, the dashboard shows an error with an invalid client-id. 
<img width="1139" alt="Screen Shot 2021-08-05 at 5 49 34 PM" src="https://user-images.githubusercontent.com/3323181/128419452-83a7166a-61a1-4edc-941a-b9d75169b2a5.png">
We shouldn't have to throw this error within tinacms anymore