### PR TITLE
Rich Text Styles

### DIFF
--- a/.changeset/stupid-pumas-wait.md
+++ b/.changeset/stupid-pumas-wait.md
@@ -2,4 +2,4 @@
 '@tinacms/toolkit': patch
 ---
 
-added margin to rich text elements
+add spacing and link styles to rich text field

--- a/.changeset/stupid-pumas-wait.md
+++ b/.changeset/stupid-pumas-wait.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+added margin to rich text elements

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
@@ -200,7 +200,16 @@ export const components = () => {
       nodeProps,
       className,
       ...props
-    }) => <a className={classNames(className)} {...attributes} {...props} />,
+    }) => (
+      <a
+        className={classNames(
+          className,
+          'text-blue-500 hover:text-blue-600 transition-color ease-out duration-150 underline'
+        )}
+        {...attributes}
+        {...props}
+      />
+    ),
     [MARK_CODE]: ({ editor, leaf, text, attributes, className, ...props }) => (
       <code
         className={classNames('bg-gray-100 p-1 rounded-sm', className)}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
@@ -163,7 +163,11 @@ export const components = () => {
     [ELEMENT_CODE_BLOCK]: (props) => <CodeBlock {...props} />,
     [ELEMENT_UL]: ({ attributes, editor, className, element, ...props }) => (
       <ul
-        className={classNames(blockClasses, className, 'mb-4 last:mb-0')}
+        className={classNames(
+          blockClasses,
+          className,
+          'mb-4 list-disc last:mb-0'
+        )}
         {...attributes}
         {...props}
       />
@@ -236,7 +240,7 @@ export const components = () => {
         <div
           className={classNames(
             className,
-            'cursor-pointer relative border bg-gray-200 my-2'
+            'cursor-pointer relative border bg-gray-200 my-4 first:mt-0 last:mb-0'
           )}
           {...attributes}
           {...props}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
@@ -59,7 +59,7 @@ export const components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-4xl font-medium'
+          'text-4xl font-medium mb-4 last:mb-0 mt-6 first:mt-0'
         )}
         {...attributes}
         {...props}
@@ -71,7 +71,7 @@ export const components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-3xl font-medium'
+          'text-3xl font-medium mb-4 last:mb-0 mt-6 first:mt-0'
         )}
         {...attributes}
         {...props}
@@ -83,7 +83,7 @@ export const components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-2xl font-semibold'
+          'text-2xl font-semibold mb-4 last:mb-0 mt-6 first:mt-0'
         )}
         {...attributes}
         {...props}
@@ -95,7 +95,7 @@ export const components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-xl font-bold'
+          'text-xl font-bold mb-4 last:mb-0 mt-6 first:mt-0'
         )}
         {...attributes}
         {...props}
@@ -108,7 +108,7 @@ export const components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-lg font-bold'
+          'text-lg font-bold mb-4 last:mb-0 mt-6 first:mt-0'
         )}
         {...attributes}
         {...props}
@@ -120,7 +120,7 @@ export const components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-base font-bold'
+          'text-base font-bold mb-4 last:mb-0 mt-6 first:mt-0'
         )}
         {...attributes}
         {...props}
@@ -134,7 +134,11 @@ export const components = () => {
       ...props
     }) => (
       <p
-        className={classNames(blockClasses, className, `text-base font-normal`)}
+        className={classNames(
+          blockClasses,
+          className,
+          `text-base font-normal mb-4 last:mb-0`
+        )}
         {...attributes}
         {...props}
       />
@@ -147,7 +151,11 @@ export const components = () => {
       ...props
     }) => (
       <blockquote
-        className={classNames('not-italic', blockClasses, className)}
+        className={classNames(
+          'not-italic mb-4 last:mb-0',
+          blockClasses,
+          className
+        )}
         {...attributes}
         {...props}
       />
@@ -155,7 +163,7 @@ export const components = () => {
     [ELEMENT_CODE_BLOCK]: (props) => <CodeBlock {...props} />,
     [ELEMENT_UL]: ({ attributes, editor, className, element, ...props }) => (
       <ul
-        className={classNames(blockClasses, className)}
+        className={classNames(blockClasses, className, 'mb-4 last:mb-0')}
         {...attributes}
         {...props}
       />
@@ -176,7 +184,7 @@ export const components = () => {
     ),
     [ELEMENT_LI]: ({ attributes, className, editor, element, ...props }) => (
       <li
-        className={classNames('mt-0 mb-1', className)}
+        className={classNames('mt-0 mb-2 last:mb-0', className)}
         {...attributes}
         {...props}
       />
@@ -219,7 +227,7 @@ export const components = () => {
         <div
           className={classNames(
             className,
-            'cursor-pointer relative border bg-gray-200 my-4'
+            'cursor-pointer relative border bg-gray-200 my-2'
           )}
           {...attributes}
           {...props}

--- a/packages/@tinacms/toolkit/src/styles.css
+++ b/packages/@tinacms/toolkit/src/styles.css
@@ -17,7 +17,7 @@
 
 /* if the last block has margin-bottom it makes the text box larger but some of it isn't clickable */
 .prose [data-slate-editor='true'] {
-  padding-bottom: 1em;
+  padding-bottom: 0.5em;
 }
 /* prose adds backticks, which look like they should be editable */
 .prose [data-slate-editor='true'] .slate-code::before {
@@ -40,5 +40,5 @@
 
 /* experimental floating toolbar doesn't need a large text area */
 .with-toolbar [data-slate-editor='true'] {
-  min-height: 100px;
+  min-height: 72px;
 }


### PR DESCRIPTION
<img width="667" alt="Screen Shot 2022-03-15 at 2 33 37 PM" src="https://user-images.githubusercontent.com/5075484/158437422-5f178a33-63a0-4168-a617-ba03d4766e34.png">

This improves the spacing between elements in the rich text editor and adds styles for links.