### PR TITLE
Dont memoize schema configs

### DIFF
--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -261,20 +261,12 @@ export class Database {
   }
   public getGraphQLSchemaFromBridge = async (): Promise<DocumentNode> => {
     const graphqlPath = path.join(GENERATED_FOLDER, `_graphql.json`)
-    if (!this._graphql) {
-      const _graphql = await this.bridge.get(graphqlPath)
-      this._graphql = JSON.parse(_graphql)
-    }
-    return this._graphql
+    const _graphql = await this.bridge.get(graphqlPath)
+    return JSON.parse(_graphql)
   }
   public getTinaSchema = async (): Promise<TinaCloudSchemaBase> => {
     const schemaPath = path.join(GENERATED_FOLDER, `_schema.json`)
-    if (!this._tinaSchema) {
-      const _tinaSchema = await this.store.get(schemaPath)
-      // @ts-ignore
-      this._tinaSchema = _tinaSchema
-    }
-    return this._tinaSchema
+    return this.store.get(schemaPath)
   }
 
   public getSchema = async () => {


### PR DESCRIPTION
@logan-anderson pointed out that schema updates weren't triggering from the CLI when a schema changed. This is due to the memoization of these into class properties and they weren't getting reinitialized. I think this should do for now, but I want to revisit this as part of a cleanup when the data store stuff settles.