### PR TITLE
Ensure experimental data builds during CI

### DIFF
--- a/.changeset/chilly-cars-ring.md
+++ b/.changeset/chilly-cars-ring.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix an issue where builds weren't happening during CI, this is only an issue for the experimental data layer

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -112,6 +112,16 @@ stack: ${code.stack || 'No stack was provided'}`)
   }
   let ready = false
 
+  const build = async (noSDK?: boolean) => {
+    if (!process.env.CI && !noWatch) {
+      await resetGeneratedFolder()
+    }
+    const database = await createDatabase({ store, bridge })
+    await compile(null, null)
+    const schema = await buildSchema(rootPath, database)
+    await genTypes({ schema }, () => {}, { noSDK })
+  }
+
   if (!noWatch && !process.env.CI) {
     chokidar
       .watch([`${rootPath}/**/*.{ts,gql,graphql}`], {
@@ -154,16 +164,10 @@ stack: ${code.stack || 'No stack was provided'}`)
           }
         }
       })
-  }
-
-  const build = async (noSDK?: boolean) => {
-    if (!process.env.CI && !noWatch) {
-      await resetGeneratedFolder()
+  } else {
+    if (shouldBuild) {
+      await build(noSDK)
     }
-    const database = await createDatabase({ store, bridge })
-    await compile(null, null)
-    const schema = await buildSchema(rootPath, database)
-    await genTypes({ schema }, () => {}, { noSDK })
   }
 
   const state = {


### PR DESCRIPTION
cc @kldavis4 

Also - this only affected `experimentalData`