### PR TITLE
update Database.indexContentByPaths to not require collection parameter

### DIFF
--- a/.changeset/hot-tomatoes-speak.md
+++ b/.changeset/hot-tomatoes-speak.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Modify Database.indexContentByPaths to not require collection parameter


### PR DESCRIPTION
In the initial datalayer work for querying, the indexContentByPaths method was modified to take a Collection. This isn't available to all callers, so this change removes the parameter and uses the documentPath to determine the collection.
