### PR TITLE
2113 - Prevent nagivation away from an invalid form

### DIFF
--- a/.changeset/rotten-clocks-grin.md
+++ b/.changeset/rotten-clocks-grin.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Prevents navigating away from a form while invalid

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin.tsx
@@ -37,6 +37,7 @@ import {
   GroupListMeta,
   GroupLabel,
 } from './GroupListFieldPlugin'
+import { useCMS } from '../../react-core/use-cms'
 import { useEvent } from '../../react-core'
 import { FieldHoverEvent, FieldFocusEvent } from '../field-events'
 
@@ -546,6 +547,8 @@ const Panel = function Panel({
   template,
   zIndexShift,
 }: PanelProps) {
+  const cms = useCMS()
+
   const fields: any[] = React.useMemo(() => {
     if (!template.fields) return []
 
@@ -557,7 +560,17 @@ const Panel = function Panel({
 
   return (
     <GroupPanel isExpanded={isExpanded} style={{ zIndex: zIndexShift + 1000 }}>
-      <PanelHeader onClick={() => setExpanded(false)}>
+      <PanelHeader
+        onClick={() => {
+          const state = tinaForm.finalForm.getState()
+          if (state.invalid === true) {
+            // @ts-ignore
+            cms.alerts.error('Cannot navigate away from an invalid form.')
+          } else {
+            setExpanded(false)
+          }
+        }}
+      >
         <LeftArrowIcon />
         <GroupLabel>{label}</GroupLabel>
       </PanelHeader>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
@@ -21,7 +21,7 @@ import { Field, Form } from '../../forms'
 import styled, { keyframes, css, StyledComponent } from 'styled-components'
 import { FieldsBuilder, useFormPortal } from '../../form-builder'
 import { LeftArrowIcon, RightArrowIcon } from '../../icons'
-import { wrapFieldsWithMeta } from './wrapFieldWithMeta'
+import { useCMS } from '../../react-core/use-cms'
 
 export interface GroupFieldDefinititon extends Field {
   component: 'group'
@@ -36,7 +36,7 @@ export interface GroupProps {
   tinaForm: Form
 }
 
-export const Group = wrapFieldsWithMeta(({ tinaForm, field }: GroupProps) => {
+export const Group = ({ tinaForm, field }: GroupProps) => {
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
   return (
     <>
@@ -52,7 +52,7 @@ export const Group = wrapFieldsWithMeta(({ tinaForm, field }: GroupProps) => {
       />
     </>
   )
-})
+}
 
 interface PanelProps {
   setExpanded(next: boolean): void
@@ -67,6 +67,7 @@ const Panel = function Panel({
   tinaForm,
   field,
 }: PanelProps) {
+  const cms = useCMS()
   const FormPortal = useFormPortal()
   const fields: any[] = React.useMemo(() => {
     return field.fields.map((subField: any) => ({
@@ -82,7 +83,17 @@ const Panel = function Panel({
           isExpanded={isExpanded}
           style={{ zIndex: zIndexShift + 1000 }}
         >
-          <PanelHeader onClick={() => setExpanded(false)}>
+          <PanelHeader
+            onClick={() => {
+              const state = tinaForm.finalForm.getState()
+              if (state.invalid === true) {
+                // @ts-ignore
+                cms.alerts.error('Cannot navigate away from an invalid form.')
+              } else {
+                setExpanded(false)
+              }
+            }}
+          >
             <LeftArrowIcon /> <span>{field.label || field.name}</span>
           </PanelHeader>
           <PanelBody>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
@@ -33,6 +33,7 @@ import { GroupPanel, PanelHeader, PanelBody } from './GroupFieldPlugin'
 import { FieldDescription } from './wrapFieldWithMeta'
 import { useEvent } from '../../react-core/use-cms-event'
 import { FieldHoverEvent, FieldFocusEvent } from '../field-events'
+import { useCMS } from '../../react-core/use-cms'
 
 interface GroupFieldDefinititon extends Field {
   component: 'group'
@@ -419,6 +420,7 @@ const Panel = function Panel({
   itemTitle,
   zIndexShift,
 }: PanelProps) {
+  const cms = useCMS()
   const fields: any[] = React.useMemo(() => {
     return field.fields.map((subField: any) => ({
       ...subField,
@@ -428,7 +430,17 @@ const Panel = function Panel({
 
   return (
     <GroupPanel isExpanded={isExpanded} style={{ zIndex: zIndexShift + 1000 }}>
-      <PanelHeader onClick={() => setExpanded(false)}>
+      <PanelHeader
+        onClick={() => {
+          const state = tinaForm.finalForm.getState()
+          if (state.invalid === true) {
+            // @ts-ignore
+            cms.alerts.error('Cannot navigate away from an invalid form.')
+          } else {
+            setExpanded(false)
+          }
+        }}
+      >
         <LeftArrowIcon />
         <GroupLabel>{itemTitle}</GroupLabel>
       </PanelHeader>

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -180,8 +180,21 @@ export const MultiformFormHeader = styled(
     setActiveFormId,
     ...styleProps
   }: MultiformFormHeaderProps) => {
+    const cms = useCMS()
+
     return (
-      <button {...styleProps} onClick={() => setActiveFormId('')}>
+      <button
+        {...styleProps}
+        onClick={() => {
+          const state = activeForm.finalForm.getState()
+          if (state.invalid === true) {
+            // @ts-ignore
+            cms.alerts.error('Cannot navigate away from an invalid form.')
+          } else {
+            setActiveFormId('')
+          }
+        }}
+      >
         <LeftArrowIcon />
         <span>{activeForm.label}</span>
       </button>


### PR DESCRIPTION
One of our users pointed out an interesting way to circumvent validation on forms:

> If you have a `group`, `group-list`, `blocks`, or multiple forms, you can use the "back" arrow in the form header to navigate away from an invalid form and use the Save/Reset buttons to commit those invalid changes.

The reason for this is because we're only using the currently rendered `finalForm`'s `invalid` flag to determine the state of those buttons rather than looking at all of the changes and validating them.

While a much bigger solution would probably exist in something like "Nested Forms," a much simpler solution is to simply prevent navigating away from an `invalid` form.

(As an aside, I also found a bug with `GroupFieldPlugin` where it was incorrectly being used with `wrapFieldWithMeta`.  This caused the `error` key to be for the whole `form` rather than a single `field` (because a `GroupField` is a collection of fields) and resulted in a pretty nasty `React` problem when it could not render the `error` _Object_.)

https://www.loom.com/share/02eee9862cb34998967f21ad3d3652ff

Closes #2113 