### PR TITLE
2374 - Incorrect messaging on admin when in local-mode

### DIFF
--- a/.changeset/shiny-hornets-grow.md
+++ b/.changeset/shiny-hornets-grow.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Changes messaging on login page for TinaAdmin when in local-mode

--- a/packages/tinacms/src/admin/components/AuthTemplate.tsx
+++ b/packages/tinacms/src/admin/components/AuthTemplate.tsx
@@ -22,7 +22,7 @@ const AuthTemplate = ({
 }) => {
   return (
     <div className="h-screen w-full bg-gradient-to-b from-blue-900 to-gray-900 flex items-center justify-center px-4 py-6">
-      <div className="bg-white rounded-lg overflow-hidden shadow-lg w-full max-w-md">
+      <div className="bg-white rounded-lg overflow-hidden shadow-lg w-full max-w-lg">
         <div className="px-5 py-4 border-b border-gray-150">
           <h2 className="text-2xl tracking-wide text-gray-700 flex items-center gap-0.5">
             <svg

--- a/packages/tinacms/src/admin/pages/LoginPage.tsx
+++ b/packages/tinacms/src/admin/pages/LoginPage.tsx
@@ -21,7 +21,7 @@ const LoginPage = () => {
   const { setEdit } = useEditState()
   const login = () => setEdit(true)
   return (
-    <AuthTemplate message="Please log in to Tina Cloud to access your content.">
+    <AuthTemplate>
       <a
         href="/"
         className="flex-1 text-center inline-flex justify-center items-center px-8 py-3 shadow-sm text-sm leading-4 font-medium rounded-full text-gray-600 border border-gray-150 hover:opacity-80 hover:bg-gray-50 focus:outline-none focus:shadow-outline-blue  transition duration-150 ease-out"
@@ -35,7 +35,7 @@ const LoginPage = () => {
         className="flex-1 justify-center text-center inline-flex items-center px-8 py-3 shadow-sm border border-transparent text-sm leading-4 font-medium rounded-full text-white hover:opacity-80 focus:outline-none focus:shadow-outline-blue  transition duration-150 ease-out"
         style={{ background: '#0084FF' }}
       >
-        <BiLogIn className="w-6 h-auto mr-1.5 opacity-80" /> Log in
+        <BiLogIn className="w-6 h-auto mr-1.5 opacity-80" /> Enter edit-mode
       </button>
     </AuthTemplate>
   )


### PR DESCRIPTION
When in `local-mode`, `TinaAdmin` was using old messaging about logging into "Tina Cloud".

Ideally, we'd have a way to know if we're in `localMode` or not and alter the messaging on the Login page, but unfortunately, our indicator of `localMode` is attached to a `cms` instance that doesn't exist before you've logged in.

As a quick fix, I removed the message entirely and altered the `Log In` button's label to speak more about `edit-mode` - which exists in either scenario.

Closes #2374 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
