### PR TITLE
Adds `useRelativeMedia` to local GraphQL

### DIFF
--- a/.changeset/fair-chairs-search.md
+++ b/.changeset/fair-chairs-search.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/cli': patch
+'@tinacms/graphql': patch
+---
+
+Adds `useRelativeMedia` support to local graphql client

--- a/packages/@tinacms/cli/src/cmds/start-server/server.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/server.ts
@@ -51,7 +51,11 @@ const gqlServer = async (database) => {
 
   app.post('/graphql', async (req, res) => {
     const { query, variables } = req.body
+    const config = {
+      useRelativeMedia: true,
+    }
     const result = await gqlPackage.resolve({
+      config,
       database,
       query,
       variables,

--- a/packages/@tinacms/graphql/src/resolve.ts
+++ b/packages/@tinacms/graphql/src/resolve.ts
@@ -28,13 +28,16 @@ import { optimizeDocuments } from '@graphql-tools/relay-operation-optimizer'
 import type { GraphQLResolveInfo } from 'graphql'
 import type { Database } from './database'
 import { NAMER } from './ast-builder'
+import type { GraphQLConfig } from './types'
 
 export const resolve = async ({
+  config,
   query,
   variables,
   database,
   silenceErrors,
 }: {
+  config: GraphQLConfig
   query: string
   variables: object
   database: Database
@@ -44,11 +47,11 @@ export const resolve = async ({
     const graphQLSchemaAst = await database.getGraphQLSchema()
     const graphQLSchema = buildASTSchema(graphQLSchemaAst)
 
-    const config = await database.getTinaSchema()
+    const tinaConfig = await database.getTinaSchema()
     const tinaSchema = (await createSchema({
-      schema: config,
+      schema: tinaConfig,
     })) as unknown as TinaSchema
-    const resolver = await createResolver({ database, tinaSchema })
+    const resolver = await createResolver({ config, database, tinaSchema })
 
     const res = await graphql({
       schema: graphQLSchema,

--- a/packages/@tinacms/graphql/src/resolve.ts
+++ b/packages/@tinacms/graphql/src/resolve.ts
@@ -37,7 +37,7 @@ export const resolve = async ({
   database,
   silenceErrors,
 }: {
-  config: GraphQLConfig
+  config?: GraphQLConfig
   query: string
   variables: object
   database: Database

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -29,11 +29,14 @@ import type {
   TinaSchema,
 } from '@tinacms/schema-tools'
 
+import type { GraphQLConfig } from '../types'
+
 import { TinaError } from './error'
 import { FilterCondition, makeFilterChain } from '@tinacms/datalayer'
 import { collectConditionsForField, resolveReferences } from './filter-utils'
 
 interface ResolverConfig {
+  config: GraphQLConfig
   database: Database
   tinaSchema: TinaSchema
 }
@@ -47,9 +50,11 @@ export const createResolver = (args: ResolverConfig) => {
  * values and retrieves them from the database
  */
 export class Resolver {
+  public config: GraphQLConfig
   public database: Database
   public tinaSchema: TinaSchema
   constructor(public init: ResolverConfig) {
+    this.config = init.config
     this.database = init.database
     this.tinaSchema = init.tinaSchema
   }
@@ -112,6 +117,7 @@ export class Resolver {
         this.resolveFieldData(field, rawData, data)
       )
       const titleField = template.fields.find((x) => {
+        // @ts-ignore
         if (x.type === 'string' && x?.isTitle) {
           return true
         }
@@ -706,8 +712,20 @@ export class Resolver {
       case 'boolean':
       case 'number':
       case 'reference':
-      case 'image':
         accumulator[field.name] = value
+        break
+      case 'image':
+        if (this.config) {
+          if (this.config.useRelativeMedia === true) {
+            accumulator[field.name] = value
+          } else {
+            accumulator[
+              field.name
+            ] = `https://assets.tinajs.io/${this.config.clientId}/${value}`
+          }
+        } else {
+          accumulator[field.name] = value
+        }
         break
       case 'rich-text':
         // @ts-ignore value is unknown

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -36,7 +36,7 @@ import { FilterCondition, makeFilterChain } from '@tinacms/datalayer'
 import { collectConditionsForField, resolveReferences } from './filter-utils'
 
 interface ResolverConfig {
-  config: GraphQLConfig
+  config?: GraphQLConfig
   database: Database
   tinaSchema: TinaSchema
 }
@@ -721,7 +721,7 @@ export class Resolver {
           } else {
             accumulator[
               field.name
-            ] = `https://assets.tinajs.io/${this.config.clientId}/${value}`
+            ] = `https://assets.tina.io/${this.config.clientId}/${value}`
           }
         } else {
           accumulator[field.name] = value

--- a/packages/@tinacms/graphql/src/types.ts
+++ b/packages/@tinacms/graphql/src/types.ts
@@ -333,3 +333,9 @@ export type Templateable = {
   fields: TinaFieldEnriched[]
   ui?: object
 }
+
+export type GraphQLConfig =
+  | {
+      useRelativeMedia: true
+    }
+  | { useRelativeMedia: false; clientId: string }


### PR DESCRIPTION
Part of the Repo-based Media push, this adds an extra `config` to `resolve()` that contains (for now) just `useRelativeMedia: true`.

Locally, this value will always be `true`.

In the future, a companion PR to `tina-cloud` will include a slightly different `config`:
```
{ useRelativeMedia: false, clientId: app.client_id }
```
which will be used to determine the location of the file on `assets.tinajs.io`. (https://github.com/tinacms/product-roadmap/issues/161)

> Note: This can merge without the sister PR.

Closes https://github.com/tinacms/product-roadmap/issues/50

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
