### PR TITLE
fix: not awaiting call to store.clear() when indexing

### DIFF
--- a/.changeset/clean-panthers-sit.md
+++ b/.changeset/clean-panthers-sit.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix issue where store.clear() was not being awaited causing an invalid state after reindex

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -446,7 +446,7 @@ export class Database {
       await this.bridge.get(path.join(GENERATED_FOLDER, '_lookup.json'))
     )
     if (this.store.supportsSeeding()) {
-      this.store.clear()
+      await this.store.clear()
       await this.store.seed(
         path.join(GENERATED_FOLDER, '_graphql.json'),
         graphQLSchema


### PR DESCRIPTION
Fix issue where the store.clear() call was not being awaited which was causing the store to be in an inconsistent state after reindexing
