### PR TITLE
2163 - Returns optional collection args for generic GraphQL queries

### DIFF
--- a/.changeset/grumpy-melons-shout.md
+++ b/.changeset/grumpy-melons-shout.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Adds collection arg back for generic queries as optional

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_graphql.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_graphql.json
@@ -3637,6 +3637,20 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
+                "value": "collection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
                 "value": "relativePath"
               },
               "type": {
@@ -3686,6 +3700,20 @@
             "value": "createDocument"
           },
           "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "collection"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
             {
               "kind": "InputValueDefinition",
               "name": {

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/schema.gql
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/schema.gql
@@ -278,8 +278,8 @@ type PagesConnection implements Connection {
 
 type Mutation {
   addPendingDocument(collection: String!, relativePath: String!, template: String): DocumentNode!
-  updateDocument(relativePath: String!, params: DocumentMutation!): DocumentNode!
-  createDocument(relativePath: String!, params: DocumentMutation!): DocumentNode!
+  updateDocument(collection: String, relativePath: String!, params: DocumentMutation!): DocumentNode!
+  createDocument(collection: String, relativePath: String!, params: DocumentMutation!): DocumentNode!
   updatePostsDocument(relativePath: String!, params: PostsMutation!): PostsDocument!
   createPostsDocument(relativePath: String!, params: PostsMutation!): PostsDocument!
   updateGlobalDocument(relativePath: String!, params: GlobalMutation!): GlobalDocument!

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/types.ts
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/types.ts
@@ -434,12 +434,14 @@ export type MutationAddPendingDocumentArgs = {
 
 
 export type MutationUpdateDocumentArgs = {
+  collection?: Maybe<Scalars['String']>;
   relativePath: Scalars['String'];
   params: DocumentMutation;
 };
 
 
 export type MutationCreateDocumentArgs = {
+  collection?: Maybe<Scalars['String']>;
   relativePath: Scalars['String'];
   params: DocumentMutation;
 };

--- a/packages/@tinacms/graphql/src/primitives/builder/index.ts
+++ b/packages/@tinacms/graphql/src/primitives/builder/index.ts
@@ -318,6 +318,11 @@ export class Builder {
       name: 'createDocument',
       args: [
         astBuilder.InputValueDefinition({
+          name: 'collection',
+          required: false,
+          type: astBuilder.TYPES.String,
+        }),
+        astBuilder.InputValueDefinition({
           name: 'relativePath',
           required: true,
           type: astBuilder.TYPES.String,
@@ -355,6 +360,11 @@ export class Builder {
     return astBuilder.FieldDefinition({
       name: 'updateDocument',
       args: [
+        astBuilder.InputValueDefinition({
+          name: 'collection',
+          required: false,
+          type: astBuilder.TYPES.String,
+        }),
         astBuilder.InputValueDefinition({
           name: 'relativePath',
           required: true,


### PR DESCRIPTION
Credit to Jeff for discovering this quickly, but the upcoming changes to the GraphQL queries might break some existing uses of `updateDocument()` when they are introduced for `TinaAdmin`.

Before `createDocument` and `updateDocument` took a required argument `collection`, but more recently, we've discovered that argument is really necessary.

Originally, I removed the argument entirely from those queries, but because `TinaCloud` is not up-to-date with the latest `cli` changes, we've decided to bring the argument back (optional, instead of required).

This should ensure some degree of backwards compatability.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
