### PR TITLE
in a field plugin a component can be a string

### DIFF
--- a/examples/tina-cloud-starter/.tina/__generated__/_graphql.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_graphql.json
@@ -2141,6 +2141,21 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
+            "value": "test"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
             "value": "header"
           },
           "arguments": [],
@@ -4330,6 +4345,20 @@
         "value": "GlobalMutation"
       },
       "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "test"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
         {
           "kind": "InputValueDefinition",
           "name": {

--- a/examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -84,6 +84,18 @@
       "path": "content/global",
       "fields": [
         {
+          "name": "test",
+          "type": "string",
+          "label": "test",
+          "ui": {
+            "component": "test"
+          },
+          "namespace": [
+            "global",
+            "test"
+          ]
+        },
+        {
           "type": "object",
           "label": "Header",
           "name": "header",

--- a/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
@@ -57,6 +57,14 @@
       "path": "content/global",
       "fields": [
         {
+          "name": "test",
+          "type": "string",
+          "label": "test",
+          "ui": {
+            "component": "test"
+          }
+        },
+        {
           "type": "object",
           "label": "Header",
           "name": "header",

--- a/examples/tina-cloud-starter/.tina/__generated__/schema.gql
+++ b/examples/tina-cloud-starter/.tina/__generated__/schema.gql
@@ -148,6 +148,7 @@ type GlobalTheme {
 }
 
 type Global {
+  test: String
   header: GlobalHeader
   footer: GlobalFooter
   theme: GlobalTheme
@@ -335,6 +336,7 @@ input GlobalThemeMutation {
 }
 
 input GlobalMutation {
+  test: String
   header: GlobalHeaderMutation
   footer: GlobalFooterMutation
   theme: GlobalThemeMutation

--- a/examples/tina-cloud-starter/.tina/__generated__/types.ts
+++ b/examples/tina-cloud-starter/.tina/__generated__/types.ts
@@ -264,6 +264,7 @@ export type GlobalTheme = {
 
 export type Global = {
   __typename?: 'Global';
+  test?: Maybe<Scalars['String']>;
   header?: Maybe<GlobalHeader>;
   footer?: Maybe<GlobalFooter>;
   theme?: Maybe<GlobalTheme>;
@@ -509,6 +510,7 @@ export type GlobalThemeMutation = {
 };
 
 export type GlobalMutation = {
+  test?: Maybe<Scalars['String']>;
   header?: Maybe<GlobalHeaderMutation>;
   footer?: Maybe<GlobalFooterMutation>;
   theme?: Maybe<GlobalThemeMutation>;

--- a/examples/tina-cloud-starter/.tina/schema.ts
+++ b/examples/tina-cloud-starter/.tina/schema.ts
@@ -438,6 +438,14 @@ export default defineSchema({
       path: "content/global",
       fields: [
         {
+          name: "test",
+          type: "string",
+          label: "test",
+          ui: {
+            component: "test",
+          },
+        },
+        {
           type: "object",
           label: "Header",
           name: "header",

--- a/examples/tina-cloud-starter/components/plugins.tsx
+++ b/examples/tina-cloud-starter/components/plugins.tsx
@@ -1,0 +1,10 @@
+import { FieldPlugin } from "tinacms";
+
+export const MyPlugin: FieldPlugin = {
+  __type: "field",
+  Component: "text",
+  name: "test",
+  validate: (val: string) =>
+    val?.startsWith("test") ? "" : "The input MUST start with test",
+  defaultValue: "this is not a valid",
+};

--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -24,6 +24,9 @@ const App = ({ Component, pageProps }) => {
               import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
                 cms.plugins.add(MarkdownFieldPlugin);
               });
+              import("../components/plugins").then(({ MyPlugin }) => {
+                cms.plugins.add(MyPlugin);
+              });
             }}
             documentCreatorCallback={{
               /**
@@ -51,14 +54,16 @@ const App = ({ Component, pageProps }) => {
             }}
             {...pageProps}
           >
-            {(livePageProps) => (
-              <Layout
-                rawData={livePageProps}
-                data={livePageProps.data?.getGlobalDocument?.data}
-              >
-                <Component {...livePageProps} />
-              </Layout>
-            )}
+            {(livePageProps) => {
+              return (
+                <Layout
+                  rawData={livePageProps}
+                  data={livePageProps.data?.getGlobalDocument?.data}
+                >
+                  <Component {...livePageProps} />
+                </Layout>
+              );
+            }}
           </TinaCMS>
         }
       >

--- a/packages/@tinacms/toolkit/src/packages/form-builder/field-plugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/field-plugin.tsx
@@ -21,7 +21,7 @@ import { Field } from '../forms'
 export interface FieldPlugin {
   __type: 'field'
   name: string
-  Component: React.FC<any>
+  Component: React.FC<any> | string
   type?: string
   validate?(
     value: any,

--- a/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
@@ -40,6 +40,15 @@ export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
           .find(field.component as string)
 
         let type: string | undefined
+
+        let Component = plugin.Component
+
+        if (typeof plugin?.Component === 'string') {
+          Component = cms.plugins
+            .findOrCreateMap<FieldPlugin>('field')
+            .find(plugin.Component as string).Component
+        }
+
         if (plugin && plugin.type) {
           type = plugin.type
         }
@@ -98,7 +107,7 @@ export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
 
               if (plugin) {
                 return (
-                  <plugin.Component
+                  <Component
                     {...fieldProps}
                     form={form.finalForm}
                     tinaForm={form}

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -59,11 +59,11 @@ class ErrorBoundary extends React.Component {
   constructor(props) {
     super(props)
 
-    this.state = { 
-      hasError: props.hasError, 
+    this.state = {
+      hasError: props.hasError,
       message: '',
-      pageRefresh: false
-     }
+      pageRefresh: false,
+    }
   }
 
   static getDerivedStateFromError(error) {
@@ -117,8 +117,9 @@ class ErrorBoundary extends React.Component {
             <br />
             <p>
               If you've just updated the form, undo your most recent changes and
-              click "refresh". If after a few refreshes, you're still encountering this error. 
-              There is a bigger issue with the site. Please reach out to your site admin.
+              click "refresh". If after a few refreshes, you're still
+              encountering this error. There is a bigger issue with the site.
+              Please reach out to your site admin.
             </p>
             <div style={{ padding: '10px 0' }}>
               <button
@@ -136,7 +137,11 @@ class ErrorBoundary extends React.Component {
                 onClick={() => {
                   /* @ts-ignore */
                   this.setState({ pageRefresh: true })
-                  setTimeout(() => this.setState({ hasError: false, pageRefresh: false}), 3000)
+                  setTimeout(
+                    () =>
+                      this.setState({ hasError: false, pageRefresh: false }),
+                    3000
+                  )
                 }}
               >
                 Refresh
@@ -146,14 +151,13 @@ class ErrorBoundary extends React.Component {
         </div>
       )
     }
-    {/* @ts-ignore */}
-    { if (this.state.pageRefresh) {
-      return (
-        <Loader>
-          Let's try that again.
-        </Loader>
-      )
+    {
+      /* @ts-ignore */
     }
+    {
+      if (this.state.pageRefresh) {
+        return <Loader>Let's try that again.</Loader>
+      }
     }
 
     return this.props.children


### PR DESCRIPTION
This allows someone to quickly extent our fields to add validation logic, format logic, parse logic, ect. 

Now one can do this.
```ts
 const MyPlugin: FieldPlugin = {
  __type: "field",
  Component: "text",
  name: "MyComponent",
  validate: (val: string) =>
    val?.startsWith("test") ? "" : "The input MUST start with test",
  defaultValue: "this is not a valid",
};

cms.api.plugins.add(MyPlugin)
```

In schema.ts

```ts
{
          name: "test",
          type: "string",
          label: "test",
          ui: {
            component: "MyComponent",
          },
        },
```
**Note:**  the name of the plugin and the `component` must match

Now in the global menu you will have a custom component.

https://www.loom.com/share/e557ec6490ac4651aef1c448af54dd7c


