### PR TITLE
1993 - Better Error Messaging when linking to Tina Cloud 

### DIFF
--- a/.changeset/wise-beans-pump.md
+++ b/.changeset/wise-beans-pump.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Better error messaging when no tina schema files are found


### PR DESCRIPTION
Something Jeff discovered:  In the event a user chooses a GitHub repository lacking a `.tina` and `.tina/__generated__` folder, they are given a very confusing error message.

I've modified the `GraphQLError` messages thrown by the `GithubBridge` to more accurately reference the file, the repository, and the reference (branch) being used.

Additionally, I've added in a suggestion to "confirm" the repository and the existence of `.tina` and `.tina/schema.ts` in the event that the error is throw while looking for the `SYSTEM_FILES`.

Closes #1993 
