### PR TITLE
Fix issues with finding the template for multitemplate collections

### DIFF
--- a/.changeset/rotten-teachers-divide.md
+++ b/.changeset/rotten-teachers-divide.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Fix issues with finding the template for multitemplate collections

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -94,10 +94,6 @@ const RenderForm = ({ cms, collection, template, fields, mutationInfo }) => {
   if (schema) {
     // the schema is being passed in from the frontend so we can use that
     const schemaCollection = schema.getCollection(collection.name)
-    const template = schema.getTemplateForData({
-      collection: schemaCollection,
-      data: {},
-    })
     const formInfo = resolveForm({
       collection: schemaCollection,
       basename: schemaCollection.name,

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -102,7 +102,7 @@ const RenderForm = ({
     const schemaCollection = schema.getCollection(collection.name)
     const template = schema.getTemplateForData({
       collection: schemaCollection,
-      data: document.value,
+      data: document.values,
     })
     const formInfo = resolveForm({
       collection: schemaCollection,


### PR DESCRIPTION
Fixes part 1 of https://github.com/tinacms/tinacms/issues/2817

> Collections break if they implement multiple different templates (i.e. passing an array of templates rather than an array of fields). [...]