### PR TITLE
Turn on new formify logic by default

### DIFF
--- a/.changeset/curvy-socks-punch.md
+++ b/.changeset/curvy-socks-punch.md
@@ -1,0 +1,11 @@
+---
+'tinacms': minor
+---
+
+Updates to the way forms are generated in contextual editing. This lays the groundwork for
+future updates but doesn't offer new behavior yet. It does come with a small breaking change:
+
+[BREAKING]: The `id` of forms is now the actual document `path`. Previously this was the name of the GraphQL query node (eg. `getPostDocument`).
+If you're using the [`formifyCallback`](https://tina.io/docs/advanced/customizing-forms/#customizing-a-form) prop to create global forms, you'll probably need to update the callback to check for the appropriate id.
+
+Eg. `formConfig.id === 'getSiteNavsDocument'` should be something like `formConfig.id === 'content/navs/mynav.md'`

--- a/.changeset/curvy-socks-punch.md
+++ b/.changeset/curvy-socks-punch.md
@@ -9,3 +9,5 @@ future updates but doesn't offer new behavior yet. It does come with a small bre
 If you're using the [`formifyCallback`](https://tina.io/docs/advanced/customizing-forms/#customizing-a-form) prop to create global forms, you'll probably need to update the callback to check for the appropriate id.
 
 Eg. `formConfig.id === 'getSiteNavsDocument'` should be something like `formConfig.id === 'content/navs/mynav.md'`
+
+If you're experiencing any issues with contextual editing, you can disable this flag for now by specifying `cms.flags.set('use-unstable-formify', false)`.

--- a/cypress/integration/kitchen-sink/sidebar.spec.js
+++ b/cypress/integration/kitchen-sink/sidebar.spec.js
@@ -66,7 +66,7 @@ describe('Tina side bar', () => {
     // Delete all text in rich text editor
     // Best practice is to clean up state BEFORE the test: https://docs.cypress.io/guides/references/best-practices#Using-after-or-afterEach-hooks
 
-    // cy.get('[data-test="form:getPageDocument"]')
+    // cy.get('[data-test="form:content/page/home.mdx"]')
     //   .first()
     //   .scrollTo('bottomLeft', {
     //     easing: 'linear',
@@ -87,7 +87,7 @@ describe('Tina side bar', () => {
     // cy.get(`[aria-label="opens cms sidebar"]`, { timeout: 5000 }).click()
   })
   it('Can edit text', () => {
-    cy.get('[data-test="form:getPageDocument"]')
+    cy.get('[data-test="form:content/page/home.mdx"]')
       .first()
       .scrollTo('top', {
         easing: 'linear',
@@ -100,7 +100,7 @@ describe('Tina side bar', () => {
           .type(SUBTITLE_TEXT)
         cy.get('[data-test="subtitle"]').should('contain', SUBTITLE_TEXT)
 
-        // cy.get('[data-test="form:getPageDocument"]').first().scrollTo('top')
+        // cy.get('[data-test="form:content/page/home.mdx"]').first().scrollTo('top')
         // Editing heading
         cy.get('input[name="heading"]', { timeout: 3000 })
           .click()
@@ -110,7 +110,7 @@ describe('Tina side bar', () => {
   })
 
   it('Can edit rich text', () => {
-    cy.get('[data-test="form:getPageDocument"]')
+    cy.get('[data-test="form:content/page/home.mdx"]')
       .first()
       .scrollTo('bottom', {
         easing: 'linear',

--- a/experimental-examples/kitchen-sink/.tina/__generated__/_graphql.json
+++ b/experimental-examples/kitchen-sink/.tina/__generated__/_graphql.json
@@ -675,6 +675,20 @@
                   "value": "Float"
                 }
               }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
             }
           ],
           "type": {
@@ -801,6 +815,20 @@
                   "value": "Float"
                 }
               }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
             }
           ],
           "type": {
@@ -907,6 +935,20 @@
                 "name": {
                   "kind": "Name",
                   "value": "Float"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
                 }
               }
             }
@@ -1239,6 +1281,20 @@
                 "name": {
                   "kind": "Name",
                   "value": "Float"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
                 }
               }
             }

--- a/experimental-examples/kitchen-sink/.tina/__generated__/schema.gql
+++ b/experimental-examples/kitchen-sink/.tina/__generated__/schema.gql
@@ -47,12 +47,12 @@ type Query {
   getCollections: [Collection!]!
   node(id: String): Node!
   getDocument(collection: String, relativePath: String): DocumentNode!
-  getDocumentList(before: String, after: String, first: Float, last: Float): DocumentConnection!
+  getDocumentList(before: String, after: String, first: Float, last: Float, sort: String): DocumentConnection!
   getDocumentFields: JSON!
   getPageDocument(relativePath: String): PageDocument!
-  getPageList(before: String, after: String, first: Float, last: Float): PageConnection!
+  getPageList(before: String, after: String, first: Float, last: Float, sort: String): PageConnection!
   getPostDocument(relativePath: String): PostDocument!
-  getPostList(before: String, after: String, first: Float, last: Float): PostConnection!
+  getPostList(before: String, after: String, first: Float, last: Float, sort: String): PostConnection!
 }
 
 type DocumentConnectionEdges {
@@ -75,7 +75,7 @@ type Collection {
   matches: String
   templates: [JSON]
   fields: [JSON]
-  documents(before: String, after: String, first: Float, last: Float): DocumentConnection!
+  documents(before: String, after: String, first: Float, last: Float, sort: String): DocumentConnection!
 }
 
 union DocumentNode = PageDocument | PostDocument

--- a/experimental-examples/kitchen-sink/.tina/__generated__/types.ts
+++ b/experimental-examples/kitchen-sink/.tina/__generated__/types.ts
@@ -100,6 +100,7 @@ export type QueryGetDocumentListArgs = {
   after?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Float']>;
   last?: Maybe<Scalars['Float']>;
+  sort?: Maybe<Scalars['String']>;
 };
 
 
@@ -113,6 +114,7 @@ export type QueryGetPageListArgs = {
   after?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Float']>;
   last?: Maybe<Scalars['Float']>;
+  sort?: Maybe<Scalars['String']>;
 };
 
 
@@ -126,6 +128,7 @@ export type QueryGetPostListArgs = {
   after?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Float']>;
   last?: Maybe<Scalars['Float']>;
+  sort?: Maybe<Scalars['String']>;
 };
 
 export type DocumentConnectionEdges = {
@@ -160,6 +163,7 @@ export type CollectionDocumentsArgs = {
   after?: Maybe<Scalars['String']>;
   first?: Maybe<Scalars['Float']>;
   last?: Maybe<Scalars['Float']>;
+  sort?: Maybe<Scalars['String']>;
 };
 
 export type DocumentNode = PageDocument | PostDocument;

--- a/experimental-examples/kitchen-sink/content/page/home.mdx
+++ b/experimental-examples/kitchen-sink/content/page/home.mdx
@@ -2,3 +2,4 @@
 heading: ''
 subtitle: ''
 ---
+

--- a/experimental-examples/tina-cloud-starter/pages/_app.tsx
+++ b/experimental-examples/tina-cloud-starter/pages/_app.tsx
@@ -31,7 +31,6 @@ const App = ({ Component, pageProps }) => {
                * Enables the Branch Switcher
                */
               cms.flags.set("branch-switcher", true);
-              cms.flags.set("use-unstable-formify", true);
 
               /**
                * Plugins

--- a/experimental-examples/unit-test-example/.tina/schema.tsx
+++ b/experimental-examples/unit-test-example/.tina/schema.tsx
@@ -246,7 +246,6 @@ export const tinaConfig = defineConfig({
   apiURL,
   cmsCallback: (cms) => {
     cms.flags.set('tina-admin', true)
-    cms.flags.set('use-unstable-formify', true)
     return cms
   },
 })

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -49,10 +49,6 @@ export function useGraphqlFormsUnstable<T extends object>({
 }): [T, Boolean] {
   const cms = useCMS()
 
-  React.useEffect(() => {
-    console.log('NOTE: using unstable formify')
-  }, [])
-
   const state = useFormify({
     query,
     cms,
@@ -186,12 +182,15 @@ export function useGraphqlForms<T extends object>({
       return
     }
 
+    const useUnstableFormify =
+      cms?.flags.get('use-unstable-formify') === false ? false : true
+
     const formIds: string[] = []
     setIsLoading(true)
     cms.api.tina
       .requestWithForm((gql) => gql(query), {
         variables,
-        useUnstableFormify: cms.flags.get('use-unstable-formify'),
+        useUnstableFormify,
       })
       .then((payload) => {
         cms.plugins.remove(new FormMetaPlugin({ name: 'tina-admin-link' }))

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -400,10 +400,10 @@ export const TinaDataProvider = ({
   })
   const cms = useCMS()
   const useUnstableFormify = React.useMemo(() => {
-    if (cms?.flags.get('use-unstable-formify')) {
-      return true
+    if (cms?.flags.get('use-unstable-formify') === false) {
+      return false
     }
-    return false
+    return true
   }, [cms?.flags])
 
   return (


### PR DESCRIPTION
Should be merged after https://github.com/tinacms/tinacms/pull/2751

Closes https://github.com/tinacms/tinacms/issues/2417

You can disable this flag for now by specifying `cms.flags.set('use-unstable-formify', false)`.