### PR TITLE
Pin version number and meta data during schema compilation

### DIFF
--- a/.changeset/sixty-kiwis-listen.md
+++ b/.changeset/sixty-kiwis-listen.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Pin version number from @tinacms/graphql during schema compilation. This can be used to ensure the proper version is provided when working with Tina Cloud

--- a/examples/basic/.tina/__generated__/_schema.json
+++ b/examples/basic/.tina/__generated__/_schema.json
@@ -5,6 +5,7 @@
     "minor": "57",
     "patch": "2"
   },
+  "meta": {},
   "collections": [
     {
       "label": "Page Content",

--- a/examples/basic/.tina/__generated__/_schema.json
+++ b/examples/basic/.tina/__generated__/_schema.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "fullVersion": "0.57.2",
+    "major": "0",
+    "minor": "57",
+    "patch": "2"
+  },
   "collections": [
     {
       "label": "Page Content",

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "fullVersion": "0.57.2",
+    "major": "0",
+    "minor": "57",
+    "patch": "2"
+  },
   "collections": [
     {
       "label": "Blog Posts",

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -5,6 +5,7 @@
     "minor": "57",
     "patch": "2"
   },
+  "meta": {},
   "collections": [
     {
       "label": "Blog Posts",

--- a/packages/@tinacms/graphql/package.json
+++ b/packages/@tinacms/graphql/package.json
@@ -4,6 +4,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "files": [
+    "package.json",
     "dist"
   ],
   "license": "Apache-2.0",

--- a/packages/@tinacms/graphql/src/build.ts
+++ b/packages/@tinacms/graphql/src/build.ts
@@ -35,7 +35,11 @@ export const indexDB = async ({
   database: Database
   config: TinaSchema['config']
 }) => {
-  const tinaSchema = await createSchema({ schema: config })
+  const flags = []
+  if (database.store.supportsIndexing()) {
+    flags.push('experimentalData')
+  }
+  const tinaSchema = await createSchema({ schema: config, flags })
   const builder = await createBuilder({
     database,
     tinaSchema,

--- a/packages/@tinacms/graphql/src/schema/index.ts
+++ b/packages/@tinacms/graphql/src/schema/index.ts
@@ -29,11 +29,17 @@ import { TinaError } from '../resolver/error'
 
 export const createSchema = async ({
   schema,
+  flags = [],
 }: {
   schema: TinaCloudSchemaBase
+  flags: string[]
 }) => {
   const validSchema = await validateSchema(schema)
   const [major, minor, patch] = packageJSON.version.split('.')
+  const meta = {}
+  if (flags.length > 0) {
+    meta['flags'] = flags
+  }
   return new TinaSchema({
     version: {
       fullVersion: packageJSON.version,
@@ -41,6 +47,7 @@ export const createSchema = async ({
       minor,
       patch,
     },
+    meta,
     ...validSchema,
   })
 }
@@ -53,12 +60,21 @@ type Version = {
 }
 
 /**
+ * Metadata about how the schema was built
+ */
+type Meta = {
+  flags?: string[]
+}
+
+/**
  * TinaSchema is responsible for allowing you to look up certain
  * properties of the user-provided schema with ease.
  */
 export class TinaSchema {
   public schema: TinaCloudSchemaEnriched
-  constructor(public config: { version: Version } & TinaCloudSchemaBase) {
+  constructor(
+    public config: { version: Version; meta: Meta } & TinaCloudSchemaBase
+  ) {
     // @ts-ignore
     this.schema = config
   }

--- a/packages/@tinacms/graphql/src/schema/index.ts
+++ b/packages/@tinacms/graphql/src/schema/index.ts
@@ -13,6 +13,8 @@ limitations under the License.
 
 import { lastItem, assertShape } from '../util'
 import { validateSchema } from './validate'
+// @ts-ignore File '...' is not under 'rootDir'
+import packageJSON from '../../package.json'
 
 import type {
   CollectionTemplateable,
@@ -31,7 +33,23 @@ export const createSchema = async ({
   schema: TinaCloudSchemaBase
 }) => {
   const validSchema = await validateSchema(schema)
-  return new TinaSchema(validSchema)
+  const [major, minor, patch] = packageJSON.version.split('.')
+  return new TinaSchema({
+    version: {
+      fullVersion: packageJSON.version,
+      major,
+      minor,
+      patch,
+    },
+    ...validSchema,
+  })
+}
+
+type Version = {
+  fullVersion: string
+  major: string
+  minor: string
+  patch: string
 }
 
 /**
@@ -40,7 +58,7 @@ export const createSchema = async ({
  */
 export class TinaSchema {
   public schema: TinaCloudSchemaEnriched
-  constructor(public config: TinaCloudSchemaBase) {
+  constructor(public config: { version: Version } & TinaCloudSchemaBase) {
     // @ts-ignore
     this.schema = config
   }

--- a/packages/@tinacms/graphql/src/spec/forestry-sample/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/forestry-sample/.tina/__generated__/_schema.json
@@ -5,6 +5,7 @@
     "minor": "57",
     "patch": "2"
   },
+  "meta": {},
   "collections": [
     {
       "label": "Author",

--- a/packages/@tinacms/graphql/src/spec/forestry-sample/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/forestry-sample/.tina/__generated__/_schema.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "fullVersion": "0.57.2",
+    "major": "0",
+    "minor": "57",
+    "patch": "2"
+  },
   "collections": [
     {
       "label": "Author",

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "fullVersion": "0.57.2",
+    "major": "0",
+    "minor": "57",
+    "patch": "2"
+  },
   "collections": [
     {
       "label": "Movie",

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
@@ -5,6 +5,11 @@
     "minor": "57",
     "patch": "2"
   },
+  "meta": {
+    "flags": [
+      "experimentalData"
+    ]
+  },
   "collections": [
     {
       "label": "Movie",

--- a/packages/@tinacms/graphql/src/spec/movies/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies/.tina/__generated__/_schema.json
@@ -1,4 +1,10 @@
 {
+  "version": {
+    "fullVersion": "0.57.2",
+    "major": "0",
+    "minor": "57",
+    "patch": "2"
+  },
   "collections": [
     {
       "label": "Movie",

--- a/packages/@tinacms/graphql/src/spec/movies/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies/.tina/__generated__/_schema.json
@@ -5,6 +5,7 @@
     "minor": "57",
     "patch": "2"
   },
+  "meta": {},
   "collections": [
     {
       "label": "Movie",


### PR DESCRIPTION
Pin version number and metadata from @tinacms/graphql during schema compilation. This can be used to ensure the proper version is provided when working with Tina Cloud and appropriate features (like data are switched on)

Updated schemas will now look like this:
```json
  "version": {
    "fullVersion": "0.57.2",
    "major": "0",
    "minor": "57",
    "patch": "2"
  },
  "meta": {
    "flags": [
      "experimentalData"
    ]
  },
```

@kldavis4 and I discussed this and while including the API version in the URL is great, the data layer work will mean that webhooks coming from Github also need to know which version to build the index with. The upshot from this is that it's a more fullproof way of know that if the CLI compiled with a given schema, they're guaranteed to get that same version on Tina Cloud without needing to do anything.

One thing I'm not sure about, how do we handle npm tags like `beta`, etc.? Their version numbers are like this: `0.0.0-202111212155`, and in an ideal world we at least have a "beta" tag supported on Tina Cloud 🤔 