### PR TITLE
Smaller Cloudinary images in media manager

### DIFF
--- a/.changeset/eleven-schools-design.md
+++ b/.changeset/eleven-schools-design.md
@@ -1,0 +1,5 @@
+---
+'next-tinacms-cloudinary': minor
+---
+
+Show smaller versions of images in the media manager

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -173,7 +173,17 @@ function cloudinaryToTina(file: any): Media {
     id: file.public_id,
     filename,
     directory,
-    previewSrc: file.url,
+    previewSrc: transformCloudinaryImage(file.url, 'w_75,h_75,c_fill,q_auto'),
     type: 'file',
   }
+}
+
+function transformCloudinaryImage(url: string, transformations: string): string {
+  const parts = url.split('/image/upload/')
+
+  if (parts.length === 2) {
+    return parts[0] + '/image/upload/' + transformations + '/' + parts[1]
+  }
+
+  return url
 }


### PR DESCRIPTION
Currently, the Cloudinary media manager loads images in their full resolution, even though only a small thumbnail is shown. The PR addresses this issue by applying these transformations to the `previewSrc` of images in the media manager: `w_75,h_75,c_fill,q_auto`.