### PR TITLE
2163 - Adds support for collection.templates to TinaAdmin

### DIFF
--- a/.changeset/blue-walls-vanish.md
+++ b/.changeset/blue-walls-vanish.md
@@ -1,0 +1,7 @@
+---
+'tina-cloud-starter': patch
+'@tinacms/graphql': patch
+'tinacms': patch
+---
+
+Adds support for collection.templates to TinaAdmin

--- a/examples/tina-cloud-starter/.tina/__generated__/_graphql.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_graphql.json
@@ -3637,23 +3637,6 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
-                "value": "collection"
-              },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "String"
-                  }
-                }
-              }
-            },
-            {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
                 "value": "relativePath"
               },
               "type": {
@@ -3703,23 +3686,6 @@
             "value": "createDocument"
           },
           "arguments": [
-            {
-              "kind": "InputValueDefinition",
-              "name": {
-                "kind": "Name",
-                "value": "collection"
-              },
-              "type": {
-                "kind": "NonNullType",
-                "type": {
-                  "kind": "NamedType",
-                  "name": {
-                    "kind": "Name",
-                    "value": "String"
-                  }
-                }
-              }
-            },
             {
               "kind": "InputValueDefinition",
               "name": {

--- a/examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -4,6 +4,7 @@
       "label": "Blog Posts",
       "name": "posts",
       "path": "content/posts",
+      "format": "mdx",
       "fields": [
         {
           "type": "rich-text",

--- a/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
+++ b/examples/tina-cloud-starter/.tina/__generated__/config/schema.json
@@ -4,6 +4,7 @@
       "label": "Blog Posts",
       "name": "posts",
       "path": "content/posts",
+      "format": "mdx",
       "fields": [
         {
           "type": "rich-text",

--- a/examples/tina-cloud-starter/.tina/__generated__/schema.gql
+++ b/examples/tina-cloud-starter/.tina/__generated__/schema.gql
@@ -278,8 +278,8 @@ type PagesConnection implements Connection {
 
 type Mutation {
   addPendingDocument(collection: String!, relativePath: String!, template: String): DocumentNode!
-  updateDocument(collection: String!, relativePath: String!, params: DocumentMutation!): DocumentNode!
-  createDocument(collection: String!, relativePath: String!, params: DocumentMutation!): DocumentNode!
+  updateDocument(relativePath: String!, params: DocumentMutation!): DocumentNode!
+  createDocument(relativePath: String!, params: DocumentMutation!): DocumentNode!
   updatePostsDocument(relativePath: String!, params: PostsMutation!): PostsDocument!
   createPostsDocument(relativePath: String!, params: PostsMutation!): PostsDocument!
   updateGlobalDocument(relativePath: String!, params: GlobalMutation!): GlobalDocument!

--- a/examples/tina-cloud-starter/.tina/__generated__/types.ts
+++ b/examples/tina-cloud-starter/.tina/__generated__/types.ts
@@ -435,14 +435,12 @@ export type MutationAddPendingDocumentArgs = {
 
 
 export type MutationUpdateDocumentArgs = {
-  collection: Scalars['String'];
   relativePath: Scalars['String'];
   params: DocumentMutation;
 };
 
 
 export type MutationCreateDocumentArgs = {
-  collection: Scalars['String'];
   relativePath: Scalars['String'];
   params: DocumentMutation;
 };

--- a/examples/tina-cloud-starter/.tina/schema.ts
+++ b/examples/tina-cloud-starter/.tina/schema.ts
@@ -387,6 +387,7 @@ export default defineSchema({
       label: "Blog Posts",
       name: "posts",
       path: "content/posts",
+      format: "mdx",
       fields: [
         {
           type: "rich-text",

--- a/packages/@tinacms/graphql/src/primitives/builder/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/builder/index.ts
@@ -313,11 +313,6 @@ export class Builder {
       name: 'createDocument',
       args: [
         astBuilder.InputValueDefinition({
-          name: 'collection',
-          required: true,
-          type: astBuilder.TYPES.String,
-        }),
-        astBuilder.InputValueDefinition({
           name: 'relativePath',
           required: true,
           type: astBuilder.TYPES.String,
@@ -355,11 +350,6 @@ export class Builder {
     return astBuilder.FieldDefinition({
       name: 'updateDocument',
       args: [
-        astBuilder.InputValueDefinition({
-          name: 'collection',
-          required: true,
-          type: astBuilder.TYPES.String,
-        }),
         astBuilder.InputValueDefinition({
           name: 'relativePath',
           required: true,

--- a/packages/@tinacms/graphql/src/primitives/resolve.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolve.ts
@@ -212,11 +212,11 @@ export const resolve = async ({
                * FIXME: this should probably be it's own lookup
                */
               return resolver.resolveDocument({
-                value,
                 args: { ...args, params: {} },
                 collection: args.collection,
                 isMutation,
                 isCreation: true,
+                isAddPendingDocument: true,
               })
             }
             if (
@@ -228,16 +228,16 @@ export const resolve = async ({
                * `getDocument`/`createDocument`/`updateDocument`
                */
               const result = await resolver.resolveDocument({
-                value,
                 args,
                 collection: args.collection,
                 isMutation,
                 isCreation,
+                isAddPendingDocument: false,
+                isCollectionSpecific: false,
               })
 
               if (!isMutation) {
                 const mutationPath = buildMutationPath(info, {
-                  // @ts-ignore
                   relativePath: result.sys.relativePath,
                 })
                 if (mutationPath) {
@@ -270,11 +270,12 @@ export const resolve = async ({
             const result =
               value ||
               (await resolver.resolveDocument({
-                value,
                 args,
                 collection: lookup.collection,
                 isMutation,
                 isCreation,
+                isAddPendingDocument: false,
+                isCollectionSpecific: true,
               }))
             if (!isMutation) {
               const mutationPath = buildMutationPath(info, {
@@ -476,6 +477,7 @@ const buildMutationPath = (
   const mutationName = collection
     ? NAMER.updateName([collection.name])
     : 'updateDocument'
+
   const mutations = JSON.parse(
     JSON.stringify(info.schema.getMutationType()?.getFields())
   ) as GraphQLFieldMap<any, any>

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -300,6 +300,7 @@ export class Resolver {
     if (isAddPendingDocument === true) {
       const templateInfo =
         this.tinaSchema.getTemplatesForCollectable(collection)
+
       switch (templateInfo.type) {
         case 'object':
           await this.database.put(realPath, {})
@@ -321,7 +322,9 @@ export class Resolver {
           // @ts-ignore
           if (!template) {
             throw new Error(
-              `Expected to find template named ${templateString} in collection "${collectionName}" but none was found. Possible templates are: ${templateInfo.templates
+              `Expected to find template named ${templateString} in collection "${
+                collection.name
+              }" but none was found. Possible templates are: ${templateInfo.templates
                 .map((t) => lastItem(t.namespace))
                 .join(' ')}`
             )
@@ -329,8 +332,8 @@ export class Resolver {
           await this.database.put(realPath, {
             _template: lastItem(template.namespace),
           })
-          return this.getDocument(realPath)
       }
+      return this.getDocument(realPath)
     }
 
     const params = this.buildObjectMutations(

--- a/packages/@tinacms/graphql/src/primitives/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/resolver/index.ts
@@ -20,8 +20,14 @@ import { Database, CollectionDocumentListLookup } from '../database'
 import isValid from 'date-fns/isValid'
 import { parseMDX, stringifyMDX } from '../mdx'
 
-import type { Templateable, TinaFieldEnriched } from '../types'
+import type {
+  Templateable,
+  TinaFieldEnriched,
+  Collectable,
+  TinaCloudCollection,
+} from '../types'
 import { TinaError } from './error'
+
 interface ResolverConfig {
   database: Database
   tinaSchema: TinaSchema
@@ -174,6 +180,7 @@ export class Resolver {
              */
             await sequential(collectable.templates, async (template) => {
               templates[lastItem(template.namespace)] = {
+                template,
                 fields: await sequential(template.fields, async (field) => {
                   return this.resolveField(field)
                 }),
@@ -195,87 +202,169 @@ export class Resolver {
     }
   }
 
-  public resolveDocument = async ({
-    value,
-    args,
-    collection: collectionName,
-    isMutation,
-    isCreation,
-  }: {
-    value: unknown
-    args: unknown
-    collection: string
-    isMutation: boolean
-    isCreation?: boolean
-  }) => {
-    const collectionNames = this.tinaSchema
-      .getCollections()
-      .map((item) => item.name)
-    assertShape<string>(
-      collectionName,
-      (yup) => {
-        return yup.mixed().oneOf(collectionNames)
-      },
-      `"collection" must be one of: [${collectionNames.join(
-        ', '
-      )}] but got ${collectionName}`
-    )
-    assertShape<{ relativePath: string }>(args, (yup) =>
-      yup.object({ relativePath: yup.string().required() })
-    )
-    const collection = await this.tinaSchema.getCollection(collectionName)
-    const realPath = path.join(collection?.path, args.relativePath)
-
-    if (isMutation) {
-      if (isCreation) {
-        if (await this.database.documentExists(realPath)) {
-          throw new Error(`Unable to add document, ${realPath} already exists`)
-        }
-
-        const templateInfo =
-          this.tinaSchema.getTemplatesForCollectable(collection)
-        switch (templateInfo.type) {
-          case 'object':
-            await this.database.put(realPath, {})
-            break
-          case 'union':
-            // @ts-ignore
-            const templateString = args.template
-            const template = templateInfo.templates.find(
-              (template) => lastItem(template.namespace) === templateString
-            )
-            // @ts-ignore
-            if (!args.template) {
-              throw new Error(
-                `Must specify a template when creating content for a collection with multiple templates. Possible templates are: ${templateInfo.templates
-                  .map((t) => lastItem(t.namespace))
-                  .join(' ')}`
-              )
-            }
-            // @ts-ignore
-            if (!template) {
-              throw new Error(
-                `Expected to find template named ${templateString} in collection "${collectionName}" but none was found. Possible templates are: ${templateInfo.templates
-                  .map((t) => lastItem(t.namespace))
-                  .join(' ')}`
-              )
-            }
-            await this.database.put(realPath, {
-              _template: lastItem(template.namespace),
-            })
-            return this.getDocument(realPath)
-        }
+  public buildObjectMutations = (fieldValue: any, field: Collectable) => {
+    if (field.fields) {
+      const objectTemplate =
+        typeof field.fields === 'string'
+          ? this.tinaSchema.getGlobalTemplate(field.fields)
+          : field
+      if (Array.isArray(fieldValue)) {
+        return fieldValue.map((item) =>
+          // @ts-ignore FIXME Argument of type 'string | object' is not assignable to parameter of type '{ [fieldName: string]: string | object | (string | object)[]; }'
+          this.buildFieldMutations(item, objectTemplate)
+        )
       } else {
-        if (!(await this.database.documentExists(realPath))) {
+        return this.buildFieldMutations(
+          // @ts-ignore FIXME Argument of type 'string | object' is not assignable to parameter of type '{ [fieldName: string]: string | object | (string | object)[]; }'
+          fieldValue,
+          //@ts-ignore
+          objectTemplate
+        )
+      }
+    }
+    if (field.templates) {
+      if (Array.isArray(fieldValue)) {
+        return fieldValue.map((item) => {
+          if (typeof item === 'string') {
+            throw new Error(
+              //@ts-ignore
+              `Expected object for template value for field ${field.name}`
+            )
+          }
+          const templates = field.templates.map((templateOrTemplateName) => {
+            if (typeof templateOrTemplateName === 'string') {
+              return this.tinaSchema.getGlobalTemplate(templateOrTemplateName)
+            }
+            return templateOrTemplateName
+          })
+          const [templateName] = Object.entries(item)[0]
+          const template = templates.find(
+            //@ts-ignore
+            (template) => template.name === templateName
+          )
+          if (!template) {
+            throw new Error(`Expected to find template ${templateName}`)
+          }
+          return {
+            // @ts-ignore FIXME Argument of type 'unknown' is not assignable to parameter of type '{ [fieldName: string]: string | { [key: string]: unknown; } | (string | { [key: string]: unknown; })[]; }'
+            ...this.buildFieldMutations(item[template.name], template),
+            //@ts-ignore
+            _template: template.name,
+          }
+        })
+      } else {
+        if (typeof fieldValue === 'string') {
           throw new Error(
-            `Unable to update document, ${realPath} does not exist`
+            //@ts-ignore
+            `Expected object for template value for field ${field.name}`
           )
         }
+        const templates = field.templates.map((templateOrTemplateName) => {
+          if (typeof templateOrTemplateName === 'string') {
+            return this.tinaSchema.getGlobalTemplate(templateOrTemplateName)
+          }
+          return templateOrTemplateName
+        })
+        const [templateName] = Object.entries(fieldValue)[0]
+        const template = templates.find(
+          //@ts-ignore
+          (template) => template.name === templateName
+        )
+        if (!template) {
+          throw new Error(`Expected to find template ${templateName}`)
+        }
+        return {
+          // @ts-ignore FIXME Argument of type 'unknown' is not assignable to parameter of type '{ [fieldName: string]: string | { [key: string]: unknown; } | (string | { [key: string]: unknown; })[]; }'
+          ...this.buildFieldMutations(fieldValue[template.name], template),
+          //@ts-ignore
+          _template: template.name,
+        }
       }
+    }
+  }
+
+  public createResolveDocument = async ({
+    collection,
+    realPath,
+    args,
+    isAddPendingDocument,
+  }: {
+    collection: TinaCloudCollection<true>
+    realPath: string
+    args: unknown
+    isAddPendingDocument: boolean
+  }) => {
+    /**
+     * TODO: Remove when `addPendingDocument` is no longer needed.
+     */
+    if (isAddPendingDocument === true) {
       const templateInfo =
         this.tinaSchema.getTemplatesForCollectable(collection)
-      const params = this.buildParams(args)
+      switch (templateInfo.type) {
+        case 'object':
+          await this.database.put(realPath, {})
+          break
+        case 'union':
+          // @ts-ignore
+          const templateString = args.template
+          const template = templateInfo.templates.find(
+            (template) => lastItem(template.namespace) === templateString
+          )
+          // @ts-ignore
+          if (!args.template) {
+            throw new Error(
+              `Must specify a template when creating content for a collection with multiple templates. Possible templates are: ${templateInfo.templates
+                .map((t) => lastItem(t.namespace))
+                .join(' ')}`
+            )
+          }
+          // @ts-ignore
+          if (!template) {
+            throw new Error(
+              `Expected to find template named ${templateString} in collection "${collectionName}" but none was found. Possible templates are: ${templateInfo.templates
+                .map((t) => lastItem(t.namespace))
+                .join(' ')}`
+            )
+          }
+          await this.database.put(realPath, {
+            _template: lastItem(template.namespace),
+          })
+          return this.getDocument(realPath)
+      }
+    }
 
+    const params = this.buildObjectMutations(
+      // @ts-ignore
+      args.params[collection.name],
+      collection
+    )
+
+    // @ts-ignore
+    await this.database.put(realPath, params)
+    return this.getDocument(realPath)
+  }
+
+  public updateResolveDocument = async ({
+    collection,
+    realPath,
+    args,
+    isAddPendingDocument,
+    isCollectionSpecific,
+  }: {
+    collection: TinaCloudCollection<true>
+    realPath: string
+    args: unknown
+    isAddPendingDocument: boolean
+    isCollectionSpecific: boolean
+  }) => {
+    /**
+     * TODO: Remove when `addPendingDocument` is no longer needed.
+     */
+    if (isAddPendingDocument === true) {
+      const templateInfo =
+        this.tinaSchema.getTemplatesForCollectable(collection)
+
+      const params = this.buildParams(args)
       switch (templateInfo.type) {
         case 'object':
           if (params) {
@@ -293,7 +382,7 @@ export class Resolver {
             if (templateParams) {
               if (typeof templateParams === 'string') {
                 throw new Error(
-                  `Expected to find an objet for template params, but got string`
+                  `Expected to find an object for template params, but got string`
                 )
               }
               const values = {
@@ -305,9 +394,108 @@ export class Resolver {
             }
           })
       }
+      return this.getDocument(realPath)
     }
+
+    const params = this.buildObjectMutations(
+      //@ts-ignore
+      isCollectionSpecific ? args.params : args.params[collection.name],
+      collection
+    )
+    //@ts-ignore
+    await this.database.put(realPath, params)
     return this.getDocument(realPath)
   }
+
+  public resolveDocument = async ({
+    args,
+    collection: collectionName,
+    isMutation,
+    isCreation,
+    isAddPendingDocument,
+    isCollectionSpecific,
+  }: {
+    args: unknown
+    collection?: string
+    isMutation: boolean
+    isCreation?: boolean
+    isAddPendingDocument?: boolean
+    isCollectionSpecific?: boolean
+  }) => {
+    /**
+     * `collectionName` is passed in:
+     *    * `addPendingDocument()` has `collection` on `args`
+     *    * `getDocument()` provides a `collection` on `args`
+     *    * `get<Collection>Document()` has `collection` on `lookup`
+     */
+    let collectionLookup = collectionName || undefined
+
+    /**
+     * For generic functions (like `createDocument()` and `updateDocument()`), `collection` is the top key of the `params`
+     */
+    if (!collectionLookup && isCollectionSpecific === false) {
+      //@ts-ignore
+      collectionLookup = Object.keys(args.params)[0]
+    }
+
+    const collectionNames = this.tinaSchema
+      .getCollections()
+      .map((item) => item.name)
+
+    assertShape<string>(
+      collectionLookup,
+      (yup) => {
+        return yup.mixed().oneOf(collectionNames)
+      },
+      `"collection" must be one of: [${collectionNames.join(
+        ', '
+      )}] but got ${collectionLookup}`
+    )
+
+    assertShape<{ relativePath: string }>(args, (yup) =>
+      yup.object({ relativePath: yup.string().required() })
+    )
+
+    const collection = await this.tinaSchema.getCollection(collectionLookup)
+    const realPath = path.join(collection?.path, args.relativePath)
+    const alreadyExists = await this.database.documentExists(realPath)
+
+    if (isMutation) {
+      if (isCreation) {
+        /**
+         * createDocument, create<Collection>Document
+         */
+        if (alreadyExists === true) {
+          throw new Error(`Unable to add document, ${realPath} already exists`)
+        }
+        return this.createResolveDocument({
+          collection,
+          realPath,
+          args,
+          isAddPendingDocument,
+        })
+      }
+      /**
+       * updateDocument, update<Collection>Document
+       */
+      if (alreadyExists === false) {
+        throw new Error(`Unable to update document, ${realPath} does not exist`)
+      }
+      return this.updateResolveDocument({
+        collection,
+        realPath,
+        args,
+        isAddPendingDocument,
+        isCollectionSpecific,
+      })
+    } else {
+      /**
+       * getDocument, get<Collection>Document
+       */
+      return this.getDocument(realPath)
+    }
+  }
+
   public resolveCollectionConnections = async ({ ids }: { ids: string[] }) => {
     return {
       totalCount: ids.length,
@@ -368,62 +556,7 @@ export class Resolver {
           accum[fieldName] = fieldValue
           break
         case 'object':
-          if (field.fields) {
-            const objectTemplate =
-              typeof field.fields === 'string'
-                ? this.tinaSchema.getGlobalTemplate(field.fields)
-                : field
-            if (Array.isArray(fieldValue)) {
-              accum[fieldName] = fieldValue.map((item) =>
-                // @ts-ignore FIXME Argument of type 'string | object' is not assignable to parameter of type '{ [fieldName: string]: string | object | (string | object)[]; }'
-                this.buildFieldMutations(item, objectTemplate)
-              )
-            } else {
-              accum[fieldName] = this.buildFieldMutations(
-                // @ts-ignore FIXME Argument of type 'string | object' is not assignable to parameter of type '{ [fieldName: string]: string | object | (string | object)[]; }'
-                fieldValue,
-                objectTemplate
-              )
-            }
-            break
-          }
-          if (field.templates) {
-            if (Array.isArray(fieldValue)) {
-              accum[fieldName] = fieldValue.map((item) => {
-                if (typeof item === 'string') {
-                  throw new Error(
-                    `Expected object for template value for field ${field.name}`
-                  )
-                }
-                const templates = field.templates.map(
-                  (templateOrTemplateName) => {
-                    if (typeof templateOrTemplateName === 'string') {
-                      return this.tinaSchema.getGlobalTemplate(
-                        templateOrTemplateName
-                      )
-                    }
-                    return templateOrTemplateName
-                  }
-                )
-                const [templateName] = Object.entries(item)[0]
-                const template = templates.find(
-                  (template) => template.name === templateName
-                )
-                if (!template) {
-                  throw new Error(`Expected to find template ${templateName}`)
-                }
-                return {
-                  // @ts-ignore FIXME Argument of type 'unknown' is not assignable to parameter of type '{ [fieldName: string]: string | { [key: string]: unknown; } | (string | { [key: string]: unknown; })[]; }'
-                  ...this.buildFieldMutations(item[template.name], template),
-                  _template: template.name,
-                }
-              })
-            } else {
-              throw new Error(
-                'Not implement for polymorphic objects which are not lists'
-              )
-            }
-          }
+          accum[fieldName] = this.buildObjectMutations(fieldValue, field)
           break
         case 'rich-text':
           field

--- a/packages/@tinacms/graphql/src/primitives/spec/forestry-sample/requests/updateDocument-no-collection/request.gql
+++ b/packages/@tinacms/graphql/src/primitives/spec/forestry-sample/requests/updateDocument-no-collection/request.gql
@@ -1,9 +1,8 @@
 mutation {
   updateDocument(
-    collection: "some-fake-collection"
     relativePath: "hello-world.md"
     params: {
-      post: {
+      someFakeCollection: {
         post: { title: "Hello, again!", author: "content/authors/marge.md" }
       }
     }

--- a/packages/@tinacms/graphql/src/primitives/spec/forestry-sample/requests/updateDocument-no-collection/response.json
+++ b/packages/@tinacms/graphql/src/primitives/spec/forestry-sample/requests/updateDocument-no-collection/response.json
@@ -2,7 +2,7 @@
   "data": null,
   "errors": [
     {
-      "message": "\"collection\" must be one of: [author, post] but got some-fake-collection",
+      "message": "\"collection\" must be one of: [author, post] but got someFakeCollection",
       "locations": [
         {
           "column": 3,

--- a/packages/@tinacms/graphql/src/primitives/spec/forestry-sample/requests/updateDocument/request.gql
+++ b/packages/@tinacms/graphql/src/primitives/spec/forestry-sample/requests/updateDocument/request.gql
@@ -1,6 +1,5 @@
 mutation {
   updateDocument(
-    collection: "post"
     relativePath: "hello-world.md"
     params: {
       post: {

--- a/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/request.gql
+++ b/packages/@tinacms/graphql/src/primitives/spec/movies/requests/updateDocument/request.gql
@@ -1,10 +1,13 @@
 mutation {
   updateDocument(
-    collection: "movie"
     relativePath: "star-wars.md"
     # Changes the genre to action
     params: {
-      movie: { genre: "action", archived: true, releaseDate: "2021-02-02T07:00:00.000Z" }
+      movie: {
+        genre: "action"
+        archived: true
+        releaseDate: "2021-02-02T07:00:00.000Z"
+      }
     }
   ) {
     ... on MovieDocument {

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -17,6 +17,7 @@ import type { TinaCMS } from '@tinacms/toolkit'
 interface Document {
   node: {
     sys: {
+      template: string
       breadcrumbs: string[]
       path: string
       basename: string
@@ -26,10 +27,17 @@ interface Document {
     }
   }
 }
+
+export interface Template {
+  name: string
+  label: string
+  fields: any[]
+}
 export interface Collection {
   label: string
   name: string
   format: string
+  templates: Template[]
   documents: {
     totalCount: number
     edges: Document[]
@@ -55,12 +63,14 @@ export const useGetCollection = (
               name
               label
               format
+              templates
               documents @include(if: $includeDocuments) {
                 totalCount
                 edges {
                   node {
                     ... on Document {
                       sys {
+                        template
                         breadcrumbs
                         path
                         basename

--- a/packages/tinacms/src/admin/components/GetDocumentFields.tsx
+++ b/packages/tinacms/src/admin/components/GetDocumentFields.tsx
@@ -15,10 +15,15 @@ import React, { useState, useEffect } from 'react'
 import type { TinaCMS } from '@tinacms/toolkit'
 
 interface GetDocumentFields {
-  [collectionName: string]: { collection: Object; fields: Object[] }
+  [collectionName: string]: {
+    collection: Object
+    templates?: Object[]
+    fields?: Object[]
+  }
 }
 export interface Info {
   collection: Object | undefined
+  template: Object | undefined
   fields: Object[] | undefined
   mutationInfo: {
     includeCollection: boolean
@@ -26,9 +31,14 @@ export interface Info {
   }
 }
 
-export const useGetDocumentFields = (cms: TinaCMS, collectionName: string) => {
+export const useGetDocumentFields = (
+  cms: TinaCMS,
+  collectionName: string,
+  templateName: string
+) => {
   const [info, setInfo] = useState<Info>({
     collection: undefined,
+    template: undefined,
     fields: undefined,
     mutationInfo: undefined,
   })
@@ -42,14 +52,31 @@ export const useGetDocumentFields = (cms: TinaCMS, collectionName: string) => {
 
       const documentFields = response.getDocumentFields
       const collection: Object = documentFields[collectionName].collection
-      const fields: Object[] = documentFields[collectionName].fields
       const mutationInfo: {
         includeCollection: boolean
         includeTemplate: boolean
       } = documentFields[collectionName].mutationInfo
+      let fields: Object[] = undefined
+      let template: { name: string; label: string } = undefined
+
+      /***
+       * Collection `collectionName` has template `templateName`...
+       */
+      if (
+        templateName &&
+        documentFields[collectionName].templates &&
+        documentFields[collectionName].templates[templateName]
+      ) {
+        template =
+          documentFields[collectionName].templates[templateName].template
+        fields = documentFields[collectionName].templates[templateName].fields
+      } else {
+        fields = documentFields[collectionName].fields
+      }
 
       setInfo({
         collection,
+        template,
         fields,
         mutationInfo,
       })
@@ -64,20 +91,24 @@ export const useGetDocumentFields = (cms: TinaCMS, collectionName: string) => {
 const GetDocumentFields = ({
   cms,
   collectionName,
+  templateName,
   children,
 }: {
   cms: TinaCMS
   collectionName: string
+  templateName?: string
   children: any
 }) => {
-  const { collection, fields, mutationInfo } = useGetDocumentFields(
+  const { collection, template, fields, mutationInfo } = useGetDocumentFields(
     cms,
-    collectionName
+    collectionName,
+    templateName
   )
-  if (!collection || !fields || !mutationInfo) {
+
+  if (!collection) {
     return null
   }
-  return <>{children(collection, fields, mutationInfo)}</>
+  return <>{children({ collection, template, fields, mutationInfo })}</>
 }
 
 export default GetDocumentFields

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -16,7 +16,6 @@ import {
   BrowserRouter as Router,
   Switch,
   Route,
-  Link,
   NavLink,
 } from 'react-router-dom'
 import { ImFilesEmpty } from 'react-icons/im'
@@ -182,6 +181,11 @@ export const TinaAdmin = () => {
                   <div className="flex-1">
                     <Switch>
                       <Route path={`/admin/collections/:collectionName/new`}>
+                        <CollectionCreatePage />
+                      </Route>
+                      <Route
+                        path={`/admin/collections/:collectionName/:templateName/new`}
+                      >
                         <CollectionCreatePage />
                       </Route>
                       <Route

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -11,14 +11,83 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react'
+import React, { Fragment } from 'react'
 import { BiEdit } from 'react-icons/bi'
 import { useParams, useLocation, Link } from 'react-router-dom'
+import { Menu, Transition } from '@headlessui/react'
 
 import GetCMS from '../components/GetCMS'
-import GetCollection, { Collection } from '../components/GetCollection'
+import GetCollection, {
+  Collection,
+  Template,
+} from '../components/GetCollection'
 
 import type { TinaCMS } from '@tinacms/toolkit'
+
+const TemplateMenu = ({ templates }: { templates: Template[] }) => {
+  return (
+    <Menu as="div" className="relative inline-block text-left">
+      {({ open }) => (
+        <div>
+          <div>
+            <Menu.Button
+              className="inline-flex items-center px-8 py-2.5 shadow-sm border border-transparent text-sm leading-4 font-medium rounded-full text-white hover:opacity-80 focus:outline-none focus:shadow-outline-blue  transition duration-150 ease-out"
+              style={{ background: '#0084FF' }}
+            >
+              Create New
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                xmlns="http://www.w3.org/2000/svg"
+                className={`ml-1 flex-0 inline-block opacity-50 group-hover:opacity-80 transition-all duration-300 ease-in-out transform ${
+                  open ? `rotate-90 opacity-100` : `rotate-0`
+                }`}
+              >
+                <g opacity="1.0">
+                  <path
+                    d="M7.91675 13.8086L9.16675 15.0586L14.2253 10L9.16675 4.9414L7.91675 6.1914L11.7253 10L7.91675 13.8086Z"
+                    fill="currentColor"
+                  />
+                </g>
+              </svg>
+            </Menu.Button>
+          </div>
+
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <Menu.Items className="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+              <div className="py-1">
+                {templates.map((template) => (
+                  <Menu.Item key={`${template.label}-${template.name}`}>
+                    {({ active }) => (
+                      <Link
+                        to={`${location.pathname}/${template.name}/new`}
+                        className={`w-full text-md px-4 py-2 tracking-wide flex items-center opacity-80 text-gray-600 ${
+                          active && 'text-gray-800 opacity-100'
+                        }`}
+                      >
+                        {template.label}
+                      </Link>
+                    )}
+                  </Menu.Item>
+                ))}
+              </div>
+            </Menu.Items>
+          </Transition>
+        </div>
+      )}
+    </Menu>
+  )
+}
 
 const CollectionListPage = () => {
   const location = useLocation()
@@ -41,13 +110,18 @@ const CollectionListPage = () => {
                 <div className="max-w-screen-md w-full">
                   <div className="w-full flex justify-between items-end">
                     <h3 className="text-3xl">{collection.label}</h3>
-                    <Link
-                      to={`${location.pathname}/new`}
-                      className="inline-flex items-center px-8 py-3 shadow-sm border border-transparent text-sm leading-4 font-medium rounded-full text-white hover:opacity-80 focus:outline-none focus:shadow-outline-blue  transition duration-150 ease-out"
-                      style={{ background: '#0084FF' }}
-                    >
-                      Create New
-                    </Link>
+                    {!collection.templates && (
+                      <Link
+                        to={`${location.pathname}/new`}
+                        className="inline-flex items-center px-8 py-3 shadow-sm border border-transparent text-sm leading-4 font-medium rounded-full text-white hover:opacity-80 focus:outline-none focus:shadow-outline-blue  transition duration-150 ease-out"
+                        style={{ background: '#0084FF' }}
+                      >
+                        Create New
+                      </Link>
+                    )}
+                    {collection.templates && (
+                      <TemplateMenu templates={collection.templates} />
+                    )}
                   </div>
 
                   {totalCount > 0 && (
@@ -78,6 +152,14 @@ const CollectionListPage = () => {
                                 </span>
                                 <span className="h-5 leading-5 block text-sm font-medium text-gray-900">
                                   {document.node.sys.extension}
+                                </span>
+                              </td>
+                              <td className="px-6 py-4 whitespace-nowrap">
+                                <span className="block text-xs text-gray-400 mb-1 uppercase">
+                                  Template
+                                </span>
+                                <span className="h-5 leading-5 block text-sm font-medium text-gray-900">
+                                  {document.node.sys.template}
                                 </span>
                               </td>
                             </tr>

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -87,15 +87,6 @@ const CollectionUpdatePage = () => {
 
                   return (
                     <div className="w-full h-screen">
-                      {/* <h3 className="text-xl mb-6">
-                        <Link
-                          className="opacity-80 hover:opacity-100 transition-opacity ease-out"
-                          to={`/admin/collections/${collection.name}`}
-                        >
-                          {collection.label}
-                        </Link>{' '}
-                        - Create New
-                      </h3> */}
                       <div className="flex flex-col items-center w-full flex-1">
                         <FullscreenFormBuilder
                           label={collection.label + ` - ` + filename}


### PR DESCRIPTION
`TinaAdmin` now supports `collections` with `templates` (instead of `fields`).  While our documentation has moved away from explicitly talking about `templates`, our schema still supports them, so I personally felt the `TinaAdmin` story was incomplete with support for them, as well.

This necessitated some backend work that Jeff and I had been planning for a while, restructuring `resolveDocument()` to be broken up into small chunks of functionality - `get`, `create`, and `update`.

Things are still a little messy:  I'd like to rework/restructure `getDocumentFields()` now that I've a better idea of what TinaAdmin needs, but that's for a later time.

https://www.loom.com/share/acf56a87c13b4a55b3ac53144285c62f

Closes #2163 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
