### PR TITLE
temporary fix for edit state context issues

### DIFF
--- a/packages/tinacms/src/auth/AuthModal.tsx
+++ b/packages/tinacms/src/auth/AuthModal.tsx
@@ -42,7 +42,7 @@ export function ModalBuilder(modalProps: ModalBuilderProps) {
           </ModalBody>
           <ModalActions>
             {modalProps.actions.map((action) => (
-              <AsyncButton {...action} />
+              <AsyncButton key={action.name} {...action} />
             ))}
           </ModalActions>
         </ModalPopup>

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -18,7 +18,7 @@ import { TinaCMS, TinaProvider, MediaStore } from '@tinacms/toolkit'
 import { Client } from '../client'
 import { useTinaAuthRedirect } from './useTinaAuthRedirect'
 import { CreateClientProps, createClient } from '../utils'
-import { useEditState } from '../edit-state'
+import { setEditing } from '../edit-state'
 
 type ModalNames = null | 'authenticate'
 
@@ -49,7 +49,6 @@ export const AuthWallInner = ({
 
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
   const [showChildren, setShowChildren] = useState<boolean>(false)
-  const { setEdit } = useEditState()
 
   React.useEffect(() => {
     client.isAuthenticated().then((isAuthenticated) => {
@@ -93,8 +92,14 @@ export const AuthWallInner = ({
             ...otherModalActions,
             {
               action: async () => {
-                setActiveModal(null)
-                setEdit(false)
+                // This does not work it looks like we have somehow getting two contexts
+                // console.log({ setEdit })
+                // setEdit(false)
+                // setActiveModal(null)
+
+                // This is a temp fix
+                setEditing(false) // set editing just sets the local storage
+                window.location.reload()
               },
               name: 'Close',
               primary: false,

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -83,9 +83,9 @@ export const setEditing = (isEditing: boolean) => {
   }
 }
 
-const EditContext = React.createContext({
+export const EditContext = React.createContext({
   edit: isEditing(),
-  setEdit: (editing: boolean) => {},
+  setEdit: undefined as (edit: boolean) => void,
 })
 
 /*
@@ -112,4 +112,10 @@ export const EditProvider: React.FC = ({ children }) => {
   )
 }
 
-export const useEditState = () => useContext(EditContext)
+export const useEditState = () => {
+  const { edit, setEdit } = useContext(EditContext)
+  if (!setEdit) {
+    throw new Error('No `TinaEditProvider` found')
+  }
+  return { edit, setEdit }
+}


### PR DESCRIPTION
There was an issue that was introduced with our new build set. For some reason the edit context is not getting shared. This caused the close button not to work. 

This PR is a temp fix that allows the close button to work once again.
