### PR TITLE
fix: #2785: link to MDX docs when unregistered component is used

### DIFF
--- a/.changeset/pink-ads-jog.md
+++ b/.changeset/pink-ads-jog.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Link to MDX documentation when unregistered component error occurs

--- a/packages/@tinacms/graphql/src/mdx/parse.ts
+++ b/packages/@tinacms/graphql/src/mdx/parse.ts
@@ -98,7 +98,7 @@ export const parseMDXInner = (tree: any, field: RichTypeInner) => {
         // this is a fragment <> </>, ignore it
       } else {
         throw new Error(
-          `Found unregistered JSX or HTML: <${node.name}>. Please ensure all structured elements have been registered with your schema.`
+          `Found unregistered JSX or HTML: <${node.name}>. Please ensure all structured elements have been registered with your schema. https://tina.io/docs/editing/mdx/`
         )
       }
     }


### PR DESCRIPTION
# what
Update the error message displayed when an unregistered MDX component is used to include link to documentation