### PR TITLE
2548 - Adds loading indicators throughout TinaAdmin

### DIFF
--- a/.changeset/dull-laws-hug.md
+++ b/.changeset/dull-laws-hug.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+Adds an activity indicator throughout Admin

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Nav.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Nav.tsx
@@ -35,7 +35,6 @@ interface NavProps {
   collectionsInfo: {
     collections: { label: string; name: string }[]
     loading: boolean
-    error: boolean
   }
   contentCreators?: any
   screens?: ScreenPlugin[]
@@ -173,12 +172,10 @@ export const Nav = ({
 const CollectionsList = ({
   collections,
   loading,
-  error,
   RenderNavCollection,
 }: {
   collections: { label: string; name: string }[]
   loading: boolean
-  error: boolean
   RenderNavCollection: React.ComponentType<{
     collection: { label: string; name: string }
   }>

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -75,32 +75,23 @@ interface SidebarProps {
 type displayStates = 'closed' | 'open' | 'fullscreen'
 
 const useFetchCollections = (cms) => {
-  const [info, setInfo] = useState<{
-    loading: boolean
-    error: boolean
-    collections: any[]
-  }>({
-    loading: true,
-    error: false,
-    collections: [],
-  })
+  const [collections, setCollections] = useState<any[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const fetchCollections = async () => {
       const response = await cms.api.admin.fetchCollections()
-      setInfo({
-        loading: false,
-        error: false,
-        collections: response.getCollections,
-      })
+      setCollections(response.getCollections)
+      setLoading(false)
     }
 
     if (cms.api.admin) {
+      setLoading(true)
       fetchCollections()
     }
   }, [cms.api.admin])
 
-  return info
+  return { collections, loading }
 }
 
 const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -14,6 +14,7 @@ limitations under the License.
 import React, { useEffect, useState } from 'react'
 import type { TinaCMS } from '@tinacms/toolkit'
 import { TinaAdminApi } from '../api'
+import LoadingPage from '../components/LoadingPage'
 import type { Collection } from '../types'
 
 export const useGetCollection = (
@@ -25,6 +26,7 @@ export const useGetCollection = (
   const [collection, setCollection] = useState<Collection | undefined>(
     undefined
   )
+  const [loading, setLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const fetchCollection = async () => {
@@ -33,12 +35,14 @@ export const useGetCollection = (
         includeDocuments
       )
       setCollection(response.getCollection)
+      setLoading(false)
     }
 
+    setLoading(true)
     fetchCollection()
   }, [cms, collectionName])
 
-  return collection
+  return { collection, loading }
 }
 
 const GetCollection = ({
@@ -52,11 +56,15 @@ const GetCollection = ({
   includeDocuments?: boolean
   children: any
 }) => {
-  const collection = useGetCollection(cms, collectionName, includeDocuments)
-  if (!collection) {
-    return null
+  const { collection, loading } = useGetCollection(
+    cms,
+    collectionName,
+    includeDocuments
+  )
+  if (!collection || loading === true) {
+    return <LoadingPage />
   }
-  return <>{children(collection)}</>
+  return <>{children(collection, loading)}</>
 }
 
 export default GetCollection

--- a/packages/tinacms/src/admin/components/GetCollections.tsx
+++ b/packages/tinacms/src/admin/components/GetCollections.tsx
@@ -18,32 +18,29 @@ import type { Collection } from '../types'
 
 export const useGetCollections = (cms: TinaCMS) => {
   const api = new TinaAdminApi(cms)
-  const [info, setInfo] = useState<{
-    collections: Collection[]
-    loading: boolean
-    error: boolean
-  }>({ collections: [], loading: true, error: false })
+  const [collections, setCollections] = useState<Collection[]>([])
+  const [loading, setLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const fetchCollections = async () => {
       const response = await api.fetchCollections()
-      setInfo({
-        collections: response.getCollections,
-        loading: false,
-        error: false,
-      })
+      setCollections(response.getCollections)
+      setLoading(false)
     }
 
+    setLoading(true)
     fetchCollections()
   }, [cms])
 
-  return info
+  return { collections, loading }
 }
 
 const GetCollections = ({ cms, children }: { cms: TinaCMS; children: any }) => {
-  const { collections, loading, error } = useGetCollections(cms)
-  if (!collections) return null
-  return <>{children(collections, loading, error)}</>
+  const { collections, loading } = useGetCollections(cms)
+  if (!collections || loading === true) {
+    return null
+  }
+  return <>{children(collections, loading)}</>
 }
 
 export default GetCollections

--- a/packages/tinacms/src/admin/components/GetDocument.tsx
+++ b/packages/tinacms/src/admin/components/GetDocument.tsx
@@ -15,6 +15,7 @@ import React, { useState, useEffect } from 'react'
 import type { TinaCMS } from '@tinacms/toolkit'
 import { TinaAdminApi } from '../api'
 import type { DocumentForm } from '../types'
+import LoadingPage from './LoadingPage'
 
 export const useGetDocument = (
   cms: TinaCMS,
@@ -23,18 +24,21 @@ export const useGetDocument = (
 ) => {
   const api = new TinaAdminApi(cms)
   const [document, setDocument] = useState<DocumentForm>(undefined)
+  const [loading, setLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const fetchDocument = async () => {
       const response = await api.fetchDocument(collectionName, relativePath)
 
       setDocument(response.getDocument)
+      setLoading(false)
     }
 
+    setLoading(true)
     fetchDocument()
   }, [cms, collectionName, relativePath])
 
-  return document
+  return { document, loading }
 }
 
 const GetDocument = ({
@@ -48,11 +52,15 @@ const GetDocument = ({
   relativePath: string
   children: any
 }) => {
-  const document = useGetDocument(cms, collectionName, relativePath)
-  if (!document) {
-    return null
+  const { document, loading } = useGetDocument(
+    cms,
+    collectionName,
+    relativePath
+  )
+  if (!document || loading) {
+    return <LoadingPage />
   }
-  return <>{children(document)}</>
+  return <>{children(document, loading)}</>
 }
 
 export default GetDocument

--- a/packages/tinacms/src/admin/components/GetDocumentFields.tsx
+++ b/packages/tinacms/src/admin/components/GetDocumentFields.tsx
@@ -14,6 +14,7 @@ limitations under the License.
 import React, { useState, useEffect } from 'react'
 import type { TinaCMS } from '@tinacms/toolkit'
 import { TinaAdminApi } from '../api'
+import LoadingPage from './LoadingPage'
 
 export interface Info {
   collection: Object | undefined
@@ -37,6 +38,7 @@ export const useGetDocumentFields = (
     fields: undefined,
     mutationInfo: undefined,
   })
+  const [loading, setLoading] = useState<boolean>(true)
 
   useEffect(() => {
     const fetchDocumentFields = async () => {
@@ -71,12 +73,14 @@ export const useGetDocumentFields = (
         fields,
         mutationInfo,
       })
+      setLoading(false)
     }
 
+    setLoading(true)
     fetchDocumentFields()
   }, [cms, collectionName])
 
-  return info
+  return { ...info, loading }
 }
 
 const GetDocumentFields = ({
@@ -90,16 +94,15 @@ const GetDocumentFields = ({
   templateName?: string
   children: any
 }) => {
-  const { collection, template, fields, mutationInfo } = useGetDocumentFields(
-    cms,
-    collectionName,
-    templateName
-  )
+  const { collection, template, fields, mutationInfo, loading } =
+    useGetDocumentFields(cms, collectionName, templateName)
 
-  if (!collection) {
-    return null
+  if (!collection || loading) {
+    return <LoadingPage />
   }
-  return <>{children({ collection, template, fields, mutationInfo })}</>
+  return (
+    <>{children({ collection, template, fields, mutationInfo, loading })}</>
+  )
 }
 
 export default GetDocumentFields

--- a/packages/tinacms/src/admin/components/LoadingPage.tsx
+++ b/packages/tinacms/src/admin/components/LoadingPage.tsx
@@ -1,0 +1,120 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react'
+
+const LoadingPage = () => (
+  <>
+    <div
+      style={{
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        width: '100%',
+        height: '100%',
+        zIndex: 200,
+        opacity: '0.8',
+        display: 'flex',
+        alignItems: 'start',
+        justifyContent: 'center',
+        padding: '120px 40px 40px 40px',
+      }}
+    >
+      <div
+        style={{
+          background: '#FFF',
+          border: '1px solid #EDECF3',
+          boxShadow:
+            '0px 2px 3px rgba(0, 0, 0, 0.05), 0 4px 12px rgba(0, 0, 0, 0.1)',
+          borderRadius: '8px',
+          padding: '32px 24px',
+          width: '460px',
+          maxWidth: '90%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexDirection: 'column',
+        }}
+      >
+        <svg
+          style={{
+            width: '64px',
+            color: '#2296fe',
+            marginTop: '-8px',
+            marginBottom: '16px',
+          }}
+          version="1.1"
+          id="L5"
+          xmlns="http://www.w3.org/2000/svg"
+          xmlnsXlink="http://www.w3.org/1999/xlink"
+          x="0px"
+          y="0px"
+          viewBox="0 0 100 64"
+          enableBackground="new 0 0 0 0"
+          xmlSpace="preserve"
+        >
+          <circle fill="currentColor" stroke="none" cx={6} cy={32} r={6}>
+            <animateTransform
+              attributeName="transform"
+              dur="1s"
+              type="translate"
+              values="0 15 ; 0 -15; 0 15"
+              calcMode="spline"
+              keySplines="0.8 0 0.4 1; 0.4 0 0.2 1"
+              repeatCount="indefinite"
+              begin="0.1"
+            />
+          </circle>
+          <circle fill="currentColor" stroke="none" cx={30} cy={32} r={6}>
+            <animateTransform
+              attributeName="transform"
+              dur="1s"
+              type="translate"
+              values="0 15 ; 0 -10; 0 15"
+              calcMode="spline"
+              keySplines="0.8 0 0.4 1; 0.4 0 0.2 1"
+              repeatCount="indefinite"
+              begin="0.2"
+            />
+          </circle>
+          <circle fill="currentColor" stroke="none" cx={54} cy={32} r={6}>
+            <animateTransform
+              attributeName="transform"
+              dur="1s"
+              type="translate"
+              values="0 15 ; 0 -5; 0 15"
+              calcMode="spline"
+              keySplines="0.8 0 0.4 1; 0.4 0 0.2 1"
+              repeatCount="indefinite"
+              begin="0.3"
+            />
+          </circle>
+        </svg>
+        <p
+          style={{
+            fontSize: '16px',
+            color: '#716c7f',
+            textAlign: 'center',
+            lineHeight: '1.3',
+            fontFamily: "'Inter', sans-serif",
+            fontWeight: 'normal',
+          }}
+        >
+          Please wait, Tina is loading data...
+        </p>
+      </div>
+    </div>
+  </>
+)
+
+export default LoadingPage

--- a/packages/tinacms/src/admin/components/Sidebar.tsx
+++ b/packages/tinacms/src/admin/components/Sidebar.tsx
@@ -14,13 +14,12 @@ limitations under the License.
 import React from 'react'
 import { NavLink } from 'react-router-dom'
 import { ImFilesEmpty } from 'react-icons/im'
-
-import type { TinaCMS, ScreenPlugin } from '@tinacms/toolkit'
-import { Nav } from '@tinacms/toolkit'
-
-import GetCollections from './GetCollections'
-import type { Collection } from '../types'
 import type { IconType } from 'react-icons/lib'
+
+import { Nav } from '@tinacms/toolkit'
+import type { TinaCMS, ScreenPlugin } from '@tinacms/toolkit'
+
+import { useGetCollections } from './GetCollections'
 
 export const slugify = (text) => {
   return text
@@ -33,37 +32,30 @@ export const slugify = (text) => {
 }
 
 const Sidebar = ({ cms }: { cms: TinaCMS }) => {
+  const collectionsInfo = useGetCollections(cms)
   const screens = cms.plugins.getType<ScreenPlugin>('screen').all()
   return (
-    <GetCollections cms={cms}>
-      {(collections: [Collection], loading: boolean, error: boolean) => (
-        <Nav
-          sidebarWidth={360}
-          showCollections={true}
-          collectionsInfo={{
-            collections,
-            loading,
-            error,
-          }}
-          screens={screens}
-          contentCreators={[]}
-          RenderNavSite={({ view }) => (
-            <SidebarLink
-              label={view.name}
-              to={`screens/${slugify(view.name)}`}
-              Icon={view.Icon ? view.Icon : ImFilesEmpty}
-            />
-          )}
-          RenderNavCollection={({ collection }) => (
-            <SidebarLink
-              label={collection.label ? collection.label : collection.name}
-              to={`collections/${collection.name}`}
-              Icon={ImFilesEmpty}
-            />
-          )}
+    <Nav
+      sidebarWidth={360}
+      showCollections={true}
+      collectionsInfo={collectionsInfo}
+      screens={screens}
+      contentCreators={[]}
+      RenderNavSite={({ view }) => (
+        <SidebarLink
+          label={view.name}
+          to={`screens/${slugify(view.name)}`}
+          Icon={view.Icon ? view.Icon : ImFilesEmpty}
         />
       )}
-    </GetCollections>
+      RenderNavCollection={({ collection }) => (
+        <SidebarLink
+          label={collection.label ? collection.label : collection.name}
+          to={`collections/${collection.name}`}
+          Icon={ImFilesEmpty}
+        />
+      )}
+    />
   )
 }
 

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -66,7 +66,7 @@ export const TinaAdmin = () => {
               <Router basename={'/admin'}>
                 <div className="flex items-stretch h-screen overflow-hidden">
                   <Sidebar cms={cms} />
-                  <div className="flex-1">
+                  <div className="flex-1 relative">
                     <Routes>
                       <Route
                         path="collections/:collectionName/new"

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -159,6 +159,11 @@ export const TinaCloudProvider = (
   if (!cms.api.tina) {
     cms.registerApi('tina', createClient(props))
   }
+
+  if (!cms.api.admin) {
+    cms.registerApi('admin', new TinaAdminApi(cms))
+  }
+
   const setupMedia = async () => {
     if (props.mediaStore) {
       // Check to see if the media was store was passed in?
@@ -191,15 +196,6 @@ export const TinaCloudProvider = (
   }
 
   setupMedia()
-
-  /**
-   * Attaches a new instance of the TinaAdminApi to `cms.api.admin`
-   */
-  React.useMemo(() => {
-    if (cms.flags.get('tina-admin') === true) {
-      cms.registerApi('admin', new TinaAdminApi(cms))
-    }
-  }, [cms, cms.flags.get('tina-admin')])
 
   const [branchingEnabled, setBranchingEnabled] = React.useState(() =>
     cms.flags.get('branch-switcher')


### PR DESCRIPTION
While locally, the Admin is snappy, in production or on Tina Cloud, there is some delay in loading a Collection List or Document.

Before, there was no way to tell that the request had even been made - resulting in potentially repeat clicking (which would further increase the delay) or a general lack of confidence that the Admin was even working.  This PR adds a simple acitivity indicator through the Admin for _most_ of the requests.

Closes #2548 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
