### PR TITLE
fix: use user-specific document creator callback

### DIFF
--- a/packages/@tinacms/graphql/src/spec/forestry-sample/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/forestry-sample/.tina/__generated__/_schema.json
@@ -1,9 +1,9 @@
 {
   "version": {
-    "fullVersion": "0.59.4",
+    "fullVersion": "0.59.5",
     "major": "0",
     "minor": "59",
-    "patch": "4"
+    "patch": "5"
   },
   "meta": {},
   "collections": [

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
@@ -1,9 +1,9 @@
 {
   "version": {
-    "fullVersion": "0.59.4",
+    "fullVersion": "0.59.5",
     "major": "0",
     "minor": "59",
-    "patch": "4"
+    "patch": "5"
   },
   "meta": {
     "flags": [

--- a/packages/@tinacms/graphql/src/spec/movies/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies/.tina/__generated__/_schema.json
@@ -1,9 +1,9 @@
 {
   "version": {
-    "fullVersion": "0.59.4",
+    "fullVersion": "0.59.5",
     "major": "0",
     "minor": "59",
-    "patch": "4"
+    "patch": "5"
   },
   "meta": {},
   "collections": [

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "types": "yarn tsc",
     "build": "echo \"Run `yarn build` from the root of the repository instead\"",
-    "test": "jest --env=jsdom --passWithNoTests"
+    "test": "jest --env=jsdom --passWithNoTests",
+    "test-watch": "jest --env=jsdom --passWithNoTests --watch"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.1",

--- a/packages/tinacms/src/tina-cms.test.tsx
+++ b/packages/tinacms/src/tina-cms.test.tsx
@@ -16,13 +16,14 @@ limitations under the License.
 
 */
 
-import { render, waitFor } from '@testing-library/react'
+import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 
 import React, { ReactNode } from 'react'
 import { TinaCMSProvider2 } from './tina-cms'
 
 import { useTina } from './edit-state'
+import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
 
 jest.mock('./auth', () => {
   return {
@@ -30,7 +31,7 @@ jest.mock('./auth', () => {
   }
 })
 jest.mock('./hooks/use-content-creator', () => {
-  return { useDocumentCreatorPlugin: () => {} }
+  return { useDocumentCreatorPlugin: jest.fn(() => {}) }
 })
 jest.mock('@tinacms/toolkit', () => {
   return { useCMS: () => {} }
@@ -107,6 +108,26 @@ describe('TinaCMSProvider', () => {
       const text = queryByText(/liveDataProp/)
 
       expect(text).toBeInTheDocument()
+    })
+
+    it('registers document creator callback', () => {
+      let mockDocumentCreatorCallback = jest.fn()
+      const request = {
+        query: 'my-query',
+        variables: { foo: 'my-variable-val' },
+        data: { foo: 'my-data' },
+        documentCreatorCallback: mockDocumentCreatorCallback,
+      }
+      render(
+        <TinaCMSProvider2 {...request}>
+          {(liveProps) => <DummyChild {...liveProps} />}
+        </TinaCMSProvider2>
+      )
+
+      expect(useDocumentCreatorPlugin).toHaveBeenCalledTimes(1)
+      expect(useDocumentCreatorPlugin).toHaveBeenCalledWith(
+        mockDocumentCreatorCallback
+      )
     })
   })
 

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -305,7 +305,7 @@ export const TinaCMSProvider2 = ({
       >
         <style>{styles}</style>
         <ErrorBoundary>
-          <DocumentCreator />
+          <DocumentCreator documentCreatorCallback={documentCreatorCallback} />
           <TinaDataProvider formifyCallback={formifyCallback}>
             {typeof props.children == 'function' ? (
               <TinaQuery


### PR DESCRIPTION
Fix an issue introduced in https://github.com/tinacms/tinacms/pull/2426, where we stopped passing the documentCreatorCallback into useDocumentCreatorPlugin