### PR TITLE
chore: Export data provider

### DIFF
--- a/.changeset/popular-crabs-marry.md
+++ b/.changeset/popular-crabs-marry.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+chore: Export low-level data provider from "tinacms", for the playground and other sandboz environments

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -367,7 +367,7 @@ const TinaQueryInner = ({ children, ...props }: TinaQueryProps) => {
 }
 
 // TinaDataProvider can only manage one "request" object at a timee
-const TinaDataProvider = ({
+export const TinaDataProvider = ({
   children,
   formifyCallback,
 }: {


### PR DESCRIPTION
Our playground does some mocking & manually uses the inner pieces of the TinaCMSProvider. We need to export this new component, so that our playground can use useTina
