### PR TITLE
2342 - [TinaAdmin] Truncates the `filename` column for the Document List View

### DIFF
--- a/.changeset/eight-kangaroos-grow.md
+++ b/.changeset/eight-kangaroos-grow.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+2342 - [TinaAdmin] Truncates the `filename` column for the Document List View

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -1,9 +1,9 @@
 {
   "version": {
-    "fullVersion": "0.57.2",
+    "fullVersion": "0.59.1",
     "major": "0",
-    "minor": "57",
-    "patch": "2"
+    "minor": "59",
+    "patch": "1"
   },
   "meta": {},
   "collections": [

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -1,4 +1,11 @@
 {
+  "version": {
+    "fullVersion": "0.57.2",
+    "major": "0",
+    "minor": "57",
+    "patch": "2"
+  },
+  "meta": {},
   "collections": [
     {
       "label": "Blog Posts",
@@ -1346,6 +1353,5 @@
         "pages"
       ]
     }
-  ],
-  "namespace": []
+  ]
 }

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -1,11 +1,4 @@
 {
-  "version": {
-    "fullVersion": "0.59.1",
-    "major": "0",
-    "minor": "59",
-    "patch": "1"
-  },
-  "meta": {},
   "collections": [
     {
       "label": "Blog Posts",
@@ -1353,5 +1346,6 @@
         "pages"
       ]
     }
-  ]
+  ],
+  "namespace": []
 }

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -151,12 +151,12 @@ const CollectionListPage = () => {
                                     </span>
                                     <Link
                                       to={`${location.pathname}/${document.node.sys.filename}`}
-                                      className="h-5 leading-5 block"
+                                      className="h-5 leading-5 flex max-w-xs"
                                     >
-                                      <span className="leading-5 font-medium text-base overflow-ellipsis overflow-hidden whitespace-nowrap text-gray-700">
+                                      <span className="flex-shrink-1 leading-5 font-medium text-base overflow-ellipsis overflow-hidden whitespace-nowrap text-gray-700">
                                         {document.node.sys.filename}
                                       </span>
-                                      <span className="leading-5 text-base font-medium text-gray-300">
+                                      <span className="flex-shrink-0 leading-5 text-base font-medium text-gray-300">
                                         {document.node.sys.extension}
                                       </span>
                                     </Link>


### PR DESCRIPTION
I converted the `filename` column to use `flex` with `flex-shrink-1` on the `filename` portion to force longer filenames to truncate in the event they are too long.

Closes #2342 

<img width="1281" alt="Screen Shot 2021-12-14 at 5 29 39 PM" src="https://user-images.githubusercontent.com/1699544/146096350-cdefc3ba-7bfd-4122-abd8-da6b7f49cdb0.png">

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
