### PR TITLE
Add changeset which was missing when new export was added to the toolkit

### DIFF
--- a/.changeset/spotty-poets-allow.md
+++ b/.changeset/spotty-poets-allow.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Export OverflowMenu


### PR DESCRIPTION
Our latest release shows this error in the admin, but didn't surface as an issue in the monorepo.
```
Error: Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: undefined. You likely forgot to export your component from the file it's defined in, or you might have mixed up default and named imports.

Check the render method of `GetCollection`.
```
This is because the monorepo always uses the latest code from a given workspace. But a recent update that added the `OverflowMenu` as an export was missing a changeset 