### PR TITLE
fix: Don't treat client w/ missing client-id as LocalClient

### DIFF
--- a/.changeset/seven-ducks-camp.md
+++ b/.changeset/seven-ducks-camp.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+Don't treat cloud client with missing client-id as local client

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -186,22 +186,10 @@ mutation addPendingDocumentMutation(
   }
 
   async isAuthorized(): Promise<boolean> {
-    if (this.isLocalClient()) {
-      return true
-    }
-
     return this.isAuthenticated() // TODO - check access
   }
 
-  isLocalClient(): boolean {
-    return !this.clientId
-  }
-
   async isAuthenticated(): Promise<boolean> {
-    if (this.isLocalClient()) {
-      return true
-    }
-
     return !!(await this.getUser())
   }
 
@@ -266,5 +254,13 @@ export class LocalClient extends Client {
           : DEFAULT_LOCAL_TINA_GQL_SERVER_URL,
     }
     super(clientProps)
+  }
+
+  async isAuthorized(): Promise<boolean> {
+    return true
+  }
+
+  async isAuthenticated(): Promise<boolean> {
+    return true
   }
 }

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -222,6 +222,10 @@ mutation addPendingDocumentMutation(
   }
 
   async getUser() {
+    if (!this.clientId) {
+      return null
+    }
+
     const url = `${IDENTITY_API_URL}/v2/apps/${this.clientId}/currentUser`
 
     try {


### PR DESCRIPTION
We were treating the base client as a localClient when clientId not set. This caused weird behaviour, such as our on starter:
When the user has local-mode turned off, but hasn't set a client-id: if they enter edit-mode, it immediately thinks the user is authenticated and [tried to render the root components children](https://github.com/tinacms/tinacms/blob/main/packages/tinacms/src/auth/TinaCloudProvider.tsx#L54). This causes things to blow up.

Instead, we want to avoid rendering children if we are not logged in (including when we don't have a valid client-id to log into.)

On a refactoring level, the base class was also a bit too aware of its LocalClient child implementation.

