### PR TITLE
feat: override existing scripts with cli init

### DIFF
--- a/.changeset/five-beds-raise.md
+++ b/.changeset/five-beds-raise.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+use standard next script names

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -27,6 +27,10 @@ import { blogPost, nextPostPage, AppJsContent, adminPage } from './setup-files'
 import { logger } from '../../logger'
 import chalk from 'chalk'
 import { TinaProvider, TinaProviderDynamic } from './setup-files/tinaProvider'
+import {
+  generateGqlScript,
+  extendNextScripts,
+} from '../../utils/script-helpers'
 
 /**
  * Executes a shell command and return it as a Promise.
@@ -163,12 +167,7 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
   const newPack = JSON.stringify(
     {
       ...pack,
-      scripts: {
-        ...oldScripts,
-        'tina-dev': 'yarn tinacms server:start -c "next dev"',
-        'tina-build': 'yarn tinacms server:start -c "next build"',
-        'tina-start': 'yarn tinacms server:start -c "next start"',
-      },
+      scripts: extendNextScripts(oldScripts),
     },
     null,
     2
@@ -191,7 +190,7 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
 export async function successMessage(ctx: any, next: () => void, options) {
   logger.info(`Tina setup ${chalk.underline.green('done')}  ✅
 \t Start your dev server with ${successText(
-    `yarn tina-dev`
+    `yarn dev`
   )} and go to http://localhost:3000/demo/blog/HelloWorld to ${successText(
     'check it out the page that was created for you'
   )}

--- a/packages/@tinacms/cli/src/utils/script-helpers.test.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.test.ts
@@ -1,0 +1,62 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import { generateGqlScript, extendNextScripts } from './script-helpers'
+
+describe('generateGqlScript', () => {
+  it('wraps original script correctly', () => {
+    const newScript = generateGqlScript('yarn dev -p 3000')
+
+    expect(newScript).toEqual('yarn tinacms server:start -c "yarn dev -p 3000"')
+  })
+})
+
+describe('extendNextScripts', () => {
+  describe('with all existing scrpts', () => {
+    it('returns new scripts correctly', () => {
+      const newScripts = extendNextScripts({
+        foo: 'bar',
+        dev: 'next dev -p 3000',
+        build: 'next build -p 3000',
+        start: 'next start -p 3000',
+      })
+
+      expect(newScripts).toEqual({
+        foo: 'bar',
+        dev: 'yarn tinacms server:start -c "next dev -p 3000"',
+        build: 'yarn tinacms server:start -c "next build -p 3000"',
+        start: 'yarn tinacms server:start -c "next start -p 3000"',
+      })
+    })
+  })
+
+  describe('with missing existing scrpts', () => {
+    it('returns new scripts correctly', () => {
+      const newScripts = extendNextScripts({
+        foo: 'bar',
+      })
+
+      expect(newScripts).toEqual({
+        foo: 'bar',
+        dev: 'yarn tinacms server:start -c "next dev"',
+        build: 'yarn tinacms server:start -c "next build"',
+        start: 'yarn tinacms server:start -c "next start"',
+      })
+    })
+  })
+})

--- a/packages/@tinacms/cli/src/utils/script-helpers.test.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.test.ts
@@ -20,9 +20,9 @@ import { generateGqlScript, extendNextScripts } from './script-helpers'
 
 describe('generateGqlScript', () => {
   it('wraps original script correctly', () => {
-    const newScript = generateGqlScript('yarn dev -p 3000')
+    const newScript = generateGqlScript('next dev -p 3000')
 
-    expect(newScript).toEqual('yarn tinacms server:start -c "yarn dev -p 3000"')
+    expect(newScript).toEqual('tinacms server:start -c "next dev -p 3000"')
   })
 })
 
@@ -38,9 +38,9 @@ describe('extendNextScripts', () => {
 
       expect(newScripts).toEqual({
         foo: 'bar',
-        dev: 'yarn tinacms server:start -c "next dev -p 3000"',
-        build: 'yarn tinacms server:start -c "next build -p 3000"',
-        start: 'yarn tinacms server:start -c "next start -p 3000"',
+        dev: 'tinacms server:start -c "next dev -p 3000"',
+        build: 'tinacms server:start -c "next build -p 3000"',
+        start: 'tinacms server:start -c "next start -p 3000"',
       })
     })
   })
@@ -53,9 +53,9 @@ describe('extendNextScripts', () => {
 
       expect(newScripts).toEqual({
         foo: 'bar',
-        dev: 'yarn tinacms server:start -c "next dev"',
-        build: 'yarn tinacms server:start -c "next build"',
-        start: 'yarn tinacms server:start -c "next start"',
+        dev: 'tinacms server:start -c "next dev"',
+        build: 'tinacms server:start -c "next build"',
+        start: 'tinacms server:start -c "next start"',
       })
     })
   })

--- a/packages/@tinacms/cli/src/utils/script-helpers.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.ts
@@ -1,5 +1,5 @@
 export function generateGqlScript(scriptValue) {
-  return `yarn tinacms server:start -c "${scriptValue}"`
+  return `tinacms server:start -c "${scriptValue}"`
 }
 
 export function extendNextScripts(scripts) {

--- a/packages/@tinacms/cli/src/utils/script-helpers.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.ts
@@ -1,3 +1,21 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
 export function generateGqlScript(scriptValue) {
   return `tinacms server:start -c "${scriptValue}"`
 }

--- a/packages/@tinacms/cli/src/utils/script-helpers.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.ts
@@ -1,0 +1,12 @@
+export function generateGqlScript(scriptValue) {
+  return `yarn tinacms server:start -c "${scriptValue}"`
+}
+
+export function extendNextScripts(scripts) {
+  return {
+    ...scripts,
+    dev: generateGqlScript(scripts.dev || 'next dev'),
+    build: generateGqlScript(scripts.build || 'next build'),
+    start: generateGqlScript(scripts.start || 'next start'),
+  }
+}


### PR DESCRIPTION
fixes [#2633](https://github.com/tinacms/tinacms/issues/2633)

Overrides existing script names instead of introducing new `tina-*` scripts

Docs here: https://github.com/tinacms/tinacms.org/pull/1251