### PR TITLE
Fix missing Typescript typings for react-tinacms-inline package

### DIFF
--- a/.changeset/cool-pianos-pull.md
+++ b/.changeset/cool-pianos-pull.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-inline': patch
+---
+
+fixed path to Typescript typings, so that they are included in generated NPM package

--- a/packages/react-tinacms-inline/package.json
+++ b/packages/react-tinacms-inline/package.json
@@ -3,7 +3,7 @@
   "version": "0.53.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
-  "typings": "dist/src/index.d.ts",
+  "typings": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixed path to Typescript typings, so that they are included in generated NPM package.