### PR TITLE
Style list page overflow menu

### DIFF
--- a/.changeset/fifty-houses-confess.md
+++ b/.changeset/fifty-houses-confess.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+Styles list page overflow menu, removes unused prop

--- a/packages/@tinacms/toolkit/src/packages/styles/OverflowMenu.tsx
+++ b/packages/@tinacms/toolkit/src/packages/styles/OverflowMenu.tsx
@@ -25,67 +25,70 @@ export function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ')
 }
 
-export const OverflowMenu = ({ toolbarItems, showEmbed }) => {
+export const OverflowMenu = ({ toolbarItems }) => {
   return (
-    <Popover as="span" className="relative block w-full">
-      <Popover.Button
-        data-test="popoverRichTextButton"
-        as="span"
-        className={`cursor-pointer relative w-full justify-center inline-flex border border-gray-200 focus:border-blue-500 items-center px-2 py-2 bg-white text-sm font-medium text-gray-600 hover:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-blue-500 pointer-events-auto ${
-          showEmbed ? `rounded-none` : `rounded-r-md`
-        }`}
-        onMouseDown={(e) => {
-          e.preventDefault()
-        }}
-      >
-        <svg
-          xmlns="http://www.w3.org/2000/svg"
-          className="h-5 w-5"
-          fill="none"
-          viewBox="0 0 24 24"
-          stroke="currentColor"
-        >
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
-          />
-        </svg>
-      </Popover.Button>
-      <Transition
-        as={Fragment}
-        enter="transition ease-out duration-100"
-        enterFrom="transform opacity-0 scale-95"
-        enterTo="transform opacity-100 scale-100"
-        leave="transition ease-in duration-75"
-        leaveFrom="transform opacity-100 scale-100"
-        leaveTo="transform opacity-0 scale-95"
-      >
-        <div className="z-20 origin-top-right absolute right-0 mt-2 -mr-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1">
-          {toolbarItems.map((toolbarItem) => {
-            return (
-              <span
-                data-test={`${toolbarItem.name}OverflowButton`}
-                key={toolbarItem.name}
-                onMouseDown={(event) => {
-                  event.preventDefault()
-                  toolbarItem.onMouseDown(event)
-                }}
-                className={classNames(
-                  toolbarItem.active
-                    ? 'bg-gray-50 text-blue-500'
-                    : 'bg-white text-gray-600',
-                  'hover:bg-gray-50 hover:text-blue-500 cursor-pointer pointer-events-auto px-4 py-2 text-sm w-full flex items-center'
-                )}
-              >
-                <div className="mr-2 opacity-80">{toolbarItem.Icon}</div>{' '}
-                {toolbarItem.label}
-              </span>
-            )
-          })}
-        </div>
-      </Transition>
+    <Popover as="div" className="relative block w-full">
+      {({ open }) => (
+        <>
+          <Popover.Button
+            data-test="popoverRichTextButton"
+            className={`cursor-pointer relative w-full justify-center inline-flex border items-center p-3 text-sm font-medium focus:outline-none pointer-events-auto ${
+              open ? `text-blue-400` : `text-gray-300 hover:text-blue-500`
+            }`}
+            onMouseDown={(e) => {
+              e.preventDefault()
+            }}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              className="h-5 w-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z"
+              />
+            </svg>
+          </Popover.Button>
+          <Transition
+            as={Fragment}
+            enter="transition ease-out duration-100"
+            enterFrom="transform opacity-0 scale-95"
+            enterTo="transform opacity-100 scale-100"
+            leave="transition ease-in duration-75"
+            leaveFrom="transform opacity-100 scale-100"
+            leaveTo="transform opacity-0 scale-95"
+          >
+            <div className="z-20 origin-top-right absolute right-0 mt-0 -mr-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1">
+              {toolbarItems.map((toolbarItem) => {
+                return (
+                  <span
+                    data-test={`${toolbarItem.name}OverflowButton`}
+                    key={toolbarItem.name}
+                    onMouseDown={(event) => {
+                      event.preventDefault()
+                      toolbarItem.onMouseDown(event)
+                    }}
+                    className={classNames(
+                      toolbarItem.active
+                        ? 'bg-gray-50 text-blue-500'
+                        : 'bg-white text-gray-600',
+                      'hover:bg-gray-50 hover:text-blue-500 cursor-pointer pointer-events-auto px-4 py-2 text-sm w-full flex items-center whitespace-nowrap'
+                    )}
+                  >
+                    <div className="mr-2 opacity-80">{toolbarItem.Icon}</div>{' '}
+                    {toolbarItem.label}
+                  </span>
+                )
+              })}
+            </div>
+          </Transition>
+        </>
+      )}
     </Popover>
   )
 }

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -243,7 +243,6 @@ const CollectionListPage = () => {
                                     </td>
                                     <td className="w-0">
                                       <OverflowMenu
-                                        showEmbed={true}
                                         toolbarItems={[
                                           {
                                             name: 'edit',


### PR DESCRIPTION
This adjusts the list page overflow menu styling given the existing styling was designed for another context. This also removes the `showEmbed` prop given it was specific to the other context (MDX toolbar) and reverts to rendering the button as a button instead of a `<span>` (Maybe that was necessary for the toolbar?). 

<img width="450" alt="Screen Shot 2022-04-29 at 12 02 32 PM" src="https://user-images.githubusercontent.com/5075484/165971207-adc7b195-88da-483b-a30f-ba277a00822f.png">

