### PR TITLE
2535 - Updated relativePath field on Create Page

### DIFF
--- a/.changeset/twenty-llamas-hang.md
+++ b/.changeset/twenty-llamas-hang.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Updates the relativePath field for clarity

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -28,14 +28,16 @@ import { transformDocumentIntoMutationRequestPayload } from '../../hooks/use-gra
 
 const createDocument = async (
   cms: TinaCMS,
-  collection: { name: string },
+  collection: { name: string; format: string },
   template: { name: string },
   mutationInfo: { includeCollection: boolean; includeTemplate: boolean },
   values: any
 ) => {
   const api = new TinaAdminApi(cms)
-  const { relativePath, ...leftover } = values
+  const { filename, ...leftover } = values
   const { includeCollection, includeTemplate } = mutationInfo
+
+  const relativePath = `${filename}.${collection.format}`
   const params = transformDocumentIntoMutationRequestPayload(
     {
       _collection: collection.name,
@@ -87,11 +89,24 @@ const RenderForm = ({ cms, collection, template, fields, mutationInfo }) => {
       label: 'form',
       fields: [
         {
-          name: 'relativePath',
-          label: 'Relative Path',
+          name: 'filename',
+          label: 'Filename',
           component: 'text',
-          required: true,
-          defaultValue: `${collection.name}${Date.now()}.${collection.format}`,
+          description: `A unique filename for the content.  Example: My_Document`,
+          placeholder: `My_Document`,
+          validate: (value, allValues, meta) => {
+            if (!value) {
+              if (meta.dirty) {
+                return 'Required'
+              }
+              return true
+            }
+
+            const isValid = /^[_a-zA-Z][-,_a-zA-Z0-9]*$/.test(value)
+            if (value && !isValid) {
+              return 'Must begin with a-z, A-Z, or _ and contain only a-z, A-Z, 0-9, - or _'
+            }
+          },
         },
         ...fields,
       ],


### PR DESCRIPTION
For a non-developer, the "Relative Path" field can be confusing.  In reality, this is just the "Filename" where the Document will reside (against the collection's `path` and `format`).

I've taken the old "Name" field from the `ContentCreator` and ported it over to the Collection Create Page, removing the need to specify the file extension, and adding some simple validation around the field.

https://www.loom.com/share/26019016d2ca41e0b7d3e8a2e2d36812

Related to #2530 
Closes #2535
