### PR TITLE
Collection name as fallback in Admin UI

### DIFF
--- a/.changeset/two-sloths-hammer.md
+++ b/.changeset/two-sloths-hammer.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+use collection name as fallback for label

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -407,7 +407,8 @@ const SidebarCollectionLink = ({
     href={`/admin/collections/${collection.name}`}
     className="text-base tracking-wide text-gray-500 hover:text-blue-600 flex items-center opacity-90 hover:opacity-100"
   >
-    <ImFilesEmpty className="mr-2 h-6 opacity-80 w-auto" /> {collection.label}
+    <ImFilesEmpty className="mr-2 h-6 opacity-80 w-auto" />{' '}
+    {collection.label ? collection.label : collection.name}
   </a>
 )
 

--- a/packages/tinacms/src/admin/components/Sidebar.tsx
+++ b/packages/tinacms/src/admin/components/Sidebar.tsx
@@ -56,7 +56,7 @@ const Sidebar = ({ cms }: { cms: TinaCMS }) => {
           )}
           RenderNavCollection={({ collection }) => (
             <SidebarLink
-              label={collection.label}
+              label={collection.label ? collection.label : collection.name}
               to={`collections/${collection.name}`}
               Icon={ImFilesEmpty}
             />

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -129,7 +129,7 @@ const RenderForm = ({ cms, collection, template, fields, mutationInfo }) => {
                   to={`/collections/${collection.name}`}
                   className="inline-block text-current hover:text-blue-400 focus:underline focus:outline-none focus:text-blue-400 font-medium transition-colors duration-150 ease-out"
                 >
-                  {collection.label}
+                  {collection.label ? collection.label : collection.name}
                 </Link>
                 <HiChevronRight className="inline-block -mt-0.5 opacity-50" />
               </span>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -102,7 +102,9 @@ const CollectionListPage = () => {
                     <PageHeader isLocalMode={cms?.api?.tina?.isLocalMode}>
                       <>
                         <h3 className="text-2xl text-gray-700">
-                          {collection.label}
+                          {collection.label
+                            ? collection.label
+                            : collection.name}
                         </h3>
                         {!collection.templates && (
                           <Link

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -121,7 +121,7 @@ const RenderForm = ({
                   to={`/collections/${collection.name}`}
                   className="inline-block text-current hover:text-blue-400 focus:underline focus:outline-none focus:text-blue-400 font-medium transition-colors duration-150 ease-out"
                 >
-                  {collection.label}
+                  {collection.label ? collection.label : collection.name}
                 </Link>
                 <HiChevronRight className="inline-block -mt-0.5 opacity-50" />
               </span>


### PR DESCRIPTION
Right now if you don't provide a label for a collection, different parts of the UI appear broken or invisible. This makes everything fallback to the 'name' value, which is always provided. 