### PR TITLE
Add an MDX field to the CLI init example.

### DIFF
--- a/.changeset/eighty-jokes-kneel.md
+++ b/.changeset/eighty-jokes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Adds an MDX example when you run @tinacms/cli init

--- a/packages/@tinacms/cli/src/cmds/compile/defaultSchema.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/defaultSchema.ts
@@ -27,13 +27,31 @@ export default defineSchema({
           name: "title",
         },
         {
-          type: "string",
+          type: "rich-text",
           label: "Blog Post Body",
           name: "body",
           isBody: true,
-          ui: {
-            component: "textarea"
-          },
+          templates: [
+            {
+              name: "PageSection",
+              label: "Page Section",
+              fields: [
+                {
+                  type: "string",
+                  name: "heading",
+                  label: "Heading",
+                },
+                {
+                  type: "string",
+                  name: "content",
+                  label: "Content",
+                  ui: {
+                    component: "textarea"
+                  }
+                }
+              ],
+            },
+          ]
         },
       ],
     },

--- a/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
@@ -24,14 +24,12 @@ title: Vote For Pedro
 
 # Dixi gaude Arethusa
 
-## Oscula mihi
-
-Lorem markdownum numerabilis armentorum platanus, cultros coniunx sibi per
+<PageSection heading="Oscula mihi" content="Lorem markdownum numerabilis armentorum platanus, cultros coniunx sibi per
 silvas, nostris clausit sequemur diverso scopulosque. Fecit tum alta sed non
 falcato murmura, geminas donata Amyntore, quoque Nox. Invitam inquit, modo
 nocte; ut ignis faciemque manes in imagine sinistra ut mucrone non ramos
 sepulcro supplex. Crescentesque populos motura, fit cumque. Verumque est; retro
-sibi tristia bracchia Aetola telae caruerunt et.
+sibi tristia bracchia Aetola telae caruerunt et."/>
 
 
 ## Mutato fefellimus sit demisit aut alterius sollicito
@@ -54,6 +52,7 @@ export const nextPostPage =
   import Head from "next/head";
   import { createGlobalStyle } from "styled-components";
   import { useTina } from "tinacms/dist/edit-state";
+  import { TinaMarkdown } from 'tinacms/dist/rich-text'
 
   const query = gql\`
     query BlogPostQuery($relativePath: String!) {
@@ -99,7 +98,6 @@ export const nextPostPage =
     text-decoration: underline;
   }
   \`;
-  const defaultMarked = (markdown) => markdown;
   // Use the props returned by get static props (this can be deleted when the edit provider and tina-wrapper are moved to _app.js)
   const BlogPage = (props) => {
     const { data } = useTina({
@@ -135,12 +133,9 @@ export const nextPostPage =
             <h1 className="text-3xl m-8 text-center leading-8 font-extrabold tracking-tight text-gray-900 sm:text-4xl">
               {data.getPostsDocument.data.title}
             </h1>
-            {/* Convert markdown to html in the browser only */}
-            {typeof window !== "undefined" && (
-              <ContentSection
-                content={window.marked.parse(data.getPostsDocument.data.body)}
-              ></ContentSection>
-            )}
+            <ContentSection
+              content={data.getPostsDocument.data.body}
+            ></ContentSection>
           </div>
           <div className="bg-green-100 text-center">
             Lost and looking for a place to start?
@@ -205,6 +200,19 @@ export const nextPostPage =
   };
   
   export default BlogPage;
+
+  const PageSection = props => {
+    return (
+      <>
+        <h2>{ props.heading }</h2>
+        <p>{ props.content }</p>
+      </>
+    )
+  }
+
+  const components = {
+    PageSection: PageSection,
+  }
   
   const ContentSection = ({ content }) => {
     return (
@@ -314,7 +322,7 @@ export const nextPostPage =
         </div>
         <div className="relative px-4 sm:px-6 lg:px-8">
           <div className="text-lg max-w-prose mx-auto">
-            <div dangerouslySetInnerHTML={{ __html: content }}></div>
+            <TinaMarkdown components={components} content={content}/>
             <GlobalStyle />
           </div>
         </div>

--- a/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
@@ -98,7 +98,7 @@ export const nextPostPage =
     text-decoration: underline;
   }
   \`;
-  // Use the props returned by get static props (this can be deleted when the edit provider and tina-wrapper are moved to _app.js)
+  
   const BlogPage = (props) => {
     const { data } = useTina({
       query,
@@ -116,12 +116,6 @@ export const nextPostPage =
             integrity="sha512-y6ZMKFUQrn+UUEVoqYe8ApScqbjuhjqzTuwUMEGMDuhS2niI8KA3vhH2LenreqJXQS+iIXVTRL2iaNfJbDNA1Q=="
             crossOrigin="anonymous"
             referrerPolicy="no-referrer"
-          />
-          {/* Marked CDN */}
-          <script
-            type="text/javascript"
-            crossOrigin="anonymous"
-            src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.0.0/marked.min.js"
           />
         </Head>
         <div>


### PR DESCRIPTION
Closes #2641 

This PR adds a simple MDX field to the example you get when you run `@tinacms/cli init`.

<img width="1594" alt="image" src="https://user-images.githubusercontent.com/5082908/159351397-9fee45c0-bbad-49f0-acd0-a3e82fc6d2f6.png">

Nothing extremely beautiful. I considered pulling in the `CallOut` component that we have in some docs and blog posts but didn't want to add in that much boilerplate. But happy to make the component a bit more exciting it that seems desirable.

1. To test this I've been starting with a next-js starter `npx create-next-app nextjs-blog --use-npm --example "https://github.com/vercel/next-learn/tree/master/basics/learn-starter"`
2. Then you can use a dev version that I've pushed to npm `npx @tinacms/cli@0.0.0-2022221193751 init`

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
3. It must be up-to-date with master
4. It must be approved by at least 1 tinacms core member
5. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
