### PR TITLE
fix(react-tinacms-strapi): Main file in package.json

### DIFF
--- a/.changeset/empty-gifts-tease.md
+++ b/.changeset/empty-gifts-tease.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-strapi': minor
+---
+
+Fixes a bug, that npm package is missing `dist` folder and is not working, because of changed build path.

--- a/packages/react-tinacms-strapi/package.json
+++ b/packages/react-tinacms-strapi/package.json
@@ -2,7 +2,7 @@
   "name": "react-tinacms-strapi",
   "version": "0.50.7",
   "description": "",
-  "main": "build/index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "jest --passWithNoTests",
     "watch": "tinacms-scripts watch",


### PR DESCRIPTION
Fixes an issue #2098

Fixes a bug, that npm package is missing `dist` folder, because of the changed build path.

