### PR TITLE
Add tinaioconfig to override API endpoints

### DIFF
--- a/.changeset/fast-spiders-repeat.md
+++ b/.changeset/fast-spiders-repeat.md
@@ -1,0 +1,33 @@
+---
+'tinacms': patch
+---
+
+Allow tina.io URLs to be supplied as a a prop:
+
+```tsx
+<TinaEditProvider
+  editMode={
+    <TinaCMS
+      branch="main"
+      clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
+      tinaioConfig={{
+        baseUrl: "some-base.io"
+      }}
+      //...
+```
+
+Or just the identity/content URLs:
+
+```tsx
+<TinaEditProvider
+  editMode={
+    <TinaCMS
+      branch="main"
+      clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
+      tinaioConfig={{
+        identityApiUrl: "https://some-base.io"
+        // AND/OR
+        contentApiUrl: "https://content.some-base.io"
+      }}
+      //...
+```

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -15,7 +15,7 @@ import { ModalBuilder } from './AuthModal'
 import React, { useState } from 'react'
 import { TinaCMS, TinaProvider, MediaStore } from '@tinacms/toolkit'
 
-import { Client } from '../client'
+import { Client, TinaIOConfig } from '../client'
 import { useTinaAuthRedirect } from './useTinaAuthRedirect'
 import { CreateClientProps, createClient } from '../utils'
 import { setEditing } from '../edit-state'
@@ -33,6 +33,7 @@ export interface TinaCloudAuthWallProps {
   cms?: TinaCMS
   children: React.ReactNode
   loginScreen?: React.ReactNode
+  tinaioConfig?: TinaIOConfig
   getModalActions?: (args: {
     closeModal: () => void
   }) => { name: string; action: () => Promise<void>; primary: boolean }[]

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -62,11 +62,6 @@ export class Client {
     } else {
       this.identityApiUrl = `https://identity.${this.baseUrl}`
     }
-    console.log('hello', {
-      options,
-      contentApiUrl: this.contentApiUrl,
-      identityURL: this.identityApiUrl,
-    })
 
     this.clientId = options.clientId
 

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -22,39 +22,51 @@ import {
 
 import { formify } from './formify'
 import gql from 'graphql-tag'
+export type TinaIOConfig =
+  | { baseUrl?: string; identityApiUrl: undefined; contentApiUrl: undefined }
+  | { baseUrl: undefined; identityApiUrl?: string; contentApiUrl?: string }
 
 interface ServerOptions {
   clientId: string
   branch: string
   customContentApiUrl?: string
   getTokenFn?: () => TokenObject
+  tinaioConfig?: TinaIOConfig
   tokenStorage?: 'MEMORY' | 'LOCAL_STORAGE' | 'CUSTOM'
 }
 
-const BASE_TINA_URL = process.env.BASE_TINA_URL || `tinajs.io`
-const IDENTITY_API_URL =
-  process.env.IDENTITY_API_OVERRIDE || `https://identity.${BASE_TINA_URL}`
-const CONTENT_API_URL =
-  process.env.CONTENT_API_OVERRIDE || `https://content.${BASE_TINA_URL}`
-
 export class Client {
   contentApiUrl: string
+  identityApiUrl: string
   schema: GraphQLSchema
   clientId: string
   query: string
   setToken: (_token: TokenObject) => void
   private getToken: () => TokenObject
   private token: string // used with memory storage
+  private baseUrl: string
 
   constructor({ tokenStorage = 'MEMORY', ...options }: ServerOptions) {
-    /**
-     * Prevents a CORS-issue when the `branch` has slashes in it.
-     * https://github.com/tinacms/tinacms/issues/219
-     */
     const encodedBranch = encodeURIComponent(options.branch)
-    this.contentApiUrl =
-      options.customContentApiUrl ||
-      `${CONTENT_API_URL}/content/${options.clientId}/github/${encodedBranch}`
+    this.baseUrl = options.tinaioConfig?.baseUrl || 'tinajs.io'
+    if (options.tinaioConfig?.contentApiUrl) {
+      this.contentApiUrl =
+        options.customContentApiUrl || options.tinaioConfig.contentApiUrl
+    } else {
+      this.contentApiUrl =
+        options.customContentApiUrl ||
+        `https://content.${this.baseUrl}/content/${options.clientId}/github/${encodedBranch}`
+    }
+    if (options.tinaioConfig?.identityApiUrl) {
+      this.identityApiUrl = options.tinaioConfig.identityApiUrl
+    } else {
+      this.identityApiUrl = `https://identity.${this.baseUrl}`
+    }
+    console.log('hello', {
+      options,
+      contentApiUrl: this.contentApiUrl,
+      identityURL: this.identityApiUrl,
+    })
 
     this.clientId = options.clientId
 
@@ -226,7 +238,7 @@ mutation addPendingDocumentMutation(
       return null
     }
 
-    const url = `${IDENTITY_API_URL}/v2/apps/${this.clientId}/currentUser`
+    const url = `${this.identityApiUrl}/v2/apps/${this.clientId}/currentUser`
 
     try {
       const res = await this.fetchWithToken(url, {

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -16,6 +16,7 @@ import { useGraphqlForms } from './hooks/use-graphql-forms'
 import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
 import { TinaCloudProvider, TinaCloudMediaStoreClass } from './auth'
 import { LocalClient } from './client/index'
+import type { TinaIOConfig } from './client/index'
 import { useCMS } from '@tinacms/toolkit'
 
 import type { TinaCMS } from '@tinacms/toolkit'
@@ -167,6 +168,7 @@ export const TinaCMSProvider2 = ({
   isLocalClient,
   cmsCallback,
   mediaStore,
+  tinaioConfig,
   ...props
 }: {
   /** The query from getStaticProps */
@@ -191,6 +193,7 @@ export const TinaCMSProvider2 = ({
   documentCreatorCallback?: Parameters<typeof useDocumentCreatorPlugin>[0]
   /** TinaCMS media store instance */
   mediaStore?: TinaCloudMediaStoreClass | Promise<TinaCloudMediaStoreClass>
+  tinaioConfig?: TinaIOConfig
 }) => {
   if (typeof props.query === 'string') {
     props.query
@@ -199,6 +202,7 @@ export const TinaCMSProvider2 = ({
     <TinaCloudProvider
       branch={branch}
       clientId={clientId}
+      tinaioConfig={tinaioConfig}
       isLocalClient={isLocalClient}
       cmsCallback={cmsCallback}
       mediaStore={mediaStore}

--- a/packages/tinacms/src/utils/index.ts
+++ b/packages/tinacms/src/utils/index.ts
@@ -12,25 +12,29 @@ limitations under the License.
 */
 
 import { Client, LocalClient } from '../client'
+import type { TinaIOConfig } from '../client'
 import * as yup from 'yup'
 
 export interface CreateClientProps {
   clientId?: string
   isLocalClient?: boolean
+  tinaioConfig?: TinaIOConfig
   branch?: string
 }
 export const createClient = ({
   clientId,
   isLocalClient = true,
   branch,
+  tinaioConfig,
 }: CreateClientProps) => {
   return isLocalClient
     ? new LocalClient()
     : new Client({
-      clientId: clientId || '',
-      branch: branch || 'main',
-      tokenStorage: 'LOCAL_STORAGE',
-    })
+        clientId: clientId || '',
+        branch: branch || 'main',
+        tokenStorage: 'LOCAL_STORAGE',
+        tinaioConfig,
+      })
 }
 
 export function assertShape<T extends unknown>(


### PR DESCRIPTION
Allow tina.io URLs to be supplied as a a prop:

```tsx
<TinaEditProvider
  editMode={
    <TinaCMS
      branch="main"
      clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
      tinaioConfig={{
        baseUrl: "some-base.io"
      }}
      //...
```

Or just the identity/content URLs:

```tsx
<TinaEditProvider
  editMode={
    <TinaCMS
      branch="main"
      clientId={NEXT_PUBLIC_TINA_CLIENT_ID}
      tinaioConfig={{
        identityApiUrl: "https://some-base.io"
        // AND/OR
        contentApiUrl: "https://content.some-base.io"
      }}
      //...
```

Closes https://github.com/tinacms/tinacms/issues/2086