### PR TITLE
fix: #2925: update current branch from local storage

### DIFF
--- a/.changeset/tame-nails-crash.md
+++ b/.changeset/tame-nails-crash.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+fix: update tina client with the current branch from local storage

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -157,7 +157,9 @@ export const TinaCloudProvider = (
     [props.cms]
   )
   if (!cms.api.tina) {
-    cms.registerApi('tina', createClient(props))
+    cms.registerApi('tina', createClient({ ...props, branch: currentBranch }))
+  } else {
+    cms.api.tina.setBranch(currentBranch)
   }
 
   if (!cms.api.admin) {


### PR DESCRIPTION
Addresses #2925. It appears that for contextual editing, the client was being configured with the default branch instead of the branch in local storage. This PR updates the logic in the tina cloud provider to update the branch when the value is read for local storage