### PR TITLE
Admin overflow fix

### DIFF
--- a/.changeset/angry-camels-appear.md
+++ b/.changeset/angry-camels-appear.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Updated sidebar nav component to allow scrolling if needed

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Nav.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Nav.tsx
@@ -130,7 +130,7 @@ export const Nav = ({
         </Menu>
       </div>
       {children}
-      <div className="px-6 flex-1">
+      <div className="px-6 flex-1 overflow-auto">
         {showCollections && (
           <>
             <h4 className="uppercase font-bold text-sm mb-3 mt-8 text-gray-700">


### PR DESCRIPTION
This tiny change allows for the admin area to scroll for those with a large number of collections or a very short browser viewport (or both!). 