### PR TITLE
Uses better default dateFormat for DateField

### DIFF
--- a/.changeset/cyan-radios-decide.md
+++ b/.changeset/cyan-radios-decide.md
@@ -1,0 +1,6 @@
+---
+'tina-cloud-starter': patch
+'@tinacms/toolkit': patch
+---
+
+Uses a better default dateFormat for the DateField

--- a/examples/tina-cloud-starter/components/post.tsx
+++ b/examples/tina-cloud-starter/components/post.tsx
@@ -22,7 +22,10 @@ export const Post = ({ data }) => {
   };
 
   const date = new Date(data.date);
-  const formattedDate = format(date, "MMM dd, yyyy");
+  let formattedDate = "";
+  if (!isNaN(date.getTime())) {
+    formattedDate = format(date, "MMM dd, yyyy");
+  }
 
   return (
     <Section className="flex-1">

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/DateFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/DateFieldPlugin.tsx
@@ -24,9 +24,7 @@ import { InputCss } from '../components/Input'
 import { wrapFieldsWithMeta } from './wrapFieldWithMeta'
 import ReactDatetime from 'react-datetime'
 import { DatetimepickerProps } from 'react-datetime'
-import { format, parse } from './dateFormat'
-
-const DEFAULT_DATE_FORMAT = 'MMM dd, yyyy'
+import { format, parse, DEFAULT_DATE_DISPLAY_FORMAT } from './dateFormat'
 
 export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
   ({ input, field: { dateFormat, timeFormat, ...rest } }) => {
@@ -58,7 +56,7 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
             onFocus={input.onFocus}
             onChange={input.onChange}
             open={isOpen}
-            dateFormat={dateFormat || DEFAULT_DATE_FORMAT}
+            dateFormat={dateFormat || DEFAULT_DATE_DISPLAY_FORMAT}
             timeFormat={timeFormat || false}
             {...rest}
           />

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/dateFormat.ts
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/dateFormat.ts
@@ -19,8 +19,8 @@
 import moment from 'moment'
 import { DatetimepickerProps } from 'react-datetime'
 
-const DEFAULT_DATE_DISPLAY_FORMAT = 'MMM DD, YYYY'
-const DEFAULT_TIME_DISPLAY_FORMAT = 'h:mm A'
+export const DEFAULT_DATE_DISPLAY_FORMAT = 'MMM DD, YYYY'
+export const DEFAULT_TIME_DISPLAY_FORMAT = 'h:mm A'
 
 // formats a function from default datetime format to given format
 export const format = (
@@ -30,6 +30,7 @@ export const format = (
 ): string => {
   const dateFormat = parseDateFormat(field.dateFormat)
   const timeFormat = parseTimeFormat(field.timeFormat)
+
   const combinedFormat =
     typeof timeFormat === 'string' ? `${dateFormat} ${timeFormat}` : dateFormat
 
@@ -42,7 +43,13 @@ export const format = (
 }
 
 // parses a function from the given format to default datetime format
-export const parse = (val: string) => new Date(val).toISOString()
+export const parse = (val: string) => {
+  const date = new Date(val)
+  if (!isNaN(date.getTime())) {
+    return new Date(val).toISOString()
+  }
+  return val
+}
 
 function parseDateFormat(format: string | boolean | undefined): string {
   if (typeof format === 'string') {


### PR DESCRIPTION
While dogfooding, I noticed some unusual behavior in the `react-datetime` picker when using `DEFAULT_DATE_FORMAT` (`MMM dd, yyyy`).

`dd` is actually not a supported token by `moment` (https://momentjs.com/docs/#/parsing/string-format/).  Swapping to `DD` resolves this.

We had not encountered this before because the `tina-cloud-starter` schema uses `DD` correctly for `dateFormat`.

I also made a change to better handle when a date is `invalid` (`parse` was failing).