### PR TITLE
Fix tina init app file

### DIFF
--- a/.changeset/itchy-zoos-share.md
+++ b/.changeset/itchy-zoos-share.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix issue where _app override from tina init was improperly formatted

--- a/experimental-examples/unit-test-example/package.json
+++ b/experimental-examples/unit-test-example/package.json
@@ -20,6 +20,5 @@
     "@tinacms/cli": "workspace:*",
     "eslint": "7",
     "eslint-config-next": "12.0.3"
-  },
-  "version": null
+  }
 }

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -1,4 +1,10 @@
-import { AppJsContent, adminPage, blogPost, nextPostPage } from './setup-files'
+import {
+  AppJsContent,
+  AppJsContentPrintout,
+  adminPage,
+  blogPost,
+  nextPostPage,
+} from './setup-files'
 import { TinaProvider, TinaProviderDynamic } from './setup-files/tinaProvider'
 import {
   cmdText,
@@ -277,7 +283,7 @@ export async function successMessage(ctx: any, next: () => void, options) {
     logger.info(
       `⚠️ Before using Tina, you will NEED to add the Tina wrapper to your _app.jsx \n`
     )
-    logger.info(`${AppJsContent(usingSrc)}`)
+    logger.info(`${AppJsContentPrintout(usingSrc)}`)
   }
 
   logger.info(`${chalk.bold('Run your site with Tina')}`)

--- a/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
@@ -327,6 +327,28 @@ export const nextPostPage =
 `
 
 export const AppJsContent = (usingSrc: boolean, extraImports?: string) => {
+  const importLine = `import Tina from '${
+    usingSrc ? '../' : ''
+  }../.tina/components/TinaDynamicProvider.js'`
+
+  return `${importLine}
+${extraImports || ''}
+
+const App = ({ Component, pageProps }) => {
+  return (
+    <Tina>
+      <Component {...pageProps} />
+    </Tina>
+  )
+}
+
+export default App
+`
+}
+export const AppJsContentPrintout = (
+  usingSrc: boolean,
+  extraImports?: string
+) => {
   const importLine = chalk.green(
     `+ import Tina from '${
       usingSrc ? '../' : ''
@@ -343,7 +365,7 @@ export const AppJsContent = (usingSrc: boolean, extraImports?: string) => {
     ${chalk.green('+ </Tina>')}
   )
 }
-  
+
 export default App
 `
 }


### PR DESCRIPTION
The updates to improve the printout during `tina init` made their way into the actual codegen when users choose to override `_app.js`.