### PR TITLE
Server no watch option

### DIFF
--- a/.changeset/twenty-countries-agree.md
+++ b/.changeset/twenty-countries-agree.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': minor
+---
+
+Add noWatch option to server:start command. When this option is used, the config is not regenerated on file changes. 

--- a/packages/@tinacms/cli/src/cmds/baseCmds.ts
+++ b/packages/@tinacms/cli/src/cmds/baseCmds.ts
@@ -47,6 +47,10 @@ const experimentalCommand = {
   name: '--experimental',
   description: 'Run the unstable version of this service',
 }
+const noWatchOption = {
+  name: '--noWatch',
+  description: 'Don\'t regenerate config on file changes'
+}
 const pathOption = {
   name: '--root',
   description:
@@ -57,7 +61,7 @@ export const baseCmds: Command[] = [
   {
     command: CMD_START_SERVER,
     description: 'Start Filesystem Graphql Server',
-    options: [startServerPortOption, subCommand, experimentalCommand],
+    options: [startServerPortOption, subCommand, experimentalCommand, noWatchOption],
     action: options => chain([startServer], options),
   },
   {

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -24,6 +24,7 @@ interface Options {
   port?: number
   command?: string
   experimental?: boolean
+  noWatch?: boolean
 }
 
 const gqlPackageFile = require.resolve('@tinacms/graphql')
@@ -31,7 +32,7 @@ const gqlPackageFile = require.resolve('@tinacms/graphql')
 export async function startServer(
   _ctx,
   _next,
-  { port = 4001, command, experimental }: Options
+  { port = 4001, command, experimental, noWatch }: Options
 ) {
   const startSubprocess = () => {
     if (typeof command === 'string') {
@@ -61,7 +62,7 @@ stack: ${code.stack || 'No stack was provided'}`)
   }
   const rootPath = process.cwd()
   let ready = false
-  if (!process.env.CI) {
+  if (!noWatch && !process.env.CI) {
     chokidar
       .watch(`${rootPath}/**/*.ts`, {
         ignored: `${path.resolve(rootPath)}/.tina/__generated__/**/*`,
@@ -142,7 +143,7 @@ stack: ${code.stack || 'No stack was provided'}`)
     })
   }
 
-  if (!process.env.CI) {
+  if (!noWatch && !process.env.CI) {
     chokidar
       .watch([gqlPackageFile])
       .on('ready', async () => {
@@ -155,7 +156,9 @@ stack: ${code.stack || 'No stack was provided'}`)
         }
       })
   } else {
-    logger.info('Detected CI environment, omitting watch commands...')
+    if (process.env.CI) {
+      logger.info('Detected CI environment, omitting watch commands...')
+    }
     start()
     startSubprocess()
   }


### PR DESCRIPTION
In some environments (not just when `process.CI` is `true`), watching for changes to all files is not ideal/will be a problem.

This PR addresses the issue by adding a `--noWatch` option to the `server:start` command. When this option is used, file watching is disabled.