### PR TITLE
Improve the type definition

### DIFF
--- a/.changeset/violet-games-prove.md
+++ b/.changeset/violet-games-prove.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-inline': patch
+---
+
+Improve BlockComponentProps and Block.Component

--- a/packages/react-tinacms-inline/README.md
+++ b/packages/react-tinacms-inline/README.md
@@ -345,14 +345,14 @@ A block is made of two parts: a [component](https://tinacms.org/docs/ui/inline-e
 
 ```ts
 interface Block {
-  Component: React.FC<BlockComponentProps>
+  Component: React.ComponentType<BlockComponentProps>
   template: BlockTemplate
 }
 
-interface BlockComponentProps {
+interface BlockComponentProps<DataType = any> {
   name: string
   index: number
-  data: any
+  data: DataType
 }
 
 interface BlockTemplate {

--- a/packages/react-tinacms-inline/src/blocks/block.ts
+++ b/packages/react-tinacms-inline/src/blocks/block.ts
@@ -21,12 +21,12 @@ import { BlockTemplate } from 'tinacms'
  * Blocks consist of a `template` and a `Component`
  */
 export interface Block {
-  Component: React.FC<BlockComponentProps>
+  Component: React.ComponentType<BlockComponentProps>
   template: BlockTemplate
 }
 
-export interface BlockComponentProps {
+export interface BlockComponentProps<DataType = any> {
   name: string
   index: number
-  data: any
+  data: DataType
 }


### PR DESCRIPTION
Thanks tinaCMS team
In the process of using tinaCMS, I found that the "data" type of BlockComponentProps was hard-coded to any. I suggest to modify it to generic
The type of Block is defined as `React.FC<BlockComponentProps>`, it will not be able to pass in class components, I suggest changing it to `React.ComponentType<BlockComponentProps>`