### PR TITLE
Add ability to hide sidebar nav

### DIFF
--- a/.changeset/fluffy-rocks-push.md
+++ b/.changeset/fluffy-rocks-push.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Add ability to disable sidebar nav

--- a/experimental-examples/tina-cloud-starter/.tina/schema.ts
+++ b/experimental-examples/tina-cloud-starter/.tina/schema.ts
@@ -366,6 +366,7 @@ export const tinaConfig = defineConfig({
 
     // cms.sidebar.position = "overlay";
     // cms.sidebar.defaultState = "closed";
+    // cms.sidebar.renderNav = false;
 
     /**
      * When `tina-admin` is enabled, this plugin configures contextual editing for collections

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -70,6 +70,12 @@ export function SidebarProvider({
       defaultWidth={cms?.sidebar?.defaultWidth || defaultWidth}
       // @ts-ignore
       defaultState={cms?.sidebar?.defaultState || defaultState}
+      // @ts-ignore
+      renderNav={
+        typeof cms?.sidebar?.renderNav !== undefined
+          ? cms.sidebar.renderNav
+          : true
+      }
       sidebar={sidebar}
     />
   )
@@ -80,6 +86,7 @@ interface SidebarProps {
   defaultWidth?: SidebarStateOptions['defaultWidth']
   defaultState?: SidebarStateOptions['defaultState']
   position?: SidebarStateOptions['position']
+  renderNav?: boolean
 }
 
 type displayStates = 'closed' | 'open' | 'fullscreen'
@@ -119,6 +126,7 @@ const Sidebar = ({
   defaultWidth,
   defaultState,
   position,
+  renderNav,
 }: SidebarProps) => {
   const cms = useCMS()
   const collectionsInfo = useFetchCollections(cms)
@@ -215,29 +223,33 @@ const Sidebar = ({
       <>
         <SidebarWrapper>
           <EditButton />
-          {(sidebarWidth > navBreakpoint || displayState === 'fullscreen') && (
-            <Nav
-              showCollections={isTinaAdminEnabled}
-              collectionsInfo={collectionsInfo}
-              screens={allScreens}
-              contentCreators={contentCreators}
-              sidebarWidth={sidebarWidth}
-              RenderNavSite={({ view }) => (
-                <SidebarSiteLink
-                  view={view}
-                  onClick={() => {
-                    setActiveView(view)
-                    setMenuIsOpen(false)
-                  }}
-                />
-              )}
-              RenderNavCollection={({ collection }) => (
-                <SidebarCollectionLink collection={collection} />
-              )}
-            />
-          )}
+          {renderNav &&
+            (sidebarWidth > navBreakpoint || displayState === 'fullscreen') && (
+              <Nav
+                showCollections={isTinaAdminEnabled}
+                collectionsInfo={collectionsInfo}
+                screens={allScreens}
+                contentCreators={contentCreators}
+                sidebarWidth={sidebarWidth}
+                RenderNavSite={({ view }) => (
+                  <SidebarSiteLink
+                    view={view}
+                    onClick={() => {
+                      setActiveView(view)
+                      setMenuIsOpen(false)
+                    }}
+                  />
+                )}
+                RenderNavCollection={({ collection }) => (
+                  <SidebarCollectionLink collection={collection} />
+                )}
+              />
+            )}
           <SidebarBody>
-            <SidebarHeader isLocalMode={cms.api?.tina?.isLocalMode} />
+            <SidebarHeader
+              renderNav={renderNav}
+              isLocalMode={cms.api?.tina?.isLocalMode}
+            />
             <FormsView>
               <sidebar.placeholder />
             </FormsView>
@@ -250,7 +262,7 @@ const Sidebar = ({
           </SidebarBody>
           <ResizeHandle />
         </SidebarWrapper>
-        {sidebarWidth < navBreakpoint + 1 && (
+        {renderNav && sidebarWidth < navBreakpoint + 1 && (
           <Transition show={menuIsOpen}>
             <Transition.Child
               as={React.Fragment}
@@ -353,7 +365,7 @@ export const updateBodyDisplacement = ({
   }
 }
 
-const SidebarHeader = ({ isLocalMode }) => {
+const SidebarHeader = ({ renderNav, isLocalMode }) => {
   const {
     toggleFullscreen,
     displayState,
@@ -366,18 +378,20 @@ const SidebarHeader = ({ isLocalMode }) => {
     <div className="flex-grow-0 w-full overflow-visible z-20">
       {isLocalMode && <LocalWarning />}
       <div className="mt-4 -mb-14 w-full flex items-center justify-between pointer-events-none">
-        {sidebarWidth < navBreakpoint + 1 && displayState !== 'fullscreen' && (
-          <Button
-            rounded="right"
-            variant="secondary"
-            onClick={() => {
-              setMenuIsOpen(true)
-            }}
-            className="pointer-events-auto -ml-px"
-          >
-            <BiMenu className="h-7 w-auto" />
-          </Button>
-        )}
+        {renderNav &&
+          sidebarWidth < navBreakpoint + 1 &&
+          displayState !== 'fullscreen' && (
+            <Button
+              rounded="right"
+              variant="secondary"
+              onClick={() => {
+                setMenuIsOpen(true)
+              }}
+              className="pointer-events-auto -ml-px"
+            >
+              <BiMenu className="h-7 w-auto" />
+            </Button>
+          )}
         <div className="flex-1"></div>
         <div
           className={`flex items-center gap-2 pointer-events-auto transition-opacity duration-150 ease-in-out -mr-px`}

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -70,10 +70,11 @@ export function SidebarProvider({
       defaultWidth={cms?.sidebar?.defaultWidth || defaultWidth}
       // @ts-ignore
       defaultState={cms?.sidebar?.defaultState || defaultState}
-      // @ts-ignore
       renderNav={
+        // @ts-ignore
         typeof cms?.sidebar?.renderNav !== undefined
-          ? cms.sidebar.renderNav
+          ? // @ts-ignore
+            cms.sidebar.renderNav
           : true
       }
       sidebar={sidebar}

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/Sidebar.tsx
@@ -72,7 +72,7 @@ export function SidebarProvider({
       defaultState={cms?.sidebar?.defaultState || defaultState}
       renderNav={
         // @ts-ignore
-        typeof cms?.sidebar?.renderNav !== undefined
+        typeof cms?.sidebar?.renderNav !== 'undefined'
           ? // @ts-ignore
             cms.sidebar.renderNav
           : true

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -36,6 +36,8 @@ export const FormsView = ({
 }) => {
   const [activeFormId, setActiveFormId] = useState<string>('')
   const cms = useCMS()
+  const renderNav =
+    typeof cms?.sidebar?.renderNav !== undefined ? cms.sidebar.renderNav : true
   const formPlugins = cms.plugins.getType<Form>('form')
   const { setFormIsPristine } = React.useContext(SidebarContext)
 
@@ -98,11 +100,14 @@ export const FormsView = ({
         <FormWrapper isEditing={isEditing} isMultiform={isMultiform}>
           {isMultiform && (
             <MultiformFormHeader
+              renderNav={renderNav}
               activeForm={activeForm}
               setActiveFormId={setActiveFormId}
             />
           )}
-          {!isMultiform && <FormHeader activeForm={activeForm} />}
+          {!isMultiform && (
+            <FormHeader renderNav={renderNav} activeForm={activeForm} />
+          )}
           {formMetas &&
             formMetas.map((meta) => (
               <React.Fragment key={meta.name}>
@@ -186,11 +191,13 @@ const FormWrapper = styled.div<FormWrapperProps>`
 export interface MultiformFormHeaderProps {
   activeForm: Form
   setActiveFormId(id: string): void
+  renderNav?: boolean
 }
 
 export const MultiformFormHeader = ({
   activeForm,
   setActiveFormId,
+  renderNav,
 }: MultiformFormHeaderProps) => {
   const cms = useCMS()
   const { sidebarWidth, formIsPristine } = React.useContext(SidebarContext)
@@ -198,7 +205,11 @@ export const MultiformFormHeader = ({
   return (
     <div
       className={`py-4 border-b border-gray-200 bg-white ${
-        sidebarWidth > navBreakpoint ? `px-6` : `px-20`
+        sidebarWidth > navBreakpoint && renderNav
+          ? `px-6`
+          : renderNav
+          ? `pl-20 pr-28`
+          : `pl-6 pr-28`
       }`}
     >
       <div className="max-w-form mx-auto flex flex-col items-start justify-center min-h-[2.5rem]">
@@ -228,15 +239,20 @@ export const MultiformFormHeader = ({
 
 export interface FormHeaderProps {
   activeForm: Form
+  renderNav?: boolean
 }
 
-export const FormHeader = ({ activeForm }: FormHeaderProps) => {
+export const FormHeader = ({ renderNav, activeForm }: FormHeaderProps) => {
   const { sidebarWidth, formIsPristine } = React.useContext(SidebarContext)
 
   return (
     <div
       className={`py-4 border-b border-gray-200 bg-white ${
-        sidebarWidth > navBreakpoint ? `px-6` : `px-20`
+        sidebarWidth > navBreakpoint && renderNav
+          ? `px-6`
+          : renderNav
+          ? `pl-20 pr-28`
+          : `pl-6 pr-28`
       }`}
     >
       <div className="max-w-form mx-auto  flex flex-col items-start justify-center min-h-[2.5rem]">

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -37,6 +37,7 @@ export const FormsView = ({
   const [activeFormId, setActiveFormId] = useState<string>('')
   const cms = useCMS()
   const renderNav =
+    // @ts-ignore
     typeof cms?.sidebar?.renderNav !== undefined ? cms.sidebar.renderNav : true
   const formPlugins = cms.plugins.getType<Form>('form')
   const { setFormIsPristine } = React.useContext(SidebarContext)

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -38,7 +38,7 @@ export const FormsView = ({
   const cms = useCMS()
   const renderNav =
     // @ts-ignore
-    typeof cms?.sidebar?.renderNav !== undefined ? cms.sidebar.renderNav : true
+    typeof cms?.sidebar?.renderNav !== 'undefined' ? cms.sidebar.renderNav : true
   const formPlugins = cms.plugins.getType<Form>('form')
   const { setFormIsPristine } = React.useContext(SidebarContext)
 

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/sidebar.ts
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/sidebar.ts
@@ -56,7 +56,7 @@ export class SidebarState {
   constructor(private events: EventBus, options: SidebarStateOptions = {}) {
     // @ts-ignore FIXME twind
     this.position = options.position || 'displace'
-    this.renderNav = options.nav || true
+    this.renderNav = options.renderNav || true
     this.placeholder = options.placeholder || NoFormsPlaceholder
 
     if (options.buttons?.save) {

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/sidebar.ts
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/sidebar.ts
@@ -26,6 +26,7 @@ export interface SidebarStateOptions {
   placeholder?: React.FC
   defaultWidth?: number
   defaultState?: DefaultSidebarState
+  renderNav?: boolean
 }
 
 /**
@@ -46,6 +47,7 @@ export class SidebarState {
   placeholder: React.FC
 
   position: SidebarPosition = 'displace'
+  renderNav: boolean = true
   buttons: SidebarButtons = {
     save: 'Save',
     reset: 'Reset',
@@ -54,6 +56,7 @@ export class SidebarState {
   constructor(private events: EventBus, options: SidebarStateOptions = {}) {
     // @ts-ignore FIXME twind
     this.position = options.position || 'displace'
+    this.renderNav = options.nav || true
     this.placeholder = options.placeholder || NoFormsPlaceholder
 
     if (options.buttons?.save) {


### PR DESCRIPTION
<img width="738" alt="Screen Shot 2022-05-10 at 12 20 21 PM" src="https://user-images.githubusercontent.com/5075484/167663986-aeebcb1e-a23a-48a6-8157-9aeed4346992.png">

The sidebar nav requires context provided by the `TinaProvider` to work, making it break when it's used outside of that context. This allows the user to set `cms.sidebar.renderNav = false`, disabling the nav and adjusting other components to render accordingly. 