### PR TITLE
2235 - Modifies `tinacms init` to add the new `TinaAdmin` page

### DIFF
--- a/.changeset/wicked-eagles-turn.md
+++ b/.changeset/wicked-eagles-turn.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Modifies `tinacms init` for `TinaAdmin`-ready page

--- a/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
@@ -11,38 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const adminPage = `import { useEffect } from "react";
-import { useRouter } from "next/router";
-import { useEditState } from "tinacms/dist/edit-state";
-
-const GoToEditPage = () => {
-  const { setEdit } = useEditState();
-  const router = useRouter();
-  useEffect(() => {
-    setEdit(true);
-    router.back();
-  }, []);
-  return <div>Entering edit mode..</div>;
-};
-
-export default GoToEditPage;
-`
-
-export const exitAdminPage = `import { useEffect } from "react";
-import { useRouter } from "next/router";
-import { useEditState } from "tinacms/dist/edit-state";
-
-const GoToEditPage = () => {
-  const { setEdit } = useEditState();
-  const router = useRouter();
-  useEffect(() => {
-    setEdit(false);
-    router.back();
-  }, []);
-  return <div>Exiting edit mode..</div>;;
-};
-
-export default GoToEditPage;
+export const adminPage = `import { TinaAdmin } from 'tinacms';
+export default TinaAdmin;
 `
 
 export const blogPost = `---


### PR DESCRIPTION
Replaces `/admin` and `/exit-admin` with the `TinaAdmin` pattern of `/pages/admin/[[..tina]].js`.

Closes #2235 

There will be a sister PR to change the documentation for `/admin` here:
https://tina.io/docs/tinacms-context/#manually-toggling-edit-mode

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
