### PR TITLE
Fix/cli css regex

### DIFF
--- a/.changeset/beige-berries-exist.md
+++ b/.changeset/beige-berries-exist.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': minor
+---
+
+Updated regex for CSS in tina init CLI

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -128,9 +128,14 @@ export async function tinaSetup(ctx: any, next: () => void, options) {
         ? readFileSync(appPath)
         : readFileSync(appPathTS)
       const matches = [
-        ...fileContent.toString().matchAll(/^.*import.*\.css".*$/gm),
+        ...fileContent.toString().matchAll(/^.*import.*\.css("|').*$/gm),
       ]
-      fs.writeFileSync(appPathWithExtension, AppJsContent(matches.join('\n')))
+      // This gets the primary match. see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/match#using_match
+      const primaryMatches = matches.map((x) => x[0])
+      fs.writeFileSync(
+        appPathWithExtension,
+        AppJsContent(primaryMatches.join('\n'))
+      )
     } else {
       wrapper = true
       logger.info(


### PR DESCRIPTION
Fixed issue where it would not find css imports that uses `'`

cc @scottgallant @perkinsjr 