### PR TITLE
Resolve Cloud URLs to Relative URLs when saving TinaCloudMediaStore

### DIFF
--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -34,6 +34,10 @@ import type { GraphQLConfig } from '../types'
 import { TinaError } from './error'
 import { FilterCondition, makeFilterChain } from '@tinacms/datalayer'
 import { collectConditionsForField, resolveReferences } from './filter-utils'
+import {
+  resolveMediaRelativeToCloud,
+  resolveMediaCloudToRelative,
+} from './media-utils'
 
 interface ResolverConfig {
   config?: GraphQLConfig
@@ -670,15 +674,19 @@ export class Resolver {
         case 'string':
         case 'boolean':
         case 'number':
-        case 'image':
           accum[fieldName] = fieldValue
+          break
+        case 'image':
+          accum[fieldName] = resolveMediaCloudToRelative(
+            fieldValue as string,
+            this.config
+          )
           break
         case 'object':
           accum[fieldName] = this.buildObjectMutations(fieldValue, field)
           break
         case 'rich-text':
-          field
-          accum[fieldName] = stringifyMDX(fieldValue, field)
+          accum[fieldName] = stringifyMDX(fieldValue, field, this.config)
           break
         case 'reference':
           accum[fieldName] = fieldValue
@@ -717,21 +725,14 @@ export class Resolver {
         accumulator[field.name] = value
         break
       case 'image':
-        if (this.config) {
-          if (this.config.useRelativeMedia === true) {
-            accumulator[field.name] = value
-          } else {
-            accumulator[
-              field.name
-            ] = `https://${this.config.assetsHost}/${this.config.clientId}/${value}`
-          }
-        } else {
-          accumulator[field.name] = value
-        }
+        accumulator[field.name] = resolveMediaRelativeToCloud(
+          value as string,
+          this.config
+        )
         break
       case 'rich-text':
         // @ts-ignore value is unknown
-        const tree = parseMDX(value, field)
+        const tree = parseMDX(value, field, this.config)
         accumulator[field.name] = tree
         break
       case 'object':

--- a/packages/@tinacms/graphql/src/resolver/media-utils.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.test.ts
@@ -1,0 +1,78 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type { GraphQLConfig } from '../types'
+import {
+  resolveMediaRelativeToCloud,
+  resolveMediaCloudToRelative,
+} from './media-utils'
+
+describe('resolveMedia', () => {
+  const assetsHost = `assets.tinajs.dev`
+  const clientId = `a03ff3e2-1c3a-41af-8afd-ba0d58853191`
+  const relativeAssetURL = `/llama.png`
+  const cloudAssetURL = `https://assets.tinajs.dev/a03ff3e2-1c3a-41af-8afd-ba0d58853191/llama.png`
+
+  /**
+   * When using `useRelativeMedia: true`, the URL should not be changed.
+   */
+  it('resolves relative media when useRelativeMedia: true', () => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: true,
+    }
+    const resolvedURL = resolveMediaRelativeToCloud(relativeAssetURL, config)
+    expect(resolvedURL).toEqual(resolvedURL)
+  })
+
+  /**
+   * When using `useRelativeMedia: false`, the relative URL should be changed to a Cloud URL.
+   */
+  it('resolves relative media to cloud media when useRelativeMedia: false', () => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: false,
+      assetsHost,
+      clientId,
+    }
+    const resolvedURL = resolveMediaRelativeToCloud(relativeAssetURL, config)
+    expect(resolvedURL).toEqual(cloudAssetURL)
+  })
+
+  /**
+   * When using `useRelativeMedia: false`, the Cloud URL should be changed to relative URL.
+   */
+  it('resolves cloud media to relative media when useRelativeMedia: false', () => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: false,
+      assetsHost,
+      clientId,
+    }
+    const resolvedURL = resolveMediaCloudToRelative(cloudAssetURL, config)
+    expect(resolvedURL).toEqual(relativeAssetURL)
+  })
+
+  /**
+   * A empty value should return empty, regardless of `useRelativeMedia`
+   */
+  it('resolved to empty when provided an empty value', () => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: false,
+      assetsHost,
+      clientId,
+    }
+    const aURL = resolveMediaCloudToRelative('', config)
+    expect(aURL).toEqual('')
+
+    const bURL = resolveMediaRelativeToCloud('', config)
+    expect(bURL).toEqual('')
+  })
+})

--- a/packages/@tinacms/graphql/src/resolver/media-utils.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.ts
@@ -1,0 +1,65 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import { GraphQLConfig } from '../types'
+
+/**
+ * Strips away the Tina Cloud Asset URL from an `image` value
+ *
+ * @param {string} value
+ * @param {GraphQLConfig} config
+ * @returns {string}
+ */
+
+export const resolveMediaCloudToRelative = (
+  value: string,
+  config: GraphQLConfig = { useRelativeMedia: true }
+) => {
+  if (config) {
+    if (config.useRelativeMedia === true) {
+      return value
+    } else {
+      const assetsURL = `https://${config.assetsHost}/${config.clientId}`
+      if (typeof value === 'string' && value.includes(assetsURL)) {
+        return value.replace(assetsURL, '')
+      } else {
+        return value
+      }
+    }
+  } else {
+    return value
+  }
+}
+
+/**
+ * Adds Tina Cloud Asset URL to an `image` value
+ *
+ * @param {string} value
+ * @param {GraphQLConfig} config
+ * @returns {string}
+ */
+
+export const resolveMediaRelativeToCloud = (
+  value: string,
+  config: GraphQLConfig = { useRelativeMedia: true }
+) => {
+  if (config) {
+    if (config.useRelativeMedia === true) {
+      return value
+    } else {
+      return `https://${config.assetsHost}/${config.clientId}${value}`
+    }
+  } else {
+    return value
+  }
+}


### PR DESCRIPTION
Introduces a pair of functions (inside `media-utils.ts`) for handling URLs provided by TinaCloud (`resolveMediaCloudToRelative` and `resolveMediaRelativeToCloud`).

These are used in conjuction with two pairs of functions:
* When providing data to the preview: `resolveFieldData` and `parseMDX`
* When saving data to the document: `buildFieldMutations` and `stringifyMDX`

I also introduced tests around `media-utils.ts` (`media-utils.test.ts`).

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
