### PR TITLE
fix: remove organization from cli init codegen

### DIFF
--- a/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
@@ -323,7 +323,6 @@ const App = ({ Component, pageProps }) => {
           <TinaCMS
             clientId={process.env.NEXT_PUBLIC_TINA_CLIENT_ID}
             branch={process.env.NEXT_PUBLIC_EDIT_BRANCH}
-            organization={process.env.NEXT_PUBLIC_ORGANIZATION_NAME}
             isLocalClient={Boolean(
               Number(process.env.NEXT_PUBLIC_USE_LOCAL_CLIENT ?? true)
             )}


### PR DESCRIPTION
Remove old organization param from cli codegen