### PR TITLE
media manage uses relieve dir paths

### DIFF
--- a/.changeset/stale-cooks-obey.md
+++ b/.changeset/stale-cooks-obey.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+media manage uses relieve dir paths

--- a/packages/@tinacms/cli/src/server/models/media.ts
+++ b/packages/@tinacms/cli/src/server/models/media.ts
@@ -67,7 +67,7 @@ export class MediaModel {
 
         const isFile = stat.isFile()
 
-        // It seems like our media manager wants relative paths for dirs (Seems strange but it works)
+        // It seems like our media manager wants relative paths for dirs.
         if (!isFile) {
           return {
             isFile,

--- a/packages/@tinacms/cli/src/server/models/media.ts
+++ b/packages/@tinacms/cli/src/server/models/media.ts
@@ -64,6 +64,19 @@ export class MediaModel {
         const stat = await fs.stat(filePath)
 
         let src = `/${file}`
+
+        const isFile = stat.isFile()
+
+        // It seems like our media manager wants relative paths for dirs (Seems strange but it works)
+        if (!isFile) {
+          return {
+            isFile,
+            size: stat.size,
+            src,
+            filename: file,
+          }
+        }
+
         if (searchPath) {
           src = `/${searchPath}${src}`
         }
@@ -72,7 +85,7 @@ export class MediaModel {
         }
 
         return {
-          isFile: stat.isFile(),
+          isFile,
           size: stat.size,
           src: src,
           filename: file,


### PR DESCRIPTION
It turns out out media manage expects the paths of dirs to be relative to the parent. The CLI was returning local media folders with full paths which was causing issues.