### PR TITLE
update danger file to reject any file with example in the path

### DIFF
--- a/dangerfile.ts
+++ b/dangerfile.ts
@@ -201,7 +201,7 @@ function fileNeedsLicense(filepath: string) {
   if (filepath === '.pnp.js') return false
   if (filepath.startsWith('.yarn')) return false
   return new RegExp(
-    /^(?!(examples|experimental-examples)\/).+\.(jsx?|tsx?)$/
+    /(?!(examples|experimental-examples)\/).+\.(jsx?|tsx?)$/y
   ).test(filepath)
 }
 


### PR DESCRIPTION
This updates `dangerfile.ts` so that it does not check the examples sub folder added in [this PR](https://github.com/tinacms/tinacms/pull/2251).

Can test it out here: https://regex101.com/r/c3gS2L/1/