### PR TITLE
constrain width of simple branch selector dropdown

### DIFF
--- a/.changeset/cuddly-cows-repeat.md
+++ b/.changeset/cuddly-cows-repeat.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/toolkit": patch
+---
+
+constrain width of simple branch selector dropdown

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -106,6 +106,7 @@ const SimpleBranchSelector = ({ branchList, currentBranch, onChange }) => {
           margin: '2rem',
           fontSize: '1.2rem',
           minWidth: '10em',
+          maxWidth: 'calc(100% - 4rem)',
           padding: '0.5rem',
         }}
       >


### PR DESCRIPTION
this will ensure the dropdown doesn't break the boundaries of the modal
when displaying long branch names