### PR TITLE
User tina-cloud for branch switcher

### DIFF
--- a/examples/tina-cloud-starter/pages/_app.js
+++ b/examples/tina-cloud-starter/pages/_app.js
@@ -51,6 +51,12 @@ const App = ({ Component, pageProps }) => {
 
               return createForm(formConfig);
             }}
+            //TODO: REMOVE AFTER TESTING
+            tinaioConfig={{
+              frontendUrlOverride: "http://localhost:3002",
+              identityApiUrlOverride: "https://jack1-identity.tinajs.dev",
+              contentApiUrlOverride: "https://jack1-content.tinajs.dev"
+            }}
             {...pageProps}
           >
             {(livePageProps) => (

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -13,6 +13,7 @@ limitations under the License.
 import * as React from 'react'
 import { BranchSwitcherProps, Branch } from './types'
 import styled, { StyledComponent } from 'styled-components'
+import { LoadingDots } from '../../packages/form-builder'
 
 export const BranchSwitcher = ({
   currentBranch,
@@ -20,12 +21,13 @@ export const BranchSwitcher = ({
   listBranches,
   createBranch,
 }: BranchSwitcherProps) => {
-  const [isLoading, setIsLoading] = React.useState(false)
+  const [isLoading, setIsLoading] = React.useState(true)
   const [branchList, setBranchList] = React.useState([])
 
   const handleCreateBranch = React.useCallback((value) => {
     setIsLoading(true)
-    createBranch(value)
+    const { baseBranch, branchName } = value
+    createBranch({baseBranch, branchName})
       .then(async (createdBranchName) => {
         setCurrentBranch(createdBranchName)
         await refreshBranchList()
@@ -50,16 +52,22 @@ export const BranchSwitcher = ({
   return (
     <SelectWrap isLoading={isLoading}>
       <h3>Select Branch</h3>
-      <BranchSelector
-        currentBranch={currentBranch}
-        branchList={branchList}
-        onCreateBranch={(newBranch) => {
-          handleCreateBranch(newBranch)
-        }}
-        onChange={(branchName) => {
-          setCurrentBranch(branchName)
-        }}
-      />
+      {isLoading ? <div style={{textAlign: 'center'}}>
+                     Loading...
+                     <LoadingDots dotSize={12} color='black'/>
+                   </div>
+                 : <BranchSelector
+                      currentBranch={currentBranch}
+                      branchList={branchList}
+                      onCreateBranch={(currentBranch, newBranch) => {
+                        handleCreateBranch({baseBranch: currentBranch, branchName: newBranch})
+                      }}
+                      onChange={(branchName) => {
+                        console.log('clicked')
+                        setCurrentBranch(branchName)
+                      }}
+                    />
+      }
     </SelectWrap>
   )
 }
@@ -77,7 +85,7 @@ const BranchSelector = ({
       <input value={newBranch} onChange={(e) => setNewBranch(e.target.value)} />
       <hr />
       {!branchExists && newBranch ? (
-        <SelectableItem onClick={() => onCreateBranch(newBranch)}>
+        <SelectableItem onClick={() => onCreateBranch(currentBranch, newBranch)}>
           Create New Branch `{newBranch}`...
         </SelectableItem>
       ) : (

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/plugin.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/plugin.tsx
@@ -20,20 +20,31 @@ export class BranchSwitcherPlugin implements ScreenPlugin {
   __type = 'screen' as 'screen'
   Icon = PullRequestIcon
   name = 'Select Branch'
+  Component: ScreenPlugin['Component']
   layout = 'popup' as 'popup'
   private currentBranch: string
-
+  
   cms: BranchSwitcherPluginOptions['cms']
   baseBranch: BranchSwitcherPluginOptions['baseBranch']
   listBranches: BranchSwitcherPluginOptions['listBranches']
   createBranch: BranchSwitcherPluginOptions['createBranch']
-
+  
   constructor(options: BranchSwitcherPluginOptions) {
     this.baseBranch = options.baseBranch
     this.currentBranch = options.baseBranch
     this.cms = options.cms
     this.listBranches = options.listBranches
     this.createBranch = options.createBranch
+    this.Component = () => {
+      return (
+        <BranchSwitcher
+          currentBranch={options.currentBranch}
+          setCurrentBranch={options.setCurrentBranch}
+          listBranches={options.listBranches}
+          createBranch={options.createBranch}
+        />
+      )
+    }
   }
 
   getCurrentBranch() {
@@ -46,16 +57,5 @@ export class BranchSwitcherPlugin implements ScreenPlugin {
       type: 'branch-switcher:change-branch',
       branchName: branchName,
     })
-  }
-
-  Component() {
-    return (
-      <BranchSwitcher
-        currentBranch={this.currentBranch}
-        setCurrentBranch={this.setCurrentBranch}
-        listBranches={this.listBranches}
-        createBranch={this.createBranch}
-      />
-    )
   }
 }

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/types.ts
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/types.ts
@@ -20,7 +20,7 @@ export interface BranchSwitcherProps {
   currentBranch: string
   setCurrentBranch: (branchName: string) => void
   listBranches: () => Promise<Branch[]>
-  createBranch: (branchName: string) => Promise<string>
+  createBranch: (branchName: NewBranchData) => Promise<string>
 }
 
 export interface BranchSwitcherPluginOptions extends BranchSwitcherProps {
@@ -35,9 +35,7 @@ export interface BranchChangeEvent {
   branchName: string
 }
 
-export interface BranchData {
-  owner: string,
-  repo: string,
-  baseBranch?: string,
-  branchName?: string
+export interface NewBranchData {
+  baseBranch: string,
+  branchName: string
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -156,15 +156,20 @@ export const TinaCloudProvider = (
     }
   }
   const handleListBranches = async (): Promise<Branch[]> => {
-    const { owner, repo } = props
-    const branches = await cms.api.tina.listBranches({ owner, repo })
-    
-    return branches.map((branch) => branch.name)
+    const branches = await cms.api.tina.listBranches()
+
+    return branches
   }
   const handleCreateBranch = async (data) => {
      const newBranch = await cms.api.tina.createBranch(data)
 
      return newBranch
+  }
+  const handleSetCurrentBranch = (branch) => {
+    console.log(branch)
+    cms.api.tina.setBranch(branch)
+
+    return branch
   }
 
   setupMedia()
@@ -181,11 +186,11 @@ export const TinaCloudProvider = (
         repo: props.repo,
         baseBranch: props.branch || 'main',
         currentBranch: props.branch || 'main',
-        //TODO implement these
         listBranches: handleListBranches,
         createBranch: handleCreateBranch,
-        setCurrentBranch: () => console.log(props.branch)
+        setCurrentBranch: handleSetCurrentBranch
       })
+
       cms.plugins.add(branchSwitcher)
     }
     return () => {


### PR DESCRIPTION
Just opening a draft PR for purposes of a local demo for OSS office hours.

This PR builds on a lot of the work @dwalkr implemented to build out the BranchSwitcher plugin within the toolkit.

This now leverages the `list_branches` and `create_branch` endpoints that have been added to the koa-github file in tina-cloud.

When used within the tin-cloud-starter example it can successfully list branches and create a new branch.

To Do:
Still need to resolve the setting of the current branch and where to store that info so that it doesn't reset to `main1 on a page refresh.