### PR TITLE
2935 - Fixes subitem links to use breadcrumbs

### DIFF
--- a/.changeset/warm-adults-occur.md
+++ b/.changeset/warm-adults-occur.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixes subitem links to use breadcrumbs

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -280,7 +280,9 @@ const CollectionListPage = () => {
                                             Icon: <BiEdit size="1.3rem" />,
                                             onMouseDown: () => {
                                               navigate(
-                                                `${document.node._sys.filename}`,
+                                                `${document.node._sys.breadcrumbs.join(
+                                                  '/'
+                                                )}`,
                                                 { replace: true }
                                               )
                                             },
@@ -298,7 +300,9 @@ const CollectionListPage = () => {
                                               setVars({
                                                 collection: collectionName,
                                                 relativePath:
-                                                  document.node._sys.filename +
+                                                  document.node._sys.breadcrumbs.join(
+                                                    '/'
+                                                  ) +
                                                   document.node._sys.extension,
                                               })
                                               setOpen(true)
@@ -356,27 +360,25 @@ interface ResetModalProps {
 const DeleteModal = ({ close, deleteFunc, filename }: ResetModalProps) => {
   return (
     <Modal>
-      <ModalPopup>
-        <ModalHeader close={close}>Delete {filename}</ModalHeader>
-        <ModalBody padded={true}>
-          <p>{`Are you sure you want to delete ${filename}?`}</p>
-        </ModalBody>
-        <ModalActions>
-          <Button style={{ flexGrow: 2 }} onClick={close}>
-            Cancel
-          </Button>
-          <Button
-            style={{ flexGrow: 3 }}
-            variant="danger"
-            onClick={async () => {
-              await deleteFunc()
-              close()
-            }}
-          >
-            Delete
-          </Button>
-        </ModalActions>
-      </ModalPopup>
+      <ModalHeader close={close}>Delete {filename}</ModalHeader>
+      <ModalBody padded={true}>
+        <p>{`Are you sure you want to delete ${filename}?`}</p>
+      </ModalBody>
+      <ModalActions>
+        <Button style={{ flexGrow: 2 }} onClick={close}>
+          Cancel
+        </Button>
+        <Button
+          style={{ flexGrow: 3 }}
+          variant="danger"
+          onClick={async () => {
+            await deleteFunc()
+            close()
+          }}
+        >
+          Delete
+        </Button>
+      </ModalActions>
     </Modal>
   )
 }


### PR DESCRIPTION
Because the CMS supports sub-directories, we need to account for the potential existence of those in any navigation.

The sublinks for items in the CMS were only using `filename` (which is only the `basename`).
In other places, we use `breadcrumbs` which is an array of all directories leading up to the `basename`).

Closes #2935

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
