### PR TITLE
docs: Link to main instead of master branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/contributing.md
+++ b/.github/ISSUE_TEMPLATE/contributing.md
@@ -9,7 +9,7 @@ labels: contributing
 
   Before opening a new issue, please search existing issues: https://github.com/tinacms/tinacms/issues
 
-  Also check out the troubleshooting section of the CONTRIBUTING doc: https://github.com/tinacms/tinacms/blob/master/CONTRIBUTING.md#troubleshooting-in-development
+  Also check out the troubleshooting section of the CONTRIBUTING doc: https://github.com/tinacms/tinacms/blob/main/CONTRIBUTING.md#troubleshooting-in-development
 -->
 
 ## Description

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -2,14 +2,13 @@
 
 ### Open source, extensible and community-driven
 
-Tina is made better by the wisdom of crowds. If you find a bug or have ideas about a feature, please make an [issue on github](https://github.com/tinacms/tinacms/issues/new). 
-If you have a question about how to use Tina or want to engage in broader discussions, check out the [forum](https://community.tinacms.org/). If you want to be 
+Tina is made better by the wisdom of crowds. If you find a bug or have ideas about a feature, please make an [issue on github](https://github.com/tinacms/tinacms/issues/new).
+If you have a question about how to use Tina or want to engage in broader discussions, check out the [forum](https://community.tinacms.org/). If you want to be
 a part of the daily chatter, join the [Tina Slack](https://tinacms.slack.com).
 
-Check out our [contribution guidelines](https://github.com/tinacms/tinacms/blob/master/CONTRIBUTING.md) for more info on how to 
-get involved with development. Peak at our [roadmap](https://github.com/tinacms/tinacms/blob/master/ROADMAP.md) to see what's 
+Check out our [contribution guidelines](https://github.com/tinacms/tinacms/blob/main/CONTRIBUTING.md) for more info on how to
+get involved with development. Peak at our [roadmap](https://github.com/tinacms/tinacms/blob/main/ROADMAP.md) to see what's
 coming down the line. If you are exited about TinaCMS, help us grow the community by ⭐️'ing the repo on github.
-
 
 ### Links
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-[![GitHub license](https://img.shields.io/github/license/tinacms/tinacms?color=blue)](https://github.com/tinacms/tinacms/blob/master/LICENSE) [![npm version](https://img.shields.io/npm/v/tinacms.svg?style=flat)](https://www.npmjs.com/package/tinacms) ![Status](https://github.com/tinacms/tinacms/workflows/Build,%20Test,%20Lint%20for%20Master/badge.svg)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+[![GitHub license](https://img.shields.io/github/license/tinacms/tinacms?color=blue)](https://github.com/tinacms/tinacms/blob/main/LICENSE) [![npm version](https://img.shields.io/npm/v/tinacms.svg?style=flat)](https://www.npmjs.com/package/tinacms) ![Status](https://github.com/tinacms/tinacms/workflows/Build,%20Test,%20Lint%20for%20Master/badge.svg)<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-101-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # [![TINA CMS](https://res.cloudinary.com/forestry-demo/image/upload/v1585234360/TinaCMS/TinaCMS.png 'Visit tinacms.org')](https://tina.io)
@@ -20,7 +21,7 @@ Visit https://tina.io/docs/ to view the full documentation.
 
 ## Development Process
 
-See our [ROADMAP.md](https://github.com/tinacms/tinacms/blob/master/ROADMAP.md) to learn how the maintainers work.
+See our [ROADMAP.md](https://github.com/tinacms/tinacms/blob/main/ROADMAP.md) to learn how the maintainers work.
 
 ## Questions?
 
@@ -35,7 +36,7 @@ Check the [CHANGELOG](./CHANGELOG.md) for the latest updates to TinaCMS.
 
 ## Contributing
 
-Please see our [CONTRIBUTING.md](https://github.com/tinacms/tinacms/blob/master/CONTRIBUTING.md)
+Please see our [CONTRIBUTING.md](https://github.com/tinacms/tinacms/blob/main/CONTRIBUTING.md)
 
 ### Maintainers
 
@@ -45,6 +46,7 @@ Please see our [CONTRIBUTING.md](https://github.com/tinacms/tinacms/blob/master/
 - Jeff See ([@jeffsee55](https://github.com/jeffsee55)) - Forestry.io
 - Logan Anderson ([@logan_anders0n](https://twitter.com/logan_anders0n)) - Forestry.io
 - Jack Bevis ([@jbevis](https://github.com/jbevis)) - Forestry.io
+
 ### All Contributors ✨
 
 Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/docs/en/emoji-key)):

--- a/packages/@tinacms/scripts/README.md
+++ b/packages/@tinacms/scripts/README.md
@@ -35,4 +35,4 @@ console.log('Production')
 
 ## Source
 
-- [Source Code](https://github.com/tinacms/tinacms/tree/master/packages/%40tinacms/scripts)
+- [Source Code](https://github.com/tinacms/tinacms/tree/main/packages/%40tinacms/scripts)

--- a/packages/@tinacms/webpack-helpers/README.md
+++ b/packages/@tinacms/webpack-helpers/README.md
@@ -104,7 +104,7 @@ UNHANDLED REJECTION MarkdownRemark.rawFrontmatter provided incorrect OutputType:
     [ncphillips.github.io]/[graphql-compose]/lib/TypeMapper.js:294:15
 ```
 
-This error is caused by the [setFieldsOnGraphQLNodeType](https://github.com/tinacms/tinacms/blob/master/packages/gatsby-tinacms-remark/gatsby-node.js#L18)
+This error is caused by the [setFieldsOnGraphQLNodeType](https://github.com/tinacms/tinacms/blob/main/packages/gatsby-tinacms-remark/gatsby-node.js#L18)
 method in each of those methods. The reason why `String` is not `String` is
 that the GraphQL type checking is based on the identity of the`GraphQLString`
 object imported from Gatsby.

--- a/packages/next-tinacms-github/src/next/preview.ts
+++ b/packages/next-tinacms-github/src/next/preview.ts
@@ -52,7 +52,7 @@ export const previewHandler = (signingKey: string) => (req: any, res: any) => {
   } else {
     res.status(401).json({
       message:
-        'Missing Credentials: see https://github.com/tinacms/tinacms/tree/master/packages/next-tinacms-github for implementation',
+        'Missing Credentials: see https://github.com/tinacms/tinacms/tree/main/packages/next-tinacms-github for implementation',
     })
   }
 }

--- a/packages/react-tinacms-editor/README.md
+++ b/packages/react-tinacms-editor/README.md
@@ -82,4 +82,4 @@ These will both show up in your sidebar looking roughly like this:
 
 ## Contributing 
 
-For a deeper understanding of the Wysiwyg editor and inner-workings of the `react-tinacms-editor` package, checkout the [contributor documentation](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/editor-docs)
+For a deeper understanding of the Wysiwyg editor and inner-workings of the `react-tinacms-editor` package, checkout the [contributor documentation](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/editor-docs)

--- a/packages/react-tinacms-editor/editor-docs/README.md
+++ b/packages/react-tinacms-editor/editor-docs/README.md
@@ -4,38 +4,38 @@ The documentation details the architecture of react-tina-editor, it is a wysiwyg
 
 ## High level architecture
 
-The editor components can be found [here](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/components). There are mainly 3 editing components:
+The editor components can be found [here](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/components). There are mainly 3 editing components:
 
-1. [Wysiwyg editor](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/components/Wysiwyg): this editor is the root component, it maintains information about editing mode (wysiwyg or markdown) and accordingly initialise the correct editor. It makes editor mode information available in the [editorMode](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-editor/src/context/editorMode.tsx) context. Child components can access this context and change their behaviour depending on currently selected editing mode. This component decides whether to render the Prosemirror or Markdown text editors. 
+1. [Wysiwyg editor](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/components/Wysiwyg): this editor is the root component, it maintains information about editing mode (wysiwyg or markdown) and accordingly initialise the correct editor. It makes editor mode information available in the [editorMode](https://github.com/tinacms/tinacms/blob/main/packages/react-tinacms-editor/src/context/editorMode.tsx) context. Child components can access this context and change their behaviour depending on currently selected editing mode. This component decides whether to render the Prosemirror or Markdown text editors. 
 
-2. [Prosemirror editor](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/components/ProsemirrorEditor): this is the component that provides rich text editing capabilities. It initialises a prosemirror editor object and makes it available in [editorState](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-editor/src/context/editorState.tsx) context for child components to consume.
+2. [Prosemirror editor](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/components/ProsemirrorEditor): this is the component that provides rich text editing capabilities. It initialises a prosemirror editor object and makes it available in [editorState](https://github.com/tinacms/tinacms/blob/main/packages/react-tinacms-editor/src/context/editorState.tsx) context for child components to consume.
 
-3. [Markdown editor](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/components/MarkdownEditor): this component provides plain text editing capability.
+3. [Markdown editor](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/components/MarkdownEditor): this component provides plain text editing capability.
 
-[Translator](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/translator) package is where lies the code to convert editor content to other formats like Markdown or HTML. This is also used while toggling between wysiwyg (Prosemirror Editor) and plain text (Markdown Editor) mode of editing.
+[Translator](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/translator) package is where lies the code to convert editor content to other formats like Markdown or HTML. This is also used while toggling between wysiwyg (Prosemirror Editor) and plain text (Markdown Editor) mode of editing.
 
 ![](https://i.imgur.com/5Ip2rSu.png)
 
 ### Prosemirror Editor
 
-[This](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx) is most complex part of the package. It includes an editing area which is simply a `div` and a more complex `MenuBar`. The component builds the prosemirror editor passing the `div` as DOM node for mounting the editor. Prosemirror state is than passed to the [editorState](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-editor/src/context/editorState.tsx) context and is accessible by child components including menu items and popups.
+[This](https://github.com/tinacms/tinacms/blob/main/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx) is most complex part of the package. It includes an editing area which is simply a `div` and a more complex `MenuBar`. The component builds the prosemirror editor passing the `div` as DOM node for mounting the editor. Prosemirror state is than passed to the [editorState](https://github.com/tinacms/tinacms/blob/main/packages/react-tinacms-editor/src/context/editorState.tsx) context and is accessible by child components including menu items and popups.
 
 ![](https://i.imgur.com/0HLqZRY.jpg)
 
 ##### Editor Plugins
 
-[Here](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins) are the various [Prosemirror plugins](https://prosemirror.net/docs/guide/#state.plugins) used by the editor. Each plugin groups a complete functionality, for instance the [image](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Image) plugin has the react components, prosemirror classes, node views, etc. required to support image functionality in the editor. Here is the complete list of the plugins:
+[Here](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins) are the various [Prosemirror plugins](https://prosemirror.net/docs/guide/#state.plugins) used by the editor. Each plugin groups a complete functionality, for instance the [image](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Image) plugin has the react components, prosemirror classes, node views, etc. required to support image functionality in the editor. Here is the complete list of the plugins:
 
-1. [Block](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Block)
-2. [Blockquote](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Blockquote)
-3. [CodeBlock](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/CodeBlock)
-4. [Common](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Common)
-5. [History](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/History)
-6. [Image](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Image)
-7. [Inline](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Inline)
-8. [Link](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Link)
-9. [List](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/List)
-10. [Table](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/plugins/Table)
+1. [Block](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Block)
+2. [Blockquote](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Blockquote)
+3. [CodeBlock](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/CodeBlock)
+4. [Common](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Common)
+5. [History](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/History)
+6. [Image](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Image)
+7. [Inline](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Inline)
+8. [Link](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Link)
+9. [List](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/List)
+10. [Table](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/plugins/Table)
 
 Typical structure of a plugin:
 
@@ -62,15 +62,15 @@ Currently all the [keyboard shortcuts](https://prosemirror.net/docs/ref/#keymap)
 
 ### Markdown Editor
 
-The [Markdown Editor](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/components/MarkdownEditor) is simple textarea where editor content can be edited **as plain text**. Currently, menubar options are not enabled in this editor.
+The [Markdown Editor](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/components/MarkdownEditor) is simple textarea where editor content can be edited **as plain text**. Currently, menubar options are not enabled in this editor.
 
 ### Menubar
 
-Markdown editor and Prosemirror editor have their own MenuBar component which in turn uses [BaseMenubar](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/components/BaseMenubar) component.
+Markdown editor and Prosemirror editor have their own MenuBar component which in turn uses [BaseMenubar](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/components/BaseMenubar) component.
 
 ## Translator
 
-[Translator](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/translator) helps in converting content into different formats - JSON, Markdown, HTML.
+[Translator](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/translator) helps in converting content into different formats - JSON, Markdown, HTML.
 
-- [HTML Translator](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/translator/DOMTranslator): this is built using prosemirror provided api.
-- [Markdown Translator](https://github.com/tinacms/tinacms/tree/master/packages/react-tinacms-editor/src/translator/MarkdownTranslator): this is built using [markdown-it](https://github.com/markdown-it/markdown-it) library.
+- [HTML Translator](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/translator/DOMTranslator): this is built using prosemirror provided api.
+- [Markdown Translator](https://github.com/tinacms/tinacms/tree/main/packages/react-tinacms-editor/src/translator/MarkdownTranslator): this is built using [markdown-it](https://github.com/markdown-it/markdown-it) library.

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -149,7 +149,7 @@ export function InlineText({
 }
 ```
 
-`Input` is a styled-component with some [base styling](https://github.com/tinacms/tinacms/blob/master/packages/react-tinacms-inline/src/fields/inline-text-field.tsx#L64) aimed at making this component mesh well with the surrounding site. If you ever need to override default Inline Field styles, read about this workaround to [extend styles](https://tinacms.org/docs/ui/inline-editing#extending-inline-field-styles).
+`Input` is a styled-component with some [base styling](https://github.com/tinacms/tinacms/blob/main/packages/react-tinacms-inline/src/fields/inline-text-field.tsx#L64) aimed at making this component mesh well with the surrounding site. If you ever need to override default Inline Field styles, read about this workaround to [extend styles](https://tinacms.org/docs/ui/inline-editing#extending-inline-field-styles).
 
 ### Focus Ring
 


### PR DESCRIPTION
Fix several links to main from our readme's (master branch still exists, but is behind)