### PR TITLE
Allow indexDB to skip building the query and fragment generation files

### DIFF
--- a/.changeset/eleven-wombats-press.md
+++ b/.changeset/eleven-wombats-press.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+Allow indexDB to skip building the query and fragment generation files

--- a/packages/@tinacms/graphql/src/build.ts
+++ b/packages/@tinacms/graphql/src/build.ts
@@ -31,9 +31,11 @@ import { Database } from './database'
 export const indexDB = async ({
   database,
   config,
+  buildSDK = true,
 }: {
   database: Database
   config: TinaSchema['config']
+  buildSDK?: boolean
 }) => {
   const flags = []
   if (database.store.supportsIndexing()) {
@@ -47,8 +49,10 @@ export const indexDB = async ({
   const graphQLSchema = await _buildSchema(builder, tinaSchema)
   // @ts-ignore
   await database.indexData({ graphQLSchema, tinaSchema })
-  await _buildFragments(builder, tinaSchema, database.bridge.rootPath)
-  await _buildQueries(builder, tinaSchema, database.bridge.rootPath)
+  if (buildSDK) {
+    await _buildFragments(builder, tinaSchema, database.bridge.rootPath)
+    await _buildQueries(builder, tinaSchema, database.bridge.rootPath)
+  }
 }
 
 const _buildFragments = async (


### PR DESCRIPTION
I'd updated the graphql version on tinacms.org for the GraphQL playground, which worked locally but I guess I never tested it on Vercel 😬 . The error came from trying to write the GraphQL query and fragments into the filesystem during index, which Vercel doesn't like obviously.

So the fix will be to skip that on the /api/graphiql API https://github.com/tinacms/tinacms.org/blob/8791c2264a95a2f7de2f30d9d9ea0bec5b43a1ed/pages/api/graphiql.ts#L20

```ts
  await indexDB({ database, config, buildSDK: false })
```
Closes https://github.com/tinacms/tinacms.org/issues/1141