### PR TITLE
Fix issue where items of type "string" with list: true weren't sending g the right event payload

### DIFF
--- a/.changeset/large-dryers-carry.md
+++ b/.changeset/large-dryers-carry.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix issue where items of type "string" with list: true weren't sending the right event payload

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
@@ -139,6 +139,8 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
       type: field.type,
       // @ts-ignore FIXME: this is needed for the new event system, so we know what type to record when we get a change
       list: field.list,
+      // @ts-ignore FIXME: this is needed for the new event system, so we know what type to record when we get a change
+      parentTypename: field.parentTypename,
       ...field.field,
       label: 'Value',
       name: field.name + '.' + index,


### PR DESCRIPTION
Since the event's now rely on `parentTypename` the `ListFieldPlugin` needs to pass some parent field info into the `<FieldsBuilder>`. 

Hopefully this awkwardness goes away when we make the plugins more like our primitive types.