### PR TITLE
Prose Wrapper Class Fix

### DIFF
--- a/.changeset/bright-tables-wave.md
+++ b/.changeset/bright-tables-wave.md
@@ -1,0 +1,8 @@
+---
+'@tinacms/scripts': patch
+'@tinacms/toolkit': patch
+'react-tinacms-editor': patch
+'tinacms': patch
+---
+
+Use custom wrapper class for tailwind type plugin

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -389,7 +389,9 @@ const config = (cwd = '') => {
     },
     content: [path.join(cwd, 'src/**/*.{vue,js,ts,jsx,tsx,svelte}')],
     plugins: [
-      require('@tailwindcss/typography'),
+      require('@tailwindcss/typography')({
+        className: 'tina-prose',
+      }),
       require('@tailwindcss/line-clamp'),
       require('@tailwindcss/aspect-ratio'),
     ],

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/index.tsx
@@ -72,7 +72,7 @@ export const RichEditor = wrapFieldsWithMeta<
         <div
           className={classNames(
             withToolbar ? 'min-h-[100px]' : 'min-h-auto',
-            'max-w-full prose relative shadow-inner focus:shadow-outline focus:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus:text-gray-900 rounded-md px-3 py-2 mb-5'
+            'max-w-full tina-prose relative shadow-inner focus:shadow-outline focus:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus:text-gray-900 rounded-md px-3 py-2 mb-5'
           )}
         >
           <Plate

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/toolbar/toolbar-item.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/toolbar/toolbar-item.tsx
@@ -90,7 +90,7 @@ export const ToolbarItem = ({
           <Popover.Panel>
             {({ close }) => (
               <div className="origin-top-left absolute left-0 mt-2 -mr-1 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
-                <div className="py-2 prose">
+                <div className="py-2 tina-prose">
                   {/* FIXME: this close() should be handled from within the options callback that are passed in */}
                   <span onMouseDown={() => close()}>{options}</span>
                 </div>

--- a/packages/@tinacms/toolkit/src/styles.css
+++ b/packages/@tinacms/toolkit/src/styles.css
@@ -16,25 +16,25 @@
 }
 
 /* if the last block has margin-bottom it makes the text box larger but some of it isn't clickable */
-.prose [data-slate-editor='true'] {
+.tina-prose [data-slate-editor='true'] {
   padding-bottom: 0.5em;
 }
 /* prose adds backticks, which look like they should be editable */
-.prose [data-slate-editor='true'] .slate-code::before {
+.tina-prose [data-slate-editor='true'] .slate-code::before {
   content: '';
 }
-.prose [data-slate-editor='true'] .slate-code::after {
+.tina-prose [data-slate-editor='true'] .slate-code::after {
   content: '';
 }
-.prose [data-slate-editor='true'] .slate-code_block {
+.tina-prose [data-slate-editor='true'] .slate-code_block {
   margin: 0;
 }
 /* code lines as part of a block don't need the same background formatting */
-.prose [data-slate-editor='true'] .slate-code_block .slate-code {
+.tina-prose [data-slate-editor='true'] .slate-code_block .slate-code {
   background: none;
 }
 /* prose makes the first p in a block slightly larger */
-.prose [data-slate-editor='true'] p:first-of-type {
+.tina-prose [data-slate-editor='true'] p:first-of-type {
   font-size: 1em;
 }
 

--- a/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
+++ b/packages/react-tinacms-editor/src/components/ProsemirrorEditor/index.tsx
@@ -95,7 +95,7 @@ export const ProsemirrorEditor = styled(
 const RichTextInput = ({ children }) => {
   return (
     <div
-      className="prose shadow-inner focus:shadow-outline focus:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus:text-gray-900 rounded-md p-5 mb-5"
+      className="tina-prose shadow-inner focus:shadow-outline focus:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus:text-gray-900 rounded-md p-5 mb-5"
       style={{ minHeight: '100px', maxWidth: `100%` }}
     >
       {children}


### PR DESCRIPTION
This configures and uses a custom wrapper class for the Tailwind typography plugin that we're using to wrap our rich text field. This will prevent bleed-through to the user's site if they're also using the plugin.

Closes #2952 (Thanks to user [Webarkitekt](https://github.com/Webarkitekt) for providing a solution!)