### PR TITLE
Legacy-empty-query-fix

### DIFF
--- a/.changeset/five-carrots-jam.md
+++ b/.changeset/five-carrots-jam.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+fix: When passing in queries into the root TinaCMS container, don't overwrite the data prop on an empty query

--- a/packages/tinacms/src/tina-cms.test.tsx
+++ b/packages/tinacms/src/tina-cms.test.tsx
@@ -129,6 +129,28 @@ describe('TinaCMSProvider', () => {
         mockDocumentCreatorCallback
       )
     })
+
+    describe('with no query', () => {
+      it('doesnt overwrite data property', () => {
+        useTina.mockImplementationOnce(() => {
+          return { data: null, isLoading: false }
+        })
+        const request = {
+          query: undefined,
+          variables: undefined,
+          data: { foo: 'my-data' },
+        }
+        const { queryByText } = render(
+          <TinaCMSProvider2 {...request}>
+            {(liveProps) => <DummyChild {...liveProps} />}
+          </TinaCMSProvider2>
+        )
+
+        const text = queryByText(/my-data/)
+
+        expect(text).toBeInTheDocument()
+      })
+    })
   })
 
   describe('with ReactNode children', () => {

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -363,7 +363,13 @@ const TinaQueryInner = ({ children, ...props }: TinaQueryProps) => {
     data: props.data,
   })
 
-  return <>{children(isLoading ? props : { ...props, data: liveData })}</>
+  return (
+    <>
+      {children(
+        isLoading || !props.query ? props : { ...props, data: liveData }
+      )}
+    </>
+  )
 }
 
 // TinaDataProvider can only manage one "request" object at a timee


### PR DESCRIPTION
Fixed an issue where if you were using render props with TinaCMS container, your child "data" prop would be overrided with null if there were no queries passed into the root container