### PR TITLE
Branch switcher reboot

### DIFF
--- a/packages/@tinacms/cli/src/cmds/start-server/server.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/server.ts
@@ -19,6 +19,7 @@ import { altairExpress } from 'altair-express-middleware'
 // @ts-ignore
 import bodyParser from 'body-parser'
 
+const GITHUB_ACCESS_TOKEN = process.env.GITHUB_PERSONAL_ACCESS_TOKEN
 const gqlServer = async () => {
   // This is lazily required so we can update the module
   // without having to restart the server
@@ -59,6 +60,39 @@ const gqlServer = async () => {
       variables,
     })
     return res.json(result)
+  })
+
+  app.get('/list-branches', async (req, res) => {
+    try {
+      const { query } = req
+      const { owner, repo } = query
+      const result = await gqlPackage.listBranches({
+        auth: GITHUB_ACCESS_TOKEN,
+        owner,
+        repo
+      })
+
+      return res.json(result.data)
+    } catch(error) {
+      console.error('There was a problem fetching the branches.', error)
+    }
+  })
+
+  app.post('/create-branch', async (req, res) => {
+    try {
+      const { owner, repo, name, baseBranch } = req.body
+      const result = await gqlPackage.createBranch({
+        auth: GITHUB_ACCESS_TOKEN,
+        owner,
+        repo,
+        baseBranch,
+        name
+      })
+      return res.json(result)
+    } catch(error) {
+      res.end()
+      console.error('There was a problem creating a new branch.', error)
+    }
   })
 
   return server

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -40,6 +40,37 @@ import type {
   TinaFieldBase,
 } from './primitives/types'
 
+import { Octokit } from '@octokit/rest'
+
+export const listBranches = async ({auth, owner, repo}) => {
+  const appOctoKit = new Octokit({ auth })
+  const branchList = await appOctoKit.repos.listBranches({
+    owner,
+    repo,
+    per_page: 100
+  })
+
+  return branchList
+}
+
+export const createBranch = async ({ auth, owner, repo, name, baseBranch }) => {
+  const appOctoKit = new Octokit({ auth })
+  const currentBranch = await appOctoKit.repos.getBranch({
+    owner,
+    repo,
+    branch: baseBranch
+  })
+
+  const newBranch = await appOctoKit.git.createRef({
+    owner,
+    repo,
+    ref: `refs/heads/${name}`,
+    sha: currentBranch.data.commit.sha
+  })
+
+  return newBranch
+}
+
 export type TinaCloudSchema = TinaCloudSchemaBase<false>
 // Alias to remove Cloud
 export type TinaSchema = TinaCloudSchema

--- a/packages/@tinacms/toolkit/src/index.ts
+++ b/packages/@tinacms/toolkit/src/index.ts
@@ -46,6 +46,7 @@ export * from './react-tinacms'
 export { TinaCMS } from './tina-cms'
 export type { TinaCMSConfig } from './tina-cms'
 export { GlobalFormPlugin } from './plugins/screens'
+export * from './plugins/branch-switcher'
 export {
   TinaProvider,
   // Deprecated aliases to the previous exports

--- a/packages/@tinacms/toolkit/src/packages/core/cms.ts
+++ b/packages/@tinacms/toolkit/src/packages/core/cms.ts
@@ -128,11 +128,14 @@ export class CMS {
 
   media = new MediaManager(new DummyMediaStore(), this.events)
 
+  flags: Map<string, boolean>
+
   /**
    * @hidden
    */
   constructor(config: CMSConfig = {}) {
     this.plugins = new PluginTypeManager(this.events)
+    this.flags = new Map()
 
     if (config.media) {
       this.media.store = config.media

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -1,0 +1,127 @@
+import * as React from 'react'
+import { BranchSwitcherProps, Branch } from './types'
+import styled, { StyledComponent } from 'styled-components'
+
+export const BranchSwitcher = ({
+  currentBranch,
+  setCurrentBranch,
+  listBranches,
+  createBranch,
+}: BranchSwitcherProps) => {
+  const [isLoading, setIsLoading] = React.useState(false)
+  const [branchList, setBranchList] = React.useState([])
+
+  const handleCreateBranch = React.useCallback((value) => {
+    setIsLoading(true)
+    createBranch(value)
+      .then(async (createdBranchName) => {
+        setCurrentBranch(createdBranchName)
+        await refreshBranchList()
+      })
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  const refreshBranchList = React.useCallback(async () => {
+    setIsLoading(true)
+    await listBranches()
+      .then((data: Branch[]) => {
+        setBranchList(data)
+      })
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  // load branch list
+  React.useEffect(() => {
+    refreshBranchList()
+  }, [])
+
+  return (
+    <SelectWrap isLoading={isLoading}>
+      <h3>Select Branch</h3>
+      <BranchSelector
+        currentBranch={currentBranch}
+        branchList={branchList}
+        onCreateBranch={(newBranch) => {
+          handleCreateBranch(newBranch)
+        }}
+        onChange={(branchName) => {
+          setCurrentBranch(branchName)
+        }}
+      />
+    </SelectWrap>
+  )
+}
+
+const BranchSelector = ({
+  branchList,
+  currentBranch,
+  onCreateBranch,
+  onChange,
+}) => {
+  const [newBranch, setNewBranch] = React.useState('')
+  const branchExists = branchList.find((branch) => branch.name === newBranch)
+  return (
+    <SelectorColumn>
+      <input value={newBranch} onChange={(e) => setNewBranch(e.target.value)} />
+      <hr />
+      {!branchExists && newBranch ? (
+        <SelectableItem onClick={() => onCreateBranch(newBranch)}>
+          Create New Branch `{newBranch}`...
+        </SelectableItem>
+      ) : (
+        ''
+      )}
+      <hr />
+      <ListWrap>
+        {branchList
+          .filter((branch) => !newBranch || branch.name.includes(newBranch))
+          .map((branch) => {
+            return (
+              <SelectableItem onClick={() => onChange(branch.name)}>
+                {branch.name}
+                {branch.name === currentBranch && (
+                  <span style={{ fontStyle: 'italic', opacity: 0.5 }}>
+                    (current)
+                  </span>
+                )}
+              </SelectableItem>
+            )
+          })}
+      </ListWrap>
+    </SelectorColumn>
+  )
+}
+
+const SelectWrap: StyledComponent<
+  'div',
+  any,
+  { isLoading: boolean }
+> = styled.div`
+  display: flex;
+  flex-flow: column;
+  align-items: center;
+  justify-content: center;
+  opacity: ${(props: any) => (props.isLoading ? '0.5' : '1')};
+  pointer-events: ${(props: any) => (props.isLoading ? 'none' : 'initial')};
+`
+
+const SelectorColumn = styled.div`
+  width: 100%;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+`
+
+const SelectableItem = styled.div`
+  cursor: pointer;
+  &:hover {
+    background-color: aquamarine;
+  }
+`
+const ListWrap = styled.div`
+  border: 1px solid magenta;
+  max-height: 70vh;
+  overflow-y: auto;
+`

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/index.ts
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/index.ts
@@ -1,0 +1,3 @@
+export * from './plugin'
+export * from './types'
+export * from './BranchSwitcher'

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/plugin.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/plugin.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react'
+import { PullRequestIcon } from '../../packages/icons'
+import { ScreenPlugin } from '../../packages/react-screens'
+import { BranchSwitcher } from './BranchSwitcher'
+import { BranchSwitcherPluginOptions, BranchChangeEvent } from './types'
+
+export class BranchSwitcherPlugin implements ScreenPlugin {
+  __type = 'screen' as 'screen'
+  Icon = PullRequestIcon
+  name = 'Select Branch'
+  layout = 'popup' as 'popup'
+  private currentBranch: string
+
+  cms: BranchSwitcherPluginOptions['cms']
+  baseBranch: BranchSwitcherPluginOptions['baseBranch']
+  listBranches: BranchSwitcherPluginOptions['listBranches']
+  createBranch: BranchSwitcherPluginOptions['createBranch']
+
+  constructor(options: BranchSwitcherPluginOptions) {
+    this.baseBranch = options.baseBranch
+    this.currentBranch = options.baseBranch
+    this.cms = options.cms
+    this.listBranches = options.listBranches
+    this.createBranch = options.createBranch
+  }
+
+  getCurrentBranch() {
+    return this.currentBranch
+  }
+
+  setCurrentBranch(branchName: string) {
+    this.currentBranch = branchName
+    this.cms.events.dispatch<BranchChangeEvent>({
+      type: 'branch-switcher:change-branch',
+      branchName: branchName,
+    })
+  }
+
+  Component() {
+    return (
+      <BranchSwitcher
+        currentBranch={this.currentBranch}
+        setCurrentBranch={this.setCurrentBranch}
+        listBranches={this.listBranches}
+        createBranch={this.createBranch}
+      />
+    )
+  }
+}

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/types.ts
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/types.ts
@@ -12,6 +12,8 @@ export interface BranchSwitcherProps {
 }
 
 export interface BranchSwitcherPluginOptions extends BranchSwitcherProps {
+  owner: string,
+  repo: string,
   baseBranch: string
   cms: TinaCMS
 }
@@ -19,4 +21,11 @@ export interface BranchSwitcherPluginOptions extends BranchSwitcherProps {
 export interface BranchChangeEvent {
   type: 'branch-switcher:change-branch'
   branchName: string
+}
+
+export interface BranchData {
+  owner: string,
+  repo: string,
+  baseBranch?: string,
+  branchName?: string
 }

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/types.ts
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/types.ts
@@ -1,0 +1,22 @@
+import { TinaCMS } from '../../tina-cms'
+
+export interface Branch {
+  name: string
+}
+
+export interface BranchSwitcherProps {
+  currentBranch: string
+  setCurrentBranch: (branchName: string) => void
+  listBranches: () => Promise<Branch[]>
+  createBranch: (branchName: string) => Promise<string>
+}
+
+export interface BranchSwitcherPluginOptions extends BranchSwitcherProps {
+  baseBranch: string
+  cms: TinaCMS
+}
+
+export interface BranchChangeEvent {
+  type: 'branch-switcher:change-branch'
+  branchName: string
+}

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -13,7 +13,13 @@ limitations under the License.
 
 import { ModalBuilder } from './AuthModal'
 import React, { useState } from 'react'
-import { TinaCMS, TinaProvider, MediaStore } from '@tinacms/toolkit'
+import {
+  TinaCMS,
+  TinaProvider,
+  MediaStore,
+  //@ts-ignore why can't it find you
+  BranchSwitcherPlugin,
+} from '@tinacms/toolkit'
 
 import { Client, TinaIOConfig } from '../client'
 import { useTinaAuthRedirect } from './useTinaAuthRedirect'
@@ -149,6 +155,31 @@ export const TinaCloudProvider = (
     }
   }
   setupMedia()
+
+  //@ts-ignore it's not picking up cms.flags
+  const branchingEnabled = cms.flags.get('branch-switcher')
+  React.useEffect(() => {
+    let branchSwitcher
+    if (branchingEnabled) {
+      branchSwitcher = new BranchSwitcherPlugin({
+        cms,
+        baseBranch: props.branch || 'main',
+        //TODO implement these
+        listBranches: async () => [{ name: 'test' }],
+        createBranch: async (branchName) => {
+          console.log('noop')
+          return branchName
+        },
+      })
+      cms.plugins.add(branchSwitcher)
+    }
+    return () => {
+      if (branchingEnabled) {
+        cms.plugins.remove(branchSwitcher)
+      }
+    }
+  }, [branchingEnabled, props.branch])
+
   if (props.cmsCallback) {
     props.cmsCallback(cms)
   }

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -22,6 +22,8 @@ import {
 
 import { formify } from './formify'
 import gql from 'graphql-tag'
+//@ts-ignore can't locate BranchChangeEvent
+import { EventBus, BranchChangeEvent } from '@tinacms/toolkit'
 export type TinaIOConfig = {
   frontendUrlOverride?: string // https://app.tina.io
   identityApiUrlOverride?: string // https://identity.tinajs.io
@@ -46,19 +48,19 @@ export class Client {
   setToken: (_token: TokenObject) => void
   private getToken: () => TokenObject
   private token: string // used with memory storage
+  private branch: string
+  private options: ServerOptions
+  events: EventBus // automatically hooked into global event bus when attached via cms.registerApi
 
   constructor({ tokenStorage = 'MEMORY', ...options }: ServerOptions) {
-    const encodedBranch = encodeURIComponent(options.branch)
-    this.frontendUrl =
-      options.tinaioConfig?.frontendUrlOverride || 'https://app.tina.io'
-    this.identityApiUrl =
-      options.tinaioConfig?.identityApiUrlOverride ||
-      'https://identity.tinajs.io'
-    const contentApiBase =
-      options.tinaioConfig?.contentApiUrlOverride || `https://content.tinajs.io`
-    this.contentApiUrl =
-      options.customContentApiUrl ||
-      `${contentApiBase}/content/${options.clientId}/github/${encodedBranch}`
+    this.options = options
+    this.setBranch(options.branch)
+    this.events.subscribe<BranchChangeEvent>(
+      'branch-switcher:change-branch',
+      ({ branchName }) => {
+        this.setBranch(branchName)
+      }
+    )
 
     this.clientId = options.clientId
 
@@ -105,6 +107,21 @@ export class Client {
         this.getToken = options.getTokenFn
         break
     }
+  }
+
+  setBranch(branchName: string) {
+    const encodedBranch = encodeURIComponent(branchName)
+    this.frontendUrl =
+      this.options.tinaioConfig?.frontendUrlOverride || 'https://app.tina.io'
+    this.identityApiUrl =
+      this.options.tinaioConfig?.identityApiUrlOverride ||
+      'https://identity.tinajs.io'
+    const contentApiBase =
+      this.options.tinaioConfig?.contentApiUrlOverride ||
+      `https://content.tinajs.io`
+    this.contentApiUrl =
+      this.options.customContentApiUrl ||
+      `${contentApiBase}/content/${this.options.clientId}/github/${encodedBranch}`
   }
 
   addPendingContent = async (props) => {

--- a/packages/tinacms/src/utils/index.ts
+++ b/packages/tinacms/src/utils/index.ts
@@ -19,6 +19,8 @@ export interface CreateClientProps {
   clientId?: string
   isLocalClient?: boolean
   tinaioConfig?: TinaIOConfig
+  owner?: string,
+  repo?: string,
   branch?: string
 }
 export const createClient = ({


### PR DESCRIPTION
This is a rewrite of the branch switcher work in two pieces:

1. a vendor-agnostic plugin in `@tinacms/toolkit`, and
2. an implementation of the plugin wrapped up in `TinaCloudProvider` (`tinacms` package)

My work thus far hasn't been tested and may not be working, so don't assume you've done something wrong if it doesn't.

The plugin is hidden behind a [feature flag](https://github.com/tinacms/tinacms/commit/9ce3419adcda1c4d7bf4c174032b83bb7787a1dc). To activate it, add this after creating the CMS object:

```
cms.flags.set('branch-switcher', true)
```

## Todo
- [ ] Connect to the cloud starter example to determine if screen plugin is working correctly
- [x] implement `createBranch` and `listBranches` in the plugin invocation, found in `TinaCloudProvider`
  - presumably we now want to add these endpoints to Tina Cloud, and can call out to them instead of implementing over the Github Bridge
- [ ] Re-query on branch change
- [ ] consider making the UI look slightly less prototype-y