### PR TITLE
added warning message when static request was being used outside a no…

### DIFF
--- a/.changeset/tall-cooks-battle.md
+++ b/.changeset/tall-cooks-battle.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+A warning message is added to warn the user if they are using a staticRequest at run time.

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -328,6 +328,10 @@ export const getStaticPropsForTina = async ({
   }
 }
 
+function is_server() {
+  return !(typeof window != 'undefined' && window.document)
+}
+
 /**
  * A convenience function which makes a GraphQL request
  * to a local GraphQL server. Only recommended for functions
@@ -343,9 +347,19 @@ export const staticRequest = async ({
   variables?: object
 }) => {
   const client = new LocalClient()
+  if (!is_server()) {
+    // If we are running this in the browser (for example a useEffect) we should display a warning
+    console.warn(`Whoops! Looks like you are using \`staticRequest\` in the browser to fetch data.
+
+The local server is not available outside of \`getStaticProps\` or \`getStaticPaths\` functions. 
+This function should only be called on the server at build time.
+
+This will work when developing locally but NOT when deployed to production. 
+`)
+  }
+
   return client.request(query, { variables })
 }
-
 /**
  * A passthru function which allows editors
  * to know the temlpate string is a GraphQL


### PR DESCRIPTION
Fixes https://github.com/tinacms/tinacms/issues/2094 but instead of an error message it adds a warning message. (You will still get the same error but will have this warning message directly above it). The warning message will always appear (local mode or prod).

How does this sound @perkinsjr and @jeffsee55  ? 
