### PR TITLE
fix: #1452: update indexDocument to handle adding new docs

### DIFF
--- a/.changeset/cyan-singers-smile.md
+++ b/.changeset/cyan-singers-smile.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+fix: #1452: update indexDocument to handle adding new docs


### PR DESCRIPTION
# what

With the experimentalData flag enabled, adding a new document in the admin interface was failing with this error:

```
{
  "errors": [
    {
      "message": "Unable to find '<filename>' in store for project <client_id>: '<owner>/<repo>', Ref: 'main'",
      "locations": [
        {
          "line": 3,
          "column": 9
        }
      ],
      "path": [
        "createDocument"
      ],
      "extensions": {
        "status": 404
      }
    }
  ],
  "data": null
}
```
I traced this issue to Database.indexDocument where was attempting to fetch an existing document from the store and not checking whether the document already existed. This PR adds an exception check to prevent this error from bubbling up. 

Ideally we'd probably be better off explicitly checking if a file exists (rather than checking if the get fails) _or_ if we know a request involves a new document, pass that info to this function and use it to avoid making the get.