### PR TITLE
feat: --schemaFileType cli option and NO_TELEMETRY env var

### DIFF
--- a/.changeset/fluffy-feet-joke.md
+++ b/.changeset/fluffy-feet-joke.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/cli': patch
+'@tinacms/metrics': patch
+---
+
+- Update tinacms CLI to support schemaFileType option (default 'ts') to allow user to specify the schema file type
+- Update telemetry module to optionally check NO_TELEMETRY environment variable for disabling telemetry

--- a/packages/@tinacms/cli/src/cmds/baseCmds.ts
+++ b/packages/@tinacms/cli/src/cmds/baseCmds.ts
@@ -41,6 +41,10 @@ const experimentalDatalayer = {
   name: '--experimentalData',
   description: 'Build the server with additional data querying capabilities',
 }
+const schemaFileType = {
+  name: '--schemaFileType [fileType]',
+  description: 'The file type to use for the Tina schema',
+}
 const subCommand = {
   name: '-c, --command <command>',
   description: 'The sub-command to run',
@@ -104,7 +108,7 @@ export const baseCmds: Command[] = [
   },
   {
     command: INIT,
-    options: [experimentalDatalayer, noTelemetryOption],
+    options: [experimentalDatalayer, noTelemetryOption, schemaFileType],
     description: 'Add Tina Cloud to an existing project',
     action: (options) =>
       chain(
@@ -112,8 +116,8 @@ export const baseCmds: Command[] = [
           checkDeps,
           initTina,
           installDeps,
-          async (_ctx, next) => {
-            await compile(_ctx, next)
+          async (_ctx, next, options) => {
+            await compile(_ctx, next, options)
             next()
           },
           attachSchema,
@@ -137,7 +141,7 @@ export const baseCmds: Command[] = [
             next()
           },
           async (_ctx, next) => {
-            await compile(_ctx, next)
+            await compile(_ctx, next, options)
             next()
           },
           attachSchema,

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -47,8 +47,22 @@ const cleanup = async ({ tinaTempPath }: { tinaTempPath: string }) => {
   await fs.remove(tinaTempPath)
 }
 
-export const compile = async (_ctx, _next) => {
+export const compile = async (_ctx, _next, options) => {
   logger.info(logText('Compiling...'))
+
+  const { schemaFileType: requestedSchemaFileType = 'ts' } = options
+  const schemaFileType =
+    ((requestedSchemaFileType === 'ts' || requestedSchemaFileType === 'tsx') &&
+      'ts') ||
+    ((requestedSchemaFileType === 'js' || requestedSchemaFileType === 'jsx') &&
+      'js')
+
+  if (!schemaFileType) {
+    throw new Error(
+      `Requested schema file type '${requestedSchemaFileType}' is not valid. Supported schema file types: 'ts, js, tsx, jsx'`
+    )
+  }
+
   let schemaExists = true
   try {
     getSchemaPath({ projectDir: tinaPath })
@@ -60,12 +74,12 @@ export const compile = async (_ctx, _next) => {
     // The schema.ts file does not exist
     logger.info(
       dangerText(`
-      .tina/schema.ts not found, Creating one for you...
+      .tina/schema.${schemaFileType} not found, Creating one for you...
       See Documentation: https://tina.io/docs/tina-cloud/cli/#getting-started"
       `)
     )
     // We will default to TS?
-    const file = path.join(tinaPath, 'schema.ts')
+    const file = path.join(tinaPath, `schema.${schemaFileType}`)
     // Ensure there is a .tina/schema.ts file
     await fs.ensureFile(file)
     // Write a basic schema to it

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -50,7 +50,7 @@ const cleanup = async ({ tinaTempPath }: { tinaTempPath: string }) => {
 export const compile = async (_ctx, _next, options) => {
   logger.info(logText('Compiling...'))
 
-  const { schemaFileType: requestedSchemaFileType = 'ts' } = options
+  const { schemaFileType: requestedSchemaFileType = 'ts' } = options || {}
   const schemaFileType =
     ((requestedSchemaFileType === 'ts' || requestedSchemaFileType === 'tsx') &&
       'ts') ||

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -47,10 +47,14 @@ const cleanup = async ({ tinaTempPath }: { tinaTempPath: string }) => {
   await fs.remove(tinaTempPath)
 }
 
-export const compile = async (_ctx, _next, options) => {
+export const compile = async (
+  _ctx,
+  _next,
+  options = { schemaFileType: 'ts' }
+) => {
   logger.info(logText('Compiling...'))
 
-  const { schemaFileType: requestedSchemaFileType = 'ts' } = options || {}
+  const { schemaFileType: requestedSchemaFileType = 'ts' } = options
   const schemaFileType =
     ((requestedSchemaFileType === 'ts' || requestedSchemaFileType === 'tsx') &&
       'ts') ||

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -66,6 +66,7 @@ export const compile = async (
       `Requested schema file type '${requestedSchemaFileType}' is not valid. Supported schema file types: 'ts, js, tsx, jsx'`
     )
   }
+  _ctx.schemaFileType = schemaFileType
 
   let schemaExists = true
   try {

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -66,7 +66,10 @@ export const compile = async (
       `Requested schema file type '${requestedSchemaFileType}' is not valid. Supported schema file types: 'ts, js, tsx, jsx'`
     )
   }
-  _ctx.schemaFileType = schemaFileType
+
+  if (_ctx) {
+    _ctx.schemaFileType = schemaFileType
+  }
 
   let schemaExists = true
   try {

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -51,7 +51,12 @@ function execShellCommand(cmd): Promise<string> {
 
 export async function initTina(ctx: any, next: () => void, options) {
   const telemetry = new Telemetry({ disabled: options.noTelemetry })
-  await telemetry.submitRecord({ event: { name: 'tinacms:cli:init:invoke' } })
+  await telemetry.submitRecord({
+    event: {
+      name: 'tinacms:cli:init:invoke',
+      schemaFileType: options.schemaFileType || 'ts',
+    },
+  })
   logger.info(successText('Setting up Tina...'))
   next()
 }
@@ -162,7 +167,7 @@ const TinaProviderPath = p.join(componentFolder, 'TinaProvider.js')
 const TinaDynamicProvider = p.join(componentFolder, 'TinaDynamicProvider.js')
 
 export async function tinaSetup(_ctx: any, next: () => void, _options) {
-  const useingSrc = fs.pathExistsSync(p.join(baseDir, 'src'))
+  const usingSrc = fs.pathExistsSync(p.join(baseDir, 'src'))
 
   // 1. Create a content/blog Folder and add one or two blog posts
   if (!fs.pathExistsSync(blogPostPath)) {
@@ -180,7 +185,7 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
   logger.level = 'info'
 
   // 3. Create an _app.js
-  const pagesPath = p.join(baseDir, useingSrc ? 'src' : '', 'pages')
+  const pagesPath = p.join(baseDir, usingSrc ? 'src' : '', 'pages')
   const appPath = p.join(pagesPath, '_app.js')
   const appPathTS = p.join(pagesPath, '_app.tsx')
   const appExtension = fs.existsSync(appPath) ? '.js' : '.tsx'
@@ -188,7 +193,7 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
   if (!fs.pathExistsSync(appPath) && !fs.pathExistsSync(appPathTS)) {
     // if they don't have a _app.js or an _app.tsx just make one
     logger.info(logText('Adding _app.js ... ✅'))
-    fs.writeFileSync(appPath, AppJsContent(useingSrc))
+    fs.writeFileSync(appPath, AppJsContent(usingSrc))
   } else {
     // Ask the user if they want to update there _app.js
     const override = await prompts({
@@ -212,13 +217,13 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
       const primaryMatches = matches.map((x) => x[0])
       fs.writeFileSync(
         appPathWithExtension,
-        AppJsContent(useingSrc, primaryMatches.join('\n'))
+        AppJsContent(usingSrc, primaryMatches.join('\n'))
       )
     } else {
       logger.info(
         dangerText(
           `Heads up, to enable live-editing you'll need to wrap your page or site in Tina:\n`,
-          warnText(AppJsContent(useingSrc))
+          warnText(AppJsContent(usingSrc))
         )
       )
     }

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -179,7 +179,13 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
   // 2. Create a Tina Provider
   if (!fs.existsSync(TinaProviderPath) && !fs.existsSync(TinaDynamicProvider)) {
     fs.mkdirpSync(componentFolder)
-    fs.writeFileSync(TinaProviderPath, TinaProvider)
+    fs.writeFileSync(
+      TinaProviderPath,
+      TinaProvider.replace(
+        /'\.\.\/schema\.ts'/,
+        `'../schema.${_ctx.schemaFileType || 'ts'}'`
+      )
+    )
     fs.writeFileSync(TinaDynamicProvider, TinaProviderDynamic)
   }
   logger.level = 'info'

--- a/packages/@tinacms/metrics/src/interfaces/index.ts
+++ b/packages/@tinacms/metrics/src/interfaces/index.ts
@@ -29,6 +29,7 @@ export interface TinaCMSAuditInvoke extends EventsBase {
 
 export interface TinaCMSInitInvoke extends EventsBase {
   name: 'tinacms:cli:init:invoke'
+  schemaFileType?: string
 }
 
 export interface TinaCMSServerStartInvoke extends EventsBase {

--- a/packages/@tinacms/metrics/src/telemetry/telemetry.ts
+++ b/packages/@tinacms/metrics/src/telemetry/telemetry.ts
@@ -34,7 +34,9 @@ export class Telemetry {
   constructor({ disabled }: { disabled: any }) {
     // this.config = new Conf({ projectName: 'tinacms', cwd: dir })
     this.projectIDRaw = getID()
-    this._disabled = Boolean(disabled)
+    const { NO_TELEMETRY } = process.env
+    this._disabled =
+      NO_TELEMETRY === '1' || NO_TELEMETRY === 'true' || Boolean(disabled)
   }
   private oneWayHash = (payload: BinaryLike): string => {
     const hash = createHash('sha256')


### PR DESCRIPTION
# what
- Update tinacms CLI to support schemaFileType option (default 'ts') to allow user to specify the schema file type
- Update telemetry module to optionally check NO_TELEMETRY environment variable for disabling telemetry
