### PR TITLE
Remove Form Header Label

### DIFF
--- a/.changeset/lucky-maps-draw.md
+++ b/.changeset/lucky-maps-draw.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Removes single form header label

--- a/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-sidebar/components/SidebarBody.tsx
@@ -270,11 +270,6 @@ export const FormHeader = ({ renderNav, activeForm }: FormHeaderProps) => {
       className={`py-4 border-b border-gray-200 bg-white ${headerPadding[navState]}`}
     >
       <div className="max-w-form mx-auto  flex flex-col items-start justify-center min-h-[2.5rem]">
-        {activeForm.label && (
-          <span className="block w-full text-xl mb-[6px] text-gray-700 font-medium leading-tight">
-            {activeForm.label}
-          </span>
-        )}
         <FormStatus pristine={formIsPristine} />
       </div>
     </div>


### PR DESCRIPTION
When there's a single form, the label doesn't provide useful context, so I've removed it.

<img width="669" alt="Screen Shot 2022-05-31 at 10 37 41 AM" src="https://user-images.githubusercontent.com/5075484/171186910-2ccbdd4c-5283-463c-bdde-86f3e11282a4.png">
