### PR TITLE
fix: #2740: escape index field separator in input strings

### DIFF
--- a/.changeset/dry-mirrors-smile.md
+++ b/.changeset/dry-mirrors-smile.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/datalayer': patch
+---
+
+Escape index field separator in input strings

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -21,6 +21,7 @@ import {
   makeFilterChain,
   makeFilterSuffixes,
   makeKeyForField,
+  INDEX_KEY_FIELD_SEPARATOR,
 } from '.'
 
 describe('datalayer store helper functions', () => {
@@ -204,7 +205,7 @@ describe('datalayer store helper functions', () => {
           ],
           publishedIdIndexDefn
         )
-        expect(left).toEqual('true:1')
+        expect(left).toEqual(`true${INDEX_KEY_FIELD_SEPARATOR}1`)
         expect(right).toBeUndefined()
       })
     })

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -21,8 +21,10 @@ import {
   makeFilterChain,
   makeFilterSuffixes,
   makeKeyForField,
-  INDEX_KEY_FIELD_SEPARATOR,
+  INDEX_KEY_FIELD_SEPARATOR, makeStringEscaper, DEFAULT_NUMERIC_LPAD,
 } from '.'
+
+const escapeStr = makeStringEscaper(new RegExp(INDEX_KEY_FIELD_SEPARATOR, 'gm'), encodeURIComponent(INDEX_KEY_FIELD_SEPARATOR))
 
 describe('datalayer store helper functions', () => {
   describe('buildKeyForField', () => {
@@ -37,7 +39,8 @@ describe('datalayer store helper functions', () => {
             },
           ],
         },
-        { foo: expected }
+        { foo: expected },
+        escapeStr
       )
       expect(result).toEqual(expected)
     })
@@ -54,7 +57,8 @@ describe('datalayer store helper functions', () => {
             },
           ],
         },
-        { foo: now.toISOString() }
+        { foo: now.toISOString() },
+        escapeStr
       )
       expect(result).toEqual(expected)
     })
@@ -70,7 +74,8 @@ describe('datalayer store helper functions', () => {
             },
           ],
         },
-        { bar: 'foo' }
+        { bar: 'foo' },
+        escapeStr
       )
       expect(result).toEqual(expected)
     })
@@ -362,6 +367,10 @@ describe('datalayer store helper functions', () => {
           rightOperand: 5,
           operator: OP.GT,
           type: 'number',
+          pad: {
+            fillString: '0',
+            maxLength: DEFAULT_NUMERIC_LPAD
+          }
         }
         const filterCondition: FilterCondition = {
           filterExpression: {
@@ -386,6 +395,10 @@ describe('datalayer store helper functions', () => {
           rightOperand: 5,
           operator: OP.LT,
           type: 'number',
+          pad: {
+            fillString: '0',
+            maxLength: DEFAULT_NUMERIC_LPAD
+          }
         }
         const filterCondition: FilterCondition = {
           filterExpression: {
@@ -457,6 +470,10 @@ describe('datalayer store helper functions', () => {
           leftOperator: OP.GT,
           rightOperator: OP.LT,
           type: 'number',
+          pad: {
+            fillString: '0',
+            maxLength: DEFAULT_NUMERIC_LPAD
+          }
         }
         const filterCondition: FilterCondition = {
           filterExpression: {
@@ -840,13 +857,13 @@ describe('datalayer store helper functions', () => {
         operator: OP.EQ,
         type: 'string',
       }
-      const coerced = coerceFilterChainOperands([expected])
+      const coerced = coerceFilterChainOperands([expected], escapeStr)
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)
     })
 
     it('coerces empty chain', () => {
-      const coerced = coerceFilterChainOperands([])
+      const coerced = coerceFilterChainOperands([], escapeStr)
       expect(coerced.length).toEqual(0)
     })
 
@@ -862,7 +879,7 @@ describe('datalayer store helper functions', () => {
           ...expected,
           rightOperand: new Date(expected.rightOperand as number).toISOString(),
         },
-      ])
+      ], escapeStr)
 
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)
@@ -882,7 +899,7 @@ describe('datalayer store helper functions', () => {
             new Date(expected.rightOperand[0] as number).toISOString(),
           ],
         },
-      ])
+      ], escapeStr)
 
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)
@@ -903,7 +920,7 @@ describe('datalayer store helper functions', () => {
           rightOperand: new Date(expected.rightOperand as number).toISOString(),
           leftOperand: new Date(expected.leftOperand as number).toISOString(),
         },
-      ])
+      ], escapeStr)
 
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -851,11 +851,69 @@ describe('datalayer store helper functions', () => {
 
   describe('coerceFilterChainOperands', () => {
     it('coerces string', () => {
+      const operand = 'foo'
+      const expected: BinaryFilter = {
+        pathExpression: 'title',
+        rightOperand: operand.padStart(10, ' '),
+        operator: OP.EQ,
+        type: 'string',
+        pad: {
+          fillString: ' ',
+          maxLength: 10
+        }
+      }
+      const coerced = coerceFilterChainOperands([expected], escapeStr)
+      expect(coerced.length).toEqual(1)
+      expect(coerced[0]).toEqual(expected)
+    })
+
+    it('coerces string', () => {
       const expected: BinaryFilter = {
         pathExpression: 'title',
         rightOperand: 'foo',
         operator: OP.EQ,
         type: 'string',
+      }
+      const coerced = coerceFilterChainOperands([expected], escapeStr)
+      expect(coerced.length).toEqual(1)
+      expect(coerced[0]).toEqual(expected)
+    })
+
+    it('coerces string[]', () => {
+      const expected: BinaryFilter = {
+        pathExpression: 'titles',
+        rightOperand: ['foo','bar'],
+        operator: OP.IN,
+        type: 'string',
+      }
+      const coerced = coerceFilterChainOperands([expected], escapeStr)
+      expect(coerced.length).toEqual(1)
+      expect(coerced[0]).toEqual(expected)
+    })
+
+    it('coerces string[] with padding', () => {
+      const operand = ['foo', 'bar']
+      const expected: BinaryFilter = {
+        pathExpression: 'titles',
+        rightOperand: operand.map(val => val.padStart(10, ' ')),
+        operator: OP.IN,
+        type: 'string',
+        pad: {
+          fillString: ' ',
+          maxLength: 10
+        }
+      }
+      const coerced = coerceFilterChainOperands([expected], escapeStr)
+      expect(coerced.length).toEqual(1)
+      expect(coerced[0]).toEqual(expected)
+    })
+
+    it('coerces number', () => {
+      const expected: BinaryFilter = {
+        pathExpression: 'rating',
+        rightOperand: 10,
+        operator: OP.EQ,
+        type: 'number'
       }
       const coerced = coerceFilterChainOperands([expected], escapeStr)
       expect(coerced.length).toEqual(1)
@@ -922,6 +980,20 @@ describe('datalayer store helper functions', () => {
         },
       ], escapeStr)
 
+      expect(coerced.length).toEqual(1)
+      expect(coerced[0]).toEqual(expected)
+    })
+
+    it('coerces ternary string filter', () => {
+      const expected: TernaryFilter = {
+        pathExpression: 'title',
+        leftOperand: 'foo',
+        rightOperand: 'bar',
+        leftOperator: OP.GT,
+        rightOperator: OP.LT,
+        type: 'string',
+      }
+      const coerced = coerceFilterChainOperands([expected], escapeStr)
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)
     })

--- a/packages/@tinacms/datalayer/src/database/store/index.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.ts
@@ -506,7 +506,13 @@ export const makeFilterSuffixes = (
     ) {
       ternaryFilter = true
     }
-    for (const [i, filter] of Object.entries(orderedFilterChain)) {
+    for (let i = 0; i < orderedFilterChain.length; i++) {
+      const filter = orderedFilterChain[i]
+      if (!filter) {
+        // ensure no gaps in the prefix
+        return
+      }
+
       if (Number(i) < indexFields.length - 1) {
         if (!(filter as BinaryFilter).operator) {
           // Lower order fields can not use TernaryFilter
@@ -516,11 +522,6 @@ export const makeFilterSuffixes = (
         // Lower order fields must use equality operator
         const binaryFilter: BinaryFilter = filter as BinaryFilter
         if (binaryFilter.operator !== OP.EQ) {
-          return
-        }
-
-        if (!orderedFilterChain[i]) {
-          // ensure no gaps in the prefix
           return
         }
 

--- a/packages/@tinacms/datalayer/src/database/store/level.ts
+++ b/packages/@tinacms/datalayer/src/database/store/level.ts
@@ -24,6 +24,7 @@ import {
   makeFilter,
   makeKeyForField,
   DEFAULT_COLLECTION_SORT_KEY,
+  INDEX_KEY_FIELD_SEPARATOR
 } from './index'
 import path from 'path'
 import { sequential } from '../../util'
@@ -70,18 +71,18 @@ export class LevelStore implements Store {
     const filterSuffixes =
       indexDefinition && makeFilterSuffixes(filterChain, indexDefinition)
     const indexPrefix = indexDefinition
-      ? `${collection}:${sort}`
-      : `${defaultPrefix}:`
+      ? `${collection}${INDEX_KEY_FIELD_SEPARATOR}${sort}`
+      : `${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}`
 
     if (!query.gt && !query.gte) {
       query.gte = filterSuffixes?.left
-        ? `${indexPrefix}:${filterSuffixes.left}`
+        ? `${indexPrefix}${INDEX_KEY_FIELD_SEPARATOR}${filterSuffixes.left}`
         : indexPrefix
     }
 
     if (!query.lt && !query.lte) {
       query.lte = filterSuffixes?.right
-        ? `${indexPrefix}:${filterSuffixes.right}\xFF`
+        ? `${indexPrefix}${INDEX_KEY_FIELD_SEPARATOR}${filterSuffixes.right}\xFF`
         : `${indexPrefix}\xFF`
     }
 
@@ -92,15 +93,14 @@ export class LevelStore implements Store {
     let hasNextPage = false
 
     const fieldsPattern = indexDefinition?.fields?.length
-      ? `${indexDefinition.fields.map((p) => `:(?<${p.name}>.+)`).join('')}:`
-      : ':'
+      ? `${indexDefinition.fields.map((p) => `${INDEX_KEY_FIELD_SEPARATOR}(?<${p.name}>.+)`).join('')}${INDEX_KEY_FIELD_SEPARATOR}`
+      : INDEX_KEY_FIELD_SEPARATOR
     const valuesRegex = indexDefinition
       ? new RegExp(`^${indexPrefix}${fieldsPattern}(?<_filepath_>.+)`)
       : new RegExp(`^${indexPrefix}(?<_filepath_>.+)`)
     const itemFilter = makeFilter({ filterChain })
 
-    for await (const [key, value] of (this.db as any).iterator(query)) {
-      //TODO why is typescript unhappy?
+    for await (const [key, value] of (this.db as any /*TODO why is typescript unhappy?*/).iterator(query)) {
       const matcher = valuesRegex.exec(key)
       if (
         !matcher ||
@@ -115,7 +115,7 @@ export class LevelStore implements Store {
           filterSuffixes
             ? matcher.groups
             : indexDefinition
-            ? await this.db.get(`${defaultPrefix}:${filepath}`)
+            ? await this.db.get(`${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`)
             : value
         )
       ) {
@@ -191,11 +191,11 @@ export class LevelStore implements Store {
     const p = new Promise((resolve, reject) => {
       this.db
         .createKeyStream({
-          gte: `${defaultPrefix}:${pattern}`,
-          lte: `${defaultPrefix}:${pattern}\xFF`, // stop at the last key with the prefix
+          gte: `${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}${pattern}`,
+          lte: `${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}${pattern}\xFF`, // stop at the last key with the prefix
         })
         .on('data', (data) => {
-          strings.push(data.split(`${defaultPrefix}:`)[1])
+          strings.push(data.split(`${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}`)[1])
         })
         .on('error', (message) => {
           reject(message)
@@ -216,7 +216,7 @@ export class LevelStore implements Store {
   }
   public async get(filepath: string) {
     try {
-      return await this.db.get(`${defaultPrefix}:${filepath}`)
+      return await this.db.get(`${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`)
     } catch (e) {
       return undefined
     }
@@ -231,14 +231,14 @@ export class LevelStore implements Store {
     try {
       existingData =
         options && !options.seed
-          ? await this.db.get(`${defaultPrefix}:${filepath}`)
+          ? await this.db.get(`${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`)
           : null
     } catch (err) {
       if (!err.notFound) {
         throw err
       }
     }
-    await this.db.put(`${defaultPrefix}:${filepath}`, data)
+    await this.db.put(`${defaultPrefix}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`, data)
 
     if (options?.indexDefinitions) {
       for (const [sort, definition] of Object.entries(
@@ -252,14 +252,14 @@ export class LevelStore implements Store {
         let indexKey
         let existingIndexKey = null
         if (sort === DEFAULT_COLLECTION_SORT_KEY) {
-          indexKey = `${options.collection}:${sort}:${filepath}`
+          indexKey = `${options.collection}${INDEX_KEY_FIELD_SEPARATOR}${sort}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`
           existingIndexKey = indexKey
         } else {
           indexKey = indexedValue
-            ? `${options.collection}:${sort}:${indexedValue}:${filepath}`
+            ? `${options.collection}${INDEX_KEY_FIELD_SEPARATOR}${sort}${INDEX_KEY_FIELD_SEPARATOR}${indexedValue}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`
             : null
           existingIndexKey = existingIndexedValue
-            ? `${options.collection}:${sort}:${existingIndexedValue}:${filepath}`
+            ? `${options.collection}${INDEX_KEY_FIELD_SEPARATOR}${sort}${INDEX_KEY_FIELD_SEPARATOR}${existingIndexedValue}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`
             : null
         }
 

--- a/packages/@tinacms/datalayer/src/database/store/level.ts
+++ b/packages/@tinacms/datalayer/src/database/store/level.ts
@@ -23,6 +23,7 @@ import {
   makeFilterSuffixes,
   makeFilter,
   makeKeyForField,
+  makeStringEscaper,
   DEFAULT_COLLECTION_SORT_KEY,
   INDEX_KEY_FIELD_SEPARATOR
 } from './index'
@@ -35,6 +36,7 @@ import encode from 'encoding-down'
 import { IndexDefinition } from '.'
 
 const defaultPrefix = '_ROOT_'
+const escapeStr = makeStringEscaper(new RegExp(INDEX_KEY_FIELD_SEPARATOR, 'gm'), encodeURIComponent(INDEX_KEY_FIELD_SEPARATOR))
 
 export class LevelStore implements Store {
   public rootPath
@@ -64,7 +66,7 @@ export class LevelStore implements Store {
       ...query
     } = queryOptions
 
-    const filterChain = coerceFilterChainOperands(rawFilterChain)
+    const filterChain = coerceFilterChainOperands(rawFilterChain, escapeStr)
     const indexDefinition = (sort && indexDefinitions?.[sort]) as
       | IndexDefinition
       | undefined
@@ -244,9 +246,9 @@ export class LevelStore implements Store {
       for (const [sort, definition] of Object.entries(
         options.indexDefinitions
       )) {
-        const indexedValue = makeKeyForField(definition, data)
+        const indexedValue = makeKeyForField(definition, data, escapeStr)
         const existingIndexedValue = existingData
-          ? makeKeyForField(definition, existingData)
+          ? makeKeyForField(definition, existingData, escapeStr)
           : null
 
         let indexKey

--- a/packages/@tinacms/datalayer/src/index.ts
+++ b/packages/@tinacms/datalayer/src/index.ts
@@ -23,6 +23,7 @@ export { LevelStore } from './database/store/level'
 export {
   coerceFilterChainOperands,
   DEFAULT_COLLECTION_SORT_KEY,
+  INDEX_KEY_FIELD_SEPARATOR,
   makeFilter,
   makeFilterChain,
   makeFilterSuffixes,

--- a/packages/@tinacms/datalayer/src/index.ts
+++ b/packages/@tinacms/datalayer/src/index.ts
@@ -23,6 +23,7 @@ export { LevelStore } from './database/store/level'
 export {
   coerceFilterChainOperands,
   DEFAULT_COLLECTION_SORT_KEY,
+  DEFAULT_NUMERIC_LPAD,
   INDEX_KEY_FIELD_SEPARATOR,
   makeFilter,
   makeFilterChain,
@@ -35,6 +36,7 @@ export type {
   BinaryFilter,
   FilterCondition,
   IndexDefinition,
+  PadDefinition,
   StoreQueryOptions,
   StoreQueryResponse,
   PageInfo,

--- a/packages/@tinacms/datalayer/src/index.ts
+++ b/packages/@tinacms/datalayer/src/index.ts
@@ -28,6 +28,7 @@ export {
   makeFilterChain,
   makeFilterSuffixes,
   makeKeyForField,
+  makeStringEscaper,
   OP,
 } from './database/store'
 export type {

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -35,7 +35,7 @@ import type {
   TinaFieldInner,
 } from '../types'
 import type { Bridge } from './bridge'
-import { atob, btoa, DEFAULT_COLLECTION_SORT_KEY } from '@tinacms/datalayer'
+import { atob, btoa, DEFAULT_COLLECTION_SORT_KEY, DEFAULT_NUMERIC_LPAD } from '@tinacms/datalayer'
 
 type CreateDatabase = { bridge: Bridge; store: Store }
 
@@ -312,6 +312,7 @@ export class Database {
                     {
                       name: field.name,
                       type: field.type,
+                      pad: field.type === 'number' ? { fillString: '0', maxLength: DEFAULT_NUMERIC_LPAD } : undefined,
                     },
                   ],
                 }

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_graphql.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_graphql.json
@@ -447,6 +447,39 @@
           "kind": "FieldDefinition",
           "name": {
             "kind": "Name",
+            "value": "getOptimizedQuery"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "queryString"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
             "value": "getCollection"
           },
           "arguments": [
@@ -647,6 +680,20 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
                 "value": "filter"
               },
               "type": {
@@ -787,6 +834,20 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
                 "value": "filter"
               },
               "type": {
@@ -902,6 +963,20 @@
                 "name": {
                   "kind": "Name",
                   "value": "Float"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
                 }
               }
             },
@@ -1031,6 +1106,20 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
                 "value": "filter"
               },
               "type": {
@@ -1153,6 +1242,20 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
                 "value": "filter"
               },
               "type": {
@@ -1171,6 +1274,142 @@
               "name": {
                 "kind": "Name",
                 "value": "ActorConnection"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "getRelativeDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RelativeDocument"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "getRelativeList"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "before"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "after"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "first"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Float"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "last"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "Float"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "filter"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "RelativeFilter"
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RelativeConnection"
               }
             }
           }
@@ -1223,6 +1462,23 @@
             "name": {
               "kind": "Name",
               "value": "Boolean"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "String"
+              }
             }
           }
         }
@@ -1288,6 +1544,23 @@
             "name": {
               "kind": "Name",
               "value": "Boolean"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "String"
+              }
             }
           }
         }
@@ -1383,6 +1656,23 @@
               "value": "Boolean"
             }
           }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "in"
+          },
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Float"
+              }
+            }
+          }
         }
       ]
     },
@@ -1427,6 +1717,112 @@
       "kind": "InputObjectTypeDefinition",
       "name": {
         "kind": "Name",
+        "value": "RelativeFilter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "name"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "StringFilter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "DirectorRelativesSpouseFilter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relative"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RelativeFilter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "DirectorRelativesChildFilter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relative"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RelativeFilter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "DirectorRelativesFilter"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "spouse"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelativesSpouseFilter"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "child"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelativesChildFilter"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
         "value": "DirectorFilter"
       },
       "fields": [
@@ -1441,6 +1837,48 @@
             "name": {
               "kind": "Name",
               "value": "StringFilter"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "birthday"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DatetimeFilter"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "height"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "NumberFilter"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relatives"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelativesFilter"
             }
           }
         }
@@ -1756,6 +2194,20 @@
             "name": {
               "kind": "Name",
               "value": "ActorFilter"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relative"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RelativeFilter"
             }
           }
         }
@@ -2083,6 +2535,20 @@
               "kind": "InputValueDefinition",
               "name": {
                 "kind": "Name",
+                "value": "sort"
+              },
+              "type": {
+                "kind": "NamedType",
+                "name": {
+                  "kind": "Name",
+                  "value": "String"
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
                 "value": "filter"
               },
               "type": {
@@ -2141,6 +2607,13 @@
           "name": {
             "kind": "Name",
             "value": "ActorDocument"
+          }
+        },
+        {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "RelativeDocument"
           }
         }
       ]
@@ -2527,6 +3000,81 @@
       ]
     },
     {
+      "kind": "UnionTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "DirectorRelativesSpouseDocument"
+      },
+      "directives": [],
+      "types": [
+        {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "RelativeDocument"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "UnionTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "DirectorRelativesChildDocument"
+      },
+      "directives": [],
+      "types": [
+        {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "RelativeDocument"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "interfaces": [],
+      "directives": [],
+      "name": {
+        "kind": "Name",
+        "value": "DirectorRelatives"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "spouse"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelativesSpouseDocument"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "child"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelativesChildDocument"
+            }
+          }
+        }
+      ]
+    },
+    {
       "kind": "ObjectTypeDefinition",
       "interfaces": [],
       "directives": [],
@@ -2547,6 +3095,51 @@
             "name": {
               "kind": "Name",
               "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "birthday"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "height"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Float"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relatives"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelatives"
             }
           }
         }
@@ -3410,6 +4003,277 @@
       "directives": [],
       "name": {
         "kind": "Name",
+        "value": "Relative"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "name"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "interfaces": [
+        {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Node"
+          }
+        },
+        {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Document"
+          }
+        }
+      ],
+      "directives": [],
+      "name": {
+        "kind": "Name",
+        "value": "RelativeDocument"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "id"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "ID"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "sys"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "SystemInfo"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "data"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Relative"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "form"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "JSON"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "values"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "JSON"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "dataJSON"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "JSON"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "interfaces": [],
+      "directives": [],
+      "name": {
+        "kind": "Name",
+        "value": "RelativeConnectionEdges"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "cursor"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "node"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RelativeDocument"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "interfaces": [
+        {
+          "kind": "NamedType",
+          "name": {
+            "kind": "Name",
+            "value": "Connection"
+          }
+        }
+      ],
+      "directives": [],
+      "name": {
+        "kind": "Name",
+        "value": "RelativeConnection"
+      },
+      "fields": [
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "pageInfo"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "PageInfo"
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "totalCount"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "Float"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "edges"
+          },
+          "arguments": [],
+          "type": {
+            "kind": "ListType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RelativeConnectionEdges"
+              }
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "ObjectTypeDefinition",
+      "interfaces": [],
+      "directives": [],
+      "name": {
+        "kind": "Name",
         "value": "Mutation"
       },
       "fields": [
@@ -4037,6 +4901,112 @@
               }
             }
           }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "updateRelativeDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "RelativeMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RelativeDocument"
+              }
+            }
+          }
+        },
+        {
+          "kind": "FieldDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "createRelativeDocument"
+          },
+          "arguments": [
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "relativePath"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "String"
+                  }
+                }
+              }
+            },
+            {
+              "kind": "InputValueDefinition",
+              "name": {
+                "kind": "Name",
+                "value": "params"
+              },
+              "type": {
+                "kind": "NonNullType",
+                "type": {
+                  "kind": "NamedType",
+                  "name": {
+                    "kind": "Name",
+                    "value": "RelativeMutation"
+                  }
+                }
+              }
+            }
+          ],
+          "type": {
+            "kind": "NonNullType",
+            "type": {
+              "kind": "NamedType",
+              "name": {
+                "kind": "Name",
+                "value": "RelativeDocument"
+              }
+            }
+          }
         }
       ]
     },
@@ -4100,6 +5070,20 @@
             "name": {
               "kind": "Name",
               "value": "ActorMutation"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relative"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "RelativeMutation"
             }
           }
         }
@@ -4216,6 +5200,43 @@
       "kind": "InputObjectTypeDefinition",
       "name": {
         "kind": "Name",
+        "value": "DirectorRelativesMutation"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "spouse"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "child"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
         "value": "DirectorMutation"
       },
       "fields": [
@@ -4230,6 +5251,48 @@
             "name": {
               "kind": "Name",
               "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "birthday"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "height"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "Float"
+            }
+          }
+        },
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "relatives"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "DirectorRelativesMutation"
             }
           }
         }
@@ -4344,6 +5407,29 @@
           "name": {
             "kind": "Name",
             "value": "body"
+          },
+          "type": {
+            "kind": "NamedType",
+            "name": {
+              "kind": "Name",
+              "value": "String"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "kind": "InputObjectTypeDefinition",
+      "name": {
+        "kind": "Name",
+        "value": "RelativeMutation"
+      },
+      "fields": [
+        {
+          "kind": "InputValueDefinition",
+          "name": {
+            "kind": "Name",
+            "value": "name"
           },
           "type": {
             "kind": "NamedType",

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_lookup.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_lookup.json
@@ -6,7 +6,8 @@
       "movie",
       "director",
       "crew",
-      "actor"
+      "actor",
+      "relative"
     ]
   },
   "Node": {
@@ -80,5 +81,60 @@
     "type": "ActorConnection",
     "resolveType": "collectionDocumentList",
     "collection": "actor"
+  },
+  "DirectorChildDocument": {
+    "type": "DirectorChildDocument",
+    "resolveType": "multiCollectionDocument",
+    "createDocument": "create",
+    "updateDocument": "update"
+  },
+  "ChildDocument": {
+    "type": "ChildDocument",
+    "resolveType": "collectionDocument",
+    "collection": "child",
+    "createChildDocument": "create",
+    "updateChildDocument": "update"
+  },
+  "ChildConnection": {
+    "type": "ChildConnection",
+    "resolveType": "collectionDocumentList",
+    "collection": "child"
+  },
+  "DirectorRelativesSpouseDocument": {
+    "type": "DirectorRelativesSpouseDocument",
+    "resolveType": "multiCollectionDocument",
+    "createDocument": "create",
+    "updateDocument": "update"
+  },
+  "DirectorRelativesChildrenConnection": {
+    "type": "DirectorRelativesChildrenConnection",
+    "resolveType": "multiCollectionDocumentList",
+    "collections": [
+      "relative"
+    ]
+  },
+  "RelativeDocument": {
+    "type": "RelativeDocument",
+    "resolveType": "collectionDocument",
+    "collection": "relative",
+    "createRelativeDocument": "create",
+    "updateRelativeDocument": "update"
+  },
+  "RelativeConnection": {
+    "type": "RelativeConnection",
+    "resolveType": "collectionDocumentList",
+    "collection": "relative"
+  },
+  "DirectorRelativesChildrenDocument": {
+    "type": "DirectorRelativesChildrenDocument",
+    "resolveType": "multiCollectionDocument",
+    "createDocument": "create",
+    "updateDocument": "update"
+  },
+  "DirectorRelativesChildDocument": {
+    "type": "DirectorRelativesChildDocument",
+    "resolveType": "multiCollectionDocument",
+    "createDocument": "create",
+    "updateDocument": "update"
   }
 }

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/_schema.json
@@ -1,9 +1,9 @@
 {
   "version": {
-    "fullVersion": "0.59.5",
+    "fullVersion": "0.59.8",
     "major": "0",
     "minor": "59",
-    "patch": "5"
+    "patch": "8"
   },
   "meta": {
     "flags": [
@@ -92,6 +92,33 @@
           ]
         }
       ],
+      "indexes": [
+        {
+          "name": "archived-releaseDate",
+          "fields": [
+            {
+              "name": "archived",
+              "namespace": [
+                "movie",
+                "archived-releaseDate",
+                "archived"
+              ]
+            },
+            {
+              "name": "releaseDate",
+              "namespace": [
+                "movie",
+                "archived-releaseDate",
+                "releaseDate"
+              ]
+            }
+          ],
+          "namespace": [
+            "movie",
+            "archived-releaseDate"
+          ]
+        }
+      ],
       "namespace": [
         "movie"
       ]
@@ -108,6 +135,62 @@
           "namespace": [
             "director",
             "name"
+          ]
+        },
+        {
+          "type": "datetime",
+          "label": "Birthday",
+          "name": "birthday",
+          "namespace": [
+            "director",
+            "birthday"
+          ]
+        },
+        {
+          "type": "number",
+          "label": "Height",
+          "name": "height",
+          "namespace": [
+            "director",
+            "height"
+          ]
+        },
+        {
+          "label": "Relatives",
+          "name": "relatives",
+          "type": "object",
+          "list": false,
+          "fields": [
+            {
+              "type": "reference",
+              "label": "Spouses",
+              "name": "spouse",
+              "collections": [
+                "relative"
+              ],
+              "namespace": [
+                "director",
+                "relatives",
+                "spouse"
+              ]
+            },
+            {
+              "type": "reference",
+              "label": "Child",
+              "name": "child",
+              "collections": [
+                "relative"
+              ],
+              "namespace": [
+                "director",
+                "relatives",
+                "child"
+              ]
+            }
+          ],
+          "namespace": [
+            "director",
+            "relatives"
           ]
         }
       ],
@@ -195,6 +278,25 @@
       ],
       "namespace": [
         "actor"
+      ]
+    },
+    {
+      "label": "Relative",
+      "name": "relative",
+      "path": "content/relative",
+      "fields": [
+        {
+          "type": "string",
+          "label": "Name",
+          "name": "name",
+          "namespace": [
+            "relative",
+            "name"
+          ]
+        }
+      ],
+      "namespace": [
+        "relative"
       ]
     }
   ]

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/frags.gql
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/frags.gql
@@ -14,6 +14,21 @@ fragment MovieParts on Movie {
 
 fragment DirectorParts on Director {
   name
+  birthday
+  height
+  relatives {
+    __typename
+    spouse {
+      ... on Document {
+        id
+      }
+    }
+    child {
+      ... on Document {
+        id
+      }
+    }
+  }
 }
 
 fragment CrewParts on Crew {
@@ -28,4 +43,8 @@ fragment CrewParts on Crew {
 fragment ActorParts on Actor {
   name
   body
+}
+
+fragment RelativeParts on Relative {
+  name
 }

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/queries.gql
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/queries.gql
@@ -153,3 +153,42 @@ query getActorList {
     }
   }
 }
+
+query getRelativeDocument($relativePath: String!) {
+  getRelativeDocument(relativePath: $relativePath) {
+    sys {
+      filename
+      basename
+      breadcrumbs
+      path
+      relativePath
+      extension
+    }
+    id
+    data {
+      ...RelativeParts
+    }
+  }
+}
+
+query getRelativeList {
+  getRelativeList {
+    totalCount
+    edges {
+      node {
+        id
+        sys {
+          filename
+          basename
+          breadcrumbs
+          path
+          relativePath
+          extension
+        }
+        data {
+          ...RelativeParts
+        }
+      }
+    }
+  }
+}

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/schema.gql
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/__generated__/schema.gql
@@ -41,26 +41,30 @@ interface Connection {
 }
 
 type Query {
+  getOptimizedQuery(queryString: String!): String
   getCollection(collection: String): Collection!
   getCollections: [Collection!]!
   node(id: String): Node!
   getDocument(collection: String, relativePath: String): DocumentNode!
-  getDocumentList(before: String, after: String, first: Float, last: Float, filter: DocumentFilter): DocumentConnection!
+  getDocumentList(before: String, after: String, first: Float, last: Float, sort: String, filter: DocumentFilter): DocumentConnection!
   getDocumentFields: JSON!
   getMovieDocument(relativePath: String): MovieDocument!
-  getMovieList(before: String, after: String, first: Float, last: Float, filter: MovieFilter): MovieConnection!
+  getMovieList(before: String, after: String, first: Float, last: Float, sort: String, filter: MovieFilter): MovieConnection!
   getDirectorDocument(relativePath: String): DirectorDocument!
-  getDirectorList(before: String, after: String, first: Float, last: Float, filter: DirectorFilter): DirectorConnection!
+  getDirectorList(before: String, after: String, first: Float, last: Float, sort: String, filter: DirectorFilter): DirectorConnection!
   getCrewDocument(relativePath: String): CrewDocument!
-  getCrewList(before: String, after: String, first: Float, last: Float, filter: CrewFilter): CrewConnection!
+  getCrewList(before: String, after: String, first: Float, last: Float, sort: String, filter: CrewFilter): CrewConnection!
   getActorDocument(relativePath: String): ActorDocument!
-  getActorList(before: String, after: String, first: Float, last: Float, filter: ActorFilter): ActorConnection!
+  getActorList(before: String, after: String, first: Float, last: Float, sort: String, filter: ActorFilter): ActorConnection!
+  getRelativeDocument(relativePath: String): RelativeDocument!
+  getRelativeList(before: String, after: String, first: Float, last: Float, sort: String, filter: RelativeFilter): RelativeConnection!
 }
 
 input StringFilter {
   startsWith: String
   eq: String
   exists: Boolean
+  in: [String]
 }
 
 input DatetimeFilter {
@@ -68,6 +72,7 @@ input DatetimeFilter {
   before: String
   eq: String
   exists: Boolean
+  in: [String]
 }
 
 input NumberFilter {
@@ -77,6 +82,7 @@ input NumberFilter {
   gt: Float
   eq: Float
   exists: Boolean
+  in: [Float]
 }
 
 input BooleanFilter {
@@ -84,8 +90,28 @@ input BooleanFilter {
   exists: Boolean
 }
 
+input RelativeFilter {
+  name: StringFilter
+}
+
+input DirectorRelativesSpouseFilter {
+  relative: RelativeFilter
+}
+
+input DirectorRelativesChildFilter {
+  relative: RelativeFilter
+}
+
+input DirectorRelativesFilter {
+  spouse: DirectorRelativesSpouseFilter
+  child: DirectorRelativesChildFilter
+}
+
 input DirectorFilter {
   name: StringFilter
+  birthday: DatetimeFilter
+  height: NumberFilter
+  relatives: DirectorRelativesFilter
 }
 
 input MovieDirectorFilter {
@@ -125,6 +151,7 @@ input DocumentFilter {
   director: DirectorFilter
   crew: CrewFilter
   actor: ActorFilter
+  relative: RelativeFilter
 }
 
 type DocumentConnectionEdges {
@@ -147,10 +174,10 @@ type Collection {
   matches: String
   templates: [JSON]
   fields: [JSON]
-  documents(before: String, after: String, first: Float, last: Float, filter: DocumentFilter): DocumentConnection!
+  documents(before: String, after: String, first: Float, last: Float, sort: String, filter: DocumentFilter): DocumentConnection!
 }
 
-union DocumentNode = MovieDocument | DirectorDocument | CrewDocument | ActorDocument
+union DocumentNode = MovieDocument | DirectorDocument | CrewDocument | ActorDocument | RelativeDocument
 
 union MovieDirectorDocument = DirectorDocument
 
@@ -184,8 +211,20 @@ type MovieConnection implements Connection {
   edges: [MovieConnectionEdges]
 }
 
+union DirectorRelativesSpouseDocument = RelativeDocument
+
+union DirectorRelativesChildDocument = RelativeDocument
+
+type DirectorRelatives {
+  spouse: DirectorRelativesSpouseDocument
+  child: DirectorRelativesChildDocument
+}
+
 type Director {
   name: String
+  birthday: String
+  height: Float
+  relatives: DirectorRelatives
 }
 
 type DirectorDocument implements Node & Document {
@@ -263,6 +302,30 @@ type ActorConnection implements Connection {
   edges: [ActorConnectionEdges]
 }
 
+type Relative {
+  name: String
+}
+
+type RelativeDocument implements Node & Document {
+  id: ID!
+  sys: SystemInfo!
+  data: Relative!
+  form: JSON!
+  values: JSON!
+  dataJSON: JSON!
+}
+
+type RelativeConnectionEdges {
+  cursor: String
+  node: RelativeDocument
+}
+
+type RelativeConnection implements Connection {
+  pageInfo: PageInfo
+  totalCount: Float!
+  edges: [RelativeConnectionEdges]
+}
+
 type Mutation {
   addPendingDocument(collection: String!, relativePath: String!, template: String): DocumentNode!
   updateDocument(collection: String, relativePath: String!, params: DocumentMutation!): DocumentNode!
@@ -275,6 +338,8 @@ type Mutation {
   createCrewDocument(relativePath: String!, params: CrewMutation!): CrewDocument!
   updateActorDocument(relativePath: String!, params: ActorMutation!): ActorDocument!
   createActorDocument(relativePath: String!, params: ActorMutation!): ActorDocument!
+  updateRelativeDocument(relativePath: String!, params: RelativeMutation!): RelativeDocument!
+  createRelativeDocument(relativePath: String!, params: RelativeMutation!): RelativeDocument!
 }
 
 input DocumentMutation {
@@ -282,6 +347,7 @@ input DocumentMutation {
   director: DirectorMutation
   crew: CrewMutation
   actor: ActorMutation
+  relative: RelativeMutation
 }
 
 input MovieMutation {
@@ -294,8 +360,16 @@ input MovieMutation {
   body: String
 }
 
+input DirectorRelativesMutation {
+  spouse: String
+  child: String
+}
+
 input DirectorMutation {
   name: String
+  birthday: String
+  height: Float
+  relatives: DirectorRelativesMutation
 }
 
 input CrewCostumeDesignerMutation {
@@ -314,4 +388,8 @@ input CrewMutation {
 input ActorMutation {
   name: String
   body: String
+}
+
+input RelativeMutation {
+  name: String
 }

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/schema.ts
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/.tina/schema.ts
@@ -67,6 +67,10 @@ const tinaSchema: TinaCloudSchema<false> = {
           isBody: true,
         },
       ],
+      indexes: [{
+        name: 'archived-releaseDate',
+        fields: [{ name: 'archived' }, {name: 'releaseDate' }]
+      }]
     },
     {
       label: 'Director',
@@ -77,6 +81,36 @@ const tinaSchema: TinaCloudSchema<false> = {
           type: 'string',
           label: 'Name',
           name: 'name',
+        },
+        {
+          type: 'datetime',
+          label: 'Birthday',
+          name: 'birthday',
+        },
+        {
+          type: 'number',
+          label: 'Height',
+          name: 'height',
+        },
+        {
+          label: "Relatives",
+          name: "relatives",
+          type: "object",
+          list: false,
+          fields: [
+            {
+              type: "reference",
+              label: "Spouses",
+              name: "spouse",
+              collections: ["relative"],
+            },
+            {
+              type: "reference",
+              label: "Child",
+              name: "child",
+              collections: ["relative"],
+            },
+          ],
         },
       ],
     },
@@ -124,6 +158,18 @@ const tinaSchema: TinaCloudSchema<false> = {
           type: 'string',
           label: 'Body',
           name: 'body',
+        },
+      ],
+    },
+    {
+      label: 'Relative',
+      name: 'relative',
+      path: 'content/relative',
+      fields: [
+        {
+          type: 'string',
+          label: 'Name',
+          name: 'name',
         },
       ],
     },

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/directors/francis.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/directors/francis.md
@@ -1,3 +1,7 @@
 ---
 name: Francis Ford Coppolla
+birthday: '1939-04-07T07:00:00.000Z'
+height: 183
+relatives:
+    child: content/relative/sofia-coppolla.md
 ---

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/directors/george.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/directors/george.md
@@ -1,3 +1,7 @@
 ---
 name: George Lucas
+birthday: '1944-05-14T07:00:00.000Z'
+height: 168
+relatives:
+    child: content/relative/jett-lucas.md
 ---

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/movies/indiana-jones.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/movies/indiana-jones.md
@@ -1,6 +1,6 @@
 ---
-title: Indiana Jones
-releaseDate: '1995-02-02T07:00:00.000Z'
+title: Raiders of the Lost Ark
+releaseDate: '1981-06-12T07:00:00.000Z'
 archived: true
 director: content/directors/george.md
 genre: action

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/movies/star-wars.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/movies/star-wars.md
@@ -1,6 +1,6 @@
 ---
 title: Star Wars
-releaseDate: '2021-02-02T07:00:00.000Z'
+releaseDate: '1977-05-25T07:00:00.000Z'
 archived: true
 director: content/directors/george.md
 genre: scifi

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/movies/the-rock.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/movies/the-rock.md
@@ -1,6 +1,6 @@
 ---
 title: The Rock
-releaseDate: '2005-08-02T07:00:00.000Z'
+releaseDate: '1996-06-07T07:00:00.000Z'
 director: content/directors/francis.md
 archived: false
 genre: action

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/relative/jett-lucas.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/relative/jett-lucas.md
@@ -1,0 +1,3 @@
+---
+name: Jett Lucas
+---

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/relative/sofia-coppolla.md
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/content/relative/sofia-coppolla.md
@@ -1,0 +1,3 @@
+---
+name: Sofia Coppolla
+---

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests.spec.ts
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests.spec.ts
@@ -20,7 +20,7 @@ const rootPath = path.join(__dirname, '/')
 const fixtures: Fixture[] = [
   {
     name: 'getMovieList',
-    description: "Querying a list with 'eq'",
+    description: "Filtering on movies collection",
     assert: 'output',
   },
   {

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getDirectorList/_query.movies-with-datalayer.gql
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getDirectorList/_query.movies-with-datalayer.gql
@@ -1,4 +1,4 @@
-query {
+{
   getDirectorList {
     edges {
       node {
@@ -7,5 +7,23 @@ query {
         }
       }
     }
-  }
+  },
+  sortedByHeight: getDirectorList(sort: "height") {
+    edges {
+      node {
+        data {
+          name
+        }
+      }
+    }
+  },
+  sofiaParent: getDirectorList(sort: "name", filter: { relatives: { child: { relative: { name: { eq: "Sofia Coppolla" } } } } }) {
+    edges {
+      node {
+        data {
+          name
+        }
+      }
+    }
+  },
 }

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getDirectorList/_response.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getDirectorList/_response.json
@@ -17,6 +17,35 @@
           }
         }
       ]
+    },
+    "sortedByHeight": {
+      "edges": [
+        {
+          "node": {
+            "data": {
+              "name": "George Lucas"
+            }
+          }
+        },
+        {
+          "node": {
+            "data": {
+              "name": "Francis Ford Coppolla"
+            }
+          }
+        }
+      ]
+    },
+    "sofiaParent": {
+      "edges": [
+        {
+          "node": {
+            "data": {
+              "name": "Francis Ford Coppolla"
+            }
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getMovieList/_query.movies-with-datalayer.gql
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getMovieList/_query.movies-with-datalayer.gql
@@ -1,5 +1,168 @@
-query {
+{
   getMovieList(filter: { archived: { eq: true } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  sortedByReleaseDate: getMovieList(filter: { archived: { eq: true } }, sort: "releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  releaseDateAfter: getMovieList(filter: { releaseDate: { after: "1990-01-01T07:00:00.000Z" } }, sort: "releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  releaseDateBefore: getMovieList(filter: { releaseDate: { before: "1990-01-01T07:00:00.000Z" } }, sort: "releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  releaseDateBetween: getMovieList(filter: { releaseDate: { after: "1980-01-01T07:00:00.000Z", before: "1990-01-01T07:00:00.000Z" } }, sort: "releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  releaseDateNotArchivedAfter: getMovieList(filter: { archived: { eq: false }, releaseDate: { after: "1990-01-01T07:00:00.000Z" } }, sort: "archived-releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  releaseDateArchivedBefore: getMovieList(filter: { archived: { eq: true }, releaseDate: { before: "1990-01-01T07:00:00.000Z" } }, sort: "archived-releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  ratingIN: getMovieList(filter: { rating: { in: [7, 10] } }, sort: "releaseDate") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  ratingBetween: getMovieList(filter: { rating: { gt: 7, lte: 10 } }, sort: "rating") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  ratingGTE: getMovieList(filter: { rating: { gte: 7 } }, sort: "rating") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  ratingGT: getMovieList(filter: { rating: { gt: 7 } }, sort: "rating") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  ratingLTE: getMovieList(filter: { rating: { lte: 8 } }, sort: "rating") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  ratingLT: getMovieList(filter: { rating: { lt: 8 } }, sort: "rating") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  titleEQ: getMovieList(filter: { title: { eq: "Raiders of the Lost Ark" } }, sort: "title") {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  titleStartsWith: getMovieList(filter: { title: { startsWith: "Raiders" } }, sort: "title") {
+   edges {
+     node {
+       id
+     }
+   }
+  },
+  paginatedAsc: getMovieList(sort: "releaseDate", first: 1) {
+    edges {
+      node {
+        id
+      }
+    }
+    pageInfo {
+        hasNextPage
+        endCursor
+    }
+  },
+  paginatedAscPage2: getMovieList(sort: "releaseDate", first: 1, after: "bW92aWUjcmVsZWFzZURhdGUjMjMzMzkxNjAwMDAwI2NvbnRlbnQvbW92aWVzL3N0YXItd2Fycy5tZA==") {
+    edges {
+      node {
+        id
+      }
+    }
+    pageInfo {
+        hasNextPage
+        endCursor
+    }
+  },
+  paginatedDesc: getMovieList(sort: "releaseDate", last: 1) {
+    edges {
+      node {
+        id
+      }
+    }
+    pageInfo {
+        hasPreviousPage
+        endCursor
+    }
+  },
+  paginatedDescPage2: getMovieList(sort: "releaseDate", last: 1, before: "bW92aWUjcmVsZWFzZURhdGUjODM0MTMwODAwMDAwI2NvbnRlbnQvbW92aWVzL3RoZS1yb2NrLm1k") {
+    edges {
+      node {
+        id
+      }
+    }
+    pageInfo {
+        hasPreviousPage
+        endCursor
+    }
+  },
+  moviesByGeorgeLucas: getMovieList(filter: { director: { director: { name: { eq: "George Lucas" } } } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  moviesByCoppolla: getMovieList(filter: { director: { director: { name: { eq: "Francis Ford Coppolla" } } } }) {
+    edges {
+      node {
+        id
+      }
+    }
+  },
+  moviesBySofiasParent: getMovieList(sort: "director", filter: { director: { director: { relatives: { child: { relative: { name: { eq: "Sofia Coppolla" } } } } } } }) {
     edges {
       node {
         id

--- a/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getMovieList/_response.json
+++ b/packages/@tinacms/graphql/src/spec/movies-with-datalayer/requests/getMovieList/_response.json
@@ -13,6 +13,261 @@
           }
         }
       ]
+    },
+    "sortedByReleaseDate": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "releaseDateAfter": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ]
+    },
+    "releaseDateBefore": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "releaseDateBetween": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "releaseDateNotArchivedAfter": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ]
+    },
+    "releaseDateArchivedBefore": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "ratingIN": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ]
+    },
+    "ratingBetween": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        }
+      ]
+    },
+    "ratingGTE": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        }
+      ]
+    },
+    "ratingGT": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        }
+      ]
+    },
+    "ratingLTE": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "ratingLT": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ]
+    },
+    "titleEQ": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "titleStartsWith": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ]
+    },
+    "paginatedAsc": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "bW92aWUjcmVsZWFzZURhdGUjMjMzMzkxNjAwMDAwI2NvbnRlbnQvbW92aWVzL3N0YXItd2Fycy5tZA=="
+      }
+    },
+    "paginatedAscPage2": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasNextPage": true,
+        "endCursor": "bW92aWUjcmVsZWFzZURhdGUjMzYxMTc3MjAwMDAwI2NvbnRlbnQvbW92aWVzL2luZGlhbmEtam9uZXMubWQ="
+      }
+    },
+    "paginatedDesc": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "endCursor": "bW92aWUjcmVsZWFzZURhdGUjODM0MTMwODAwMDAwI2NvbnRlbnQvbW92aWVzL3RoZS1yb2NrLm1k"
+      }
+    },
+    "paginatedDescPage2": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        }
+      ],
+      "pageInfo": {
+        "hasPreviousPage": true,
+        "endCursor": "bW92aWUjcmVsZWFzZURhdGUjMzYxMTc3MjAwMDAwI2NvbnRlbnQvbW92aWVzL2luZGlhbmEtam9uZXMubWQ="
+      }
+    },
+    "moviesByGeorgeLucas": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/indiana-jones.md"
+          }
+        },
+        {
+          "node": {
+            "id": "content/movies/star-wars.md"
+          }
+        }
+      ]
+    },
+    "moviesByCoppolla": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ]
+    },
+    "moviesBySofiasParent": {
+      "edges": [
+        {
+          "node": {
+            "id": "content/movies/the-rock.md"
+          }
+        }
+      ]
     }
   }
 }

--- a/packages/@tinacms/graphql/src/types.ts
+++ b/packages/@tinacms/graphql/src/types.ts
@@ -93,7 +93,6 @@ export type TinaIndex = {
   name: string
   fields: {
     name: string
-    default?: string | number | boolean
   }[]
 }
 


### PR DESCRIPTION
Update the datalayer movie tests in graphql and updates the data layer store code to fix these issues:
- properly escape the index field separate ('#') when it is present in a field and when used in a query
- pad numeric values for proper sorting. (NOTE: this hardcodes numeric values to 4 places. I'm currently thinking we can expose this as an optional field property in the schema but for now this should be sufficient for most use-cases)
- fix a bug in how fields were being ordered
- removes unused default property in the TinaIndex type

closes #2740 

# testing

You can test this by running `yarn dev-data` in the experimental examples tina-cloud-starter after adding a '#' character to the title of one of the blog posts and then executing a query like:

```
        query GetPostsList(
            $first: Float,
            $after: String, 
            $last: Float, 
            $before: String, 
            $sort: String,
            $filter: PostsFilter!) {
          getPostsList(first: $first, after: $after, last: $last, before: $before, sort: $sort, filter: $filter) {
            edges {
              cursor
              node {
                data {
                  title
                  date
                  published
                }
              }
            }
            pageInfo {
                hasNextPage
                endCursor
            }
          }
        }
```

```
{
    "filter": {
        "title": {
            "eq": "Just# Another Blog Post"
        }
    },
    "sort": "title"
}
```