### PR TITLE
fix: refresh token before it expires

### DIFF
--- a/.changeset/large-garlics-push.md
+++ b/.changeset/large-garlics-push.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Adjust the JWT token refresh logic to refresh tokens _before_ they expire.

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -239,8 +239,8 @@ mutation addPendingDocumentMutation(
     const { access_token, id_token, refresh_token } = JSON.parse(tokens)
     const { exp, iss, client_id } = this.parseJwt(access_token)
 
-    if (Date.now() / 1000 >= exp) {
-      // refresh the token
+    // if the token is going to expire within the next minute, refresh it now
+    if (Date.now() / 1000 >= exp - 60) {
       const refreshResponse = await fetch(iss, {
         method: 'POST',
         headers: {

--- a/packages/tinacms/src/client/index.ts
+++ b/packages/tinacms/src/client/index.ts
@@ -239,8 +239,8 @@ mutation addPendingDocumentMutation(
     const { access_token, id_token, refresh_token } = JSON.parse(tokens)
     const { exp, iss, client_id } = this.parseJwt(access_token)
 
-    // if the token is going to expire within the next minute, refresh it now
-    if (Date.now() / 1000 >= exp - 60) {
+    // if the token is going to expire within the next two minutes, refresh it now
+    if (Date.now() / 1000 >= exp - 120) {
       const refreshResponse = await fetch(iss, {
         method: 'POST',
         headers: {


### PR DESCRIPTION
We recently pulled back how long it takes auth/id tokens to expire to 10 minutes. Having tokens expire more quickly has led 
to an increase in 400 errors from the content-api. This is probably because we aren't refreshing the tokens until _after_ they expire.

Made a quick update to refresh the tokens if they are going to expire within the next 2 minutes. This will hopefully cut back on clients sending us expired tokens.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
