### PR TITLE
Local Mode Branch Switcher Warning

### DIFF
--- a/.changeset/wild-poets-push.md
+++ b/.changeset/wild-poets-push.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Displays a helpful message in branch switcher when running locally

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/NoFormsPlaceHolder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/NoFormsPlaceHolder.tsx
@@ -18,6 +18,7 @@ limitations under the License.
 
 import styled, { keyframes } from 'styled-components'
 import * as React from 'react'
+import { Button } from '../../styles'
 
 export const NoFormsPlaceholder = () => (
   <EmptyState>
@@ -28,9 +29,13 @@ export const NoFormsPlaceholder = () => (
       generate forms for.
     </p>
     <p>
-      <LinkButton href="https://tina.io/docs/tinacms-context/" target="_blank">
+      <Button
+        href="https://tina.io/docs/tinacms-context/"
+        target="_blank"
+        as="a"
+      >
         <Emoji>📖</Emoji> Contextual Editing
-      </LinkButton>
+      </Button>
     </p>
   </EmptyState>
 )
@@ -71,8 +76,14 @@ const EmptyState = styled.div`
   > *:first-child {
     margin: 0 0 var(--tina-padding-big) 0;
   }
-  > ${Emoji} {
+  ${Emoji} {
     display: block;
+    font-size: 24px;
+  }
+  a {
+    ${Emoji} {
+      margin-right: 0.25em;
+    }
   }
   h3 {
     font-size: var(--tina-font-size-5);
@@ -86,39 +97,5 @@ const EmptyState = styled.div`
   p {
     display: block;
     margin: 0 0 var(--tina-padding-big) 0;
-  }
-`
-
-const LinkButton = styled.a`
-  text-align: center;
-  border: 0;
-  border-radius: var(--tina-radius-big);
-  border: 1px solid var(--tina-color-grey-2);
-  box-shadow: var(--tina-shadow-small);
-  font-weight: var(--tina-font-weight-regular);
-  cursor: pointer;
-  font-size: var(--tina-font-size-0);
-  transition: all var(--tina-timing-short) ease-out;
-  background-color: white;
-  color: var(--tina-color-grey-8);
-  padding: var(--tina-padding-small) var(--tina-padding-big)
-    var(--tina-padding-small) 56px;
-  position: relative;
-  text-decoration: none;
-  display: inline-block;
-  ${Emoji} {
-    font-size: 24px;
-    position: absolute;
-    left: var(--tina-padding-big);
-    top: 50%;
-    transform-origin: 50% 50%;
-    transform: translate3d(0, -50%, 0);
-    transition: all var(--tina-timing-short) ease-out;
-  }
-  &:hover {
-    color: var(--tina-color-primary);
-    ${Emoji} {
-      transform: translate3d(0, -50%, 0);
-    }
   }
 `

--- a/packages/@tinacms/toolkit/src/packages/styles/Button.tsx
+++ b/packages/@tinacms/toolkit/src/packages/styles/Button.tsx
@@ -21,6 +21,8 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'white' | 'ghost' | 'danger'
   as?: React.ElementType
+  href?: string
+  target?: string
   size?: 'small' | 'medium' | 'custom'
   busy?: boolean
   rounded?: 'full' | 'left' | 'right'

--- a/packages/@tinacms/toolkit/src/packages/styles/Button.tsx
+++ b/packages/@tinacms/toolkit/src/packages/styles/Button.tsx
@@ -20,6 +20,7 @@ import * as React from 'react'
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: 'primary' | 'secondary' | 'white' | 'ghost' | 'danger'
+  as?: React.ElementType
   size?: 'small' | 'medium' | 'custom'
   busy?: boolean
   rounded?: 'full' | 'left' | 'right'
@@ -30,6 +31,7 @@ export interface ButtonProps
 
 export const Button = ({
   variant = 'secondary',
+  as: Tag = 'button',
   size = 'medium',
   busy,
   disabled,
@@ -65,12 +67,12 @@ export const Button = ({
   }
 
   return (
-    <button
+    <Tag
       className={`${baseClasses} ${variantClasses[variant]} ${sizeClasses[size]} ${stateClasses[state]} ${roundedClasses[rounded]} ${className}`}
       {...props}
     >
       {children}
-    </button>
+    </Tag>
   )
 }
 

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -17,7 +17,9 @@ import { BaseTextField } from '../../packages/fields'
 import { Button } from '../../packages/styles'
 import { LoadingDots } from '../../packages/form-builder'
 import { BiPlus, BiRefresh, BiSearch } from 'react-icons/bi'
-import { MdOutlineClear } from 'react-icons/md'
+import { MdArrowForward, MdOutlineClear } from 'react-icons/md'
+import { useCMS } from '../../packages/react-core'
+import { AiFillWarning } from 'react-icons/ai'
 
 type ListState = 'loading' | 'ready' | 'error'
 
@@ -25,6 +27,8 @@ export const BranchSwitcher = ({
   listBranches,
   createBranch,
 }: BranchSwitcherProps) => {
+  const cms = useCMS()
+  const isLocalMode = cms.api?.tina?.isLocalMode
   const [listState, setListState] = React.useState<ListState>('loading')
   const [branchList, setBranchList] = React.useState([])
   const { currentBranch, setCurrentBranch } = useBranchData()
@@ -58,7 +62,33 @@ export const BranchSwitcher = ({
   return (
     <div className="w-full flex justify-center p-5">
       <div className="w-full max-w-form">
-        {listState === 'loading' ? (
+        {isLocalMode ? (
+          <div className="px-6 py-8 w-full h-full flex flex-col items-center justify-center">
+            <p className="text-base mb-4 text-center">
+              <AiFillWarning className="w-7 h-auto inline-block mr-0.5 opacity-70 text-yellow-600" />
+            </p>
+            <p className="text-base mb-6 text-center">
+              Tina's branch switcher isn't available in local mode.{' '}
+              <a
+                target="_blank"
+                className="transition-all duration-150 ease-out text-blue-600 hover:text-blue-400 hover:underline no-underline"
+                href="https://tina.io/docs/tina-cloud/"
+              >
+                Learn more about moving to production with Tina Cloud.
+              </a>
+            </p>
+            <p>
+              <Button
+                href="https://tina.io/docs/tina-cloud/"
+                target="_blank"
+                as="a"
+              >
+                Read Our Docs{' '}
+                <MdArrowForward className="w-5 h-auto ml-1.5 opacity-80" />
+              </Button>
+            </p>
+          </div>
+        ) : listState === 'loading' ? (
           <div style={{ margin: '32px auto', textAlign: 'center' }}>
             <LoadingDots color={'var(--tina-color-primary)'} />
           </div>


### PR DESCRIPTION
<img width="810" alt="Screen Shot 2022-05-11 at 3 44 30 PM" src="https://user-images.githubusercontent.com/5075484/167923144-6d343357-0f8f-4153-97da-710b8632997a.png">

The branch switcher will now display a helpful message when running in local mode rather than simply appearing broken. 

I've adapted the button component to render as a link when needed. Previously we had a one-off component for doing this in the sidebar empty state component, which I've removed. 

Closes #2501.