### PR TITLE
Style Rich Text Input Lists

### DIFF
--- a/.changeset/poor-elephants-sleep.md
+++ b/.changeset/poor-elephants-sleep.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Improve rich text input list styles

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/updated/plate/plugins/ui/components.tsx
@@ -166,7 +166,7 @@ export const components = () => {
         className={classNames(
           blockClasses,
           className,
-          'mb-4 list-disc last:mb-0'
+          'mb-4 pl-2 list-disc list-inside last:mb-0'
         )}
         {...attributes}
         {...props}
@@ -174,21 +174,25 @@ export const components = () => {
     ),
     [ELEMENT_LI]: ({ attributes, editor, className, element, ...props }) => (
       <li
-        className={classNames(blockClasses, className)}
+        className={classNames('p-0 mt-0 mb-2 last:mb-0', className)}
         {...attributes}
         {...props}
       />
     ),
     [ELEMENT_OL]: ({ attributes, editor, className, element, ...props }) => (
       <ol
-        className={classNames(blockClasses, className)}
+        className={classNames(
+          blockClasses,
+          className,
+          'mb-4 pl-2 list-decimal list-inside last:mb-0'
+        )}
         {...attributes}
         {...props}
       />
     ),
     [ELEMENT_LI]: ({ attributes, className, editor, element, ...props }) => (
       <li
-        className={classNames('mt-0 mb-2 last:mb-0', className)}
+        className={classNames('p-0 mt-0 mb-2 last:mb-0', className)}
         {...attributes}
         {...props}
       />

--- a/packages/@tinacms/toolkit/src/preflight.css
+++ b/packages/@tinacms/toolkit/src/preflight.css
@@ -187,6 +187,10 @@
     padding: 0;
   }
 
+  li:before {
+    display: none;
+  }
+
   textarea {
     resize: vertical;
   }


### PR DESCRIPTION
New list styles:
<img width="561" alt="Screen Shot 2022-04-01 at 11 37 04 AM" src="https://user-images.githubusercontent.com/5075484/161285317-4e0fc328-b746-450c-9e64-94264f27486b.png">

Previous, broken list styles:
<img width="202" alt="Screen Shot 2022-04-01 at 11 37 44 AM" src="https://user-images.githubusercontent.com/5075484/161285459-83e3ee28-52d6-48af-9483-0bd011dfaa91.png">

Changes:
- Adds `li:before` reset to try and catch common user list styling.
- Adds left padding to lists.
- Resets padding on list elements.
- Explicitly sets list styling and positioning for both unordered and ordered lists.
