### PR TITLE
Fix parsing error for `rich-text` fields with `null` values

### DIFF
--- a/.changeset/brown-keys-hammer.md
+++ b/.changeset/brown-keys-hammer.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix issue where un-normalized rich-text fields which send `null` values to the server on save would cause a parsing error

--- a/packages/@tinacms/graphql/src/mdx/stringify.ts
+++ b/packages/@tinacms/graphql/src/mdx/stringify.ts
@@ -52,6 +52,9 @@ const allChildrenEmpty = (children: any[]) => {
 }
 
 const stringifyChildren = (children: any[], field) => {
+  if (!children) {
+    return []
+  }
   return (
     children
       .map((child) => stringify(child, field))


### PR DESCRIPTION
Fix issue where un-normalized rich-text fields which send `null` values to the server on save would cause a parsing error

To reproduce this without the fix I think you just need the `rich-text` field to be nested inside an object list of some sort, add a new object and hit save.