### PR TITLE
Improvement of select dropdown. Make arrow icon clickable

### DIFF
--- a/.changeset/five-coats-protect.md
+++ b/.changeset/five-coats-protect.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/toolkit": patch
+---
+
+Improvement of select dropdown. Make arrow icon clickable

--- a/packages/@tinacms/toolkit/src/packages/fields/components/Select.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/Select.tsx
@@ -60,7 +60,7 @@ export const Select: React.FC<SelectProps> = ({ input, field, options }) => {
           <option>{input.value}</option>
         )}
       </select>
-      <MdKeyboardArrowDown className="absolute top-1/2 right-3 w-6 h-auto -translate-y-1/2 text-gray-300 group-hover:text-blue-500 transition duration-150 ease-out" />
+      <MdKeyboardArrowDown className="absolute top-1/2 right-3 w-6 h-auto -translate-y-1/2 text-gray-300 group-hover:text-blue-500 transition duration-150 ease-out pointer-events-none" />
     </div>
   )
 }


### PR DESCRIPTION
Status Quo: The arrow icon on top of the HTML5 select element cannot be clicked by the user. There is also no hover effect.
The arrow icon is created using an react-icon svg which is moved on top of the dropdown.

Solution:
https://tailwindcss.com/docs/pointer-events