### PR TITLE
TinaCloud by composition POC

### DIFF
--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -3,7 +3,7 @@ import dynamic from "next/dynamic";
 import { TinaEditProvider } from "tinacms/dist/edit-state";
 import { Layout } from "../components/layout";
 import { TinaCMS, TinaProvider } from "tinacms";
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 // @ts-ignore FIXME: default export needs to be 'ComponentType<{}>
 const TinaCloudProvider = dynamic(() => import("tinacms"), { ssr: false });
 
@@ -13,6 +13,11 @@ const NEXT_PUBLIC_USE_LOCAL_CLIENT =
 
 const App = ({ Component, pageProps }) => {
   const cms = useMemo(() => new TinaCMS({ enabled: true, sidebar: true }));
+  useEffect(() => {
+    import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
+      cms.plugins.add(MarkdownFieldPlugin);
+    });
+  });
   return (
     <>
       <TinaEditProvider
@@ -27,13 +32,6 @@ const App = ({ Component, pageProps }) => {
                 ({ TinaCloudCloudinaryMediaStore }) =>
                   TinaCloudCloudinaryMediaStore
               )}
-              cmsCallback={(cms) => {
-                import("react-tinacms-editor").then(
-                  ({ MarkdownFieldPlugin }) => {
-                    cms.plugins.add(MarkdownFieldPlugin);
-                  }
-                );
-              }}
               documentCreatorCallback={{
                 /**
                  * After a new document is created, redirect to its location

--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -2,75 +2,53 @@ import "../styles.css";
 import dynamic from "next/dynamic";
 import { TinaEditProvider } from "tinacms/dist/edit-state";
 import { Layout } from "../components/layout";
-import { TinaCMS, TinaProvider, Client, LocalClient } from "tinacms";
-import { useMemo, useEffect } from "react";
+import {
+  TinaCMS,
+  TinaProvider,
+  Client,
+  LocalClient,
+  useCloudForms,
+  useCMS,
+  GlobalFormPlugin,
+} from "tinacms";
+import { useEffect } from "react";
 // @ts-ignore FIXME: default export needs to be 'ComponentType<{}>
-const TinaCloudProvider = dynamic(() => import("tinacms"), { ssr: false });
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
 const NEXT_PUBLIC_USE_LOCAL_CLIENT =
   process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || true;
 
 const EditMode = ({ Component, pageProps }) => {
+  const cms = useCMS();
   useEffect(() => {
     import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
       cms.plugins.add(MarkdownFieldPlugin);
     });
   });
 
-  const cms = useMemo(
-    () =>
-      new TinaCMS({
-        enabled: true,
-        sidebar: true,
-        apis: {
-          tina:
-            process.env.NODE_ENV == "production"
-              ? new Client({ branch: "main", clientId: "" })
-              : new LocalClient(),
-        },
-      })
-  );
-  return (
-    <TinaProvider cms={cms}>
-      <TinaCloudProvider
-        mediaStore={import("next-tinacms-cloudinary").then(
-          ({ TinaCloudCloudinaryMediaStore }) => TinaCloudCloudinaryMediaStore
-        )}
-        documentCreatorCallback={{
-          /**
-           * After a new document is created, redirect to its location
-           */
-          onNewDocument: ({ collection: { slug }, breadcrumbs }) => {
-            const relativeUrl = `/${slug}/${breadcrumbs.join("/")}`;
-            return (window.location.href = relativeUrl);
-          },
-          /**
-           * Only allows documents to be created to the `Blog Posts` Collection
-           */
-          filterCollections: (options) => {
-            return options.filter((option) => option.label === "Blog Posts");
-          },
-        }}
-        formifyCallback={({ formConfig, createForm, createGlobalForm }) => {
-          if (formConfig.id === "getGlobalDocument") {
-            return createGlobalForm(formConfig);
-          }
+  const {
+    data,
+    forms,
+    isLoading: isLoadingForms,
+  } = useCloudForms({
+    query: pageProps.query,
+    variables: pageProps.variables,
+  });
 
-          return createForm(formConfig);
-        }}
-        {...pageProps}
-      >
-        {(livePageProps) => (
-          <Layout
-            rawData={livePageProps}
-            data={livePageProps.data?.getGlobalDocument?.data}
-          >
-            <Component {...livePageProps} />
-          </Layout>
-        )}
-      </TinaCloudProvider>
-    </TinaProvider>
+  useEffect(() => {
+    forms.forEach((form) => {
+      if (form.id === "getGlobalDocument") {
+        cms.plugins.add(new GlobalFormPlugin(form));
+      } else {
+        cms.forms.add(form);
+      }
+    });
+  }, [isLoadingForms]);
+
+  return (
+    <Layout rawData={data} data={data?.getGlobalDocument?.data}>
+      <Component data={data} />
+    </Layout>
   );
 };
 
@@ -79,7 +57,24 @@ const App = ({ Component, pageProps }) => {
     <>
       <TinaEditProvider
         showEditButton={true}
-        editMode={<EditMode Component={Component} pageProps={pageProps} />}
+        editMode={
+          <TinaProvider
+            cms={
+              new TinaCMS({
+                enabled: true,
+                sidebar: true,
+                apis: {
+                  tina:
+                    process.env.NODE_ENV == "production"
+                      ? new Client({ branch: "main", clientId: "" })
+                      : new LocalClient(),
+                },
+              })
+            }
+          >
+            <EditMode Component={Component} pageProps={pageProps} />
+          </TinaProvider>
+        }
       >
         <Layout
           rawData={pageProps}

--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -69,7 +69,6 @@ const App = ({ Component, pageProps }) => {
 
                 return createForm(formConfig);
               }}
-              cms={cms}
               {...pageProps}
             >
               {(livePageProps) => (

--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -11,41 +11,25 @@ import {
   useCMS,
   GlobalFormPlugin,
   Form,
-  TinaCloudProvider,
+  TinaCloudProvider as TinaCloudAuthProvider,
+  TinaCloudQuery,
 } from "tinacms";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 // @ts-ignore FIXME: default export needs to be 'ComponentType<{}>
 
 const NEXT_PUBLIC_TINA_CLIENT_ID = process.env.NEXT_PUBLIC_TINA_CLIENT_ID;
 const NEXT_PUBLIC_USE_LOCAL_CLIENT =
   process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT || true;
 
-const EditMode = ({ Component, pageProps }) => {
+const TinaForms = ({ forms }: { forms: Form[] }) => {
   const cms = useCMS();
+
   useEffect(() => {
     import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
       cms.plugins.add(MarkdownFieldPlugin);
     });
-  });
+  }, []);
 
-  const {
-    data,
-    forms,
-    isLoading: isLoadingForms,
-  } = useCloudForms({
-    query: pageProps.query,
-    variables: pageProps.variables,
-  });
-
-  useEffect(() => {
-    forms.forEach((form) => {
-      if (form.id === "getGlobalDocument") {
-        cms.plugins.add(new GlobalFormPlugin(form));
-      } else {
-        cms.forms.add(form);
-      }
-    });
-  }, [isLoadingForms]);
   useEffect(() => {
     cms.forms.add(
       new Form({
@@ -74,36 +58,55 @@ const EditMode = ({ Component, pageProps }) => {
     );
   }, []);
 
-  return (
-    <Layout rawData={data} data={data?.getGlobalDocument?.data}>
-      <Component data={data} />
-    </Layout>
-  );
+  useEffect(() => {
+    forms.forEach((form) => {
+      if (form.id === "getGlobalDocument") {
+        cms.plugins.add(new GlobalFormPlugin(form));
+      } else {
+        cms.forms.add(form);
+      }
+    });
+  }, [forms]);
+
+  return <div />;
 };
 
 const App = ({ Component, pageProps }) => {
+  const cms = useMemo(
+    () =>
+      new TinaCMS({
+        enabled: true,
+        sidebar: true,
+        apis: {
+          tina:
+            process.env.NODE_ENV == "production"
+              ? new Client({ branch: "main", clientId: "" })
+              : new LocalClient(),
+        },
+      })
+  );
   return (
     <>
       <TinaEditProvider
         showEditButton={true}
         editMode={
-          <TinaProvider
-            cms={
-              new TinaCMS({
-                enabled: true,
-                sidebar: true,
-                apis: {
-                  tina:
-                    process.env.NODE_ENV == "production"
-                      ? new Client({ branch: "main", clientId: "" })
-                      : new LocalClient(),
-                },
-              })
-            }
-          >
-            <TinaCloudProvider>
-              <EditMode Component={Component} pageProps={pageProps} />
-            </TinaCloudProvider>
+          <TinaProvider cms={cms}>
+            <TinaCloudAuthProvider>
+              <TinaCloudQuery
+                query={pageProps.query}
+                variables={pageProps.variables}
+              >
+                {({ forms, data }) => (
+                  <>
+                    <TinaForms forms={forms} />
+                    {/* Preview the content */}
+                    <Layout rawData={data} data={data?.getGlobalDocument?.data}>
+                      <Component data={data} />
+                    </Layout>
+                  </>
+                )}
+              </TinaCloudQuery>{" "}
+            </TinaCloudAuthProvider>
           </TinaProvider>
         }
       >

--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -11,6 +11,7 @@ import {
   useCMS,
   GlobalFormPlugin,
   Form,
+  TinaCloudProvider,
 } from "tinacms";
 import { useEffect } from "react";
 // @ts-ignore FIXME: default export needs to be 'ComponentType<{}>
@@ -100,7 +101,9 @@ const App = ({ Component, pageProps }) => {
               })
             }
           >
-            <EditMode Component={Component} pageProps={pageProps} />
+            <TinaCloudProvider>
+              <EditMode Component={Component} pageProps={pageProps} />
+            </TinaCloudProvider>
           </TinaProvider>
         }
       >

--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -10,6 +10,7 @@ import {
   useCloudForms,
   useCMS,
   GlobalFormPlugin,
+  Form,
 } from "tinacms";
 import { useEffect } from "react";
 // @ts-ignore FIXME: default export needs to be 'ComponentType<{}>
@@ -44,6 +45,33 @@ const EditMode = ({ Component, pageProps }) => {
       }
     });
   }, [isLoadingForms]);
+  useEffect(() => {
+    cms.forms.add(
+      new Form({
+        id: "cool-form",
+        label: "Edit Post",
+        fields: [
+          {
+            name: "title",
+            label: "Title",
+            component: "text",
+          },
+          {
+            name: "markdownContent",
+            label: "content",
+            component: "markdown",
+          },
+        ],
+        initialValues: {
+          title: "Default value",
+          markdownContent: "",
+        },
+        onSubmit: async (formData) => {
+          alert("You saved a dummy form");
+        },
+      })
+    );
+  }, []);
 
   return (
     <Layout rawData={data} data={data?.getGlobalDocument?.data}>

--- a/examples/tina-cloud-starter/pages/_app.tsx
+++ b/examples/tina-cloud-starter/pages/_app.tsx
@@ -24,40 +24,44 @@ const NEXT_PUBLIC_USE_LOCAL_CLIENT =
 const TinaForms = ({ forms }: { forms: Form[] }) => {
   const cms = useCMS();
 
+  // Register some custom plugins like so:
   useEffect(() => {
     import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
       cms.plugins.add(MarkdownFieldPlugin);
     });
   }, []);
 
-  useEffect(() => {
-    cms.forms.add(
-      new Form({
-        id: "cool-form",
-        label: "Edit Post",
-        fields: [
-          {
-            name: "title",
-            label: "Title",
-            component: "text",
-          },
-          {
-            name: "markdownContent",
-            label: "content",
-            component: "markdown",
-          },
-        ],
-        initialValues: {
-          title: "Default value",
-          markdownContent: "",
-        },
-        onSubmit: async (formData) => {
-          alert("You saved a dummy form");
-        },
-      })
-    );
-  }, []);
+  // You could register a custom form here like so:
 
+  // useEffect(() => {
+  //   cms.forms.add(
+  //     new Form({
+  //       id: "cool-form",
+  //       label: "Edit Post",
+  //       fields: [
+  //         {
+  //           name: "title",
+  //           label: "Title",
+  //           component: "text",
+  //         },
+  //         {
+  //           name: "markdownContent",
+  //           label: "content",
+  //           component: "markdown",
+  //         },
+  //       ],
+  //       initialValues: {
+  //         title: "Default value",
+  //         markdownContent: "",
+  //       },
+  //       onSubmit: async (formData) => {
+  //         alert("You saved a dummy form");
+  //       },
+  //     })
+  //   );
+  // }, []);
+
+  // register the forms that came from Tina Cloud
   useEffect(() => {
     forms.forEach((form) => {
       if (form.id === "getGlobalDocument") {
@@ -78,6 +82,7 @@ const App = ({ Component, pageProps }) => {
         enabled: true,
         sidebar: true,
         apis: {
+          // Register the local or production Tina Cloud backend
           tina:
             process.env.NODE_ENV == "production"
               ? new Client({ branch: "main", clientId: "" })
@@ -91,6 +96,7 @@ const App = ({ Component, pageProps }) => {
         showEditButton={true}
         editMode={
           <TinaProvider cms={cms}>
+            {/* Container to maoe sure user is logged in */}
             <TinaCloudAuthProvider>
               <TinaCloudQuery
                 query={pageProps.query}
@@ -98,6 +104,7 @@ const App = ({ Component, pageProps }) => {
               >
                 {({ forms, data }) => (
                   <>
+                    {/* Custom component to register our forms */}
                     <TinaForms forms={forms} />
                     {/* Preview the content */}
                     <Layout rawData={data} data={data?.getGlobalDocument?.data}>
@@ -105,11 +112,12 @@ const App = ({ Component, pageProps }) => {
                     </Layout>
                   </>
                 )}
-              </TinaCloudQuery>{" "}
+              </TinaCloudQuery>
             </TinaCloudAuthProvider>
           </TinaProvider>
         }
       >
+        {/* Production page */}
         <Layout
           rawData={pageProps}
           data={pageProps.data?.getGlobalDocument?.data}

--- a/examples/tina-tailwind-sidebar-demo/pages/_app.js
+++ b/examples/tina-tailwind-sidebar-demo/pages/_app.js
@@ -21,11 +21,6 @@ const App = ({ Component, pageProps }) => {
             //   ({ TinaCloudCloudinaryMediaStore }) =>
             //     TinaCloudCloudinaryMediaStore
             // )}
-            // cmsCallback={(cms) => {
-            //   import('react-tinacms-editor').then(({ MarkdownFieldPlugin }) => {
-            //     cms.plugins.add(MarkdownFieldPlugin)
-            //   })
-            // }}
             // formifyCallback={({ formConfig, createForm, createGlobalForm }) => {
             //   if (formConfig.id === 'getGlobalDocument') {
             //     return createGlobalForm(formConfig)

--- a/packages/tinacms/CHANGELOG.md
+++ b/packages/tinacms/CHANGELOG.md
@@ -272,8 +272,6 @@
         branch="main"
         // Optional: Your identifier when connecting to Tina Cloud
         clientId="<some-id-from-tina-cloud>"
-        // Optional: A callback for altering the CMS object if needed
-        cmsCallback={cms => {}}
         // Optional: A callback for altering the form generation if needed
         formifyCallback={args => {}}
         // Optional: A callback for altering the document creator plugin

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -134,60 +134,55 @@ export const AuthWallInner = ({
  *
  * Note: this will not restrict access for local filesystem clients
  */
-export const TinaCloudProvider = (
-  props: TinaCloudAuthWallProps & CreateClientProps
-) => {
+export const TinaCloudProvider = (props: TinaCloudAuthWallProps) => {
   useTinaAuthRedirect()
   const cms = useCMS()
-  if (!cms.api.tina) {
-    cms.api.tina = createClient(props)
-  }
   const setupMedia = async () => {
     if (props.mediaStore) {
       cms.media.store = new (await props.mediaStore)(cms.api.tina)
     }
   }
-  const handleListBranches = async (): Promise<Branch[]> => {
-    const { owner, repo } = props
-    const branches = await cms.api.tina.listBranches({ owner, repo })
+  // const handleListBranches = async (): Promise<Branch[]> => {
+  //   const { owner, repo } = props
+  //   const branches = await cms.api.tina.listBranches({ owner, repo })
 
-    return branches.map((branch) => branch.name)
-  }
-  const handleCreateBranch = async (data) => {
-    const newBranch = await cms.api.tina.createBranch(data)
+  //   return branches.map((branch) => branch.name)
+  // }
+  // const handleCreateBranch = async (data) => {
+  //   const newBranch = await cms.api.tina.createBranch(data)
 
-    return newBranch
-  }
+  //   return newBranch
+  // }
 
   setupMedia()
 
   //@ts-ignore it's not picking up cms.flags
   const branchingEnabled = cms.flags.get('branch-switcher')
 
-  React.useEffect(() => {
-    let branchSwitcher
-    if (branchingEnabled) {
-      branchSwitcher = new BranchSwitcherPlugin({
-        cms,
-        owner: props.owner,
-        repo: props.repo,
-        baseBranch: props.branch || 'main',
-        currentBranch: props.branch || 'main',
-        //TODO implement these
-        listBranches: handleListBranches,
-        createBranch: handleCreateBranch,
-        setCurrentBranch: () => console.log(props.branch),
-      })
-      cms.plugins.add(branchSwitcher)
-    }
-    return () => {
-      if (!branchingEnabled) {
-        if (branchSwitcher) {
-          cms.plugins.remove(branchSwitcher)
-        }
-      }
-    }
-  }, [branchingEnabled, props.branch])
+  // React.useEffect(() => {
+  //   let branchSwitcher
+  //   if (branchingEnabled) {
+  //     branchSwitcher = new BranchSwitcherPlugin({
+  //       cms,
+  //       owner: props.owner,
+  //       repo: props.repo,
+  //       baseBranch: props.branch || 'main',
+  //       currentBranch: props.branch || 'main',
+  //       //TODO implement these
+  //       listBranches: handleListBranches,
+  //       createBranch: handleCreateBranch,
+  //       setCurrentBranch: () => console.log(props.branch),
+  //     })
+  //     cms.plugins.add(branchSwitcher)
+  //   }
+  //   return () => {
+  //     if (!branchingEnabled) {
+  //       if (branchSwitcher) {
+  //         cms.plugins.remove(branchSwitcher)
+  //       }
+  //     }
+  //   }
+  // }, [branchingEnabled, props.branch])
 
   return <AuthWallInner {...props} cms={cms} />
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -20,6 +20,7 @@ import {
   //@ts-ignore why can't it find you
   BranchSwitcherPlugin,
   Branch,
+  useCMS,
 } from '@tinacms/toolkit'
 
 import { Client, TinaIOConfig } from '../client'
@@ -138,15 +139,7 @@ export const TinaCloudProvider = (
     CreateClientProps & { cmsCallback?: (cms: TinaCMS) => TinaCMS }
 ) => {
   useTinaAuthRedirect()
-  const cms = React.useMemo(
-    () =>
-      props.cms ||
-      new TinaCMS({
-        enabled: true,
-        sidebar: true,
-      }),
-    [props.cms]
-  )
+  const cms = useCMS()
   if (!cms.api.tina) {
     cms.api.tina = createClient(props)
   }
@@ -201,11 +194,7 @@ export const TinaCloudProvider = (
     props.cmsCallback(cms)
   }
 
-  return (
-    <TinaProvider cms={cms}>
-      <AuthWallInner {...props} cms={cms} />
-    </TinaProvider>
-  )
+  return <AuthWallInner {...props} cms={cms} />
 }
 
 /**

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -135,8 +135,7 @@ export const AuthWallInner = ({
  * Note: this will not restrict access for local filesystem clients
  */
 export const TinaCloudProvider = (
-  props: TinaCloudAuthWallProps &
-    CreateClientProps & { cmsCallback?: (cms: TinaCMS) => TinaCMS }
+  props: TinaCloudAuthWallProps & CreateClientProps
 ) => {
   useTinaAuthRedirect()
   const cms = useCMS()
@@ -189,10 +188,6 @@ export const TinaCloudProvider = (
       }
     }
   }, [branchingEnabled, props.branch])
-
-  if (props.cmsCallback) {
-    props.cmsCallback(cms)
-  }
 
   return <AuthWallInner {...props} cms={cms} />
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -19,7 +19,7 @@ import {
   MediaStore,
   //@ts-ignore why can't it find you
   BranchSwitcherPlugin,
-  Branch
+  Branch,
 } from '@tinacms/toolkit'
 
 import { Client, TinaIOConfig } from '../client'
@@ -158,20 +158,20 @@ export const TinaCloudProvider = (
   const handleListBranches = async (): Promise<Branch[]> => {
     const { owner, repo } = props
     const branches = await cms.api.tina.listBranches({ owner, repo })
-    
+
     return branches.map((branch) => branch.name)
   }
   const handleCreateBranch = async (data) => {
-     const newBranch = await cms.api.tina.createBranch(data)
+    const newBranch = await cms.api.tina.createBranch(data)
 
-     return newBranch
+    return newBranch
   }
 
   setupMedia()
 
   //@ts-ignore it's not picking up cms.flags
   const branchingEnabled = cms.flags.get('branch-switcher')
-  
+
   React.useEffect(() => {
     let branchSwitcher
     if (branchingEnabled) {
@@ -184,13 +184,13 @@ export const TinaCloudProvider = (
         //TODO implement these
         listBranches: handleListBranches,
         createBranch: handleCreateBranch,
-        setCurrentBranch: () => console.log(props.branch)
+        setCurrentBranch: () => console.log(props.branch),
       })
       cms.plugins.add(branchSwitcher)
     }
     return () => {
       if (!branchingEnabled) {
-        if(branchSwitcher) {
+        if (branchSwitcher) {
           cms.plugins.remove(branchSwitcher)
         }
       }

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -21,25 +21,12 @@ import { assertShape, safeAssertShape } from '../utils'
 import type { FormOptions, TinaCMS } from '@tinacms/toolkit'
 import type { DocumentNode } from 'graphql'
 
-export function useGraphqlForms<T extends object>({
-  query,
-  variables,
-  onSubmit,
-  formify = null,
-}: {
-  query: (gqlTag: typeof gql) => DocumentNode
-  variables: object
-  onSubmit?: (args: onSubmitArgs) => void
-  formify?: formifyCallback
-}): [T, Boolean] {
+const useLinkedForm = () => {
   const cms = useCMS()
-  const [formValues, setFormValues] = React.useState<FormValues>({})
+
   const [data, setData] = React.useState<object>(null)
-  const [initialData, setInitialData] = React.useState<Data>({})
-  const [pendingReset, setPendingReset] = React.useState(null)
-  const [isLoading, setIsLoading] = React.useState(true)
+  const [formValues, setFormValues] = React.useState<FormValues>({})
   const [newUpdate, setNewUpdate] = React.useState<NewUpdate | null>(null)
-  const [formNames, setFormNames] = React.useState([])
 
   /**
    * FIXME: this design is pretty flaky, but better than what
@@ -127,6 +114,29 @@ export function useGraphqlForms<T extends object>({
   React.useEffect(() => {
     updateData()
   }, [JSON.stringify(formValues)])
+
+  return { setFormValues, formValues, setNewUpdate, setData, data }
+}
+
+export function useGraphqlForms<T extends object>({
+  query,
+  variables,
+  onSubmit,
+  formify = null,
+}: {
+  query: (gqlTag: typeof gql) => DocumentNode
+  variables: object
+  onSubmit?: (args: onSubmitArgs) => void
+  formify?: formifyCallback
+}): [T, Boolean] {
+  const cms = useCMS()
+  const [initialData, setInitialData] = React.useState<Data>({})
+  const [pendingReset, setPendingReset] = React.useState(null)
+  const [isLoading, setIsLoading] = React.useState(true)
+
+  //foobar
+  const { setFormValues, formValues, setNewUpdate, setData, data } =
+    useLinkedForm()
 
   const queryString = print(query(gql))
 

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -245,27 +245,29 @@ export function useGraphqlForms<T extends object>({
           }
           const { change } = form.finalForm
           form.finalForm.change = (name, value) => {
-            /**
-             * Reference paths returned from the server don't include array values
-             * as part of their paths: so ["data", "getPostDocument", "blocks", 0, "author", "name"]
-             * should actually be: ["data", "getPostDocument", "blocks", "author", "name"]
-             */
-            let referenceName = ''
-            if (typeof name === 'string') {
-              referenceName = name
-                .split('.')
-                .filter((item) => isNaN(Number(item)))
-                .join('.')
-            } else {
+            if (typeof name !== 'string') {
               throw new Error(
                 `Expected name to be of type string for FinalForm change callback`
               )
             }
+
             setNewUpdate({
               queryName,
               get: [queryName, 'values', name].join('.'),
               set: [queryName, 'data', name].join('.'),
-              setReference: [queryName, 'data', referenceName].join('.'),
+              /**
+               * Reference paths returned from the server don't include array values
+               * as part of their paths: so ["data", "getPostDocument", "blocks", 0, "author", "name"]
+               * should actually be: ["data", "getPostDocument", "blocks", "author", "name"]
+               */
+              setReference: [
+                queryName,
+                'data',
+                name
+                  .split('.')
+                  .filter((item) => isNaN(Number(item)))
+                  .join('.'),
+              ].join('.'),
             })
             return change(name, value)
           }

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -349,10 +349,9 @@ export function useGraphqlForms<T extends object>({
   const cms = useCMS()
 
   const { updateFormValue, setNewUpdate, reset, data } = useLinkedForm(payload)
-
-  const forms = generateTinaCloudForms(cms, payload, onSubmit, formify, reset)
-
   React.useEffect(() => {
+    const forms = generateTinaCloudForms(cms, payload, onSubmit, formify, reset)
+
     ;(forms || []).forEach((form) => {
       augmentForm(cms, form, setNewUpdate, updateFormValue)
     })

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -173,7 +173,7 @@ const generateTinaCloudForms = (
   cms: any,
   payload: any,
   onSubmit,
-  formify = null,
+  formify,
   reset: (queryName: string) => void
 ) => {
   let forms: any[]
@@ -243,11 +243,7 @@ const generateTinaCloudForms = (
     }
     if (skipped) return
 
-    if (formify) {
-      form = formify({ formConfig, createForm, createGlobalForm, skip }, cms)
-    } else {
-      form = createForm(formConfig)
-    }
+    form = formify({ formConfig, createForm, createGlobalForm, skip }, cms)
 
     if (!(form instanceof Form)) {
       if (skipped === SKIPPED) {
@@ -348,7 +344,7 @@ export function useGraphqlForms<T extends object>({
 }: {
   payload: any
   onSubmit?: (args: onSubmitArgs) => void
-  formify?: formifyCallback
+  formify: formifyCallback
 }): [T] {
   const cms = useCMS()
 

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -131,8 +131,9 @@ const useLinkedForm = (payload) => {
   }, [JSON.stringify(formValues)])
 
   return {
-    setFormValues,
-    formValues,
+    updateFormValue: (queryName, values) => {
+      setFormValues({ ...formValues, [queryName]: { values: values } })
+    },
     setNewUpdate,
     reset: (queryId: string) => setPendingReset(queryId),
     data,
@@ -179,8 +180,7 @@ export function useGraphqlForms<T extends object>({
 }): [T] {
   const cms = useCMS()
 
-  const { setFormValues, formValues, setNewUpdate, reset, data } =
-    useLinkedForm(payload)
+  const { updateFormValue, setNewUpdate, reset, data } = useLinkedForm(payload)
 
   React.useEffect(() => {
     try {
@@ -332,7 +332,7 @@ export function useGraphqlForms<T extends object>({
         }
         form.subscribe(
           ({ values }) => {
-            setFormValues({ ...formValues, [queryName]: { values: values } })
+            updateFormValue(queryName, values)
           },
           { values: true }
         )

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -118,6 +118,16 @@ const useLinkedForm = () => {
   return { setFormValues, formValues, setNewUpdate, setData, data }
 }
 
+const canBeFormified = (query) =>
+  safeAssertShape<{
+    form: { mutationInfo: string }
+  }>(query, (yup) =>
+    yup.object({
+      values: yup.object().required(),
+      form: yup.object().required(),
+    })
+  )
+
 export function useGraphqlForms<T extends object>({
   query,
   variables,
@@ -156,15 +166,7 @@ export function useGraphqlForms<T extends object>({
         setInitialData(payload)
         setIsLoading(false)
         Object.entries(payload).map(([queryName, result]) => {
-          const canBeFormified = safeAssertShape<{
-            form: { mutationInfo: string }
-          }>(result, (yup) =>
-            yup.object({
-              values: yup.object().required(),
-              form: yup.object().required(),
-            })
-          )
-          if (!canBeFormified) {
+          if (!canBeFormified(result)) {
             // This is a list or collection query, no forms can be built
             return
           }

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -144,11 +144,8 @@ export function useGraphqlForms<T extends object>({
   const [pendingReset, setPendingReset] = React.useState(null)
   const [isLoading, setIsLoading] = React.useState(true)
 
-  //foobar
   const { setFormValues, formValues, setNewUpdate, setData, data } =
     useLinkedForm()
-
-  const queryString = print(query(gql))
 
   React.useEffect(() => {
     if (pendingReset) {
@@ -323,7 +320,7 @@ export function useGraphqlForms<T extends object>({
         console.error(e)
         setIsLoading(false)
       })
-  }, [queryString, JSON.stringify(variables)])
+  }, [print(query(gql)), JSON.stringify(variables)])
 
   return [data as T, isLoading]
 }

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -234,25 +234,25 @@ const generateTinaCloudForms = (
         }
       },
     }
-    const { createForm, createGlobalForm } = generateFormCreators(cms)
-    const SKIPPED = 'SKIPPED'
-    let form
-    let skipped
-    const skip = () => {
-      skipped = SKIPPED
-    }
-    if (skipped) return
+    // const { createForm, createGlobalForm } = generateFormCreators(cms)
+    // const SKIPPED = 'SKIPPED'
+    // let form
+    // let skipped
+    // const skip = () => {
+    //   skipped = SKIPPED
+    // }
+    // if (skipped) return
 
-    form = formify({ formConfig, createForm, createGlobalForm, skip }, cms)
+    // form = formify({ formConfig, createForm, createGlobalForm, skip }, cms)
 
-    if (!(form instanceof Form)) {
-      if (skipped === SKIPPED) {
-        return
-      }
-      throw new Error('formify must return a form or skip()')
-    }
+    // if (!(form instanceof Form)) {
+    //   if (skipped === SKIPPED) {
+    //     return
+    //   }
+    //   throw new Error('formify must return a form or skip()')
+    // }
 
-    forms.push(form)
+    forms.push(new Form(formConfig))
   })
   return forms
 }
@@ -345,9 +345,10 @@ export function useGraphqlForms<T extends object>({
   payload: any
   onSubmit?: (args: onSubmitArgs) => void
   formify: formifyCallback
-}): [T] {
+}): [T, Form[]] {
   const cms = useCMS()
 
+  const [forms, setForms] = React.useState<Form[]>([])
   const { updateFormValue, setNewUpdate, reset, data } = useLinkedForm(payload)
   React.useEffect(() => {
     const forms = generateTinaCloudForms(cms, payload, onSubmit, formify, reset)
@@ -355,9 +356,10 @@ export function useGraphqlForms<T extends object>({
     ;(forms || []).forEach((form) => {
       augmentForm(cms, form, setNewUpdate, updateFormValue)
     })
+    setForms(forms)
   }, [payload])
 
-  return [data as T]
+  return [data as T, forms]
 }
 
 export const transformDocumentIntoMutationRequestPayload = (

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -176,8 +176,8 @@ const generateTinaCloudForms = (
   formify,
   reset: (queryName: string) => void
 ) => {
-  let forms: any[]
-  Object.entries(payload).map(([queryName, result]) => {
+  let forms: any[] = []
+  Object.entries(payload || {}).map(([queryName, result]) => {
     if (!canBeFormified(result)) {
       // This is a list or collection query, no forms can be built
       return
@@ -353,7 +353,7 @@ export function useGraphqlForms<T extends object>({
   const forms = generateTinaCloudForms(cms, payload, onSubmit, formify, reset)
 
   React.useEffect(() => {
-    forms.forEach((form) => {
+    ;(forms || []).forEach((form) => {
       augmentForm(cms, form, setNewUpdate, updateFormValue)
     })
   }, [payload])

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -164,6 +164,11 @@ export function useGraphqlForms<T extends object>({
     useLinkedForm()
 
   React.useEffect(() => {
+    setData(payload)
+    setInitialData(payload)
+  }, [payload])
+
+  React.useEffect(() => {
     if (pendingReset) {
       setData({ ...data, [pendingReset]: initialData[pendingReset] })
       setPendingReset(null)
@@ -172,8 +177,6 @@ export function useGraphqlForms<T extends object>({
 
   React.useEffect(() => {
     try {
-      setData(payload)
-      setInitialData(payload)
       Object.entries(payload).map(([queryName, result]) => {
         if (!canBeFormified(result)) {
           // This is a list or collection query, no forms can be built

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -184,13 +184,12 @@ export const TinaCMSProvider2 = ({
   documentCreatorCallback?: Parameters<typeof useDocumentCreatorPlugin>[0]
   /** TinaCMS media store instance */
   mediaStore?: TinaCloudMediaStoreClass | Promise<TinaCloudMediaStoreClass>
-  tinaioConfig?: TinaIOConfig
 }) => {
   if (typeof props.query === 'string') {
     props.query
   }
   return (
-    <TinaCloudProvider tinaioConfig={tinaioConfig} mediaStore={mediaStore}>
+    <TinaCloudProvider mediaStore={mediaStore}>
       {props.query ? (
         <SetupHooks key={props.query} {...props} query={props.query || ''}>
           {children}

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -16,11 +16,35 @@ import { useGraphqlForms, useTinaCloudPayload } from './hooks/use-graphql-forms'
 import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
 import { TinaCloudProvider, TinaCloudMediaStoreClass } from './auth'
 import { LocalClient } from './client/index'
-import type { TinaIOConfig } from './client/index'
 import { useCMS } from '@tinacms/toolkit'
 
-import type { TinaCMS } from '@tinacms/toolkit'
 import type { formifyCallback } from './hooks/use-graphql-forms'
+
+export const useCloudForms = ({
+  query,
+  variables,
+}: {
+  query: string
+  variables?: object
+}) => {
+  const cms = useCMS()
+  const [tinaCloudPayload, isLoading] = useTinaCloudPayload(
+    (gql) => gql(query),
+    variables || {}
+  )
+  const [data, forms] = useGraphqlForms({
+    payload: tinaCloudPayload,
+    formify: (args) => {
+      args.skip()
+    },
+  })
+
+  return {
+    data,
+    forms,
+    isLoading,
+  }
+}
 
 const SetupHooks = (props: {
   query: string
@@ -167,7 +191,6 @@ class ErrorBoundary extends React.Component {
 export const TinaCMSProvider2 = ({
   children,
   mediaStore,
-  tinaioConfig,
   ...props
 }: {
   /** The query from getStaticProps */

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -169,7 +169,6 @@ export const TinaCMSProvider2 = ({
   branch,
   clientId,
   isLocalClient,
-  cmsCallback,
   mediaStore,
   tinaioConfig,
   ...props
@@ -188,8 +187,6 @@ export const TinaCMSProvider2 = ({
   branch?: string
   /** Your clientID from tina.aio */
   clientId?: string
-  /** Callback if you need access to the TinaCMS instance */
-  cmsCallback?: (cms: TinaCMS) => TinaCMS
   /** Callback if you need access to the "formify" API */
   formifyCallback?: formifyCallback
   /** Callback if you need access to the "document creator" API */
@@ -207,7 +204,6 @@ export const TinaCMSProvider2 = ({
       clientId={clientId}
       tinaioConfig={tinaioConfig}
       isLocalClient={isLocalClient}
-      cmsCallback={cmsCallback}
       mediaStore={mediaStore}
     >
       {props.query ? (

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -166,9 +166,6 @@ class ErrorBoundary extends React.Component {
 
 export const TinaCMSProvider2 = ({
   children,
-  branch,
-  clientId,
-  isLocalClient,
   mediaStore,
   tinaioConfig,
   ...props
@@ -181,12 +178,6 @@ export const TinaCMSProvider2 = ({
   data: object
   /** Your React page component */
   children: () => React.ReactNode
-  /** Point to the local version of GraphQL instead of tina.io */
-  isLocalClient?: boolean
-  /** The base branch to pull content from. Note that this is ignored for local development */
-  branch?: string
-  /** Your clientID from tina.aio */
-  clientId?: string
   /** Callback if you need access to the "formify" API */
   formifyCallback?: formifyCallback
   /** Callback if you need access to the "document creator" API */
@@ -199,13 +190,7 @@ export const TinaCMSProvider2 = ({
     props.query
   }
   return (
-    <TinaCloudProvider
-      branch={branch}
-      clientId={clientId}
-      tinaioConfig={tinaioConfig}
-      isLocalClient={isLocalClient}
-      mediaStore={mediaStore}
-    >
+    <TinaCloudProvider tinaioConfig={tinaioConfig} mediaStore={mediaStore}>
       {props.query ? (
         <SetupHooks key={props.query} {...props} query={props.query || ''}>
           {children}

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -16,7 +16,7 @@ import { useGraphqlForms, useTinaCloudPayload } from './hooks/use-graphql-forms'
 import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
 import { TinaCloudProvider, TinaCloudMediaStoreClass } from './auth'
 import { LocalClient } from './client/index'
-import { useCMS } from '@tinacms/toolkit'
+import { useCMS, Form } from '@tinacms/toolkit'
 
 import type { formifyCallback } from './hooks/use-graphql-forms'
 
@@ -44,6 +44,38 @@ export const useCloudForms = ({
     forms,
     isLoading,
   }
+}
+
+export const TinaCloudQuery = ({
+  query,
+  variables,
+  children,
+}: {
+  query: string
+  variables?: object
+  children: (args: { forms: Form[]; data: object }) => React.ReactNode
+}) => {
+  const {
+    data,
+    forms,
+    isLoading: isLoadingForms,
+  } = useCloudForms({
+    query,
+    variables,
+  })
+
+  console.log('123 ', data, forms, query, variables, isLoadingForms)
+
+  return (
+    <ErrorBoundary>
+      {isLoadingForms ? (
+        <Loader />
+      ) : (
+        // pass the new edit state data to the child
+        children({ forms, data })
+      )}
+    </ErrorBoundary>
+  )
 }
 
 const SetupHooks = (props: {

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -34,7 +34,7 @@ const SetupHooks = (props: {
     (gql) => gql(props.query),
     props.variables || {}
   )
-  const [payload] = useGraphqlForms({
+  const [data] = useGraphqlForms({
     payload: tinaCloudPayload,
     formify: (args) => {
       if (props.formifyCallback) {
@@ -53,7 +53,7 @@ const SetupHooks = (props: {
         <Loader>{props.children(props)}</Loader>
       ) : (
         // pass the new edit state data to the child
-        props.children({ ...props, data: payload })
+        props.children({ ...props, data })
       )}
     </ErrorBoundary>
   )

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -12,7 +12,7 @@ limitations under the License.
 */
 
 import React from 'react'
-import { useGraphqlForms } from './hooks/use-graphql-forms'
+import { useGraphqlForms, useTinaCloudPayload } from './hooks/use-graphql-forms'
 import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
 import { TinaCloudProvider, TinaCloudMediaStoreClass } from './auth'
 import { LocalClient } from './client/index'
@@ -30,9 +30,12 @@ const SetupHooks = (props: {
   children: (args) => React.ReactNode
 }) => {
   const cms = useCMS()
-  const [payload, isLoading] = useGraphqlForms({
-    query: (gql) => gql(props.query),
-    variables: props.variables || {},
+  const [tinaCloudPayload, isLoading] = useTinaCloudPayload(
+    (gql) => gql(props.query),
+    props.variables || {}
+  )
+  const [payload] = useGraphqlForms({
+    payload: tinaCloudPayload,
     formify: (args) => {
       if (props.formifyCallback) {
         return props.formifyCallback(args, cms)


### PR DESCRIPTION
WIP, but wanted to get some opinions on this.
IMO, we're wrapping up a bit too much within the new `<TinaCMS />` container.

There's still some cleanup within the TinaCMS package, but the main bones of the changes are seen in the tina-cloud-starter _app.tsx. 

See: https://github.com/tinacms/tinacms/blob/7a6eac8060ed6bbf07b80d8b32a9db08aa2eda31/examples/tina-cloud-starter/pages/_app.tsx


There's more for the user to set up, but I think this approach would be easier to extend, and is closer to our SDK API, so docs would be able to be shared between TinaCMS w/ TinaCloud, & without.

A few details to note:

- `<TinaProvider />`, from the `@tinacms/toolkit` package, is now used. This attaches the cms object to context, so `cms` no longer needs to be controlled through callbacks. 
- `<TinaCloudAuthProvider>` is the main Tina Cloud wrapper. It makes sure the user is logged in.
- ` <TinaCloudQuery />` takes in a TinaCloud query & variables, and returns the data & forms as a HOC. It is then up to the user to register the returned forms. Now the user doesn't need to use formify, the can tweak/omit any forms that they want before registering them. 
- My `<TinaForms />` component is just an example of registering the forms from `TinaCloudQuery`, and also a custom dummy form.

This IMO exposes control of the underlying toolkit library, so we no longer would need two separate sets of docs. The only things specific to Tina Cloud are: `TinaCloudAuthProvider` & the `TinaCloudQuery` component.