### PR TITLE
fix scrollbar ui bug

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/combobox.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/combobox.tsx
@@ -173,7 +173,7 @@ export function SearchAutocomplete(props: {
   return (
     <span
       ref={ref}
-      className="block w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none max-h-[10rem] overflow-scroll"
+      className="block w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none max-h-[10rem] overflow-y-auto"
     >
       <span className="block py-1">
         {state.activeTemplates.length === 0 && (

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/dropdown.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/dropdown.tsx
@@ -49,7 +49,7 @@ export function Dropdown({
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Menu.Items className="origin-top-right absolute right-0 mt-2 w-32 h-64 overflow-scroll rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Menu.Items className="origin-top-right absolute right-0 mt-2 w-32 h-64 overflow-y-auto rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
           <div className="py-1">
             {items.map((item) => (
               <Menu.Item key={item.key}>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/toolbar/toolbar-item.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/toolbar/toolbar-item.tsx
@@ -225,7 +225,7 @@ export const EmbedButton = ({
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <div className="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1 max-h-[10rem] overflow-scroll">
+            <div className="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1 max-h-[10rem] overflow-y-auto">
               {templates.map((template) => (
                 <span
                   key={template.name}


### PR DESCRIPTION
There was a double scrollbar always showing up in a few dropdown menus, this replaces it with a vertical scrollbar when needed.

Issue:

<img width="382" alt="Screen Shot 2022-03-11 at 11 06 03 AM" src="https://user-images.githubusercontent.com/5075484/157893435-d86f39c0-1fa2-4050-86cb-43dd7083d3e9.png">

After change:

<img width="371" alt="Screen Shot 2022-03-11 at 11 06 27 AM" src="https://user-images.githubusercontent.com/5075484/157893490-47530f46-d080-42d5-9d12-1f8e9665218c.png">

