### PR TITLE
Memoize cms initialization so hot-reloads don't run into race-conditions

### DIFF
--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -125,12 +125,15 @@ export const TinaCloudProvider = (
     CreateClientProps & { cmsCallback?: (cms: TinaCMS) => TinaCMS }
 ) => {
   useTinaAuthRedirect()
-  const cms =
-    props.cms ||
-    new TinaCMS({
-      enabled: true,
-      sidebar: true,
-    })
+  const cms = React.useMemo(
+    () =>
+      props.cms ||
+      new TinaCMS({
+        enabled: true,
+        sidebar: true,
+      }),
+    [props.cms]
+  )
   if (!cms.api.tina) {
     cms.api.tina = createClient(props)
   }


### PR DESCRIPTION
This fixes the issue where you have to refresh your page on save during development since a hot-reload would wipe out your sidebar form

`new TinaCMS` wasn't protected by memoization in the React component so was getting reinitialized on each render. Since this was higher in the tree I guess we didn't see too many issues with it, but was probably hurting performance. At any rate, it was also wiping out the work `useGraphQLForms` was doing because the re-render didn't trigger a re-run of the hook (something that's also not ideal).