### PR TITLE
fix: non-indexed date values need to be converted from iso date format to number before comparison

### DIFF
--- a/.changeset/giant-berries-glow.md
+++ b/.changeset/giant-berries-glow.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/datalayer': patch
+---
+
+Fix datetime filtering to handle both indexed and non-indexed queries

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -21,10 +21,15 @@ import {
   makeFilterChain,
   makeFilterSuffixes,
   makeKeyForField,
-  INDEX_KEY_FIELD_SEPARATOR, makeStringEscaper, DEFAULT_NUMERIC_LPAD,
+  INDEX_KEY_FIELD_SEPARATOR,
+  makeStringEscaper,
+  DEFAULT_NUMERIC_LPAD,
 } from '.'
 
-const escapeStr = makeStringEscaper(new RegExp(INDEX_KEY_FIELD_SEPARATOR, 'gm'), encodeURIComponent(INDEX_KEY_FIELD_SEPARATOR))
+const escapeStr = makeStringEscaper(
+  new RegExp(INDEX_KEY_FIELD_SEPARATOR, 'gm'),
+  encodeURIComponent(INDEX_KEY_FIELD_SEPARATOR)
+)
 
 describe('datalayer store helper functions', () => {
   describe('buildKeyForField', () => {
@@ -369,8 +374,8 @@ describe('datalayer store helper functions', () => {
           type: 'number',
           pad: {
             fillString: '0',
-            maxLength: DEFAULT_NUMERIC_LPAD
-          }
+            maxLength: DEFAULT_NUMERIC_LPAD,
+          },
         }
         const filterCondition: FilterCondition = {
           filterExpression: {
@@ -397,8 +402,8 @@ describe('datalayer store helper functions', () => {
           type: 'number',
           pad: {
             fillString: '0',
-            maxLength: DEFAULT_NUMERIC_LPAD
-          }
+            maxLength: DEFAULT_NUMERIC_LPAD,
+          },
         }
         const filterCondition: FilterCondition = {
           filterExpression: {
@@ -472,8 +477,8 @@ describe('datalayer store helper functions', () => {
           type: 'number',
           pad: {
             fillString: '0',
-            maxLength: DEFAULT_NUMERIC_LPAD
-          }
+            maxLength: DEFAULT_NUMERIC_LPAD,
+          },
         }
         const filterCondition: FilterCondition = {
           filterExpression: {
@@ -771,6 +776,21 @@ describe('datalayer store helper functions', () => {
         expect(itemFilter({ rating: 3 })).toBeTruthy()
         expect(itemFilter({ rating: 5 })).toBeFalsy()
       })
+
+      it('filters with datetime after', () => {
+        const itemFilter = makeFilter({
+          filterChain: [
+            {
+              pathExpression: 'date',
+              rightOperand: 1623481200000,
+              operator: OP.GT,
+              type: 'datetime',
+            },
+          ],
+        })
+        expect(itemFilter({ date: '2021-04-03T20:30:00.000Z' })).toBeFalsy()
+        expect(itemFilter({ date: '2021-07-03T20:30:00.000Z' })).toBeTruthy()
+      })
     })
 
     describe('ternary', () => {
@@ -859,8 +879,8 @@ describe('datalayer store helper functions', () => {
         type: 'string',
         pad: {
           fillString: ' ',
-          maxLength: 10
-        }
+          maxLength: 10,
+        },
       }
       const coerced = coerceFilterChainOperands([expected], escapeStr)
       expect(coerced.length).toEqual(1)
@@ -882,7 +902,7 @@ describe('datalayer store helper functions', () => {
     it('coerces string[]', () => {
       const expected: BinaryFilter = {
         pathExpression: 'titles',
-        rightOperand: ['foo','bar'],
+        rightOperand: ['foo', 'bar'],
         operator: OP.IN,
         type: 'string',
       }
@@ -895,13 +915,13 @@ describe('datalayer store helper functions', () => {
       const operand = ['foo', 'bar']
       const expected: BinaryFilter = {
         pathExpression: 'titles',
-        rightOperand: operand.map(val => val.padStart(10, ' ')),
+        rightOperand: operand.map((val) => val.padStart(10, ' ')),
         operator: OP.IN,
         type: 'string',
         pad: {
           fillString: ' ',
-          maxLength: 10
-        }
+          maxLength: 10,
+        },
       }
       const coerced = coerceFilterChainOperands([expected], escapeStr)
       expect(coerced.length).toEqual(1)
@@ -913,7 +933,7 @@ describe('datalayer store helper functions', () => {
         pathExpression: 'rating',
         rightOperand: 10,
         operator: OP.EQ,
-        type: 'number'
+        type: 'number',
       }
       const coerced = coerceFilterChainOperands([expected], escapeStr)
       expect(coerced.length).toEqual(1)
@@ -932,12 +952,17 @@ describe('datalayer store helper functions', () => {
         operator: OP.GT,
         type: 'datetime',
       }
-      const coerced = coerceFilterChainOperands([
-        {
-          ...expected,
-          rightOperand: new Date(expected.rightOperand as number).toISOString(),
-        },
-      ], escapeStr)
+      const coerced = coerceFilterChainOperands(
+        [
+          {
+            ...expected,
+            rightOperand: new Date(
+              expected.rightOperand as number
+            ).toISOString(),
+          },
+        ],
+        escapeStr
+      )
 
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)
@@ -950,14 +975,17 @@ describe('datalayer store helper functions', () => {
         operator: OP.IN,
         type: 'datetime',
       }
-      const coerced = coerceFilterChainOperands([
-        {
-          ...expected,
-          rightOperand: [
-            new Date(expected.rightOperand[0] as number).toISOString(),
-          ],
-        },
-      ], escapeStr)
+      const coerced = coerceFilterChainOperands(
+        [
+          {
+            ...expected,
+            rightOperand: [
+              new Date(expected.rightOperand[0] as number).toISOString(),
+            ],
+          },
+        ],
+        escapeStr
+      )
 
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)
@@ -972,13 +1000,18 @@ describe('datalayer store helper functions', () => {
         rightOperator: OP.LT,
         type: 'datetime',
       }
-      const coerced = coerceFilterChainOperands([
-        {
-          ...expected,
-          rightOperand: new Date(expected.rightOperand as number).toISOString(),
-          leftOperand: new Date(expected.leftOperand as number).toISOString(),
-        },
-      ], escapeStr)
+      const coerced = coerceFilterChainOperands(
+        [
+          {
+            ...expected,
+            rightOperand: new Date(
+              expected.rightOperand as number
+            ).toISOString(),
+            leftOperand: new Date(expected.leftOperand as number).toISOString(),
+          },
+        ],
+        escapeStr
+      )
 
       expect(coerced.length).toEqual(1)
       expect(coerced[0]).toEqual(expected)

--- a/packages/@tinacms/datalayer/src/database/store/index.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.ts
@@ -295,7 +295,7 @@ export const makeFilter = ({
       } else if (dataType === 'datetime') {
         operands = resolvedValues.map((resolvedValue) => {
           const coerced = new Date(resolvedValue).getTime()
-          return isNaN(coerced) ? resolvedValue : coerced
+          return isNaN(coerced) ? Number(resolvedValue) : coerced
         })
       } else if (dataType === 'boolean') {
         operands = resolvedValues.map(

--- a/packages/@tinacms/datalayer/src/database/store/index.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.ts
@@ -29,7 +29,8 @@ export enum OP {
 }
 
 export type PadDefinition = {
-  fillString: string, maxLength: number
+  fillString: string
+  maxLength: number
 }
 
 export type BinaryFilter = {
@@ -215,7 +216,10 @@ export const makeFilterChain = ({
         rightOperand: filterExpression[key1],
         operator: inferOperatorFromFilter(key1),
         type: _type as string,
-        pad: _type === 'number' ? { fillString: '0', maxLength: DEFAULT_NUMERIC_LPAD } : undefined
+        pad:
+          _type === 'number'
+            ? { fillString: '0', maxLength: DEFAULT_NUMERIC_LPAD }
+            : undefined,
       })
     } else if (key1 && key2) {
       const leftFilterOperator =
@@ -252,7 +256,10 @@ export const makeFilterChain = ({
             | OP.LT
             | OP.LTE,
           type: _type as string,
-          pad: _type === 'number' ? { fillString: '0', maxLength: DEFAULT_NUMERIC_LPAD } : undefined
+          pad:
+            _type === 'number'
+              ? { fillString: '0', maxLength: DEFAULT_NUMERIC_LPAD }
+              : undefined,
         })
       } else {
         throw new Error(
@@ -283,8 +290,13 @@ export const makeFilter = ({
       let operands: FilterOperand[]
       if (dataType === 'string' || dataType === 'reference') {
         operands = resolvedValues
-      } else if (dataType === 'number' || dataType === 'datetime') {
+      } else if (dataType === 'number') {
         operands = resolvedValues.map((resolvedValue) => Number(resolvedValue))
+      } else if (dataType === 'datetime') {
+        operands = resolvedValues.map((resolvedValue) => {
+          const coerced = new Date(resolvedValue).getTime()
+          return isNaN(coerced) ? resolvedValue : coerced
+        })
       } else if (dataType === 'boolean') {
         operands = resolvedValues.map(
           (resolvedValue) =>
@@ -397,10 +409,15 @@ export const makeFilter = ({
 
 type StringEscaper = <T extends string | string[]>(input: T) => T
 
-export const makeStringEscaper = (regex: RegExp, replacement: string): StringEscaper => {
+export const makeStringEscaper = (
+  regex: RegExp,
+  replacement: string
+): StringEscaper => {
   return <T extends string | string[]>(input: T): T => {
     if (Array.isArray(input)) {
-      return (input as string[]).map(val => val.replace(regex, replacement)) as T
+      return (input as string[]).map((val) =>
+        val.replace(regex, replacement)
+      ) as T
     } else {
       return (input as string).replace(regex, replacement) as T
     }
@@ -410,7 +427,9 @@ export const makeStringEscaper = (regex: RegExp, replacement: string): StringEsc
 const applyPadding = (input: any, pad?: PadDefinition) => {
   if (pad) {
     if (Array.isArray(input)) {
-      return (input as any[]).map(val => String(val).padStart(pad.maxLength, pad.fillString))
+      return (input as any[]).map((val) =>
+        String(val).padStart(pad.maxLength, pad.fillString)
+      )
     } else {
       return String(input).padStart(pad.maxLength, pad.fillString)
     }
@@ -453,13 +472,26 @@ export const coerceFilterChainOperands = (
         }
       } else if (dataType === 'string') {
         if ((filter as TernaryFilter).leftOperand !== undefined) {
-          result.push({ ...filter,
-            rightOperand: applyPadding(stringEscaper(filter.rightOperand as string | string[]), filter.pad),
-            leftOperand: applyPadding(stringEscaper((filter as TernaryFilter).leftOperand as string | string[]), filter.pad),
+          result.push({
+            ...filter,
+            rightOperand: applyPadding(
+              stringEscaper(filter.rightOperand as string | string[]),
+              filter.pad
+            ),
+            leftOperand: applyPadding(
+              stringEscaper(
+                (filter as TernaryFilter).leftOperand as string | string[]
+              ),
+              filter.pad
+            ),
           })
         } else {
-          result.push({ ...filter,
-            rightOperand: applyPadding(stringEscaper(filter.rightOperand as string | string[]), filter.pad)
+          result.push({
+            ...filter,
+            rightOperand: applyPadding(
+              stringEscaper(filter.rightOperand as string | string[]),
+              filter.pad
+            ),
           })
         }
       } else {
@@ -525,14 +557,28 @@ export const makeFilterSuffixes = (
           return
         }
 
-        baseFragments.push(applyPadding(orderedFilterChain[i].rightOperand, orderedFilterChain[i].pad))
+        baseFragments.push(
+          applyPadding(
+            orderedFilterChain[i].rightOperand,
+            orderedFilterChain[i].pad
+          )
+        )
       } else {
         if (ternaryFilter) {
-          leftSuffix = applyPadding(orderedFilterChain[i].leftOperand, orderedFilterChain[i].pad)
-          rightSuffix = applyPadding(orderedFilterChain[i].rightOperand, orderedFilterChain[i].pad)
+          leftSuffix = applyPadding(
+            orderedFilterChain[i].leftOperand,
+            orderedFilterChain[i].pad
+          )
+          rightSuffix = applyPadding(
+            orderedFilterChain[i].rightOperand,
+            orderedFilterChain[i].pad
+          )
         } else {
           const op = orderedFilterChain[i].operator
-          const operand = applyPadding(orderedFilterChain[i].rightOperand, orderedFilterChain[i].pad)
+          const operand = applyPadding(
+            orderedFilterChain[i].rightOperand,
+            orderedFilterChain[i].pad
+          )
           if (op === OP.LT || op === OP.LTE) {
             rightSuffix = operand
           } else if (op === OP.GT || op === OP.GTE) {
@@ -548,9 +594,13 @@ export const makeFilterSuffixes = (
 
     return {
       left:
-        (leftSuffix && [...baseFragments, leftSuffix].join(INDEX_KEY_FIELD_SEPARATOR)) || undefined,
+        (leftSuffix &&
+          [...baseFragments, leftSuffix].join(INDEX_KEY_FIELD_SEPARATOR)) ||
+        undefined,
       right:
-        (rightSuffix && [...baseFragments, rightSuffix].join(INDEX_KEY_FIELD_SEPARATOR)) || undefined,
+        (rightSuffix &&
+          [...baseFragments, rightSuffix].join(INDEX_KEY_FIELD_SEPARATOR)) ||
+        undefined,
     }
   } else {
     return {}
@@ -569,7 +619,9 @@ export const makeKeyForField = (
       const resolvedValue = String(
         field.type === 'datetime'
           ? new Date(data[field.name]).getTime()
-          : field.type === 'string' ? stringEscaper(data[field.name] as string | string[]) : data[field.name]
+          : field.type === 'string'
+          ? stringEscaper(data[field.name] as string | string[])
+          : data[field.name]
       )
       valueParts.push(applyPadding(resolvedValue, field.pad))
     } else {


### PR DESCRIPTION
# what

If you are filtering on a datetime field and the field is not indexed, the resolved value is a string date which needs to be converted. If the field is indexed, then it should just convert the string to a number
