### PR TITLE
Update the error boundary to provide more visual affordance to the us…

### DIFF
--- a/.changeset/six-gorillas-pump.md
+++ b/.changeset/six-gorillas-pump.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+Provide better error boundary message and visual affordances to user in <ErrorBoundary />.

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -59,11 +59,15 @@ class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)
 
-    this.state = { hasError: props.hasError, message: '' }
+    this.state = { 
+      hasError: props.hasError, 
+      message: '',
+      pageRefresh: false
+     }
   }
 
   static getDerivedStateFromError(error) {
-    return { hasError: true, message: error.message }
+    return { hasError: true, message: error.message, timesErrorHit: error.timesErrorHit++ }
   }
 
   /**
@@ -75,7 +79,7 @@ class ErrorBoundary extends React.Component {
    */
   render() {
     // @ts-ignore
-    if (this.state.hasError) {
+    if (this.state.hasError && !this.state.pageRefresh) {
       return (
         <div
           style={{
@@ -110,9 +114,11 @@ class ErrorBoundary extends React.Component {
             <p>Tina caught an error while updating the page:</p>
             {/* @ts-ignore */}
             <pre>{this.state.message}</pre>
+            <br />
             <p>
               If you've just updated the form, undo your most recent changes and
-              click "refresh"
+              click "refresh". If after a few refreshes, you're still encountering this error. 
+              There is a bigger issue with the site. Please reach out to your site admin.
             </p>
             <div style={{ padding: '10px 0' }}>
               <button
@@ -127,7 +133,11 @@ class ErrorBoundary extends React.Component {
                   border: 'none',
                   color: 'white',
                 }}
-                onClick={() => this.setState({ hasError: false })}
+                onClick={() => {
+                  /* @ts-ignore */
+                  this.setState({ pageRefresh: true })
+                  setTimeout(() => this.setState({ hasError: false, pageRefresh: false}), 3000)
+                }}
               >
                 Refresh
               </button>
@@ -135,6 +145,15 @@ class ErrorBoundary extends React.Component {
           </div>
         </div>
       )
+    }
+    {/* @ts-ignore */}
+    { if (this.state.pageRefresh) {
+      return (
+        <Loader>
+          Let's try that again.
+        </Loader>
+      )
+    }
     }
 
     return this.props.children

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -67,7 +67,7 @@ class ErrorBoundary extends React.Component {
   }
 
   static getDerivedStateFromError(error) {
-    return { hasError: true, message: error.message, timesErrorHit: error.timesErrorHit++ }
+    return { hasError: true, message: error.message }
   }
 
   /**


### PR DESCRIPTION
Closes #2002 

This PR will Update the ErrorBoundary component to provide a bit more context to the user if it is repeatedly hit.

Additionally a click of the `Refresh` button will trigger a loading state to provide more of a visual affordance to the user.

This feels like more of a temporary fix for the immediate need of the issue. I think we can continue to refine how we're handling the error boundary.

NOTE:
To test this locally I would recommend adding a breaking piece to one of the blog posts e.g. 
```
<p>{data.shouldFail.toUpperCase()}</p>
```

And clicking `Refresh` to trigger the loading state.