### PR TITLE
2335 - Prevents navigation into objects when parent form is invalid 

### DIFF
--- a/.changeset/fifty-boxes-sparkle.md
+++ b/.changeset/fifty-boxes-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Prevents navigation into objects when parent form is invalid

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin.tsx
@@ -211,6 +211,7 @@ const BlockListItem = ({
   template,
   block,
 }: BlockListItemProps) => {
+  const cms = useCMS()
   const FormPortal = useFormPortal()
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
 
@@ -239,6 +240,13 @@ const BlockListItem = ({
             <DragHandle />
             <ItemClickTarget
               onClick={() => {
+                const state = tinaForm.finalForm.getState()
+                if (state.invalid === true) {
+                  // @ts-ignore
+                  cms.alerts.error('Cannot navigate away from an invalid form.')
+                  return
+                }
+
                 setExpanded(true)
                 setFocusedField({ fieldName: `${field.name}.${index}` })
               }}
@@ -567,9 +575,10 @@ const Panel = function Panel({
           if (state.invalid === true) {
             // @ts-ignore
             cms.alerts.error('Cannot navigate away from an invalid form.')
-          } else {
-            setExpanded(false)
+            return
           }
+
+          setExpanded(false)
         }}
       >
         <LeftArrowIcon />

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
@@ -37,10 +37,22 @@ export interface GroupProps {
 }
 
 export const Group = ({ tinaForm, field }: GroupProps) => {
+  const cms = useCMS()
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
   return (
     <>
-      <Header onClick={() => setExpanded((p) => !p)}>
+      <Header
+        onClick={() => {
+          const state = tinaForm.finalForm.getState()
+          if (state.invalid === true) {
+            // @ts-ignore
+            cms.alerts.error('Cannot navigate away from an invalid form.')
+            return
+          }
+
+          setExpanded((p) => !p)
+        }}
+      >
         {field.label || field.name}
         <RightArrowIcon />
       </Header>
@@ -89,9 +101,10 @@ const Panel = function Panel({
               if (state.invalid === true) {
                 // @ts-ignore
                 cms.alerts.error('Cannot navigate away from an invalid form.')
-              } else {
-                setExpanded(false)
+                return
               }
+
+              setExpanded(false)
             }}
           >
             <LeftArrowIcon /> <span>{field.label || field.name}</span>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
@@ -140,6 +140,7 @@ interface ItemProps {
 }
 
 const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
+  const cms = useCMS()
   const FormPortal = useFormPortal()
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
   const removeItem = React.useCallback(() => {
@@ -171,6 +172,13 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
               }
               onMouseOut={() => setHoveredField({ fieldName: null })}
               onClick={() => {
+                const state = tinaForm.finalForm.getState()
+                if (state.invalid === true) {
+                  // @ts-ignore
+                  cms.alerts.error('Cannot navigate away from an invalid form.')
+                  return
+                }
+
                 setExpanded(true)
                 setFocusedField({ fieldName: `${field.name}.${index}` })
               }}
@@ -436,9 +444,10 @@ const Panel = function Panel({
           if (state.invalid === true) {
             // @ts-ignore
             cms.alerts.error('Cannot navigate away from an invalid form.')
-          } else {
-            setExpanded(false)
+            return
           }
+
+          setExpanded(false)
         }}
       >
         <LeftArrowIcon />


### PR DESCRIPTION
Pointed out by Tina User, while we prevented navigation away from a form when the form was invalid, we did _not_ prevent navigation into objects (`block`, `group`, `group-list`).

This could result in a frustrating situation where the user could not navigate back to the invalid form to fix its invalid state after drilling down.

This is a more comprehensive fix than the adjustment I made in #2115.

Closes #2335

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
