### PR TITLE
2110 - Adds support for `create` document mutations

### DIFF
--- a/.changeset/odd-eels-jump.md
+++ b/.changeset/odd-eels-jump.md
@@ -1,0 +1,6 @@
+---
+'tina-cloud-starter': patch
+'@tinacms/graphql': patch
+---
+
+Adds create document mutations

--- a/examples/tina-cloud-starter/.tina/__generated__/_graphql.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_graphql.json
@@ -3646,7 +3646,130 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
+            "value": "createDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "collection"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "DocumentMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "DocumentNode"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
             "value": "updatePostsDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "PostsMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "PostsDocument"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "createPostsDocument"
           },
           "arguments": [
             {
@@ -3752,6 +3875,59 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
+            "value": "createGlobalDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "GlobalMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "GlobalDocument"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
             "value": "updateAuthorsDocument"
           },
           "arguments": [
@@ -3805,7 +3981,113 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
+            "value": "createAuthorsDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "AuthorsMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "AuthorsDocument"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
             "value": "updatePagesDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "PagesMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "PagesDocument"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "createPagesDocument"
           },
           "arguments": [
             {

--- a/examples/tina-cloud-starter/.tina/__generated__/_lookup.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_lookup.json
@@ -15,75 +15,51 @@
   },
   "DocumentNode": {
     "type": "DocumentNode",
-    "resolveType": "multiCollectionDocument"
+    "resolveType": "multiCollectionDocument",
+    "createDocument": "create",
+    "updateDocument": "update"
   },
-  "PostsArticleAuthorDocument": {
-    "type": "PostsArticleAuthorDocument",
-    "resolveType": "multiCollectionDocument"
-  },
-  "Posts": {
-    "type": "Posts",
-    "resolveType": "unionData",
-    "typeMap": {
-      "article": "PostsArticle"
-    }
+  "PostsAuthorDocument": {
+    "type": "PostsAuthorDocument",
+    "resolveType": "multiCollectionDocument",
+    "createDocument": "create",
+    "updateDocument": "update"
   },
   "PostsDocument": {
     "type": "PostsDocument",
     "resolveType": "collectionDocument",
-    "collection": "posts"
+    "collection": "posts",
+    "createPostsDocument": "create",
+    "updatePostsDocument": "update"
   },
   "PostsConnection": {
     "type": "PostsConnection",
     "resolveType": "collectionDocumentList",
     "collection": "posts"
   },
-  "Authors": {
-    "type": "Authors",
-    "resolveType": "unionData",
-    "typeMap": {
-      "author": "AuthorsAuthor"
-    }
+  "GlobalDocument": {
+    "type": "GlobalDocument",
+    "resolveType": "collectionDocument",
+    "collection": "global",
+    "createGlobalDocument": "create",
+    "updateGlobalDocument": "update"
+  },
+  "GlobalConnection": {
+    "type": "GlobalConnection",
+    "resolveType": "collectionDocumentList",
+    "collection": "global"
   },
   "AuthorsDocument": {
     "type": "AuthorsDocument",
     "resolveType": "collectionDocument",
-    "collection": "authors"
+    "collection": "authors",
+    "createAuthorsDocument": "create",
+    "updateAuthorsDocument": "update"
   },
   "AuthorsConnection": {
     "type": "AuthorsConnection",
     "resolveType": "collectionDocumentList",
     "collection": "authors"
-  },
-  "PagesPageBlocks": {
-    "type": "PagesPageBlocks",
-    "resolveType": "unionData",
-    "typeMap": {
-      "raw": "PagesPageBlocksRaw",
-      "content": "PagesPageBlocksContent",
-      "image": "PagesPageBlocksImage"
-    }
-  },
-  "Pages": {
-    "type": "Pages",
-    "resolveType": "unionData",
-    "typeMap": {
-      "page": "PagesPage"
-    }
-  },
-  "PagesDocument": {
-    "type": "PagesDocument",
-    "resolveType": "collectionDocument",
-    "collection": "pages"
-  },
-  "PagesConnection": {
-    "type": "PagesConnection",
-    "resolveType": "collectionDocumentList",
-    "collection": "pages"
-  },
-  "PostsAuthorDocument": {
-    "type": "PostsAuthorDocument",
-    "resolveType": "multiCollectionDocument"
   },
   "PagesBlocks": {
     "type": "PagesBlocks",
@@ -95,29 +71,16 @@
       "testimonial": "PagesBlocksTestimonial"
     }
   },
-  "GlobalDocument": {
-    "type": "GlobalDocument",
+  "PagesDocument": {
+    "type": "PagesDocument",
     "resolveType": "collectionDocument",
-    "collection": "global"
+    "collection": "pages",
+    "createPagesDocument": "create",
+    "updatePagesDocument": "update"
   },
-  "GlobalConnection": {
-    "type": "GlobalConnection",
+  "PagesConnection": {
+    "type": "PagesConnection",
     "resolveType": "collectionDocumentList",
-    "collection": "global"
-  },
-  "GlobalFooterSocialTestDocument": {
-    "type": "GlobalFooterSocialTestDocument",
-    "resolveType": "multiCollectionDocument"
-  },
-  "PostsTestDocument": {
-    "type": "PostsTestDocument",
-    "resolveType": "multiCollectionDocument"
-  },
-  "PostsTestConnection": {
-    "type": "PostsTestConnection",
-    "resolveType": "multiCollectionDocumentList",
-    "collections": [
-      "posts"
-    ]
+    "collection": "pages"
   }
 }

--- a/examples/tina-cloud-starter/.tina/__generated__/schema.gql
+++ b/examples/tina-cloud-starter/.tina/__generated__/schema.gql
@@ -276,10 +276,15 @@ type PagesConnection implements Connection {
 type Mutation {
   addPendingDocument(collection: String!, relativePath: String!, template: String): DocumentNode!
   updateDocument(collection: String!, relativePath: String!, params: DocumentMutation!): DocumentNode!
+  createDocument(collection: String!, relativePath: String!, params: DocumentMutation!): DocumentNode!
   updatePostsDocument(relativePath: String!, params: PostsMutation!): PostsDocument!
+  createPostsDocument(relativePath: String!, params: PostsMutation!): PostsDocument!
   updateGlobalDocument(relativePath: String!, params: GlobalMutation!): GlobalDocument!
+  createGlobalDocument(relativePath: String!, params: GlobalMutation!): GlobalDocument!
   updateAuthorsDocument(relativePath: String!, params: AuthorsMutation!): AuthorsDocument!
+  createAuthorsDocument(relativePath: String!, params: AuthorsMutation!): AuthorsDocument!
   updatePagesDocument(relativePath: String!, params: PagesMutation!): PagesDocument!
+  createPagesDocument(relativePath: String!, params: PagesMutation!): PagesDocument!
 }
 
 input DocumentMutation {

--- a/examples/tina-cloud-starter/.tina/__generated__/types.ts
+++ b/examples/tina-cloud-starter/.tina/__generated__/types.ts
@@ -412,10 +412,15 @@ export type Mutation = {
   __typename?: 'Mutation';
   addPendingDocument: DocumentNode;
   updateDocument: DocumentNode;
+  createDocument: DocumentNode;
   updatePostsDocument: PostsDocument;
+  createPostsDocument: PostsDocument;
   updateGlobalDocument: GlobalDocument;
+  createGlobalDocument: GlobalDocument;
   updateAuthorsDocument: AuthorsDocument;
+  createAuthorsDocument: AuthorsDocument;
   updatePagesDocument: PagesDocument;
+  createPagesDocument: PagesDocument;
 };
 
 
@@ -433,7 +438,20 @@ export type MutationUpdateDocumentArgs = {
 };
 
 
+export type MutationCreateDocumentArgs = {
+  collection: Scalars['String'];
+  relativePath: Scalars['String'];
+  params: DocumentMutation;
+};
+
+
 export type MutationUpdatePostsDocumentArgs = {
+  relativePath: Scalars['String'];
+  params: PostsMutation;
+};
+
+
+export type MutationCreatePostsDocumentArgs = {
   relativePath: Scalars['String'];
   params: PostsMutation;
 };
@@ -445,13 +463,31 @@ export type MutationUpdateGlobalDocumentArgs = {
 };
 
 
+export type MutationCreateGlobalDocumentArgs = {
+  relativePath: Scalars['String'];
+  params: GlobalMutation;
+};
+
+
 export type MutationUpdateAuthorsDocumentArgs = {
   relativePath: Scalars['String'];
   params: AuthorsMutation;
 };
 
 
+export type MutationCreateAuthorsDocumentArgs = {
+  relativePath: Scalars['String'];
+  params: AuthorsMutation;
+};
+
+
 export type MutationUpdatePagesDocumentArgs = {
+  relativePath: Scalars['String'];
+  params: PagesMutation;
+};
+
+
+export type MutationCreatePagesDocumentArgs = {
   relativePath: Scalars['String'];
   params: PagesMutation;
 };

--- a/packages/@tinacms/graphql/src/primitives/ast-builder/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/ast-builder/index.ts
@@ -524,8 +524,11 @@ export const NAMER = {
   dataMutationTypeName: (namespace: string[]) => {
     return generateNamespacedFieldName(namespace, 'Mutation')
   },
-  mutationName: (namespace: string[]) => {
+  updateName: (namespace: string[]) => {
     return 'update' + generateNamespacedFieldName(namespace, 'Document')
+  },
+  createName: (namespace: string[]) => {
+    return 'create' + generateNamespacedFieldName(namespace, 'Document')
   },
   queryName: (namespace: string[]) => {
     return 'get' + generateNamespacedFieldName(namespace, 'Document')

--- a/packages/@tinacms/graphql/src/primitives/build.ts
+++ b/packages/@tinacms/graphql/src/primitives/build.ts
@@ -62,7 +62,10 @@ const _buildSchema = async (builder: Builder, tinaSchema: TinaSchema) => {
     await builder.addMultiCollectionDocumentMutation()
   )
   mutationTypeDefinitionFields.push(
-    await builder.buildMultiCollectionDocumentMutation(collections)
+    await builder.buildUpdateCollectionDocumentMutation(collections)
+  )
+  mutationTypeDefinitionFields.push(
+    await builder.buildCreateCollectionDocumentMutation(collections)
   )
   queryTypeDefinitionFields.push(
     await builder.multiCollectionDocumentList(collections)
@@ -75,6 +78,9 @@ const _buildSchema = async (builder: Builder, tinaSchema: TinaSchema) => {
     queryTypeDefinitionFields.push(await builder.collectionDocument(collection))
     mutationTypeDefinitionFields.push(
       await builder.updateCollectionDocumentMutation(collection)
+    )
+    mutationTypeDefinitionFields.push(
+      await builder.createCollectionDocumentMutation(collection)
     )
     queryTypeDefinitionFields.push(
       await builder.collectionDocumentList(collection)

--- a/packages/@tinacms/graphql/src/primitives/database/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/database/index.ts
@@ -328,6 +328,8 @@ type CollectionDocumentLookup = {
 type MultiCollectionDocumentLookup = {
   type: string
   resolveType: 'multiCollectionDocument'
+  createDocument: 'create'
+  updateDocument: 'update'
 }
 type MultiCollectionDocumentListLookup = {
   type: string

--- a/packages/@tinacms/graphql/src/primitives/resolve.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolve.ts
@@ -151,6 +151,7 @@ export const resolve = async ({
         const lookup = await database.getLookup(returnType)
         const isMutation = info.parentType.toString() === 'Mutation'
         const value = source[info.fieldName]
+
         /**
          * `getCollection`
          */
@@ -169,6 +170,9 @@ export const resolve = async ({
         if (!lookup) {
           return value
         }
+
+        const isCreation = lookup[info.fieldName] === 'create'
+
         /**
          * From here, we need more information on how to resolve this, aided
          * by the lookup value for the given return type, we can enrich the request
@@ -207,15 +211,20 @@ export const resolve = async ({
                 isCreation: true,
               })
             }
-            if (['getDocument', 'updateDocument'].includes(info.fieldName)) {
+            if (
+              ['getDocument', 'createDocument', 'updateDocument'].includes(
+                info.fieldName
+              )
+            ) {
               /**
-               * `getDocument`/`updateDocument`
+               * `getDocument`/`createDocument`/`updateDocument`
                */
               return resolver.resolveDocument({
                 value,
                 args,
                 collection: args.collection,
                 isMutation,
+                isCreation,
               })
             }
             return value
@@ -229,7 +238,7 @@ export const resolve = async ({
             })
           /**
            * Collections-specific getter
-           * eg. `getPostDocument`/`updatePostDocument`
+           * eg. `getPostDocument`/`createPostDocument`/`updatePostDocument`
            *
            * if coming from a query result
            * the field will be `node`
@@ -245,6 +254,7 @@ export const resolve = async ({
                 args,
                 collection: lookup.collection,
                 isMutation,
+                isCreation,
               }))
             if (!isMutation) {
               const mutationPath = buildMutationPath(info, {
@@ -412,7 +422,7 @@ const buildMutationPath = (
   if (!queryNode) {
     throw new Error(`exptected to find field node for ${info.fieldName}`)
   }
-  const mutationName = NAMER.mutationName([collection.name])
+  const mutationName = NAMER.updateName([collection.name])
   const mutations = JSON.parse(
     JSON.stringify(info.schema.getMutationType()?.getFields())
   ) as GraphQLFieldMap<any, any>
@@ -489,6 +499,7 @@ const buildMutationPath = (
     },
   }
   const mutationString = addFragmentsToQuery(info, newNode, q)
+
   return {
     path: ['data', ...buildPath(info.path, []), 'form'],
     string: mutationString,

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -202,6 +202,12 @@ export class Resolver {
             })
             return this.getDocument(realPath)
         }
+      } else {
+        if (!(await this.database.documentExists(realPath))) {
+          throw new Error(
+            `Unable to update document, ${realPath} does not exist`
+          )
+        }
       }
       const templateInfo =
         this.tinaSchema.getTemplatesForCollectable(collection)


### PR DESCRIPTION
Adds mutations for `createDocument(collection, relativePath, params)` and `create<Collection>Document(relativePath, params)`.

This includes adding errors when attempting to `update` a document that doesn't exist or `create` a document that already exists.

Renamed a couple of `multi` functions to be `update`, reflecting their actual use.

Related to #2110 