### PR TITLE
2612 - Sets the tina-admin flag to true by default

### DIFF
--- a/.changeset/fluffy-files-hope.md
+++ b/.changeset/fluffy-files-hope.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+Sets `tina-admin` to default to `true`

--- a/packages/@tinacms/toolkit/src/packages/fields/components/Reference.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/Reference.tsx
@@ -92,7 +92,7 @@ export const Reference: React.FC<ReferenceProps> = ({
   options,
 }) => {
   const cms = useCMS()
-  const hasTinaAdmin = cms.flags.get('tina-admin') || true
+  const hasTinaAdmin = cms.flags.get('tina-admin') === false ? false : true
 
   const selectOptions = options || field.options
   return (

--- a/packages/@tinacms/toolkit/src/packages/fields/components/Reference.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/Reference.tsx
@@ -92,7 +92,7 @@ export const Reference: React.FC<ReferenceProps> = ({
   options,
 }) => {
   const cms = useCMS()
-  const hasTinaAdmin = cms.flags.get('tina-admin')
+  const hasTinaAdmin = cms.flags.get('tina-admin') || true
 
   const selectOptions = options || field.options
   return (
@@ -123,7 +123,7 @@ export const Reference: React.FC<ReferenceProps> = ({
               className="text-gray-700 hover:text-blue-500 flex items-center uppercase text-sm mt-2 mb-2 leading-none"
             >
               <BiEdit className="h-5 w-auto opacity-80 mr-2" />
-              Edit in Admin
+              Edit in CMS
             </a>
           )}
         </GetReference>

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -113,9 +113,10 @@ const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {
   /**
    * Only show ContentCreators when TinaAdmin is disabled
    */
-  const contentCreators = cms.flags.get('tina-admin')
-    ? []
-    : cms.plugins.getType('content-creator').all()
+  const contentCreators =
+    cms.flags.get('tina-admin') || true
+      ? []
+      : cms.plugins.getType('content-creator').all()
 
   const toggleFullscreen = () => {
     if (displayState === 'fullscreen') {
@@ -181,7 +182,7 @@ const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {
           <EditButton />
           {(sidebarWidth > navBreakpoint || displayState === 'fullscreen') && (
             <Nav
-              showCollections={cms.flags.get('tina-admin')}
+              showCollections={cms.flags.get('tina-admin') || true}
               collectionsInfo={collectionsInfo}
               screens={allScreens}
               contentCreators={contentCreators}
@@ -228,7 +229,7 @@ const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {
               <div className="fixed left-0 top-0 z-overlay h-full transform">
                 <Nav
                   className="rounded-r-md"
-                  showCollections={cms.flags.get('tina-admin')}
+                  showCollections={cms.flags.get('tina-admin') || true}
                   collectionsInfo={collectionsInfo}
                   screens={allScreens}
                   contentCreators={contentCreators}

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -110,13 +110,15 @@ const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {
   const [resizingSidebar, setResizingSidebar] = React.useState(false)
   const [formIsPristine, setFormIsPristine] = React.useState(true)
 
+  const isTinaAdminEnabled =
+    cms.flags.get('tina-admin') === false ? false : true
+
   /**
    * Only show ContentCreators when TinaAdmin is disabled
    */
-  const contentCreators =
-    cms.flags.get('tina-admin') || true
-      ? []
-      : cms.plugins.getType('content-creator').all()
+  const contentCreators = isTinaAdminEnabled
+    ? []
+    : cms.plugins.getType('content-creator').all()
 
   const toggleFullscreen = () => {
     if (displayState === 'fullscreen') {
@@ -182,7 +184,7 @@ const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {
           <EditButton />
           {(sidebarWidth > navBreakpoint || displayState === 'fullscreen') && (
             <Nav
-              showCollections={cms.flags.get('tina-admin') || true}
+              showCollections={isTinaAdminEnabled}
               collectionsInfo={collectionsInfo}
               screens={allScreens}
               contentCreators={contentCreators}
@@ -229,7 +231,7 @@ const Sidebar = ({ sidebar, defaultWidth, position }: SidebarProps) => {
               <div className="fixed left-0 top-0 z-overlay h-full transform">
                 <Nav
                   className="rounded-r-md"
-                  showCollections={cms.flags.get('tina-admin') || true}
+                  showCollections={isTinaAdminEnabled}
                   collectionsInfo={collectionsInfo}
                   screens={allScreens}
                   contentCreators={contentCreators}

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -58,7 +58,8 @@ export const TinaAdmin = () => {
   return (
     <GetCMS>
       {(cms: TinaCMS) => {
-        const isTinaAdminEnabled = cms.flags.get('tina-admin') || true
+        const isTinaAdminEnabled =
+          cms.flags.get('tina-admin') === false ? false : true
 
         if (isTinaAdminEnabled) {
           return (

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -58,7 +58,7 @@ export const TinaAdmin = () => {
   return (
     <GetCMS>
       {(cms: TinaCMS) => {
-        const isTinaAdminEnabled = cms.flags.get('tina-admin')
+        const isTinaAdminEnabled = cms.flags.get('tina-admin') || true
 
         if (isTinaAdminEnabled) {
           return (


### PR DESCRIPTION
A user can still disable `tina-admin` by setting the flag to `false`, but any lookups related to the flag will assume it is `true` if it isn't provided.

Closes #2612 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
