### PR TITLE
2917 - Surface `message` when available for errors from `client`

### DIFF
--- a/.changeset/long-planes-hide.md
+++ b/.changeset/long-planes-hide.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Adds more useful error messages from internalClient

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -280,7 +280,12 @@ mutation addPendingDocumentMutation(
     })
 
     if (res.status !== 200) {
-      throw new Error(`Unable to complete request, ${res.statusText}`)
+      let errorMessage = `Unable to complete request, ${res.statusText}`
+      const resBody = await res.json()
+      if (resBody.message) {
+        errorMessage = `${errorMessage}, Response: ${resBody.message}`
+      }
+      throw new Error(errorMessage)
     }
 
     const json = await res.json()


### PR DESCRIPTION
`internalClient` was swallowing up an `error` and just using `statusText`.

I modified the error message to continue to do that, but also check the `res` for a `message` key and use that, as well.

This should result in more useful error messages (specifically, a `404` not only responds with `Not Found`, but also what document the server failed to find).

Before
<img width="574" alt="Screen Shot 2022-06-03 at 3 28 45 PM" src="https://user-images.githubusercontent.com/1699544/171947577-a4803212-6bc3-4c8e-8314-2fed5da99cb2.png">
After
<img width="1549" alt="Screen Shot 2022-06-03 at 3 16 36 PM" src="https://user-images.githubusercontent.com/1699544/171947706-b9f1cad8-2024-43cd-8b2a-64897e2dbf22.png">

Addresses part of https://github.com/tinacms/tinacms/issues/2917

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
