### PR TITLE
2596 - Allows RouteMapping to be dynamically imported

### DIFF
--- a/experimental-examples/tina-cloud-starter/pages/_app.tsx
+++ b/experimental-examples/tina-cloud-starter/pages/_app.tsx
@@ -19,37 +19,44 @@ const App = ({ Component, pageProps }) => {
               return pack.TinaCloudCloudinaryMediaStore;
             }}
             cmsCallback={(cms) => {
-              import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
-                cms.plugins.add(MarkdownFieldPlugin);
-              });
+              /**
+               * Flags
+               */
+              /**
+               * Enables the Tina Admin Experience
+               */
+              cms.flags.set("tina-admin", true);
+              /**
+               * Enables the Branch Switcher
+               */
               cms.flags.set("branch-switcher", true);
 
               /**
-               * Enables `tina-admin` specific features in the Tina Sidebar
+               * Plugins
                */
-              cms.flags.set("tina-admin", true);
-
-              /**
-               * An example of a RouteMapping plugin for TinaAdmin
-               */
-              const RouteMapping = new RouteMappingPlugin(
-                (collection, document) => {
-                  if (["authors", "global"].includes(collection.name)) {
-                    return undefined;
-                  }
-                  if (["pages"].includes(collection.name)) {
-                    if (document.sys.filename === "home") {
-                      return `/`;
+              import("tinacms").then(({ RouteMappingPlugin }) => {
+                const RouteMapping = new RouteMappingPlugin(
+                  (collection, document) => {
+                    if (["authors", "global"].includes(collection.name)) {
+                      return undefined;
                     }
-                    if (document.sys.filename === "about") {
-                      return `/about`;
+                    if (["pages"].includes(collection.name)) {
+                      if (document.sys.filename === "home") {
+                        return `/`;
+                      }
+                      if (document.sys.filename === "about") {
+                        return `/about`;
+                      }
+                      return undefined;
                     }
-                    return undefined;
+                    return `/${collection.name}/${document.sys.filename}`;
                   }
-                  return `/${collection.name}/${document.sys.filename}`;
-                }
-              );
-              cms.plugins.add(RouteMapping);
+                );
+                cms.plugins.add(RouteMapping);
+              });
+              import("react-tinacms-editor").then(({ MarkdownFieldPlugin }) => {
+                cms.plugins.add(MarkdownFieldPlugin);
+              });
             }}
             documentCreatorCallback={{
               /**

--- a/packages/tinacms/src/admin/README.md
+++ b/packages/tinacms/src/admin/README.md
@@ -120,8 +120,6 @@ A new `RouteMappingPlugin` accepts a single argument - the `mapper` function - t
 Below is an example of how a `RouteMappingPlugin` might be added to our `tina-cloud-starter`:
 
 ```tsx
-import { RouteMappingPlugin } from "tinacms";
-
 const App = ({ Component, pageProps }) => {
   return (
     <>
@@ -131,44 +129,46 @@ const App = ({ Component, pageProps }) => {
           <TinaCMS
             ...
             cmsCallback={(cms) => {
-              /**
-               * 1. Define the `RouteMappingPlugin`
-               **/
-              const RouteMapping = new RouteMappingPlugin(
-                (collection, document) => {
-                  /**
-                   * Because the `authors` and `global` collections do not
-                   * have dedicated pages, we return `undefined`.
-                   **/
-                  if (["authors", "global"].includes(collection.name)) {
-                    return undefined;
-                  }
-
-                  /**
-                   * While the `pages` collection does have dedicated pages,
-                   * their URLs are different than their document names.
-                   **/
-                  if (["pages"].includes(collection.name)) {
-                    if (document.sys.filename === "home") {
-                      return `/`;
+              import("tinacms").then(({ RouteMappingPlugin }) => {
+                /**
+                 * 1. Define the `RouteMappingPlugin`
+                 **/
+                const RouteMapping = new RouteMappingPlugin(
+                  (collection, document) => {
+                    /**
+                     * Because the `authors` and `global` collections do not
+                     * have dedicated pages, we return `undefined`.
+                     **/
+                    if (["authors", "global"].includes(collection.name)) {
+                      return undefined;
                     }
-                    if (document.sys.filename === "about") {
-                      return `/about`;
+  
+                    /**
+                     * While the `pages` collection does have dedicated pages,
+                     * their URLs are different than their document names.
+                     **/
+                    if (["pages"].includes(collection.name)) {
+                      if (document.sys.filename === "home") {
+                        return `/`;
+                      }
+                      if (document.sys.filename === "about") {
+                        return `/about`;
+                      }
+                      return undefined;
                     }
-                    return undefined;
+                    /**
+                     * Finally, any other collections (`posts`, for example)
+                     * have URLs based on values in the `collection` and `document`.
+                     **/
+                    return `/${collection.name}/${document.sys.filename}`;
                   }
-                  /**
-                   * Finally, any other collections (`posts`, for example)
-                   * have URLs based on values in the `collection` and `document`.
-                   **/
-                  return `/${collection.name}/${document.sys.filename}`;
-                }
-              );
-
-              /**
-               * 2. Add the `RouteMappingPlugin` to the `cms`.
-               **/
-              cms.plugins.add(RouteMapping);
+                );
+  
+                /**
+                 * 2. Add the `RouteMappingPlugin` to the `cms`.
+                 **/
+                cms.plugins.add(RouteMapping);
+              })
             }}
             ...
           >


### PR DESCRIPTION
Scott (@spbyrne) found an interesting race condition when trying to dynamically import `RouteMappingPlugin` via the `cmsCallback`.

This resulted in the overriden links only being present on subsequent loads of the List page rather than the first (because the plugin had not been attached yet).

I've changed the code so that RouteMapping is called when needed (when the link is clicked, for example).

Closes #2596 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
