### PR TITLE
Allow-multiword-tags

### DIFF
--- a/.changeset/nasty-poets-refuse.md
+++ b/.changeset/nasty-poets-refuse.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+fix: allow multiword tags

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/TagsFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/TagsFieldPlugin.tsx
@@ -50,7 +50,7 @@ export const TagsField = wrapFieldsWithMeta<
         onChange={(event) => setValue(event.target.value)}
         placeholder={field.placeholder}
         onKeyPress={(event) => {
-          if (event.key === ' ' || event.key === 'Enter') {
+          if (event.key === ',' || event.key === 'Enter') {
             event.preventDefault()
             addTag(value)
           }


### PR DESCRIPTION
Allow multiword tags when using the tags field with:

```
    {
      type: "string",
      label: "tags",
      name: "tags",
      ui: {
        component: "tags",
      },
      list: true,
    },
```

Instead, break on a comma

fixes #2612
