### PR TITLE
Ensure branch switcher exists before trying to remove it

### DIFF
--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -190,7 +190,9 @@ export const TinaCloudProvider = (
     }
     return () => {
       if (!branchingEnabled) {
-        cms.plugins.remove(branchSwitcher)
+        if(branchSwitcher) {
+          cms.plugins.remove(branchSwitcher)
+        }
       }
     }
   }, [branchingEnabled, props.branch])


### PR DESCRIPTION
Fast refresh while developing seems to get this into a weird state where the `branchSwitcher` is null, resulting in an error when things remount