### PR TITLE
Fix 404s for new documents on hosted site

### DIFF
--- a/.changeset/good-frogs-appear.md
+++ b/.changeset/good-frogs-appear.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixes an issue where new documents returned a 404 when on a hosted deployement. Instead, `getStaticPropsForTina` will catch and return an empty object for the data key. This allows us to replace it with real data client-side.

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -7,7 +7,7 @@ import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
 const NEXT_PUBLIC_USE_LOCAL_CLIENT =
-  process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || true;
+  process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || 0;
 
 const App = ({ Component, pageProps }) => {
   return (

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -7,7 +7,7 @@ import { TinaCloudCloudinaryMediaStore } from "next-tinacms-cloudinary";
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
 const NEXT_PUBLIC_USE_LOCAL_CLIENT =
-  process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || 0;
+  process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || true;
 
 const App = ({ Component, pageProps }) => {
   return (

--- a/examples/tina-cloud-starter/pages/posts/[filename].tsx
+++ b/examples/tina-cloud-starter/pages/posts/[filename].tsx
@@ -7,7 +7,10 @@ import type { PostsDocument } from "../../.tina/__generated__/types";
 export default function BlogPostPage(
   props: AsyncReturnType<typeof getStaticProps>["props"]
 ) {
-  return <Post {...props.data.getPostsDocument} />;
+  if (props.data && props.data.getPostsDocument) {
+    return <Post {...props.data.getPostsDocument} />;
+  }
+  return <div>No data</div>;
 }
 
 export const getStaticProps = async ({ params }) => {
@@ -69,7 +72,7 @@ export const getStaticPaths = async () => {
     paths: postsListData.getPostsList.edges.map((post) => ({
       params: { filename: post.node.sys.filename },
     })),
-    fallback: false,
+    fallback: true,
   };
 };
 

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -282,11 +282,22 @@ export const getStaticPropsForTina = async ({
   query: string
   variables?: object
 }) => {
-  const data = await staticRequest({ query, variables })
-  return {
-    data,
-    query,
-    variables,
+  try {
+    const data = await staticRequest({ query, variables })
+    return {
+      data,
+      query,
+      variables,
+    }
+  } catch (e) {
+    // FIXME: no need to catch all errors, just the ones that are related to
+    // a new document being created, if there's a way to surface those only
+    // we can still throw when real errors occur
+    return {
+      data: {},
+      query,
+      variables,
+    }
   }
 }
 


### PR DESCRIPTION
Fixes an issue where new documents returned a 404 when on a hosted deployement. Instead, `getStaticPropsForTina` will catch and return an empty object for the data key. This allows us to replace it with real data client-side.

Relates to https://github.com/tinacms/tina-cloud-starter/issues/147