### PR TITLE
Fix console warning about a ref being passed to a function component

### DIFF
--- a/.changeset/dirty-peaches-greet.md
+++ b/.changeset/dirty-peaches-greet.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix console warning about a ref being passed to a function component

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/BlockSelector.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/BlockSelector.tsx
@@ -48,7 +48,7 @@ export const BlockSelector = ({
     <Popover>
       {({ open }) => (
         <>
-          <Popover.Button as={React.Fragment}>
+          <Popover.Button as={'span'}>
             <IconButton
               variant={open ? 'secondary' : 'primary'}
               size="small"


### PR DESCRIPTION
Got the error:

```
Function components cannot have refs. Did you mean to use React.forwardRef()
```

I think the issue was that under the hood the `Popover.Button` was passing a ref to whatever was supplied in the `as` prop. Setting this to a `span` addresses it and seems ok from a UI perspective. 

cc @spbyrne 