### PR TITLE
fix: 0 no longer evaluated as false

### DIFF
--- a/.changeset/wicked-tips-itch.md
+++ b/.changeset/wicked-tips-itch.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/datalayer': patch
+---
+
+Fixed an issue where `0` as a numerical operand was being evaluated as falsy.

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -12,15 +12,15 @@
  */
 
 import {
-  FilterCondition,
-  makeFilterChain,
-  OP,
-  makeFilterSuffixes,
-  makeFilter,
-  makeKeyForField,
-  coerceFilterChainOperands,
-  TernaryFilter,
   BinaryFilter,
+  FilterCondition,
+  OP,
+  TernaryFilter,
+  coerceFilterChainOperands,
+  makeFilter,
+  makeFilterChain,
+  makeFilterSuffixes,
+  makeKeyForField,
 } from '.'
 
 describe('datalayer store helper functions', () => {
@@ -429,6 +429,33 @@ describe('datalayer store helper functions', () => {
           leftOperator: OP.GT,
           rightOperator: OP.LT,
           type: 'datetime',
+        }
+        const filterCondition: FilterCondition = {
+          filterExpression: {
+            [expected.rightOperator.toLowerCase()]: expected.rightOperand,
+            [expected.leftOperator.toLowerCase()]: expected.leftOperand,
+            _type: expected.type,
+          },
+          filterPath: pathExpression,
+        }
+        const filterChain = makeFilterChain({
+          conditions: [filterCondition],
+        })
+
+        expect(filterChain).toBeDefined()
+        expect(filterChain).toHaveLength(1)
+        expect(filterChain[0]).toEqual(expected)
+      })
+
+      it('numerical ternary filter with 0 as operand', () => {
+        const pathExpression = 'foo.bar'
+        const expected = {
+          pathExpression,
+          rightOperand: 0,
+          leftOperand: 1,
+          leftOperator: OP.GT,
+          rightOperator: OP.LT,
+          type: 'number',
         }
         const filterCondition: FilterCondition = {
           filterExpression: {

--- a/packages/@tinacms/datalayer/src/database/store/index.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.ts
@@ -11,9 +11,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { JSONPath } from 'jsonpath-plus'
-
 import { FilterOperand } from '../../index'
+import { JSONPath } from 'jsonpath-plus'
 
 export const DEFAULT_COLLECTION_SORT_KEY = '__filepath__'
 
@@ -174,6 +173,13 @@ export type FilterCondition = {
   filterPath: string
 }
 
+const getFilterOperator = (
+  expression: Record<string, FilterOperand>,
+  operand: string
+) => {
+  return (expression[operand] || expression[operand] === 0) && operand
+}
+
 export const makeFilterChain = ({
   conditions,
 }: {
@@ -203,15 +209,17 @@ export const makeFilterChain = ({
       })
     } else if (key1 && key2) {
       const leftFilterOperator =
-        (filterExpression['gt'] && 'gt') ||
-        (filterExpression['gte'] && 'gte') ||
-        (filterExpression['after'] && 'after') ||
+        getFilterOperator(filterExpression, 'gt') ||
+        getFilterOperator(filterExpression, 'gte') ||
+        getFilterOperator(filterExpression, 'after') ||
         undefined
+
       const rightFilterOperator =
-        (filterExpression['lt'] && 'lt') ||
-        (filterExpression['lte'] && 'lte') ||
-        (filterExpression['before'] && 'before') ||
+        getFilterOperator(filterExpression, 'lt') ||
+        getFilterOperator(filterExpression, 'lte') ||
+        getFilterOperator(filterExpression, 'before') ||
         undefined
+
       let leftOperand: FilterOperand
       let rightOperand: FilterOperand
       if (rightFilterOperator && leftFilterOperator) {


### PR DESCRIPTION
Closes #2734

Kelly correctly pointed out on that ticket that `0` was being evaluated as falsy so an operator was being returned as undefined. 

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/5082908/160695693-4fe87d7b-12a9-47c4-a4fa-a7b4245ddfb3.png">


<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
