### PR TITLE
Fix types declaration for next-tinacms-github

### DIFF
--- a/.changeset/long-jokes-compete.md
+++ b/.changeset/long-jokes-compete.md
@@ -1,0 +1,5 @@
+---
+'next-tinacms-github': patch
+---
+
+Fix types declaration for next-tinacms-github

--- a/packages/next-tinacms-github/package.json
+++ b/packages/next-tinacms-github/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.22",
   "description": "",
   "main": "dist/index.js",
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "watch": "tinacms-scripts watch",
     "build": "tinacms-scripts build",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24110,7 +24110,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-tinacms-editor@^0.52.4, react-tinacms-editor@workspace:*, react-tinacms-editor@workspace:packages/react-tinacms-editor":
+"react-tinacms-editor@^0.52.5, react-tinacms-editor@workspace:*, react-tinacms-editor@workspace:packages/react-tinacms-editor":
   version: 0.0.0-use.local
   resolution: "react-tinacms-editor@workspace:packages/react-tinacms-editor"
   dependencies:
@@ -24211,7 +24211,7 @@ fsevents@~2.1.2:
   languageName: unknown
   linkType: soft
 
-"react-tinacms-inline@^0.53.4, react-tinacms-inline@workspace:packages/react-tinacms-inline":
+"react-tinacms-inline@^0.53.5, react-tinacms-inline@workspace:packages/react-tinacms-inline":
   version: 0.0.0-use.local
   resolution: "react-tinacms-inline@workspace:packages/react-tinacms-inline"
   dependencies:
@@ -27738,8 +27738,8 @@ resolve@^2.0.0-next.3:
     react-dom: ^16.14.0
     react-icons: ^4.2.0
     react-is: ^17.0.2
-    react-tinacms-editor: ^0.52.4
-    react-tinacms-inline: ^0.53.4
+    react-tinacms-editor: ^0.52.5
+    react-tinacms-inline: ^0.53.5
     styled-components: ^5.3.0
     tailwindcss: ^2.0.4
     tinacms: "workspace:*"


### PR DESCRIPTION
Closes https://github.com/tinacms/tinacms/issues/2037 (maybe)

I only fixed the ones for `next-tinacms-github`, but I suspect that this was missing and was causing the nested package `react-tinacms-github` to also appear to be missing