### PR TITLE
Replace field meta styled components with tailwind

### DIFF
--- a/.changeset/chatty-olives-wink.md
+++ b/.changeset/chatty-olives-wink.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Replace field meta components, fix text wrapping

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
@@ -22,13 +22,7 @@ import styled, { css } from 'styled-components'
 import { FieldsBuilder, useFormPortal } from '../../form-builder'
 import { IconButton } from '../../styles'
 import { Droppable, Draggable } from 'react-beautiful-dnd'
-import {
-  AddIcon,
-  DragIcon,
-  ReorderIcon,
-  TrashIcon,
-  LeftArrowIcon,
-} from '../../icons'
+import { AddIcon, DragIcon, ReorderIcon, TrashIcon } from '../../icons'
 import { GroupPanel, PanelHeader, PanelBody } from './GroupFieldPlugin'
 import { FieldDescription } from './wrapFieldWithMeta'
 import { useEvent } from '../../react-core/use-cms-event'
@@ -95,7 +89,9 @@ const Group = ({ tinaForm, form, field, input }: GroupProps) => {
         <GroupListMeta>
           <GroupLabel>{field.label || field.name}</GroupLabel>
           {field.description && (
-            <FieldDescription>{field.description}</FieldDescription>
+            <FieldDescription className="whitespace-nowrap text-ellipsis overflow-hidden">
+              {field.description}
+            </FieldDescription>
           )}
         </GroupListMeta>
         <IconButton onClick={addItem} variant="primary" size="small">
@@ -259,11 +255,6 @@ export const GroupListHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
-  ${FieldDescription} {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 `
 
 export const GroupListMeta = styled.div`

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
@@ -19,11 +19,11 @@ limitations under the License.
 import * as React from 'react'
 import { Field, Form } from '../../forms'
 import styled, { css } from 'styled-components'
-import { FieldsBuilder, FieldsGroup } from '../../form-builder'
+import { FieldsBuilder } from '../../form-builder'
 import { IconButton } from '../../styles'
 import { Droppable, Draggable } from 'react-beautiful-dnd'
-import { AddIcon, ReorderIcon, TrashIcon } from '../../icons'
-import { FieldDescription, FieldWrapper } from './wrapFieldWithMeta'
+import { AddIcon } from '../../icons'
+import { FieldDescription } from './wrapFieldWithMeta'
 import {
   DragHandle,
   ItemClickTarget,
@@ -91,7 +91,9 @@ const List = ({ tinaForm, form, field, input }: ListProps) => {
         <ListMeta>
           <Label>{field.label || field.name}</Label>
           {field.description && (
-            <FieldDescription>{field.description}</FieldDescription>
+            <FieldDescription className="whitespace-nowrap text-ellipsis overflow-hidden">
+              {field.description}
+            </FieldDescription>
           )}
         </ListMeta>
         <IconButton onClick={addItem} variant="primary" size="small">
@@ -210,11 +212,6 @@ const ListHeader = styled.div`
   justify-content: space-between;
   align-items: center;
   margin-bottom: 8px;
-  ${FieldDescription} {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
 `
 
 const ListMeta = styled.div`

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
@@ -172,7 +172,7 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
         >
           <DragHandle />
           <ItemClickTarget>
-            <FieldsBuilder form={tinaForm} fields={fields} />
+            <FieldsBuilder padding={false} form={tinaForm} fields={fields} />
           </ItemClickTarget>
           <ItemDeleteButton onClick={removeItem} />
         </ItemHeader>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -71,7 +71,7 @@ export const FieldMeta = ({
       onClick={() => setFocusedField({ fieldName: name })}
       {...props}
     >
-      <FieldLabel htmlFor={name}>
+      <FieldLabel name={name}>
         {label || name}
         {description && <FieldDescription>{description}</FieldDescription>}
       </FieldLabel>
@@ -86,7 +86,6 @@ export const FieldMeta = ({
   )
 }
 
-// Styling
 export const FieldWrapper = ({
   margin,
   children,
@@ -102,9 +101,21 @@ export const FieldWrapper = ({
   )
 }
 
-export const FieldLabel = ({ children, className, ...props }) => {
+export interface FieldLabel extends React.HTMLAttributes<HTMLLabelElement> {
+  children?: any | any[]
+  className?: string
+  name?: string
+}
+
+export const FieldLabel = ({
+  children,
+  className,
+  name,
+  ...props
+}: FieldLabel) => {
   return (
     <label
+      htmlFor={name}
       className={`block font-sans text-xs font-semibold text-gray-700 whitespace-normal mb-2 ${className}`}
       {...props}
     >
@@ -113,7 +124,14 @@ export const FieldLabel = ({ children, className, ...props }) => {
   )
 }
 
-export const FieldDescription = ({ children, className, ...props }) => {
+export const FieldDescription = ({
+  children,
+  className,
+  ...props
+}: {
+  children?: any | any[]
+  className?: string
+}) => {
   return (
     <span
       className={`block font-sans text-xs italic font-light text-gray-400 pt-0.5 whitespace-normal m-0 ${className}`}
@@ -124,7 +142,14 @@ export const FieldDescription = ({ children, className, ...props }) => {
   )
 }
 
-export const FieldError = ({ children, className, ...props }) => {
+export const FieldError = ({
+  children,
+  className,
+  ...props
+}: {
+  children?: any | any[]
+  className?: string
+}) => {
   return (
     <span
       className={`block font-sans text-xs font-normal text-red-500 pt-2 whitespace-normal m-0 ${className}`}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -18,7 +18,6 @@ limitations under the License.
 
 import * as React from 'react'
 import { FieldProps } from './fieldProps'
-import styled, { css } from 'styled-components'
 import { useEvent } from '../../react-core/use-cms-event'
 import { FieldHoverEvent, FieldFocusEvent } from '../field-events'
 
@@ -103,38 +102,35 @@ export const FieldWrapper = ({
   )
 }
 
-export const FieldLabel = styled.label`
-  all: unset;
-  font-family: 'Inter', sans-serif;
-  display: block;
-  font-size: var(--tina-font-size-1);
-  font-weight: 600;
-  letter-spacing: 0.01em;
-  line-height: 1.35;
-  color: var(--tina-color-grey-8);
-  margin-bottom: 8px;
-  text-overflow: ellipsis;
-  width: 100%;
-  overflow: hidden;
-`
+export const FieldLabel = ({ children, ...props }) => {
+  return (
+    <label
+      className="block font-sans text-xs font-semibold text-gray-700 whitespace-normal mb-2"
+      {...props}
+    >
+      {children}
+    </label>
+  )
+}
 
-export const FieldDescription = styled.span`
-  all: unset;
-  display: block;
-  font-family: 'Inter', sans-serif;
-  font-size: var(--tina-font-size-0);
-  font-style: italic;
-  font-weight: lighter;
-  color: var(--tina-color-grey-6);
-  padding-top: 4px;
-  white-space: normal;
-  margin: 0;
-`
+export const FieldDescription = ({ children, ...props }) => {
+  return (
+    <span
+      className="block font-sans text-xs italic font-light text-gray-400 pt-0.5 whitespace-normal m-0"
+      {...props}
+    >
+      {children}
+    </span>
+  )
+}
 
-const FieldError = styled.span`
-  display: block;
-  color: red;
-  font-size: var(--tina-font-size-1);
-  margin-top: 8px;
-  font-weight: var(--tina-font-weight-regular);
-`
+export const FieldError = ({ children, ...props }) => {
+  return (
+    <span
+      className="block font-sans text-xs font-normal text-red-500 pt-2 whitespace-normal m-0"
+      {...props}
+    >
+      {children}
+    </span>
+  )
+}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -102,10 +102,10 @@ export const FieldWrapper = ({
   )
 }
 
-export const FieldLabel = ({ children, ...props }) => {
+export const FieldLabel = ({ children, className, ...props }) => {
   return (
     <label
-      className="block font-sans text-xs font-semibold text-gray-700 whitespace-normal mb-2"
+      className={`block font-sans text-xs font-semibold text-gray-700 whitespace-normal mb-2 ${className}`}
       {...props}
     >
       {children}
@@ -113,10 +113,10 @@ export const FieldLabel = ({ children, ...props }) => {
   )
 }
 
-export const FieldDescription = ({ children, ...props }) => {
+export const FieldDescription = ({ children, className, ...props }) => {
   return (
     <span
-      className="block font-sans text-xs italic font-light text-gray-400 pt-0.5 whitespace-normal m-0"
+      className={`block font-sans text-xs italic font-light text-gray-400 pt-0.5 whitespace-normal m-0 ${className}`}
       {...props}
     >
       {children}
@@ -124,10 +124,10 @@ export const FieldDescription = ({ children, ...props }) => {
   )
 }
 
-export const FieldError = ({ children, ...props }) => {
+export const FieldError = ({ children, className, ...props }) => {
   return (
     <span
-      className="block font-sans text-xs font-normal text-red-500 pt-2 whitespace-normal m-0"
+      className={`block font-sans text-xs font-normal text-red-500 pt-2 whitespace-normal m-0 ${className}`}
       {...props}
     >
       {children}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -95,7 +95,7 @@ export const FieldWrapper = ({
   children: React.ReactNode
 } & Partial<React.ComponentPropsWithoutRef<'div'>>) => {
   return (
-    <div className={`relative ${margin ? `mb-5` : ``}`} {...props}>
+    <div className={`relative ${margin ? `mb-5 last:mb-0` : ``}`} {...props}>
       {children}
     </div>
   )

--- a/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
@@ -26,9 +26,14 @@ import styled, { css } from 'styled-components'
 export interface FieldsBuilderProps {
   form: Form
   fields: Field[]
+  padding?: boolean
 }
 
-export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
+export function FieldsBuilder({
+  form,
+  fields,
+  padding = false,
+}: FieldsBuilderProps) {
   const cms = useCMS()
 
   // re-build fields when new field plugins are registered
@@ -42,7 +47,7 @@ export function FieldsBuilder({ form, fields }: FieldsBuilderProps) {
 
   return (
     // @ts-ignore FIXME twind
-    <FieldsGroup>
+    <FieldsGroup padding={padding}>
       {fields.map((field: Field) => (
         <InnerField
           key={field.name}
@@ -142,14 +147,23 @@ const InnerField = ({ field, form, fieldPlugins }) => {
   )
 }
 
-export const FieldsGroup = styled.div<{ padding: boolean }>`
-  position: relative;
-  display: block;
-  width: 100%;
-  height: 100%;
-  white-space: nowrap;
-  overflow-x: visible !important;
-`
+export const FieldsGroup = ({
+  padding,
+  children,
+}: {
+  padding?: boolean
+  children?: any | any[]
+}) => {
+  return (
+    <div
+      className={`relative block w-full h-full whitespace-nowrap overflow-x-visible ${
+        padding ? `pb-5` : ``
+      }`}
+    >
+      {children}
+    </div>
+  )
+}
 
 /**
  *


### PR DESCRIPTION
Fixes #2891 (error messages not wrapping) and replaces the remaining field meta styled components with tailwind components. 