### PR TITLE
fixed 2320

### DIFF
--- a/.changeset/green-lobsters-sneeze.md
+++ b/.changeset/green-lobsters-sneeze.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixed issue where content creator was invalid

--- a/packages/tinacms/src/hooks/use-content-creator.tsx
+++ b/packages/tinacms/src/hooks/use-content-creator.tsx
@@ -171,7 +171,7 @@ export const useDocumentCreatorPlugin = (args?: DocumentCreatorArgs) => {
     }
 
     run()
-  }, [cms, values?.collection])
+  }, [cms])
 
   React.useEffect(() => {
     if (plugin) {


### PR DESCRIPTION
Fixes https://github.com/tinacms/tinacms/issues/2320

@Enigmatical The issue was is that the from was being  re-created when the user selected a new "collection". This caused `initialValues`===`currentValues` this making the form ["pristine"](https://final-form.org/docs/react-final-form/types/FieldRenderProps#metapristine). When a form is pristine it can not be submitted or reset.