### PR TITLE
Ensure client-side Tina code only runs on the browser

### DIFF
--- a/.changeset/loud-colts-jump.md
+++ b/.changeset/loud-colts-jump.md
@@ -1,0 +1,9 @@
+---
+'tinacms': patch
+---
+
+Ensure client-side Tina code only runs on the browser. Without this check, we'd see a server/client mismatch like:
+
+```
+warning.js:33 Warning: Expected server HTML to contain a matching <div> in <body>.
+```

--- a/packages/tinacms/src/edit-state.tsx
+++ b/packages/tinacms/src/edit-state.tsx
@@ -127,7 +127,15 @@ const ToggleButton = () => {
 
 const TinaEditProviderInner = ({ children, editMode }) => {
   const { edit } = useEditState()
-  if (edit) {
+  const [isBrowser, setIsBrowser] = React.useState(false)
+
+  // Ensure Tina doesn't initialize server-side to prevent:
+  // "Warning: Did not expect server HTML to contain a <div> in <div>."
+  React.useEffect(() => {
+    setIsBrowser(true)
+  }, [])
+
+  if (edit && isBrowser) {
     return editMode
   }
 


### PR DESCRIPTION
Ensure client-side Tina code only runs on the browser. Without this check, we'd see a server/client mismatch like:

```
warning.js:33 Warning: Expected server HTML to contain a matching <div> in <body>.
```

cc @logan-anderson I know you've been around this area of the code a lot, do you see any potential issues in blocking this initially?