### PR TITLE
2025 - Make DateFieldPlugin timezone friendly 

### DIFF
--- a/.changeset/khaki-cups-worry.md
+++ b/.changeset/khaki-cups-worry.md
@@ -1,0 +1,7 @@
+---
+'tina-cloud-starter': patch
+'@tinacms/graphql': patch
+'@tinacms/toolkit': patch
+---
+
+Makes `DateFieldPlugin` timezone-friendly

--- a/examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -30,11 +30,9 @@
           "type": "datetime",
           "label": "Posted Date",
           "name": "date",
-          "dateFormat": "MMMM DD YYYY",
-          "timeFormat": "",
           "ui": {
             "dateFormat": "MMMM DD YYYY",
-            "timeFormat": false
+            "timeFormat": "hh:mm A"
           },
           "namespace": [
             "posts",

--- a/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
@@ -22,11 +22,9 @@
           "type": "datetime",
           "label": "Posted Date",
           "name": "date",
-          "dateFormat": "MMMM DD YYYY",
-          "timeFormat": "",
           "ui": {
             "dateFormat": "MMMM DD YYYY",
-            "timeFormat": false
+            "timeFormat": "hh:mm A"
           }
         },
         {

--- a/examples/tina-cloud-starter/.tina/schema.ts
+++ b/examples/tina-cloud-starter/.tina/schema.ts
@@ -402,11 +402,9 @@ export default defineSchema({
           type: "datetime",
           label: "Posted Date",
           name: "date",
-          dateFormat: "MMMM DD YYYY",
-          timeFormat: "",
           ui: {
             dateFormat: "MMMM DD YYYY",
-            timeFormat: false,
+            timeFormat: "hh:mm A",
           },
         },
         {

--- a/examples/tina-cloud-starter/components/post.tsx
+++ b/examples/tina-cloud-starter/components/post.tsx
@@ -3,7 +3,7 @@ import Markdown from "react-markdown";
 import { Container } from "./container";
 import { Section } from "./section";
 import { ThemeContext } from "./theme";
-import format from 'date-fns/format'
+import format from "date-fns/format";
 
 export const Post = ({ data }) => {
   const theme = React.useContext(ThemeContext);
@@ -20,9 +20,9 @@ export const Post = ({ data }) => {
     yellow:
       "from-yellow-400 to-yellow-500 dark:from-yellow-300 dark:to-yellow-500",
   };
-  const date = new Date(data.date)
-  const dateUTC = date.valueOf() + date.getTimezoneOffset() * 60 * 1000
-  const formattedDate = format(dateUTC, 'MMM dd, yyyy')
+
+  const date = new Date(data.date);
+  const formattedDate = format(date, "MMM dd, yyyy");
 
   return (
     <Section className="flex-1">

--- a/examples/tina-cloud-starter/content/posts/voteForPedro.md
+++ b/examples/tina-cloud-starter/content/posts/voteForPedro.md
@@ -1,7 +1,7 @@
 ---
 title: Vote For Pedro
 author: content/authors/pedro.md
-date: '2021-04-23T00:00:00.000Z'
+date: '2021-07-03T20:30:00.000Z'
 excerpt: >-
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
   incididunt ut labore et dolore magna aliqua. Praesent elementum facilisis leo

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -80,7 +80,8 @@ export class Resolver {
       const basename = path.basename(fullPath)
       const extension = path.extname(fullPath)
       const filename = basename.replace(extension, '')
-      const relativePath = fullPath.replace('\\','/')
+      const relativePath = fullPath
+        .replace('\\', '/')
         .replace(collection.path, '')
         .replace(/^\/|\/$/g, '')
       const breadcrumbs = filename.split('/')
@@ -632,9 +633,7 @@ export class Resolver {
   }
 }
 
-const resolveDateInput = (
-  value: string
-) => {
+const resolveDateInput = (value: string) => {
   /**
    * Convert string to `new Date()`
    */
@@ -642,6 +641,10 @@ const resolveDateInput = (
   if (!isValid(date)) {
     throw 'Invalid Date'
   }
+
+  /**
+   * toISOString() converts to UTC
+   */
   return date.toISOString()
 }
 

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/DateFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/DateFieldPlugin.tsx
@@ -60,7 +60,6 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
             open={isOpen}
             dateFormat={dateFormat || DEFAULT_DATE_FORMAT}
             timeFormat={timeFormat || false}
-            utc // https://github.com/tinacms/tinacms/pull/326#issuecomment-543836469
             {...rest}
           />
         </ReactDateTimeContainer>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/dateFormat.ts
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/dateFormat.ts
@@ -34,10 +34,11 @@ export const format = (
     typeof timeFormat === 'string' ? `${dateFormat} ${timeFormat}` : dateFormat
 
   if (typeof val === 'string') {
-    const date = moment.utc(val)
+    const date = moment(val)
     return date.isValid() ? date.format(combinedFormat) : val
   }
-  return moment.utc(val).format(combinedFormat)
+
+  return moment(val).format(combinedFormat)
 }
 
 // parses a function from the given format to default datetime format


### PR DESCRIPTION
Removes any conversions to `utc` inside the `format` method for the `DateFieldPlugin`.

`toISOString()` still converts to UTC which is called both in the `parse` method and again in the `graphql/primitives/resolver`.

For example:

`July 3, 2021 3:30 PM` (Central Timezone)
saves as
`2021-07-03T20:30:00.000Z` (UTC)

Closes #2025 
