### PR TITLE
fix: 2810: Database.put fails on windows

### DIFF
--- a/.changeset/little-dryers-smoke.md
+++ b/.changeset/little-dryers-smoke.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/cli': patch
+'@tinacms/graphql': patch
+---
+
+Make schema init platform-aware and refactor database put requests

--- a/packages/@tinacms/cli/src/cmds/compile/defaultSchema.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/defaultSchema.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export const defaultSchema = `
+export const defaultSchema = (sep: string) => `
 import { defineSchema, defineConfig } from "tinacms";
 
 export default defineSchema({
@@ -19,7 +19,7 @@ export default defineSchema({
     {
       label: "Blog Posts",
       name: "posts",
-      path: "content/posts",
+      path: "content${sep}posts",
       fields: [
         {
           type: "string",

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -15,9 +15,7 @@ import path from 'path'
 import fs from 'fs-extra'
 import { build } from 'esbuild'
 import type { Loader } from 'esbuild'
-import * as _ from 'lodash'
 import type { TinaCloudSchema } from '@tinacms/graphql'
-import { TinaSchemaValidationError } from '@tinacms/schema-tools'
 import { dangerText, logText } from '../../utils/theme'
 import { defaultSchema } from './defaultSchema'
 import { logger } from '../../logger'
@@ -91,7 +89,7 @@ export const compile = async (
     // Ensure there is a .tina/schema.ts file
     await fs.ensureFile(file)
     // Write a basic schema to it
-    await fs.writeFile(file, defaultSchema)
+    await fs.writeFile(file, defaultSchema(path.sep))
   }
 
   // Turns the schema into JS files so they can be run

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -164,11 +164,14 @@ export class Database {
       throw new Error(`Unexpected put for config file ${filepath}`)
     } else {
       const tinaSchema = await this.getSchema()
+      console.log('Database.put', filepath)
       const collection = tinaSchema.schema.collections.find((collection) =>
         filepath.startsWith(collection.path)
       )
+      console.log('Database.put', collection)
       let collectionIndexDefinitions
       if (collection) {
+        console.log(collection?.name)
         const indexDefinitions = await this.getIndexDefinitions()
         collectionIndexDefinitions = indexDefinitions?.[collection.name]
       }

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -165,13 +165,14 @@ export class Database {
       throw new Error(`Unexpected put for config file ${filepath}`)
     } else {
       const tinaSchema = await this.getSchema()
-      const collection = tinaSchema.schema.collections.find((collection) =>
-        filepath.startsWith(collection.path)
-      )
+      console.log('collections', tinaSchema.schema.collections)
+      const collection = tinaSchema.schema.collections.find((collection) => {
+        console.log(filepath, collection.path)
+        return filepath.startsWith(collection.path)
+      })
       console.log('Database.put', collection)
       let collectionIndexDefinitions
       if (collection) {
-        console.log(collection?.name)
         const indexDefinitions = await this.getIndexDefinitions()
         collectionIndexDefinitions = indexDefinitions?.[collection.name]
       }
@@ -183,7 +184,7 @@ export class Database {
       }
       await this.store.put(filepath, payload, {
         keepTemplateKey,
-        collection: collection.name,
+        collection: collection?.name,
         indexDefinitions: collectionIndexDefinitions,
       })
     }

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -160,11 +160,11 @@ export class Database {
   }
 
   public put = async (filepath: string, data: { [key: string]: unknown }) => {
+    console.log('Database.put', filepath, data)
     if (SYSTEM_FILES.includes(filepath)) {
       throw new Error(`Unexpected put for config file ${filepath}`)
     } else {
       const tinaSchema = await this.getSchema()
-      console.log('Database.put', filepath)
       const collection = tinaSchema.schema.collections.find((collection) =>
         filepath.startsWith(collection.path)
       )

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -368,9 +368,8 @@ export class Resolver {
       collection
     )
 
-    console.log('calling put3', realPath)
     // @ts-ignore
-    await this.database.put(realPath, params)
+    await this.database.put(realPath, params, collection.name)
     return this.getDocument(realPath)
   }
 
@@ -402,8 +401,7 @@ export class Resolver {
               params,
               templateInfo.template
             )
-            console.log('calling put', realPath)
-            await this.database.put(realPath, values)
+            await this.database.put(realPath, values, collection.name)
           }
           break
         case 'union':
@@ -421,8 +419,7 @@ export class Resolver {
                 ...this.buildFieldMutations(templateParams, template),
                 _template: lastItem(template.namespace),
               }
-              console.log('calling put4', realPath)
-              await this.database.put(realPath, values)
+              await this.database.put(realPath, values, collection.name)
             }
           })
       }
@@ -434,9 +431,8 @@ export class Resolver {
       isCollectionSpecific ? args.params : args.params[collection.name],
       collection
     )
-    console.log('calling put2', realPath)
     //@ts-ignore
-    await this.database.put(realPath, params)
+    await this.database.put(realPath, params, collection.name)
     return this.getDocument(realPath)
   }
 

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -368,8 +368,8 @@ export class Resolver {
       collection
     )
 
-    // @ts-ignore
     console.log('calling put3', realPath)
+    // @ts-ignore
     await this.database.put(realPath, params)
     return this.getDocument(realPath)
   }
@@ -434,8 +434,8 @@ export class Resolver {
       isCollectionSpecific ? args.params : args.params[collection.name],
       collection
     )
-    //@ts-ignore
     console.log('calling put2', realPath)
+    //@ts-ignore
     await this.database.put(realPath, params)
     return this.getDocument(realPath)
   }

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -369,6 +369,7 @@ export class Resolver {
     )
 
     // @ts-ignore
+    console.log('calling put3', realPath)
     await this.database.put(realPath, params)
     return this.getDocument(realPath)
   }
@@ -401,6 +402,7 @@ export class Resolver {
               params,
               templateInfo.template
             )
+            console.log('calling put', realPath)
             await this.database.put(realPath, values)
           }
           break
@@ -419,6 +421,7 @@ export class Resolver {
                 ...this.buildFieldMutations(templateParams, template),
                 _template: lastItem(template.namespace),
               }
+              console.log('calling put4', realPath)
               await this.database.put(realPath, values)
             }
           })
@@ -432,6 +435,7 @@ export class Resolver {
       collection
     )
     //@ts-ignore
+    console.log('calling put2', realPath)
     await this.database.put(realPath, params)
     return this.getDocument(realPath)
   }


### PR DESCRIPTION
# what

Modify the schema generation in cli init to use the correct path separator depending on the platform and do some general refactoring of the database code which determines the collection based on the path.