### PR TITLE
Fix/multiple image upload

### DIFF
--- a/.changeset/olive-clouds-promise.md
+++ b/.changeset/olive-clouds-promise.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/toolkit': minor
+'next-tinacms-cloudinary': minor
+'react-tinacms-inline': minor
+---
+
+Add support for multiple image upload in the Media Store.

--- a/.changeset/olive-clouds-promise.md
+++ b/.changeset/olive-clouds-promise.md
@@ -1,7 +1,6 @@
 ---
 '@tinacms/toolkit': minor
 'next-tinacms-cloudinary': minor
-'react-tinacms-inline': minor
 ---
 
 Add support for multiple image upload in the Media Store.

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -178,7 +178,7 @@ export function MediaPicker({
   const [uploading, setUploading] = useState(false)
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: cms.media.accept || 'image/*',
-
+    multiple: true,
     onDrop: async (files) => {
       try {
         setUploading(true)
@@ -210,7 +210,7 @@ export function MediaPicker({
 
   useEffect(disableScrollBody, [])
 
-  if (listState === 'loading') {
+  if (listState === 'loading' || uploading) {
     return <LoadingMediaList />
   }
 

--- a/packages/@tinacms/toolkit/src/packages/fields/components/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/ImageUpload/ImageUpload.tsx
@@ -147,9 +147,9 @@ export const ImageUpload = ({
             <ImageLoadingIndicator />
           ) : (
             <ImgPlaceholder>
-            Drag 'n' drop some files here,
+            Drag 'n' drop a file here,
             <br />
-            or click to select files
+            or click to select a file
           </ImgPlaceholder>
           )}
         </StyledImageContainer>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ImageFieldPlugin.tsx
@@ -85,8 +85,7 @@ export const ImageField = wrapFieldsWithMeta<InputProps, ImageProps>(
       onClear = () => props.input.onChange('')
     }
 
-    async function onChange(media?: Media) {
-
+    async function onChange(media?: Media | Media[]) {
       if (media) {
         const parsedValue =
           // @ts-ignore

--- a/packages/react-tinacms-inline/src/fields/inline-image/dropzone-wrapper.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/dropzone-wrapper.tsx
@@ -38,7 +38,6 @@ export function DropzoneWrapper({
     accept: 'image/*',
     onDrop,
     noClick: !!onClick,
-    multiple: true
   })
 
   return (

--- a/packages/react-tinacms-inline/src/fields/inline-image/dropzone-wrapper.tsx
+++ b/packages/react-tinacms-inline/src/fields/inline-image/dropzone-wrapper.tsx
@@ -38,6 +38,7 @@ export function DropzoneWrapper({
     accept: 'image/*',
     onDrop,
     noClick: !!onClick,
+    multiple: true
   })
 
   return (


### PR DESCRIPTION
Based on comments from folks about how editors / users in general would want to be able to upload many assets at once, I started poking around and realized the Cloudinary Media store was only handling the first media item in an array. Thus, if someone where to upload many files, or the first item was successfully posting to Cloudinary. 

This PR updates the `persist` method in the Cloudinary media store to handle multiple files, as well as adding in a loading state to the UI to provide more visual feedback.

@jeffsee55 I'll leave this in draft status for now since you mentioned we should discuss the issue I added to the UX improvements board, but this would at least be a first pass.