### PR TITLE
Ensure `null` values aren't passed back from getStaticPropsForTina

### DIFF
--- a/.changeset/odd-ducks-raise.md
+++ b/.changeset/odd-ducks-raise.md
@@ -2,4 +2,4 @@
 "tinacms": patch
 ---
 
-Ensure `null` values aren't passed back from getStaticPropsForTina
+Ensure `undefined` values aren't passed back from getStaticPropsForTina

--- a/.changeset/odd-ducks-raise.md
+++ b/.changeset/odd-ducks-raise.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Ensure `null` values aren't passed back from getStaticPropsForTina

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -284,20 +284,24 @@ export const getStaticPropsForTina = async ({
 }) => {
   try {
     const data = await staticRequest({ query, variables })
-    return {
-      data,
-      query,
-      variables,
-    }
+    return JSON.parse(
+      JSON.stringify({
+        data,
+        query,
+        variables,
+      })
+    )
   } catch (e) {
     // FIXME: no need to catch all errors, just the ones that are related to
     // a new document being created, if there's a way to surface those only
     // we can still throw when real errors occur
-    return {
-      data: {},
-      query,
-      variables,
-    }
+    return JSON.parse(
+      JSON.stringify({
+        data: {},
+        query,
+        variables,
+      })
+    )
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/tinacms/tinacms/issues/2009