### PR TITLE
added new warning messages for list UI

### DIFF
--- a/.changeset/real-pears-chew.md
+++ b/.changeset/real-pears-chew.md
@@ -1,0 +1,7 @@
+---
+'tina-cloud-starter': minor
+'@tinacms/cli': minor
+'@tinacms/graphql': minor
+---
+
+Added new error messages for list UI that we do not support by defualt

--- a/.changeset/real-pears-chew.md
+++ b/.changeset/real-pears-chew.md
@@ -4,4 +4,4 @@
 '@tinacms/graphql': minor
 ---
 
-Added new error messages for list UI that we do not support by defualt
+Added new warning messages for list UI that we do not support by default

--- a/examples/tina-cloud-starter/.tina/__generated__/_lookup.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_lookup.json
@@ -104,5 +104,20 @@
     "type": "GlobalConnection",
     "resolveType": "collectionDocumentList",
     "collection": "global"
+  },
+  "GlobalFooterSocialTestDocument": {
+    "type": "GlobalFooterSocialTestDocument",
+    "resolveType": "multiCollectionDocument"
+  },
+  "PostsTestDocument": {
+    "type": "PostsTestDocument",
+    "resolveType": "multiCollectionDocument"
+  },
+  "PostsTestConnection": {
+    "type": "PostsTestConnection",
+    "resolveType": "multiCollectionDocumentList",
+    "collections": [
+      "posts"
+    ]
   }
 }

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -86,7 +86,7 @@ stack: ${code.stack || 'No stack was provided'}`)
             logger.info(
               dangerText(
                 'Compilation failed with errors. Server has not been restarted.'
-              )
+              ) + `see error below \n ${e.message}`
             )
           }
         }
@@ -115,15 +115,11 @@ stack: ${code.stack || 'No stack was provided'}`)
       logger.info(`Visit the playground at http://localhost:${port}/altair/`)
     })
     state.server.on('error', function (e) {
-        if (e.code === 'EADDRINUSE') {
-          logger.error(
-              dangerText(
-                  `Port 4001 already in use`
-              )
-          )
-          process.exit()
-        }
-        throw e
+      if (e.code === 'EADDRINUSE') {
+        logger.error(dangerText(`Port 4001 already in use`))
+        process.exit()
+      }
+      throw e
     })
     state.server.on('connection', (socket) => {
       state.sockets.push(socket)

--- a/packages/@tinacms/graphql/src/primitives/builder/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/builder/index.ts
@@ -723,7 +723,11 @@ export class Builder {
   }
 
   private _buildDataField = async (field: TinaFieldEnriched) => {
-    const caseErrMsg = `Field type "${field.type}"" does not support list: true`
+    const listWarningMsg = `
+WARNING: The user interface for ${field.type} does not support \`list: true\`
+Visit https://tina.io/docs/errors/ui-not-supported/ for more information
+
+`
 
     switch (field.type) {
       case 'boolean':
@@ -731,7 +735,7 @@ export class Builder {
       case 'image':
       case 'number':
         if (field.list) {
-          throw new Error(caseErrMsg)
+          console.warn(listWarningMsg)
         }
       case 'string':
         return astBuilder.FieldDefinition({
@@ -752,23 +756,21 @@ export class Builder {
       case 'reference':
         const name = NAMER.documentTypeName(field.namespace)
         if (field.list) {
-          throw new Error(caseErrMsg)
-          // }
-          // if (field.list) {
-          // return this._buildMultiCollectionDocumentListDefinition({
-          //   fieldName: field.name,
-          //   namespace: field.namespace,
-          //   nodeType: astBuilder.UnionTypeDefinition({
-          //     name,
-          //     types: field.collections.map((collectionName) =>
-          //       NAMER.documentTypeName([collectionName])
-          //     ),
-          //   }),
-          //   collections: this.tinaSchema.getCollectionsByName(
-          //     field.collections
-          //   ),
-          //   connectionNamespace: field.namespace,
-          // })
+          console.warn(listWarningMsg)
+          return this._buildMultiCollectionDocumentListDefinition({
+            fieldName: field.name,
+            namespace: field.namespace,
+            nodeType: astBuilder.UnionTypeDefinition({
+              name,
+              types: field.collections.map((collectionName) =>
+                NAMER.documentTypeName([collectionName])
+              ),
+            }),
+            collections: this.tinaSchema.getCollectionsByName(
+              field.collections
+            ),
+            connectionNamespace: field.namespace,
+          })
         } else {
           const type = await this._buildMultiCollectionDocumentDefinition({
             fieldName: name,

--- a/packages/@tinacms/graphql/src/primitives/builder/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/builder/index.ts
@@ -723,11 +723,16 @@ export class Builder {
   }
 
   private _buildDataField = async (field: TinaFieldEnriched) => {
+    const caseErrMsg = `Field type "${field.type}"" does not support list: true`
+
     switch (field.type) {
       case 'boolean':
       case 'datetime':
       case 'image':
       case 'number':
+        if (field.list) {
+          throw new Error(caseErrMsg)
+        }
       case 'string':
         return astBuilder.FieldDefinition({
           name: field.name,
@@ -747,20 +752,23 @@ export class Builder {
       case 'reference':
         const name = NAMER.documentTypeName(field.namespace)
         if (field.list) {
-          return this._buildMultiCollectionDocumentListDefinition({
-            fieldName: field.name,
-            namespace: field.namespace,
-            nodeType: astBuilder.UnionTypeDefinition({
-              name,
-              types: field.collections.map((collectionName) =>
-                NAMER.documentTypeName([collectionName])
-              ),
-            }),
-            collections: this.tinaSchema.getCollectionsByName(
-              field.collections
-            ),
-            connectionNamespace: field.namespace,
-          })
+          throw new Error(caseErrMsg)
+          // }
+          // if (field.list) {
+          // return this._buildMultiCollectionDocumentListDefinition({
+          //   fieldName: field.name,
+          //   namespace: field.namespace,
+          //   nodeType: astBuilder.UnionTypeDefinition({
+          //     name,
+          //     types: field.collections.map((collectionName) =>
+          //       NAMER.documentTypeName([collectionName])
+          //     ),
+          //   }),
+          //   collections: this.tinaSchema.getCollectionsByName(
+          //     field.collections
+          //   ),
+          //   connectionNamespace: field.namespace,
+          // })
         } else {
           const type = await this._buildMultiCollectionDocumentDefinition({
             fieldName: name,


### PR DESCRIPTION
Fixes https://github.com/tinacms/tinacms/issues/2056. It does not only fix it for the reference field but all fields that do not support list: true.

- [x] build time error message
- [x] Tina.io docs (https://github.com/tinacms/tinacms.org/pull/1038)

@jeffsee55 Should we provide a way to opt out as someone could provide their own UI and it would work as expected ?

EDIT: Maybe this change is too aggressive? We could also give a warning to the user that this UI is not currently supported and direct them to the docs for a work around (embed in object). 

EDIT again: I think I like the warning message better. I updated it to be a warning message now.