### PR TITLE
Replaced tinacms dependency with @tinacms/toolkit

### DIFF
--- a/.changeset/beige-toes-stare.md
+++ b/.changeset/beige-toes-stare.md
@@ -1,0 +1,5 @@
+---
+'react-tinacms-editor': minor
+---
+
+Replaced dependendy from react-tinacms-editor to tinacms with dependency to @tinacms/toolkit

--- a/packages/react-tinacms-editor/package.json
+++ b/packages/react-tinacms-editor/package.json
@@ -22,6 +22,7 @@
     "@storybook/react": "^5.3.19",
     "@testing-library/react": "^12.0.0",
     "@tinacms/scripts": "workspace:*",
+    "@tinacms/toolkit": "workspace:*",
     "@types/codemirror": "^0.0.71",
     "@types/color-string": "^1.5.0",
     "@types/jest": "^27.0.1",
@@ -54,7 +55,6 @@
     "react-dom": "16.14.0",
     "react-is": "^17.0.2",
     "styled-components": ">=4.1",
-    "tinacms": "workspace:*",
     "tslib": "^1.10.0",
     "typescript": "^4.3.5"
   },
@@ -81,8 +81,7 @@
   "peerDependencies": {
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0",
-    "styled-components": ">=4.1",
-    "tinacms": ">=0.50.0"
+    "styled-components": ">=4.1"
   },
   "gitHead": "87c8f9a3ca2c5bf41e1a4c54a73759d12a7c5bfd"
 }

--- a/packages/react-tinacms-editor/package.json
+++ b/packages/react-tinacms-editor/package.json
@@ -81,7 +81,8 @@
   "peerDependencies": {
     "react": ">=16.14.0",
     "react-dom": ">=16.14.0",
-    "styled-components": ">=4.1"
+    "styled-components": ">=4.1",
+    "@tinacms/toolkit": ">=0.56.21"
   },
   "gitHead": "87c8f9a3ca2c5bf41e1a4c54a73759d12a7c5bfd"
 }

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/plugin.ts
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/utils/plugin.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 */
 
-import { Plugin } from 'tinacms'
+import { Plugin } from '@tinacms/toolkit'
 
 function byType(__type: string) {
   return (plugin: Plugin) => plugin.__type === __type

--- a/packages/react-tinacms-editor/src/components/Wysiwyg/index.tsx
+++ b/packages/react-tinacms-editor/src/components/Wysiwyg/index.tsx
@@ -19,7 +19,7 @@ limitations under the License.
 import * as React from 'react'
 import styled from 'styled-components'
 
-import { TinaCMS, useCMS, Form, Media } from 'tinacms'
+import { TinaCMS, useCMS, Form, Media } from '@tinacms/toolkit'
 import { BrowserFocusProvider } from '../../context/browserFocus'
 import { EditorModeMenu } from '../EditorModeMenu'
 import {

--- a/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Menu/ProsemirrorMenu.tsx
@@ -18,8 +18,7 @@ limitations under the License.
 
 import React, { useRef } from 'react'
 
-import { useCMS, Media } from 'tinacms'
-import { MediaIcon } from '@tinacms/toolkit'
+import { useCMS, Media, MediaIcon } from '@tinacms/toolkit'
 
 import { MenuButton } from '../../../components/MenuHelpers'
 import { useEditorStateContext } from '../../../context/editorState'

--- a/packages/react-tinacms-editor/src/plugins/Image/Popups/Loader.tsx
+++ b/packages/react-tinacms-editor/src/plugins/Image/Popups/Loader.tsx
@@ -19,7 +19,7 @@ limitations under the License.
 import React, { FunctionComponent } from 'react'
 import ReactDOM from 'react-dom'
 import styled from 'styled-components'
-import { LoadingDots } from 'tinacms'
+import { LoadingDots } from '@tinacms/toolkit'
 
 export const Loader: FunctionComponent = () => {
   const markerImageLoader = document.getElementsByClassName(

--- a/packages/react-tinacms-editor/src/tinacms-plugins/MarkdownFieldPlugin.tsx
+++ b/packages/react-tinacms-editor/src/tinacms-plugins/MarkdownFieldPlugin.tsx
@@ -18,7 +18,7 @@ limitations under the License.
 
 import React from 'react'
 import { Wysiwyg } from '../components/Wysiwyg'
-import { wrapFieldsWithMeta } from 'tinacms'
+import { wrapFieldsWithMeta } from '@tinacms/toolkit'
 import { EditorProps } from '../types'
 
 export const MarkdownField = wrapFieldsWithMeta<EditorProps, any>((props) => (

--- a/packages/react-tinacms-editor/src/types.ts
+++ b/packages/react-tinacms-editor/src/types.ts
@@ -23,7 +23,7 @@ import { Node } from 'prosemirror-model'
 import { Schema } from 'prosemirror-model'
 
 import { Format } from './translator'
-import { Form, Media } from 'tinacms'
+import { Form, Media } from '@tinacms/toolkit'
 
 export interface PassedImageProps {
   parse(media: Media): string

--- a/packages/react-tinacms-editor/stories/wysiwyg.stories.tsx
+++ b/packages/react-tinacms-editor/stories/wysiwyg.stories.tsx
@@ -17,7 +17,7 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import { Media } from 'tinacms'
+import { Media } from '@tinacms/toolkit'
 import { storiesOf } from '@storybook/react'
 import { Wysiwyg } from '../src/components/Wysiwyg'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -28122,14 +28122,12 @@ fsevents@~2.1.2:
     react-dom: 16.14.0
     react-is: ^17.0.2
     styled-components: ">=4.1"
-    tinacms: "workspace:*"
     tslib: ^1.10.0
     typescript: ^4.3.5
   peerDependencies:
     react: ">=16.14.0"
     react-dom: ">=16.14.0"
     styled-components: ">=4.1"
-    tinacms: ">=0.50.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
With this pull-request I want to be able to use the `react-tinacms-editor` without dependency to the "big" tina package, as we are just using parts of the @tinacms/toolkit project.

Main changes:
* Removed devDependency and peerDependency on "tina"
* Added devDependency and peerDependency on "@tinacms/toolkit"
* Fixed imports.