### PR TITLE
Pass `secure: true` to config

### DIFF
--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -32,7 +32,7 @@ export const mediaHandlerConfig = {
 }
 
 export const createMediaHandler = (config: CloudinaryConfig) => {
-  cloudinary.config(config)
+  cloudinary.config(Object.assign({ secure: true }, config))
 
   return async (req: NextApiRequest, res: NextApiResponse) => {
     const isAuthorized = await config.authorized(req, res)


### PR DESCRIPTION
Pass `secure: true` to cloudinary config so as to return `https` urls for assets
