### PR TITLE
style: set font in tina reset wrapper

### DIFF
--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -368,7 +368,7 @@ const config = (cwd = '') => {
           },
         },
         fontFamily: {
-          sans: ['Inter var', ...defaultTheme.fontFamily.sans],
+          sans: ['Inter', ...defaultTheme.fontFamily.sans],
         },
         lineHeight: {
           3: '12px',

--- a/packages/@tinacms/toolkit/src/styles.css
+++ b/packages/@tinacms/toolkit/src/styles.css
@@ -6,6 +6,8 @@
   /* gray-600 from tailwind config */
   color: #565165;
 
+  @apply font-sans;
+
   @layer utilities {
     .icon-parent {
       svg {

--- a/packages/@tinacms/toolkit/src/styles.css
+++ b/packages/@tinacms/toolkit/src/styles.css
@@ -3,10 +3,7 @@
   @tailwind components;
   @tailwind utilities;
 
-  /* gray-600 from tailwind config */
-  color: #565165;
-
-  @apply font-sans;
+  @apply font-sans text-gray-600;
 
   @layer utilities {
     .icon-parent {

--- a/packages/tinacms/src/styles.css
+++ b/packages/tinacms/src/styles.css
@@ -6,6 +6,8 @@
   /* gray-600 from tailwind config */
   color: #565165;
 
+  @apply font-sans;
+
   @layer utilities {
     .icon-parent {
       svg {

--- a/packages/tinacms/src/styles.css
+++ b/packages/tinacms/src/styles.css
@@ -3,10 +3,7 @@
   @tailwind components;
   @tailwind utilities;
 
-  /* gray-600 from tailwind config */
-  color: #565165;
-
-  @apply font-sans;
+  @apply font-sans text-gray-600;
 
   @layer utilities {
     .icon-parent {


### PR DESCRIPTION
This sets a font on the `tina-tailwind` wrapper so any chrome components will use the custom font stack as defined in the tailwind config instead of defaulting to whatever font stack is set on the HTML or Body element. Thanks @jamespohalloran for bringing this issue to my attention. 