### PR TITLE
Fix/z index issue

### DIFF
--- a/.changeset/tall-cars-add.md
+++ b/.changeset/tall-cars-add.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fixed z index issue with nested forms

--- a/experimental-examples/unit-test-example/package.json
+++ b/experimental-examples/unit-test-example/package.json
@@ -19,6 +19,5 @@
     "@tinacms/cli": "workspace:*",
     "eslint": "7",
     "eslint-config-next": "12.0.3"
-  },
-  "version": null
+  }
 }

--- a/packages/@tinacms/toolkit/src/packages/form-builder/FormPortal.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/FormPortal.tsx
@@ -38,11 +38,11 @@ export const FormPortalProvider: React.FC = ({ children }) => {
 
   const FormPortal = React.useCallback(
     (props: any) => {
-      const portalZIndex = React.useMemo<number>(() => {
+      const portalZIndex = () => {
         const value = zIndexRef.current
         zIndexRef.current += 1
         return value
-      }, [])
+      }
 
       if (!wrapperRef.current) return null
 


### PR DESCRIPTION
Fixes a bug where if you had an object (list false) and then another object as a child (list true) you would not be able to click on any of the templates.

See https://www.loom.com/share/06404c49de004177b5d19a3c2e0ab45f
