### PR TITLE
Reference Arrow + Select Field Text Truncation 

### DIFF
--- a/.changeset/tiny-cars-serve.md
+++ b/.changeset/tiny-cars-serve.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+adds missing arrow icon to reference field, truncates text in select dropdown

--- a/packages/@tinacms/toolkit/src/packages/fields/components/Reference.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/Reference.tsx
@@ -22,6 +22,7 @@ import { BiEdit } from 'react-icons/bi'
 import { useCMS } from '../../../react-tinacms/use-cms'
 import { TinaCMS } from '../../../tina-cms'
 import { selectFieldClasses } from './Select'
+import { MdKeyboardArrowDown } from 'react-icons/md'
 
 type Option = {
   value: string
@@ -96,19 +97,22 @@ export const Reference: React.FC<ReferenceProps> = ({
   const selectOptions = options || field.options
   return (
     <div>
-      <select
-        id={input.name}
-        value={input.value}
-        onChange={input.onChange}
-        className={selectFieldClasses}
-        {...input}
-      >
-        {selectOptions ? (
-          selectOptions.map(toProps).map(toComponent)
-        ) : (
-          <option>{input.value}</option>
-        )}
-      </select>
+      <div className="relative group">
+        <select
+          id={input.name}
+          value={input.value}
+          onChange={input.onChange}
+          className={selectFieldClasses}
+          {...input}
+        >
+          {selectOptions ? (
+            selectOptions.map(toProps).map(toComponent)
+          ) : (
+            <option>{input.value}</option>
+          )}
+        </select>
+        <MdKeyboardArrowDown className="absolute top-1/2 right-3 w-6 h-auto -translate-y-1/2 text-gray-300 group-hover:text-blue-500 transition duration-150 ease-out" />
+      </div>
       {hasTinaAdmin && (
         <GetReference cms={cms} id={input.value}>
           {(document) => (

--- a/packages/@tinacms/toolkit/src/packages/fields/components/Select.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/Select.tsx
@@ -41,7 +41,7 @@ export interface SelectProps {
 }
 
 export const selectFieldClasses =
-  'shadow appearance-none bg-white text-gray-600 block px-3 py-2  w-full text-base cursor-pointer border-gray-100 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md'
+  'shadow appearance-none bg-white text-gray-600 block pl-3 pr-7 py-2 truncate w-full text-base cursor-pointer border-gray-100 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md'
 
 export const Select: React.FC<SelectProps> = ({ input, field, options }) => {
   const selectOptions = options || field.options


### PR DESCRIPTION
This adds the missing arrow icon to the reference field and adds text truncation to the select and reference fields. 

<img width="512" alt="Screen Shot 2022-02-01 at 3 44 16 PM" src="https://user-images.githubusercontent.com/5075484/152039817-b0cddf6b-3591-4274-93cc-46ae18ae6121.png">

Just a minor issue I noticed while testing the new MDX editor.
