### PR TITLE
Revert "Smaller Cloudinary images in media manager"

### DIFF
--- a/.changeset/eleven-schools-design.md
+++ b/.changeset/eleven-schools-design.md
@@ -1,5 +1,0 @@
----
-'next-tinacms-cloudinary': minor
----
-
-Show smaller versions of images in the media manager

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -173,17 +173,7 @@ function cloudinaryToTina(file: any): Media {
     id: file.public_id,
     filename,
     directory,
-    previewSrc: transformCloudinaryImage(file.url, 'w_75,h_75,c_fill,q_auto'),
+    previewSrc: file.url,
     type: 'file',
   }
-}
-
-function transformCloudinaryImage(url: string, transformations: string): string {
-  const parts = url.split('/image/upload/')
-
-  if (parts.length === 2) {
-    return parts[0] + '/image/upload/' + transformations + '/' + parts[1]
-  }
-
-  return url
 }


### PR DESCRIPTION
@employee451  thanks for the Cloudinary image improvement. I ran into a snag while testing it which is that currently the `previewSrc` value gets persisted. This isn't ideal because ideally we're storing the full image URL, so developers can modify it's size at render time in their app. I've made an adjustment to our media implementation [here](https://github.com/tinacms/tinacms/pull/2201), but we need to discuss it a bit before moving forward so just reverting this for now.