### PR TITLE
Gracefully handle useTina without a context

### DIFF
--- a/.changeset/polite-crews-confess.md
+++ b/.changeset/polite-crews-confess.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/sharedctx": patch
+"tinacms": patch
+---
+
+fix: Gracefully handle useTina without a context

--- a/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
+++ b/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
@@ -38,14 +38,16 @@ export const EditContext = React.createContext({
   setEdit: undefined as (edit: boolean) => void,
 })
 
-export const TinaDataContext = React.createContext<{
+export type TinaDataContextType = {
   state: {
     payload: object
   }
   setRequest: (props: { query: string; variables: object }) => void
   isLoading: boolean
   isDummyContainer?: boolean
-}>({
+}
+
+export const TinaDataContext = React.createContext<TinaDataContextType>({
   state: {
     payload: {},
   },

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -14,6 +14,7 @@ limitations under the License.
 import {
   EditProvider,
   TinaDataContext,
+  TinaDataContextType,
   isEditing,
   setEditing,
   useEditState,
@@ -48,21 +49,22 @@ export function useTina<T extends object>({
   variables: object
   data: T
 }): { data: T; isLoading: boolean } {
-  const {
-    setRequest,
-    state,
-    isDummyContainer,
-    isLoading: contextLoading,
-  } = React.useContext(TinaDataContext)
-
-  const tinaDataContext = React.useContext(TinaDataContext)
+  const tinaDataContext = React.useContext<TinaDataContextType>(TinaDataContext)
 
   if (!tinaDataContext) {
     console.warn(
       'Warning! You are using useTina without a <TinaCMS> provider\n.' +
         'This will return the original data unchanged, and potentially cause issues on a rerender'
     )
+    return { data, isLoading: false }
   }
+
+  const {
+    setRequest,
+    state,
+    isDummyContainer,
+    isLoading: contextLoading,
+  } = tinaDataContext
 
   const [waitForContextRerender, setWaitForContextRerender] = useState<boolean>(
     !isDummyContainer
@@ -71,9 +73,6 @@ export function useTina<T extends object>({
   const isLoading = contextLoading || waitForContextRerender
 
   React.useEffect(() => {
-    if (!tinaDataContext) {
-      return
-    }
     setRequest({ query, variables })
   }, [JSON.stringify(variables), query])
 
@@ -82,9 +81,6 @@ export function useTina<T extends object>({
   // new query that we've just sent when this hook was initialized.
   // Otherwise, things get wonky when changing pages
   useEffect(() => {
-    if (!tinaDataContext) {
-      return
-    }
     if (!isDummyContainer) {
       setTimeout(() => setWaitForContextRerender(false), 0)
     }
@@ -93,10 +89,6 @@ export function useTina<T extends object>({
       setRequest(undefined) // unregister forms
     }
   }, [isDummyContainer])
-
-  if (!tinaDataContext) {
-    return { data, isLoading: false }
-  }
 
   return {
     data: isDummyContainer || isLoading ? data : (state.payload as T),

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -48,12 +48,23 @@ export function useTina<T extends object>({
   variables: object
   data: T
 }): { data: T; isLoading: boolean } {
+  const tinaDataContext = React.useContext(TinaDataContext)
+
+  if (!tinaDataContext) {
+    // Technically breaking the rules of hooks, but we'll otherwise have to handle a lot of manual error coniditionals.
+    console.warn(
+      'Warning! You are using useTina without a <TinaCMS> provider\n.' +
+        'This will return the original data unchanged, and potentially cause issues on a rerender'
+    )
+    return { data, isLoading: false }
+  }
+
   const {
     setRequest,
     state,
     isDummyContainer,
     isLoading: contextLoading,
-  } = React.useContext(TinaDataContext)
+  } = tinaDataContext
 
   const [waitForContextRerender, setWaitForContextRerender] = useState<boolean>(
     !isDummyContainer

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -48,14 +48,14 @@ export function useTina<T extends object>({
   variables: object
   data: T
 }): { data: T; isLoading: boolean } {
-  const tinaDataContext = React.useContext(TinaDataContext)
-
   const {
     setRequest,
     state,
     isDummyContainer,
     isLoading: contextLoading,
-  } = tinaDataContext
+  } = React.useContext(TinaDataContext)
+
+  const tinaDataContext = React.useContext(TinaDataContext)
 
   if (!tinaDataContext) {
     console.warn(

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -49,22 +49,16 @@ export function useTina<T extends object>({
   variables: object
   data: T
 }): { data: T; isLoading: boolean } {
-  const tinaDataContext = React.useContext<TinaDataContextType>(TinaDataContext)
-
-  if (!tinaDataContext) {
-    console.warn(
-      'Warning! You are using useTina without a <TinaCMS> provider\n.' +
-        'This will return the original data unchanged, and potentially cause issues on a rerender'
-    )
-    return { data, isLoading: false }
-  }
-
   const {
     setRequest,
     state,
     isDummyContainer,
     isLoading: contextLoading,
-  } = tinaDataContext
+  } = React.useContext<TinaDataContextType>(TinaDataContext)
+
+  if (isDummyContainer) {
+    return { data, isLoading: false }
+  }
 
   const [waitForContextRerender, setWaitForContextRerender] = useState<boolean>(
     !isDummyContainer

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -50,21 +50,19 @@ export function useTina<T extends object>({
 }): { data: T; isLoading: boolean } {
   const tinaDataContext = React.useContext(TinaDataContext)
 
-  if (!tinaDataContext) {
-    // Technically breaking the rules of hooks, but we'll otherwise have to handle a lot of manual error coniditionals.
-    console.warn(
-      'Warning! You are using useTina without a <TinaCMS> provider\n.' +
-        'This will return the original data unchanged, and potentially cause issues on a rerender'
-    )
-    return { data, isLoading: false }
-  }
-
   const {
     setRequest,
     state,
     isDummyContainer,
     isLoading: contextLoading,
   } = tinaDataContext
+
+  if (!tinaDataContext) {
+    console.warn(
+      'Warning! You are using useTina without a <TinaCMS> provider\n.' +
+        'This will return the original data unchanged, and potentially cause issues on a rerender'
+    )
+  }
 
   const [waitForContextRerender, setWaitForContextRerender] = useState<boolean>(
     !isDummyContainer
@@ -73,6 +71,9 @@ export function useTina<T extends object>({
   const isLoading = contextLoading || waitForContextRerender
 
   React.useEffect(() => {
+    if (!tinaDataContext) {
+      return
+    }
     setRequest({ query, variables })
   }, [JSON.stringify(variables), query])
 
@@ -81,6 +82,9 @@ export function useTina<T extends object>({
   // new query that we've just sent when this hook was initialized.
   // Otherwise, things get wonky when changing pages
   useEffect(() => {
+    if (!tinaDataContext) {
+      return
+    }
     if (!isDummyContainer) {
       setTimeout(() => setWaitForContextRerender(false), 0)
     }
@@ -89,6 +93,10 @@ export function useTina<T extends object>({
       setRequest(undefined) // unregister forms
     }
   }, [isDummyContainer])
+
+  if (!tinaDataContext) {
+    return { data, isLoading: false }
+  }
 
   return {
     data: isDummyContainer || isLoading ? data : (state.payload as T),


### PR DESCRIPTION
When useTina is called without a parent provider, return original data