### PR TITLE
Form Header Fixes

### DIFF
--- a/.changeset/witty-mails-fix.md
+++ b/.changeset/witty-mails-fix.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fixes form header bug when there's no label

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/FormList.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/FormList.tsx
@@ -19,31 +19,48 @@ limitations under the License.
 import * as React from 'react'
 import { Form } from '../../forms'
 import { BiPencil } from 'react-icons/bi'
+import { Transition } from '@headlessui/react'
 
 export interface FormsListProps {
   forms: Form[]
   setActiveFormId(id: string): void
   isEditing: Boolean
+  hidden?: boolean
 }
 
-export const FormList = ({ forms, setActiveFormId }: FormsListProps) => {
+export const FormList = ({
+  hidden = false,
+  forms,
+  setActiveFormId,
+}: FormsListProps) => {
   return (
-    <ul className="pt-16">
-      {forms.sort(byId).map((form, index) => (
-        <li key={form.id} className={`relative px-6 py-2`}>
-          <button
-            onClick={() => setActiveFormId(form.id)}
-            className="w-full h-full bg-transparent border-none text-lg text-gray-700 hover:text-blue-500 transition-all ease-out duration-150 flex items-center gap-2 p-1 m-0"
-          >
-            <BiPencil className="opacity-70 w-5 h-auto fill-current" />
-            {form.label}
-          </button>
-          {index !== forms.length - 1 && (
-            <hr className="absolute bottom-0 left-0 border-t border-gray-100 w-full" />
-          )}
-        </li>
-      ))}
-    </ul>
+    <Transition
+      appear={true}
+      show={!hidden}
+      enter="transition-all ease-out duration-150"
+      enterFrom="opacity-0 -translate-x-1/2"
+      enterTo="opacity-100"
+      leave="transition-all ease-out duration-150"
+      leaveFrom="opacity-100"
+      leaveTo="opacity-0 -translate-x-1/2"
+    >
+      <ul className="pt-16">
+        {forms.sort(byId).map((form, index) => (
+          <li key={form.id} className={`relative px-6 py-2`}>
+            <button
+              onClick={() => setActiveFormId(form.id)}
+              className="w-full h-full bg-transparent border-none text-lg text-gray-700 hover:text-blue-500 transition-all ease-out duration-150 flex items-center gap-2 p-1 m-0"
+            >
+              <BiPencil className="opacity-70 w-5 h-auto fill-current" />
+              {form.label}
+            </button>
+            {index !== forms.length - 1 && (
+              <hr className="absolute bottom-0 left-0 border-t border-gray-100 w-full" />
+            )}
+          </li>
+        ))}
+      </ul>
+    </Transition>
   )
 }
 

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -333,7 +333,7 @@ const SidebarHeader = ({ isLocalMode }) => {
   return (
     <div className="flex-grow-0 w-full overflow-visible z-20">
       {isLocalMode && <LocalWarning />}
-      <div className="mt-4 -mb-14 w-full flex items-center justify-between">
+      <div className="mt-4 -mb-14 w-full flex items-center justify-between pointer-events-none">
         {sidebarWidth < navBreakpoint + 1 && displayState !== 'fullscreen' && (
           <Button
             rounded="right"

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -102,9 +102,7 @@ export const FormsView = ({
               setActiveFormId={setActiveFormId}
             />
           )}
-          {!isMultiform && activeForm.label && (
-            <FormHeader activeForm={activeForm} />
-          )}
+          {!isMultiform && <FormHeader activeForm={activeForm} />}
           {formMetas &&
             formMetas.map((meta) => (
               <React.Fragment key={meta.name}>
@@ -233,10 +231,12 @@ export const FormHeader = ({ activeForm }: FormHeaderProps) => {
         sidebarWidth > navBreakpoint ? `px-6` : `px-20`
       }`}
     >
-      <div className="max-w-form mx-auto">
-        <span className="block text-xl mb-[6px] text-gray-700 font-medium leading-tight">
-          {activeForm.label}
-        </span>
+      <div className="max-w-form mx-auto  flex flex-col items-start justify-center min-h-[2.5rem]">
+        {activeForm.label && (
+          <span className="block w-full text-xl mb-[6px] text-gray-700 font-medium leading-tight">
+            {activeForm.label}
+          </span>
+        )}
         <FormStatus pristine={formIsPristine} />
       </div>
     </div>

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -27,7 +27,7 @@ import { useCMS, useSubscribable } from '../../react-core'
 import { FormBuilder, FormStatus } from '../../form-builder'
 import { FormMetaPlugin } from '../../../plugins/form-meta'
 import { SidebarContext, navBreakpoint } from './Sidebar'
-import { IoMdClose } from 'react-icons/io'
+import { BiChevronLeft } from 'react-icons/bi'
 
 export const FormsView = ({
   children,
@@ -193,27 +193,35 @@ export const MultiformFormHeader = ({
   setActiveFormId,
 }: MultiformFormHeaderProps) => {
   const cms = useCMS()
+  const { sidebarWidth, formIsPristine } = React.useContext(SidebarContext)
 
   return (
-    <div className="pt-18">
-      <button
-        className={`relative group text-left w-full bg-white hover:bg-gray-50 py-2 border-t border-b shadow-sm
-   border-gray-100 px-6 -mt-px`}
-        onClick={() => {
-          const state = activeForm.finalForm.getState()
-          if (state.invalid === true) {
-            // @ts-ignore
-            cms.alerts.error('Cannot navigate away from an invalid form.')
-          } else {
-            setActiveFormId('')
-          }
-        }}
-      >
-        <div className="flex items-center justify-between gap-3 text-xs tracking-wide font-medium text-gray-700 group-hover:text-blue-400 uppercase max-w-form mx-auto">
-          {activeForm.label}
-          <IoMdClose className="h-auto w-5 inline-block opacity-70 -mt-0.5 -mx-0.5" />
-        </div>
-      </button>
+    <div
+      className={`py-4 border-b border-gray-200 bg-white ${
+        sidebarWidth > navBreakpoint ? `px-6` : `px-20`
+      }`}
+    >
+      <div className="max-w-form mx-auto flex flex-col items-start justify-center min-h-[2.5rem]">
+        <button
+          className="pointer-events-auto text-xs mb-1 text-gray-400 hover:text-blue-500 hover:underline transition-all ease-out duration-150 font-medium flex items-center justify-start gap-0.5"
+          onClick={() => {
+            const state = activeForm.finalForm.getState()
+            if (state.invalid === true) {
+              // @ts-ignore
+              cms.alerts.error('Cannot navigate away from an invalid form.')
+            } else {
+              setActiveFormId('')
+            }
+          }}
+        >
+          <BiChevronLeft className="h-auto w-5 inline-block opacity-70 -mt-0.5 -mx-0.5" />
+          Return to Form List
+        </button>
+        <span className="block w-full text-xl mb-[6px] text-gray-700 font-medium leading-tight">
+          {activeForm.label || activeForm.name}
+        </span>
+        <FormStatus pristine={formIsPristine} />
+      </div>
     </div>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25120,7 +25120,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-tinacms-editor@^0.53.1, react-tinacms-editor@workspace:*, react-tinacms-editor@workspace:packages/react-tinacms-editor":
+"react-tinacms-editor@^0.53.2, react-tinacms-editor@workspace:*, react-tinacms-editor@workspace:packages/react-tinacms-editor":
   version: 0.0.0-use.local
   resolution: "react-tinacms-editor@workspace:packages/react-tinacms-editor"
   dependencies:
@@ -28754,7 +28754,7 @@ resolve@^2.0.0-next.3:
     react-dom: ^16.14.0
     react-icons: ^4.2.0
     react-is: ^17.0.2
-    react-tinacms-editor: ^0.53.1
+    react-tinacms-editor: ^0.53.2
     styled-components: ^5.3.0
     tailwindcss: ^2.0.4
     tinacms: "workspace:*"


### PR DESCRIPTION
- Fixes #2546 by rendering the form header when there's no label but with additional styling to account for the missing element.
- Adds form status to multiform header & matches styling so that it feels more 'form-like' vs. a group that doesn't need to be saved before closing.
- Adds entrance animation to multiform list to match animation on form entrance so it's less jarring.

Multi-form header:
<img width="528" alt="Screen Shot 2022-02-04 at 12 40 34 PM" src="https://user-images.githubusercontent.com/5075484/152567581-18f9b724-31d4-4add-89b9-a0f030bb201b.png">

Form with no label:
<img width="552" alt="Screen Shot 2022-02-04 at 12 42 01 PM" src="https://user-images.githubusercontent.com/5075484/152567794-55fcce19-db0e-48e7-8603-5fd0a9f50f18.png">

While the form name would be an okay fallback you actually get the ID and it's not very screen friendly, so I think dropping back to the form status alone is better.
 