### PR TITLE
feat: add `tinaCloudMediaStore` cli flag

### DIFF
--- a/.changeset/bright-seahorses-warn.md
+++ b/.changeset/bright-seahorses-warn.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/cli': patch
+'@tinacms/graphql': patch
+---
+
+Update cli to accept tinaCloudMediaStore flag and add to metadata during schema compilation

--- a/packages/@tinacms/cli/src/cmds/baseCmds.ts
+++ b/packages/@tinacms/cli/src/cmds/baseCmds.ts
@@ -82,6 +82,11 @@ const verboseOption = {
   name: '-v, --verbose',
   description: 'increase verbosity of logged output',
 }
+const tinaCloudMediaStore = {
+  name: '--tinaCloudMediaStore',
+  description:
+    'Automatically pushes updates from GitHub to the Tina Cloud Media Store',
+}
 
 export const baseCmds: Command[] = [
   {
@@ -91,6 +96,7 @@ export const baseCmds: Command[] = [
       startServerPortOption,
       subCommand,
       experimentalDatalayer,
+      tinaCloudMediaStore,
       noWatchOption,
       noSDKCodegenOption,
       noTelemetryOption,
@@ -102,19 +108,29 @@ export const baseCmds: Command[] = [
   {
     command: CMD_COMPILE_MODELS,
     description: 'Compile schema into static files for the server',
-    options: [experimentalDatalayer, noTelemetryOption],
+    options: [experimentalDatalayer, tinaCloudMediaStore, noTelemetryOption],
     action: (options) => chain([compile], options),
   },
   {
     command: CMD_GEN_TYPES,
     description:
       "Generate a GraphQL query for your site's schema, (and optionally Typescript types)",
-    options: [experimentalDatalayer, noSDKCodegenOption, noTelemetryOption],
+    options: [
+      experimentalDatalayer,
+      tinaCloudMediaStore,
+      noSDKCodegenOption,
+      noTelemetryOption,
+    ],
     action: (options) => chain([attachSchema, genTypes], options),
   },
   {
     command: INIT,
-    options: [experimentalDatalayer, noTelemetryOption, schemaFileType],
+    options: [
+      experimentalDatalayer,
+      tinaCloudMediaStore,
+      noTelemetryOption,
+      schemaFileType,
+    ],
     description: 'Add Tina Cloud to an existing project',
     action: (options) =>
       chain(

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -36,6 +36,7 @@ interface Options {
   command?: string
   watchFolders?: string[]
   experimentalData?: boolean
+  tinaCloudMediaStore?: boolean
   noWatch?: boolean
   noSDK: boolean
   noTelemetry: boolean
@@ -52,6 +53,7 @@ export async function startServer(
     command,
     noWatch,
     experimentalData,
+    tinaCloudMediaStore,
     noSDK,
     noTelemetry,
     watchFolders,
@@ -131,9 +133,13 @@ stack: ${code.stack || 'No stack was provided'}`)
       if (!process.env.CI && !noWatch) {
         await resetGeneratedFolder()
       }
+      const cliFlags = []
+      if (tinaCloudMediaStore) {
+        cliFlags.push('tinaCloudMediaStore')
+      }
       const database = await createDatabase({ store, bridge })
       await compile(null, null, { verbose })
-      const schema = await buildSchema(rootPath, database)
+      const schema = await buildSchema(rootPath, database, cliFlags)
       await genTypes({ schema }, () => {}, { noSDK, verbose })
     } catch (error) {
       throw error

--- a/packages/@tinacms/graphql/src/build.ts
+++ b/packages/@tinacms/graphql/src/build.ts
@@ -31,15 +31,18 @@ import { Database } from './database'
 export const indexDB = async ({
   database,
   config,
+  flags = [],
   buildSDK = true,
 }: {
   database: Database
   config: TinaSchema['config']
+  flags?: string[]
   buildSDK?: boolean
 }) => {
-  const flags = []
   if (database.store.supportsIndexing()) {
-    flags.push('experimentalData')
+    if (flags.indexOf('experimentalData') === -1) {
+      flags.push('experimentalData')
+    }
   }
   const tinaSchema = await createSchema({ schema: config, flags })
   const builder = await createBuilder({

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -27,13 +27,17 @@ export type { Bridge } from './database/bridge'
 export { sequential, assertShape } from './util'
 export { stringifyFile, parseFile } from './database/util'
 
-export const buildSchema = async (rootPath: string, database: Database) => {
+export const buildSchema = async (
+  rootPath: string,
+  database: Database,
+  flags?: string[]
+) => {
   const tempConfig = path.join(rootPath, '.tina', '__generated__', 'config')
   const config = await fs
     .readFileSync(path.join(tempConfig, 'schema.json'))
     .toString()
   await fs.rmdir(tempConfig, { recursive: true })
-  await indexDB({ database, config: JSON.parse(config) })
+  await indexDB({ database, config: JSON.parse(config), flags })
   const gqlAst = await database.getGraphQLSchemaFromBridge()
   return buildASTSchema(gqlAst)
 }


### PR DESCRIPTION
This adds a new CLI flag (`tinaCloudMediaStore`) and writes it to the _schema.json when present.

This will be used to activate sync from github to the tina media store
