### PR TITLE
Link to error faq in boundary and bubble errors to boundary

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -17,21 +17,23 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { useState, useEffect } from 'react'
-import { FormsView } from './SidebarBody'
+
 import { BiMenu, BiPencil } from 'react-icons/bi'
 import { BsArrowsAngleContract, BsArrowsAngleExpand } from 'react-icons/bs'
-import { MdOutlineArrowBackIos } from 'react-icons/md'
-import { ImFilesEmpty } from 'react-icons/im'
-import { Button } from '../../styles'
 import { ScreenPlugin, ScreenPluginModal } from '../../react-screens'
-import { useSubscribable, useCMS } from '../../react-core'
-import { ResizeHandle } from './ResizeHandle'
 import { SidebarState, SidebarStateOptions } from '../sidebar'
-import { LocalWarning } from './LocalWarning'
-import { Nav } from './Nav'
-import { Transition } from '@headlessui/react'
+import { useCMS, useSubscribable } from '../../react-core'
+import { useEffect, useState } from 'react'
+
+import { Button } from '../../styles'
+import { FormsView } from './SidebarBody'
+import { ImFilesEmpty } from 'react-icons/im'
 import { IoMdClose } from 'react-icons/io'
+import { LocalWarning } from './LocalWarning'
+import { MdOutlineArrowBackIos } from 'react-icons/md'
+import { Nav } from './Nav'
+import { ResizeHandle } from './ResizeHandle'
+import { Transition } from '@headlessui/react'
 
 export const SidebarContext = React.createContext<any>(null)
 
@@ -85,11 +87,10 @@ const useFetchCollections = (cms) => {
           const response = await cms.api.admin.fetchCollections()
           setCollections(response.getCollections)
         } catch (error) {
-          cms.alerts.error(
-            `[ERROR] GetCollections failed: ${error.message}`,
-            30 * 1000 // 30 seconds
-          )
           setCollections([])
+          throw new Error(
+            `[${error.name}] GetCollections failed: ${error.message}`
+          )
         }
 
         setLoading(false)

--- a/packages/tinacms/src/admin/components/GetCollections.tsx
+++ b/packages/tinacms/src/admin/components/GetCollections.tsx
@@ -11,10 +11,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState, useEffect } from 'react'
-import type { TinaCMS } from '@tinacms/toolkit'
-import { TinaAdminApi } from '../api'
+import React, { useEffect, useState } from 'react'
+
 import type { Collection } from '../types'
+import { TinaAdminApi } from '../api'
+import type { TinaCMS } from '@tinacms/toolkit'
 
 export const useGetCollections = (cms: TinaCMS) => {
   const api = new TinaAdminApi(cms)
@@ -29,13 +30,12 @@ export const useGetCollections = (cms: TinaCMS) => {
           const response = await api.fetchCollections()
           setCollections(response.getCollections)
         } catch (error) {
-          cms.alerts.error(
-            `[${error.name}] GetCollections failed: ${error.message}`,
-            30 * 1000 // 30 seconds
-          )
           console.error(error)
           setCollections([])
           setError(error)
+          throw new Error(
+            `[${error.name}] GetCollections failed: ${error.message}`
+          )
         }
 
         setLoading(false)

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -11,21 +11,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useState, useMemo } from 'react'
 import { Form, FormBuilder, FormStatus } from '@tinacms/toolkit'
-import { useParams, useNavigate, Link } from 'react-router-dom'
-import { HiChevronRight } from 'react-icons/hi'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import React, { useMemo, useState } from 'react'
+import { TinaSchema, resolveForm } from '@tinacms/schema-tools'
 
-import type { TinaCMS } from '@tinacms/toolkit'
-import { LocalWarning } from '@tinacms/toolkit'
-
-import { TinaAdminApi } from '../api'
 import GetCMS from '../components/GetCMS'
 import GetDocumentFields from '../components/GetDocumentFields'
-
+import { HiChevronRight } from 'react-icons/hi'
+import { LocalWarning } from '@tinacms/toolkit'
 import { PageWrapper } from '../components/Page'
+import { TinaAdminApi } from '../api'
+import type { TinaCMS } from '@tinacms/toolkit'
 import { transformDocumentIntoMutationRequestPayload } from '../../hooks/use-graphql-forms'
-import { resolveForm, TinaSchema } from '@tinacms/schema-tools'
 
 const createDocument = async (
   cms: TinaCMS,
@@ -149,11 +147,11 @@ const RenderForm = ({ cms, collection, template, fields, mutationInfo }) => {
           cms.alerts.success('Document created!')
           navigate(`/collections/${collection.name}`)
         } catch (error) {
-          cms.alerts.error(
-            `[${error.name}] CreateDocument failed: ${error.message}`,
-            30 * 1000 // 30 seconds
-          )
           console.error(error)
+
+          throw new Error(
+            `[${error.name}] CreateDocument failed: ${error.message}`
+          )
         }
       },
     })

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -11,22 +11,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { useMemo, useState } from 'react'
 import { Form, FormBuilder, FormStatus } from '@tinacms/toolkit'
-import { useParams, useNavigate, Link } from 'react-router-dom'
-import { HiChevronRight } from 'react-icons/hi'
-
-import type { TinaCMS } from '@tinacms/toolkit'
-import { LocalWarning } from '@tinacms/toolkit'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import React, { useMemo, useState } from 'react'
+import { TinaSchema, resolveForm } from '@tinacms/schema-tools'
 
 import GetCMS from '../components/GetCMS'
-import GetDocumentFields from '../components/GetDocumentFields'
 import GetDocument from '../components/GetDocument'
-import { transformDocumentIntoMutationRequestPayload } from '../../hooks/use-graphql-forms'
-
+import GetDocumentFields from '../components/GetDocumentFields'
+import { HiChevronRight } from 'react-icons/hi'
+import { LocalWarning } from '@tinacms/toolkit'
 import { PageWrapper } from '../components/Page'
 import { TinaAdminApi } from '../api'
-import { resolveForm, TinaSchema } from '@tinacms/schema-tools'
+import type { TinaCMS } from '@tinacms/toolkit'
+import { transformDocumentIntoMutationRequestPayload } from '../../hooks/use-graphql-forms'
 
 const updateDocument = async (
   cms: TinaCMS,
@@ -132,11 +130,10 @@ const RenderForm = ({
           )
           cms.alerts.success('Document updated!')
         } catch (error) {
-          cms.alerts.error(
-            `[${error.name}] UpdateDocument failed: ${error.message}`,
-            30 * 1000 // 30 seconds
-          )
           console.error(error)
+          throw new Error(
+            `[${error.name}] UpdateDocument failed: ${error.message}`
+          )
         }
       },
     })

--- a/packages/tinacms/src/hooks/use-graphql-forms.tsx
+++ b/packages/tinacms/src/hooks/use-graphql-forms.tsx
@@ -11,23 +11,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import {
+  AnyField,
+  Form,
+  FormMetaPlugin,
+  GlobalFormPlugin,
+  useBranchData,
+  useCMS,
+} from '@tinacms/toolkit'
+import type { FormOptions, TinaCMS } from '@tinacms/toolkit'
+import { TinaSchema, resolveForm } from '@tinacms/schema-tools'
+import { assertShape, safeAssertShape } from '../utils'
+import { getIn, setIn } from 'final-form'
+
+import { BiLinkExternal } from 'react-icons/bi'
 import React from 'react'
 import gql from 'graphql-tag'
-import { getIn, setIn } from 'final-form'
-import {
-  useCMS,
-  Form,
-  GlobalFormPlugin,
-  FormMetaPlugin,
-  useBranchData,
-  AnyField,
-} from '@tinacms/toolkit'
-import { assertShape, safeAssertShape } from '../utils'
-
-import type { FormOptions, TinaCMS } from '@tinacms/toolkit'
-import { BiLinkExternal } from 'react-icons/bi'
 import { useFormify } from './formify'
-import { TinaSchema, resolveForm } from '@tinacms/schema-tools'
 
 export function useGraphqlFormsUnstable<T extends object>({
   variables,
@@ -398,10 +398,10 @@ export function useGraphqlForms<T extends object>({
         })
       })
       .catch((e) => {
-        cms.alerts.error('There was a problem setting up forms for your query')
-        console.error('There was a problem setting up forms for your query')
-        console.error(e)
         setIsLoading(false)
+        throw new Error(
+          `There was a problem setting up forms for your query: ${e.message}`
+        )
       })
 
     return () => {

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -12,24 +12,24 @@ limitations under the License.
 */
 
 import React, { useState } from 'react'
+import { TinaCloudMediaStoreClass, TinaCloudProvider } from './auth'
 import {
   useGraphqlForms,
   useGraphqlFormsUnstable,
 } from './hooks/use-graphql-forms'
-import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
-import { TinaCloudProvider, TinaCloudMediaStoreClass } from './auth'
+
 import { LocalClient } from './client/index'
+import type { TinaCMS } from '@tinacms/toolkit'
+import type { TinaCloudSchema } from '@tinacms/schema-tools'
+import { TinaDataContext } from '@tinacms/sharedctx'
 import type { TinaIOConfig } from './client/index'
-import { useCMS } from '@tinacms/toolkit'
 import UrlPattern from 'url-pattern'
+import type { formifyCallback } from './hooks/use-graphql-forms'
 // @ts-ignore importing css is not recognized
 import styles from './styles.css'
-
-import type { TinaCMS } from '@tinacms/toolkit'
-import type { formifyCallback } from './hooks/use-graphql-forms'
-import { TinaDataContext } from '@tinacms/sharedctx'
+import { useCMS } from '@tinacms/toolkit'
+import { useDocumentCreatorPlugin } from './hooks/use-content-creator'
 import { useTina } from './edit-state'
-import type { TinaCloudSchema } from '@tinacms/schema-tools'
 
 const errorButtonStyles = {
   background: '#eb6337',
@@ -116,7 +116,20 @@ class ErrorBoundary extends React.Component {
               encountering this error. There is a bigger issue with the site.
               Please reach out to your site admin.
             </p>
-
+            <br />
+            <p>
+              See our{' '}
+              <a
+                className="text-gray-600"
+                style={{ textDecoration: 'underline' }}
+                href="https://tina.io/docs/errors/faq/"
+                target="_blank"
+              >
+                {' '}
+                Error FAQ{' '}
+              </a>{' '}
+              for more information.
+            </p>
             <button
               style={errorButtonStyles as any}
               onClick={() => {
@@ -138,6 +151,20 @@ class ErrorBoundary extends React.Component {
                   compatible with the latest version of the site's layout. Click
                   the button below to switch back to the default branch for this
                   deployment.
+                </p>
+                <br />
+                <p>
+                  See our{' '}
+                  <a
+                    className="text-gray-600"
+                    style={{ textDecoration: 'underline' }}
+                    href="https://tina.io/docs/errors/faq/"
+                    target="_blank"
+                  >
+                    {' '}
+                    Error FAQ{' '}
+                  </a>{' '}
+                  for more information.
                 </p>
                 <button
                   style={errorButtonStyles as any}
@@ -173,6 +200,8 @@ const parseURL = (url: string): { branch; isLocalClient; clientId } => {
   const params = new URL(url)
   const pattern = new UrlPattern('/content/:clientId/github/:branch')
   const result = pattern.match(params.pathname)
+
+  // TODO if !result || !result.clientId || !result.branch, throw an error
 
   if (params.host !== tinaHost) {
     throw new Error(

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -116,7 +116,6 @@ class ErrorBoundary extends React.Component {
               encountering this error. There is a bigger issue with the site.
               Please reach out to your site admin.
             </p>
-            <br />
             <p>
               See our{' '}
               <a
@@ -152,7 +151,6 @@ class ErrorBoundary extends React.Component {
                   the button below to switch back to the default branch for this
                   deployment.
                 </p>
-                <br />
                 <p>
                   See our{' '}
                   <a


### PR DESCRIPTION
For #2519 

- This bubbles up errors that were previously being output as `cms.alerts` so that we instead display the error boundary.
- This also adds a link to the FAQ within the error boundary.

The messages that are shown within the error boundary are often not extremely useful, but it feels like there is probably another task to get these error messages sorted out.


<img width="423" alt="image" src="https://user-images.githubusercontent.com/5082908/161074296-42dedaa1-11fd-4afb-9bd9-2e429b00bd79.png">


To test:

I have a version `0.0.0-2022231135650` up with these changes. 

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
