### PR TITLE
Some package.json fixes for react-tinacms-strapi package

### DIFF
--- a/.changeset/cuddly-cycles-camp.md
+++ b/.changeset/cuddly-cycles-camp.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-strapi': patch
+---
+
+added path to Typescript typings, so that they are included in generated NPM package

--- a/.changeset/dry-carrots-fix.md
+++ b/.changeset/dry-carrots-fix.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-strapi': patch
+---
+
+moved `react` and `react-dom` to peer dependencies to avoid conflict with newer React versions (e.g. 17)

--- a/packages/react-tinacms-strapi/package.json
+++ b/packages/react-tinacms-strapi/package.json
@@ -31,6 +31,7 @@
   "peerDependencies": {
     "final-form": ">=4.20.2",
     "react": ">=16.14.0",
+    "react-dom": ">=16.14.0",
     "react-final-form": "^6.3.0",
     "react-is": "^17.0.2",
     "styled-components": ">4.5",
@@ -43,8 +44,6 @@
     "@types/react-dom": "^16.9.4",
     "@types/styled-components": "4.1.8",
     "js-cookie": "^2.2.1",
-    "react": "16.14.0",
-    "react-dom": "16.14.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/packages/react-tinacms-strapi/package.json
+++ b/packages/react-tinacms-strapi/package.json
@@ -3,6 +3,7 @@
   "version": "0.51.5",
   "description": "",
   "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "scripts": {
     "test": "jest --passWithNoTests",
     "watch": "tinacms-scripts watch",


### PR DESCRIPTION
1. Added path to Typescript typings, so that they are included in generated NPM package (currently they are not).
2. Moved `react` and `react-dom` to peer dependencies to avoid them to be installed in packaged "local" node_modules folder and avoid conflict with newer React versions (e.g. 17)