### PR TITLE
Determine `assetsHost` from `config` for Tina Cloud Media Store

### DIFF
--- a/.changeset/ninety-roses-cheer.md
+++ b/.changeset/ninety-roses-cheer.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Adds support for an `assetsHost` when resolving `image` fields with `useRelativeMedia`

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -721,7 +721,7 @@ export class Resolver {
           } else {
             accumulator[
               field.name
-            ] = `https://assets.tina.io/${this.config.clientId}/${value}`
+            ] = `https://${this.config.assetsHost}/${this.config.clientId}/${value}`
           }
         } else {
           accumulator[field.name] = value

--- a/packages/@tinacms/graphql/src/types.ts
+++ b/packages/@tinacms/graphql/src/types.ts
@@ -338,4 +338,4 @@ export type GraphQLConfig =
   | {
       useRelativeMedia: true
     }
-  | { useRelativeMedia: false; clientId: string }
+  | { useRelativeMedia: false; clientId: string; assetsHost: string }


### PR DESCRIPTION
Minor change that allows for `tina-cloud` to provide an override to `assetsHost` via a `config` value.

Right now, that override is provided via the environmental variable `TINA_CLOUD_MEDIA_STORE_ASSETS_HOST` (defaults to `assets.tina.io`).

Related to https://github.com/tinacms/tina-cloud/pull/1546

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
