### PR TITLE
ignore .pnp.js in license check

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -198,6 +198,7 @@ function checkForLicense({ packageJson }: TinaPackage) {
  *
  */
 function fileNeedsLicense(filepath: string) {
+  if (filepath === '.pnp.js') return false
   return new RegExp(/^(?!examples\/).+\.(jsx?|tsx?)$/).test(filepath)
 }
 


### PR DESCRIPTION
it's an autogenerated file and is too large to retrieve via the contents api, leading to failures from the danger script