### PR TITLE
Batch of console.error fixes

### DIFF
--- a/.changeset/rude-seahorses-drop.md
+++ b/.changeset/rude-seahorses-drop.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Update version of react-beautiful-dnd to silence red herrings in the console
+
+See https://github.com/atlassian/react-beautiful-dnd/issues/1108

--- a/.changeset/smart-starfishes-cross.md
+++ b/.changeset/smart-starfishes-cross.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Ensure `error` is a string before rendering it from field meta component. In situations where an object's sub-field was invalid, touching the sub-field would trigger this error to be an object at the parent, React throws an error when trying to render an object

--- a/packages/@tinacms/toolkit/package.json
+++ b/packages/@tinacms/toolkit/package.json
@@ -104,7 +104,7 @@
     "multer": "1.4.2",
     "path": "^0.12.7",
     "prop-types": "15.7.2",
-    "react-beautiful-dnd": "^11.0.5",
+    "react-beautiful-dnd": "^13.1.0",
     "react-color": "^2.17.3",
     "react-datetime": "^2.16.3",
     "react-dropzone": "10.1.8",

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/hooks/use-resize.ts
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/hooks/use-resize.ts
@@ -20,7 +20,6 @@ import React from 'react'
 
 export const useResize = (ref, callback) => {
   React.useEffect(() => {
-    //@ts-ignore
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
         callback(entry)

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -77,7 +77,12 @@ export const FieldMeta = ({
         {description && <FieldDescription>{description}</FieldDescription>}
       </FieldLabel>
       {children}
-      {error && <FieldError>{error}</FieldError>}
+      {/*
+      FIXME: when a object field has a sub-field with a validation (eg. required)
+             AND the object field is not pristine (eg. you've touched other fields)
+             the error will be an object (eg {mySubField: "required"}).
+     */}
+      {error && typeof error === 'string' && <FieldError>{error}</FieldError>}
     </FieldWrapper>
   )
 }

--- a/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
@@ -44,7 +44,12 @@ export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
     // @ts-ignore FIXME twind
     <FieldsGroup>
       {fields.map((field: Field) => (
-        <InnerField field={field} form={form} fieldPlugins={fieldPlugins} />
+        <InnerField
+          key={field.name}
+          field={field}
+          form={form}
+          fieldPlugins={fieldPlugins}
+        />
       ))}
     </FieldsGroup>
   )

--- a/packages/tinacms/src/rich-text.tsx
+++ b/packages/tinacms/src/rich-text.tsx
@@ -115,7 +115,7 @@ export const TinaMarkdown = ({
             if (components[child.type]) {
               const Component = components[child.type]
               return (
-                <Component key={key} {...props} childrenRaw={children}>
+                <Component key={key} {...props}>
                   <TinaMarkdown components={components} content={children} />
                 </Component>
               )
@@ -172,7 +172,7 @@ export const TinaMarkdown = ({
               const Component = components[child.type]
               return (
                 // @ts-ignore FIXME: TinaMarkdownContent needs to be a union of all possible node types
-                <Component key={key} {...props} childrenRaw={children}>
+                <Component key={key} {...props}>
                   {/* @ts-ignore FIXME: TinaMarkdownContent needs to be a union of all possible node types */}
                   {value}
                 </Component>


### PR DESCRIPTION
We've been getting a few messages in the console about these, most are benign but the one that does error in dev is the `error` message being an object.

The biggest change here is to `react-beautiful-dnd` which has gone from 11 to 13, though I haven't run into any issues, and from reading through them it doesn't look like we're relying on things that have broken https://github.com/atlassian/react-beautiful-dnd/releases.