### PR TITLE
Adds a paginate package to @tinacms

### DIFF
--- a/packages/@tinacms/paginate/package.json
+++ b/packages/@tinacms/paginate/package.json
@@ -17,8 +17,9 @@
   },
   "devDependencies": {
     "@tinacms/scripts": "workspace:*",
-    "typescript": "^4.3.5",
-    "jest": "^27.0.6"
+    "@types/node": "^17.0.31",
+    "jest": "^27.0.6",
+    "typescript": "^4.3.5"
   },
   "scripts": {
     "build": "echo \"Run `yarn build` from the root of the repository instead\"",

--- a/packages/@tinacms/paginate/package.json
+++ b/packages/@tinacms/paginate/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@tinacms/paginate",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist",
+    ".env"
+  ],
+  "license": "Apache-2.0",
+  "buildConfig": {
+    "entryPoints": [
+      {
+        "name": "src/index.ts",
+        "target": "node"
+      }
+    ]
+  },
+  "devDependencies": {
+    "@tinacms/scripts": "workspace:*",
+    "typescript": "^4.3.5"
+  },
+  "scripts": {
+    "build": "echo \"Run `yarn build` from the root of the repository instead\"",
+    "test": "jest --passWithNoTests",
+    "types": "yarn tsc",
+    "test-watch": "jest  --passWithNoTests --watch",
+    "generate:schema": "yarn node scripts/generateSchema.js"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "url": "https://github.com/tinacms/tinacms.git",
+    "directory": "packages/@tinacms/cli"
+  }
+}

--- a/packages/@tinacms/paginate/package.json
+++ b/packages/@tinacms/paginate/package.json
@@ -17,7 +17,8 @@
   },
   "devDependencies": {
     "@tinacms/scripts": "workspace:*",
-    "typescript": "^4.3.5"
+    "typescript": "^4.3.5",
+    "jest": "^27.0.6"
   },
   "scripts": {
     "build": "echo \"Run `yarn build` from the root of the repository instead\"",

--- a/packages/@tinacms/paginate/src/db.ts
+++ b/packages/@tinacms/paginate/src/db.ts
@@ -1,0 +1,42 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import fs from 'fs'
+
+const pathToDb = '.next/db.json'
+
+export interface Db {
+  pages: {
+    first: number
+    after: string
+    sort: string
+  }[]
+}
+
+export const readDb = async (): Promise<Db> => {
+  try {
+    const buf = await fs.promises.readFile(pathToDb)
+    return JSON.parse(buf.toString('utf-8'))
+  } catch (err) {
+    return { pages: [] }
+  }
+}
+
+export const writeDb = async (db: Db): Promise<void> => {
+  await fs.promises.writeFile(pathToDb, JSON.stringify(db))
+}

--- a/packages/@tinacms/paginate/src/index.ts
+++ b/packages/@tinacms/paginate/src/index.ts
@@ -1,0 +1,19 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+export * from './paginate'

--- a/packages/@tinacms/paginate/src/paginate.ts
+++ b/packages/@tinacms/paginate/src/paginate.ts
@@ -1,0 +1,137 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import { Db, readDb, writeDb } from './db'
+
+/**
+ * Recursively unwraps the "awaited type" of a type. Non-promise "thenables" should resolve to `never`. This emulates the behavior of `await`.
+ */
+type Awaited<T> = T extends null | undefined
+  ? T // special case for `null | undefined` when not in `--strictNullChecks` mode
+  : T extends object & { then(_: infer F): any } // `await` only unwraps object types with a callable `then`. Non-object types are not unwrapped
+  ? F extends (_: infer V, ...__: any) => any // if the argument to `then` is callable, extracts the first argument
+    ? Awaited<V> // recursively unwrap the value
+    : never // the argument to `then` was not callable
+  : T // non-object or non-thenable
+
+export class Paginate<
+  RetrieverFunc extends (_: {
+    first: number
+    after: string
+    sort: string
+  }) => Promise<unknown>
+> {
+  retriever: RetrieverFunc
+  perPage: number
+  sortedBy: string
+
+  constructor(retriever: RetrieverFunc, perPage: number, sortedBy: string) {
+    this.retriever = retriever
+    this.perPage = perPage
+    this.sortedBy = sortedBy
+  }
+
+  findPageInfo(response) {
+    const data = response.data
+
+    for (const i in data) {
+      if (data[i].pageInfo) {
+        return data[i].pageInfo
+      }
+    }
+  }
+
+  public async getPaths() {
+    const db: Db = {
+      pages: [],
+    }
+    const paths: { params: { page: string } }[] = []
+
+    const retrievePage = async (page, first, after, sort) => {
+      const response = (await this.retriever({
+        first,
+        after,
+        sort,
+      })) as Awaited<Promise<RetrieverFunc>>
+
+      const pageInfo = this.findPageInfo(response)
+
+      db.pages.push({
+        first,
+        after,
+        sort,
+      })
+
+      paths.push({
+        params: {
+          page: `${page}`,
+        },
+      })
+
+      if (pageInfo.hasNextPage) {
+        const nextPage = page + 1
+        return retrievePage(nextPage, first, pageInfo.endCursor, sort)
+      }
+    }
+
+    await retrievePage(1, this.perPage, undefined, this.sortedBy)
+    await writeDb(db)
+
+    return paths
+  }
+
+  public async getPage(page: number): Promise<{
+    page: Awaited<ReturnType<RetrieverFunc>>
+    pageInfo: {
+      prevPage: number | string
+      nextPage: number | string
+      currentPage: number
+      pageList: number[]
+    }
+  }> {
+    const db = await readDb()
+    let variables: { first: number; after: string; sort: string }
+
+    try {
+      variables = db.pages[page - 1]
+    } catch (e) {
+      throw Error(`[Error] Unable to find page matching ${page}: ${e.message}`)
+    }
+
+    const response = (await this.retriever(variables)) as Awaited<
+      Promise<ReturnType<RetrieverFunc>>
+    >
+
+    const prevPage = page > 1 ? page * 1 - 1 : ''
+    const nextPage = page < db.pages.length ? page * 1 + 1 : ''
+    const currentPage = page
+    const pageList = Array.from(Array(db.pages.length).keys()).map(
+      (p) => p * 1 + 1
+    )
+
+    return {
+      page: response,
+      pageInfo: {
+        prevPage,
+        nextPage,
+        currentPage,
+        pageList,
+      },
+    }
+  }
+}

--- a/packages/@tinacms/paginate/tsconfig.json
+++ b/packages/@tinacms/paginate/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.tsx", "src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.spec.tsx"],
+  "include": ["src"]
+}


### PR DESCRIPTION
This is an iteration on Kelly's approach to handling cursor-based pagination with patterns like `page/1`, `page/2`, etc.

It requires the use of a filesystem cache and the experimentalData flag enabled.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
