### PR TITLE
2657 - Checks isAuthenticated() before making requests to GraphQL

### DIFF
--- a/.changeset/sixty-teachers-lie.md
+++ b/.changeset/sixty-teachers-lie.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+Checks isAuthenticated() before making requests to the GraphQL client

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -80,18 +80,20 @@ const useFetchCollections = (cms) => {
 
   useEffect(() => {
     const fetchCollections = async () => {
-      try {
-        const response = await cms.api.admin.fetchCollections()
-        setCollections(response.getCollections)
-      } catch (error) {
-        cms.alerts.error(
-          `[ERROR] GetCollections failed: ${error.message}`,
-          30 * 1000 // 30 seconds
-        )
-        setCollections([])
-      }
+      if (await cms.api.admin.isAuthenticated()) {
+        try {
+          const response = await cms.api.admin.fetchCollections()
+          setCollections(response.getCollections)
+        } catch (error) {
+          cms.alerts.error(
+            `[ERROR] GetCollections failed: ${error.message}`,
+            30 * 1000 // 30 seconds
+          )
+          setCollections([])
+        }
 
-      setLoading(false)
+        setLoading(false)
+      }
     }
 
     if (cms.api.admin) {

--- a/packages/tinacms/src/admin/api.ts
+++ b/packages/tinacms/src/admin/api.ts
@@ -17,9 +17,14 @@ import type { Collection, DocumentForm, GetDocumentFields } from './types'
 export class TinaAdminApi {
   api: {
     request: (query: string, { variables }: { variables: object }) => any
+    isAuthenticated: () => boolean
   }
   constructor(cms: TinaCMS) {
     this.api = cms.api.tina
+  }
+
+  async isAuthenticated() {
+    return await this.api.isAuthenticated()
   }
 
   async fetchCollections() {

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -31,23 +31,25 @@ export const useGetCollection = (
 
   useEffect(() => {
     const fetchCollection = async () => {
-      try {
-        const response = await api.fetchCollection(
-          collectionName,
-          includeDocuments
-        )
-        setCollection(response.getCollection)
-      } catch (error) {
-        cms.alerts.error(
-          `[${error.name}] GetCollection failed: ${error.message}`,
-          30 * 1000 // 30 seconds
-        )
-        console.error(error)
-        setCollection(undefined)
-        setError(error)
-      }
+      if (await api.isAuthenticated()) {
+        try {
+          const response = await api.fetchCollection(
+            collectionName,
+            includeDocuments
+          )
+          setCollection(response.getCollection)
+        } catch (error) {
+          cms.alerts.error(
+            `[${error.name}] GetCollection failed: ${error.message}`,
+            30 * 1000 // 30 seconds
+          )
+          console.error(error)
+          setCollection(undefined)
+          setError(error)
+        }
 
-      setLoading(false)
+        setLoading(false)
+      }
     }
 
     setLoading(true)
@@ -73,13 +75,13 @@ const GetCollection = ({
     collectionName,
     includeDocuments
   )
-  if (!collection) {
-    if (loading) {
-      return <LoadingPage />
-    }
-    if (error) {
-      return null
-    }
+
+  if (error) {
+    return null
+  }
+
+  if (loading) {
+    return <LoadingPage />
   }
 
   return <>{children(collection, loading)}</>

--- a/packages/tinacms/src/admin/components/GetCollections.tsx
+++ b/packages/tinacms/src/admin/components/GetCollections.tsx
@@ -24,20 +24,22 @@ export const useGetCollections = (cms: TinaCMS) => {
 
   useEffect(() => {
     const fetchCollections = async () => {
-      try {
-        const response = await api.fetchCollections()
-        setCollections(response.getCollections)
-      } catch (error) {
-        cms.alerts.error(
-          `[${error.name}] GetCollections failed: ${error.message}`,
-          30 * 1000 // 30 seconds
-        )
-        console.error(error)
-        setCollections([])
-        setError(error)
-      }
+      if (await api.isAuthenticated()) {
+        try {
+          const response = await api.fetchCollections()
+          setCollections(response.getCollections)
+        } catch (error) {
+          cms.alerts.error(
+            `[${error.name}] GetCollections failed: ${error.message}`,
+            30 * 1000 // 30 seconds
+          )
+          console.error(error)
+          setCollections([])
+          setError(error)
+        }
 
-      setLoading(false)
+        setLoading(false)
+      }
     }
 
     setLoading(true)
@@ -49,11 +51,11 @@ export const useGetCollections = (cms: TinaCMS) => {
 
 const GetCollections = ({ cms, children }: { cms: TinaCMS; children: any }) => {
   const { collections, loading, error } = useGetCollections(cms)
-  if (!collections) {
-    if (loading || error) {
-      return null
-    }
+
+  if (loading || error) {
+    return null
   }
+
   return <>{children(collections, loading)}</>
 }
 

--- a/packages/tinacms/src/admin/components/GetDocument.tsx
+++ b/packages/tinacms/src/admin/components/GetDocument.tsx
@@ -29,20 +29,22 @@ export const useGetDocument = (
 
   useEffect(() => {
     const fetchDocument = async () => {
-      try {
-        const response = await api.fetchDocument(collectionName, relativePath)
-        setDocument(response.getDocument)
-      } catch (error) {
-        cms.alerts.error(
-          `[${error.name}] GetDocument failed: ${error.message}`,
-          30 * 1000 // 30 seconds
-        )
-        console.error(error)
-        setDocument(undefined)
-        setError(error)
-      }
+      if (api.isAuthenticated()) {
+        try {
+          const response = await api.fetchDocument(collectionName, relativePath)
+          setDocument(response.getDocument)
+        } catch (error) {
+          cms.alerts.error(
+            `[${error.name}] GetDocument failed: ${error.message}`,
+            30 * 1000 // 30 seconds
+          )
+          console.error(error)
+          setDocument(undefined)
+          setError(error)
+        }
 
-      setLoading(false)
+        setLoading(false)
+      }
     }
 
     setLoading(true)
@@ -68,14 +70,15 @@ const GetDocument = ({
     collectionName,
     relativePath
   )
-  if (!document) {
-    if (loading) {
-      return <LoadingPage />
-    }
-    if (error) {
-      return null
-    }
+
+  if (error) {
+    return null
   }
+
+  if (loading) {
+    return <LoadingPage />
+  }
+
   return <>{children(document, loading)}</>
 }
 

--- a/packages/tinacms/src/admin/components/GetDocumentFields.tsx
+++ b/packages/tinacms/src/admin/components/GetDocumentFields.tsx
@@ -43,54 +43,57 @@ export const useGetDocumentFields = (
 
   useEffect(() => {
     const fetchDocumentFields = async () => {
-      try {
-        const response = await api.fetchDocumentFields()
-        const documentFields = response.getDocumentFields
-        const collection: Object = documentFields[collectionName].collection
-        const mutationInfo: {
-          includeCollection: boolean
-          includeTemplate: boolean
-        } = documentFields[collectionName].mutationInfo
-        let fields: Object[] = undefined
-        let template: { name: string; label: string } = undefined
+      if (await api.isAuthenticated()) {
+        try {
+          const response = await api.fetchDocumentFields()
+          const documentFields = response.getDocumentFields
+          const collection: Object = documentFields[collectionName].collection
+          const mutationInfo: {
+            includeCollection: boolean
+            includeTemplate: boolean
+          } = documentFields[collectionName].mutationInfo
+          let fields: Object[] = undefined
+          let template: { name: string; label: string } = undefined
 
-        /***
-         * Collection `collectionName` has template `templateName`...
-         */
-        if (
-          templateName &&
-          documentFields[collectionName].templates &&
-          documentFields[collectionName].templates[templateName]
-        ) {
-          template =
-            documentFields[collectionName].templates[templateName].template
-          fields = documentFields[collectionName].templates[templateName].fields
-        } else {
-          fields = documentFields[collectionName].fields
+          /***
+           * Collection `collectionName` has template `templateName`...
+           */
+          if (
+            templateName &&
+            documentFields[collectionName].templates &&
+            documentFields[collectionName].templates[templateName]
+          ) {
+            template =
+              documentFields[collectionName].templates[templateName].template
+            fields =
+              documentFields[collectionName].templates[templateName].fields
+          } else {
+            fields = documentFields[collectionName].fields
+          }
+
+          setInfo({
+            collection,
+            template,
+            fields,
+            mutationInfo,
+          })
+        } catch (error) {
+          cms.alerts.error(
+            `[${error.name}] GetDocumentFields failed: ${error.message}`,
+            30 * 1000 // 30 seconds
+          )
+          console.error(error)
+          setInfo({
+            collection: undefined,
+            template: undefined,
+            fields: undefined,
+            mutationInfo: undefined,
+          })
+          setError(error)
         }
 
-        setInfo({
-          collection,
-          template,
-          fields,
-          mutationInfo,
-        })
-      } catch (error) {
-        cms.alerts.error(
-          `[${error.name}] GetDocumentFields failed: ${error.message}`,
-          30 * 1000 // 30 seconds
-        )
-        console.error(error)
-        setInfo({
-          collection: undefined,
-          template: undefined,
-          fields: undefined,
-          mutationInfo: undefined,
-        })
-        setError(error)
+        setLoading(false)
       }
-
-      setLoading(false)
     }
 
     setLoading(true)
@@ -114,14 +117,14 @@ const GetDocumentFields = ({
   const { collection, template, fields, mutationInfo, loading, error } =
     useGetDocumentFields(cms, collectionName, templateName)
 
-  if (!collection) {
-    if (loading) {
-      return <LoadingPage />
-    }
-    if (error) {
-      return null
-    }
+  if (error) {
+    return null
   }
+
+  if (loading) {
+    return <LoadingPage />
+  }
+
   return (
     <>{children({ collection, template, fields, mutationInfo, loading })}</>
   )

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -49,7 +49,15 @@ const createDocument = async (
       includeTemplate,
     }
   )
-  await api.createDocument(collection.name, relativePath, params)
+
+  if (await api.isAuthenticated()) {
+    await api.createDocument(collection.name, relativePath, params)
+  } else {
+    const authMessage = `[Error] CreateDocument failed: User is no longer authenticated; please login and try again.`
+    cms.alerts.error(authMessage, 30 * 1000)
+    console.error(authMessage)
+    return false
+  }
 }
 
 const CollectionCreatePage = () => {

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -40,8 +40,14 @@ const updateDocument = async (
     includeCollection,
     includeTemplate,
   })
-
-  await api.updateDocument(collection.name, relativePath, params)
+  if (await api.isAuthenticated()) {
+    await api.updateDocument(collection.name, relativePath, params)
+  } else {
+    const authMessage = `[Error] UpdateDocument failed: User is no longer authenticated; please login and try again.`
+    cms.alerts.error(authMessage, 30 * 1000)
+    console.error(authMessage)
+    return false
+  }
 }
 
 const CollectionUpdatePage = () => {


### PR DESCRIPTION
This was discovered during some dogfooding that the Global Nav attempts to retrieve the Collections list (via `GetCollections()`) _before_ the user is authenticated resulting in a misleading error message.

I've pulled `isAuthenticated()` into `TinaAdminApi` where it is simply calling `cms.api.tina.isAuthenticated()`.  I've wrapped the hooks in a check against that.

I also _fixed_ a bug with the loading animation not appearing (one I introduced, whoops).

Closes #2657 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
