### PR TITLE
chore: Adding defence against crash when localStorage access is denied

### DIFF
--- a/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
+++ b/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
@@ -20,7 +20,9 @@ const isSSR = typeof window === 'undefined'
 
 export const isEditing = (): boolean => {
   if (!isSSR) {
-    const isEdit = window.localStorage.getItem(LOCALSTORAGEKEY)
+    // localStorage may be intentionally disabled for site visitors, 
+    // in that case Tina can't be used so just return false
+    const isEdit = window.localStorage && window.localStorage.getItem(LOCALSTORAGEKEY)
     return isEdit && isEdit === 'true'
   }
   // assume not editing if SSR

--- a/packages/@tinacms/toolkit/src/hooks/use-local-storage.ts
+++ b/packages/@tinacms/toolkit/src/hooks/use-local-storage.ts
@@ -16,8 +16,10 @@ import * as React from 'react'
 export function useLocalStorage(key, initialValue) {
   const [storedValue, setStoredValue] = React.useState(initialValue)
   React.useEffect(() => {
-    const valueFromStorage = window.localStorage.getItem(key)
-    if (valueFromStorage != null) {
+    // localStorage may be intentionally disabled for site visitors, 
+    // in that case Tina can't be used so just bail out of value storing
+    const valueFromStorage = window.localStorage && window.localStorage.getItem(key)
+    if (valueFromStorage != null && valueFromStorage != undefined) {
       setStoredValue(JSON.parse(valueFromStorage))
     }
   }, [key])

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -63,7 +63,7 @@ class ErrorBoundary extends React.Component {
    * again in the new, hopefully valid, state.
    */
   render() {
-    const branchData = window.localStorage.getItem('tinacms-current-branch')
+    const branchData = window.localStorage && window.localStorage.getItem('tinacms-current-branch')
     const hasBranchData = branchData && branchData.length > 0
     // @ts-ignore
     if (this.state.hasError && !this.state.pageRefresh) {


### PR DESCRIPTION
This PR looks to address issue #2481 leading to crash when `window.localStorage` access is denied.