### PR TITLE
Don't attempt to formify nodes which don't have data fields

### DIFF
--- a/.changeset/three-rockets-lick.md
+++ b/.changeset/three-rockets-lick.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Don't attempt to formify nodes which don't have data fields (ie. ...on Node)

--- a/packages/tinacms/src/hooks/formify/formify.ts
+++ b/packages/tinacms/src/hooks/formify/formify.ts
@@ -383,7 +383,7 @@ export const formify = async ({
   }) => {
     const type = util.getSelectedUnionType(parentType, inlineFragmentNode)
 
-    if (util.isDocumentField(type)) {
+    if (util.isFormifiableDocument(type)) {
       return formifyInlineFragmentDocument({
         inlineFragmentNode: inlineFragmentNode,
         type,
@@ -437,7 +437,7 @@ export const formify = async ({
                     fieldNode: selectionNode,
                     type: field.type,
                   })
-                  if (util.isDocumentField(field.type)) {
+                  if (util.isFormifiableDocument(field.type)) {
                     return formifyFieldNodeDocument({
                       fieldNode: selectionNode,
                       type: field.type,

--- a/packages/tinacms/src/hooks/formify/util.ts
+++ b/packages/tinacms/src/hooks/formify/util.ts
@@ -224,7 +224,6 @@ export const buildForm = (
       schema: enrichedSchema,
       template,
     })
-    console.log('usit', formInfo)
     formConfig = {
       label: formInfo.label,
       // TODO: return correct type


### PR DESCRIPTION
@spbyrne noticed this in the starter on the post index page, which makes use of this query

```graphql
getPostList {
  edges {
    node {
      ...on Document {
        id
      }
    }
  }
}
```
The code was attempting to formify this node, even though it doesn't have any fields that can be edited.