### PR TITLE
Fix styled-components listing in strapi

### DIFF
--- a/.changeset/weak-rules-argue.md
+++ b/.changeset/weak-rules-argue.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-strapi': patch
+---
+
+Fix package dependency on styled-components which would result in multiple contexts

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -53,6 +53,9 @@ packageExtensions:
   "@udecode/plate-mention@*":
     peerDependencies:
       styled-components: latest
+  "@udecode/plate@*":
+    peerDependencies:
+      react-is: ^17.0.2
 
 
   # dependencies from needing to build unified-specific packages

--- a/packages/react-tinacms-strapi/package.json
+++ b/packages/react-tinacms-strapi/package.json
@@ -31,6 +31,8 @@
     "final-form": ">=4.20.2",
     "react": ">=16.14.0",
     "react-final-form": "^6.3.0",
+    "react-is": "^17.0.2",
+    "styled-components": ">4.5",
     "tinacms": ">=0.50.0"
   },
   "dependencies": {
@@ -42,7 +44,6 @@
     "js-cookie": "^2.2.1",
     "react": "16.14.0",
     "react-dom": "16.14.0",
-    "styled-components": ">4.5",
     "tslib": "^1.10.0"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
     "@types/jest": "^27.0.1",
     "jest": "^27.0.6",
     "react-final-form": "^6.3.0",
+    "styled-components": ">4.5",
     "tinacms": "workspace:*",
     "ts-jest": "^24.0.3",
     "typescript": "^4.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23529,7 +23529,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-tinacms-editor@^0.52.3, react-tinacms-editor@workspace:*, react-tinacms-editor@workspace:packages/react-tinacms-editor":
+"react-tinacms-editor@^0.52.4, react-tinacms-editor@workspace:*, react-tinacms-editor@workspace:packages/react-tinacms-editor":
   version: 0.0.0-use.local
   resolution: "react-tinacms-editor@workspace:packages/react-tinacms-editor"
   dependencies:
@@ -23632,7 +23632,7 @@ fsevents@~2.1.2:
   languageName: unknown
   linkType: soft
 
-"react-tinacms-inline@^0.53.3, react-tinacms-inline@workspace:packages/react-tinacms-inline":
+"react-tinacms-inline@^0.53.4, react-tinacms-inline@workspace:packages/react-tinacms-inline":
   version: 0.0.0-use.local
   resolution: "react-tinacms-inline@workspace:packages/react-tinacms-inline"
   dependencies:
@@ -23696,6 +23696,8 @@ fsevents@~2.1.2:
     final-form: ">=4.20.2"
     react: ">=16.14.0"
     react-final-form: ^6.3.0
+    react-is: ^17.0.2
+    styled-components: ">4.5"
     tinacms: ">=0.50.0"
   languageName: unknown
   linkType: soft
@@ -27085,8 +27087,8 @@ resolve@^2.0.0-next.3:
     react-dom: ^16.14.0
     react-icons: ^4.2.0
     react-is: ^17.0.2
-    react-tinacms-editor: ^0.52.3
-    react-tinacms-inline: ^0.53.3
+    react-tinacms-editor: ^0.52.4
+    react-tinacms-inline: ^0.53.4
     styled-components: ^5.3.0
     tailwindcss: ^2.0.4
     tinacms: "workspace:*"


### PR DESCRIPTION
When using the strapi package you'll run into this:
```
Module not found: Can't resolve 'react-final-form'
Module not found: Can't resolve 'zustand'
```
While `zustand` isn't something we're using, I believe you only need to install `react-final-form` and `final-form` and that will go away. But then you get to the real error, which was that `styled-components` was listed as a direct dependency:

```
error - Error: Invalid hook call. Hooks can only be called inside of the body of a function component. This could happen for one of the following reasons:
1. You might have mismatching versions of React and the renderer (such as React DOM)
2. You might be breaking the Rules of Hooks
3. You might have more than one copy of React in the same app
See https://fb.me/react-invalid-hook-call for tips about how to debug and fix this problem.
```

This PR fixes that