### PR TITLE
Alter empty sidebar message to be more specific to auto-generating logic

### DIFF
--- a/.changeset/eight-pets-eat.md
+++ b/.changeset/eight-pets-eat.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/toolkit": patch
+"tinacms": patch
+---
+
+Alter empty sidebar message to be more specific to auto-generating logic

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/NoFormsPlaceHolder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/NoFormsPlaceHolder.tsx
@@ -21,18 +21,15 @@ import * as React from 'react'
 
 export const NoFormsPlaceholder = () => (
   <EmptyState>
-    <Emoji>👋</Emoji>
-    <h3>
-      Welcome to <b>Tina</b>!
-    </h3>
+    <Emoji>🔎</Emoji>
     <p>
-      Let's get a form set up
-      <br />
-      so you can start editing.
+      Tina didn't find <br />
+      any queries to <br />
+      generate forms for.
     </p>
     <p>
-      <LinkButton href="https://tina.io/docs/schema/" target="_blank">
-        <Emoji>📖</Emoji> Content Modeling
+      <LinkButton href="https://tina.io/docs/tinacms-context/" target="_blank">
+        <Emoji>📖</Emoji> Contextual Editing
       </LinkButton>
     </p>
   </EmptyState>

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -31,7 +31,18 @@ export const TinaEditProvider = ({
 
 const ToggleButton = () => {
   const { edit } = useEditState()
-  return edit ? null : (
+
+  const [isOnAdmin, setIsOnAdmin] = React.useState(false)
+
+  React.useEffect(() => {
+    if (window) {
+      if (window.location?.pathname.startsWith('/admin')) {
+        setIsOnAdmin(true)
+      }
+    }
+  }, [setIsOnAdmin])
+
+  return edit || isOnAdmin ? null : (
     <div
       style={{ position: 'fixed', bottom: '56px', left: '0px', zIndex: 200 }}
     >


### PR DESCRIPTION
Could use some copywriting improvements but in general an empty form isn't really an indication of any sort of error, just that there's no formifiable query on the page. Also added docs PR https://github.com/tinacms/tinacms.org/pull/1089


<img width="304" alt="Screen Shot 2021-11-17 at 3 23 49 PM" src="https://user-images.githubusercontent.com/5414297/142298847-051e39f5-ef08-4fb4-989a-81b43dabed5c.png">


