### PR TITLE
update changeset tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,7 +55,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
       - name: Create release pull request
-        uses: changesets/action@master
+        uses: changesets/action@v1
         if: matrix.channel == 'latest'
         with:
           version: yarn version


### PR DESCRIPTION
I noticed a warning in some old publish logs that state we need to use `v1` instead of `master`. [See here for more details](https://github.com/changesets/action#without-publishing). I don't think this will fix the publishing issues but it should be what we use.