### PR TITLE
2590 - Improves no TinaEditProvider error message

### DIFF
--- a/.changeset/famous-cheetahs-check.md
+++ b/.changeset/famous-cheetahs-check.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/sharedctx': patch
+---
+
+Improves no TinaEditProvider error message

--- a/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
+++ b/experimental-examples/tina-cloud-starter/.tina/__generated__/_schema.json
@@ -689,6 +689,7 @@
           "type": "string",
           "label": "Name",
           "name": "name",
+          "ui": {},
           "namespace": [
             "authors",
             "name"

--- a/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
+++ b/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
@@ -20,9 +20,10 @@ const isSSR = typeof window === 'undefined'
 
 export const isEditing = (): boolean => {
   if (!isSSR) {
-    // localStorage may be intentionally disabled for site visitors, 
+    // localStorage may be intentionally disabled for site visitors,
     // in that case Tina can't be used so just return false
-    const isEdit = window.localStorage && window.localStorage.getItem(LOCALSTORAGEKEY)
+    const isEdit =
+      window.localStorage && window.localStorage.getItem(LOCALSTORAGEKEY)
     return isEdit && isEdit === 'true'
   }
   // assume not editing if SSR
@@ -79,7 +80,9 @@ export const EditProvider: React.FC = ({ children }) => {
 export const useEditState = () => {
   const { edit, setEdit } = useContext(EditContext)
   if (!setEdit) {
-    throw new Error('No `TinaEditProvider` found')
+    throw new Error(
+      'Unable to find `TinaProvider`; did you forget to add the TinaCMS container to your _app layout?  See our setup docs: https://tina.io/docs/introduction/tina-init/#adding-tina'
+    )
   }
   return { edit, setEdit }
 }

--- a/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
+++ b/packages/@tinacms/sharedctx/src/edit-state-ctx.tsx
@@ -81,7 +81,7 @@ export const useEditState = () => {
   const { edit, setEdit } = useContext(EditContext)
   if (!setEdit) {
     throw new Error(
-      'Unable to find `TinaProvider`; did you forget to add the TinaCMS container to your _app layout?  See our setup docs: https://tina.io/docs/introduction/tina-init/#adding-tina'
+      'Unable to find `TinaProvider`; did you forget to add the TinaCMS container to your app root?  See our setup docs: https://tina.io/docs/introduction/tina-init/#adding-tina'
     )
   }
   return { edit, setEdit }


### PR DESCRIPTION
A small, but (potentially) significant change to the error message presented when TinaCMS is not found in the _app layout.

This updates the language to reference the new `TinaProvider` pattern and a link to the `Adding Tina` part of the setup docs:

```
Unable to find `TinaProvider`; did you forget to add the TinaCMS container to your _app layout?  See our setup docs: https://tina.io/docs/introduction/tina-init/#adding-tina
```

Closes #2590 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
