### PR TITLE
Ensure "src" is used instead of "previewSrc" for images in MDX

### DIFF
--- a/.changeset/thick-jobs-call.md
+++ b/.changeset/thick-jobs-call.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Ensure "src" is used instead of "previewSrc" for images in MDX

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/image/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/image/index.tsx
@@ -70,7 +70,10 @@ export const Img = (props) => {
           // the base64 data url stored in markdown, which would be bad because it's
           // potentially very large. We should probably freeze form submission until
           // this is updated to mitigate that.
-          setLocalState({ ...localState, url: allMedia[0].previewSrc })
+          setLocalState({
+            ...localState,
+            url: allMedia[0].src || allMedia[0].previewSrc,
+          })
         }
       }
       Transforms.setNodes(editor, localState, {

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/toolbar/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/toolbar/index.tsx
@@ -136,7 +136,7 @@ export const ToolbarButtons = ({ name, templates }) => {
         [
           {
             type: 'img',
-            url: selectedMedia.previewSrc,
+            url: selectedMedia.src || selectedMedia.previewSrc,
             alt: '',
             caption: '',
             children: [


### PR DESCRIPTION
We recently optimized the image src for preview thumbnails in Cloudinary. This value was also being used effectively as the src, also for MDX. This PR should update things so the correct (full) url is provided instead.

Thanks @jhuggett 