### PR TITLE
2635 - Minor change to the timeout for success messaging

### DIFF
--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -112,10 +112,7 @@ const RenderForm = ({ cms, collection, template, fields, mutationInfo }) => {
       onSubmit: async (values) => {
         try {
           await createDocument(cms, collection, template, mutationInfo, values)
-          cms.alerts.success(
-            'Document Created!',
-            30 * 1000 // 30 seconds
-          )
+          cms.alerts.success('Document created!')
           navigate(`/collections/${collection.name}`)
         } catch (error) {
           cms.alerts.error(

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -105,10 +105,7 @@ const RenderForm = ({
             mutationInfo,
             values
           )
-          cms.alerts.success(
-            'Document Updated!',
-            30 * 1000 // 30 seconds
-          )
+          cms.alerts.success('Document updated!')
         } catch (error) {
           cms.alerts.error(
             `[${error.name}] UpdateDocument failed: ${error.message}`,


### PR DESCRIPTION
Scott and I added the 30 second delay on **error** messaging because we felt the default timer for `alerts` is a bit short for something important like that.

For standard messages, like **success** toasts, we can stick to the default (we don't want a lingering message to be misleading if the user is navigating multiple Documents).

Related to #2635

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
