### PR TITLE
Enables pagination for local media `list` endpoint

### DIFF
--- a/.changeset/yellow-lies-fetch.md
+++ b/.changeset/yellow-lies-fetch.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/cli': patch
+'@tinacms/toolkit': patch
+---
+
+Enables paging for local media manager

--- a/packages/@tinacms/cli/src/server/models/media.ts
+++ b/packages/@tinacms/cli/src/server/models/media.ts
@@ -17,6 +17,8 @@ import { parseMediaFolder } from '../../utils/'
 
 interface MediaArgs {
   searchPath: string
+  cursor?: string
+  limit?: string
 }
 
 interface File {
@@ -92,11 +94,21 @@ export class MediaModel {
         }
       })
 
-      const files = await Promise.all(filesProm)
+      const offset = Number(args.cursor) || 0
+      const limit = Number(args.limit) || 20
+
+      const allItems = await Promise.all(filesProm)
+      const files = allItems.filter((x) => x.isFile)
+      const directories = allItems.filter((x) => !x.isFile).map((x) => x.src)
+
+      const limitFiles = files.slice(offset, offset + limit)
+      const cursor =
+        files.length > offset + limit ? String(offset + limit + 1) : null
 
       return {
-        files: files.filter((x) => x.isFile),
-        directories: files.filter((x) => !x.isFile).map((x) => x.src),
+        files: limitFiles,
+        directories,
+        cursor,
       }
     } catch (error) {
       console.error(error)

--- a/packages/@tinacms/cli/src/server/models/media.ts
+++ b/packages/@tinacms/cli/src/server/models/media.ts
@@ -97,16 +97,25 @@ export class MediaModel {
       const offset = Number(args.cursor) || 0
       const limit = Number(args.limit) || 20
 
-      const allItems = await Promise.all(filesProm)
-      const files = allItems.filter((x) => x.isFile)
-      const directories = allItems.filter((x) => !x.isFile).map((x) => x.src)
+      const rawItems = await Promise.all(filesProm)
+      const sortedItems = rawItems.sort((a, b) => {
+        if (a.isFile && !b.isFile) {
+          return 1
+        }
+        if (!a.isFile && b.isFile) {
+          return -1
+        }
+        return 0
+      })
+      const limitItems = sortedItems.slice(offset, offset + limit)
+      const files = limitItems.filter((x) => x.isFile)
+      const directories = limitItems.filter((x) => !x.isFile).map((x) => x.src)
 
-      const limitFiles = files.slice(offset, offset + limit)
       const cursor =
-        files.length > offset + limit ? String(offset + limit + 1) : null
+        rawItems.length > offset + limit ? String(offset + limit) : null
 
       return {
-        files: limitFiles,
+        files,
         directories,
         cursor,
       }

--- a/packages/@tinacms/cli/src/server/routes/index.ts
+++ b/packages/@tinacms/cli/src/server/routes/index.ts
@@ -40,8 +40,12 @@ export const createMediaRouter = (config: PathConfig) => {
 
   mediaRouter.get('/list/*', async (req, res) => {
     const folder = req.params[0]
+    const cursor = req.query.cursor as string
+    const limit = req.query.limit as string
     const media = await mediaModel.listMedia({
       searchPath: folder,
+      cursor,
+      limit,
     })
     res.json(media)
   })

--- a/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
+++ b/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
@@ -218,7 +218,9 @@ export class TinaMediaStore implements MediaStore {
       }
     } else {
       res = await this.fetchFunction(
-        `${this.url}/list/${options.directory || ''}`
+        `${this.url}/list/${options.directory || ''}?limit=${
+          options.limit | 20
+        }${options.offset ? `&cursor=${options.offset}` : ''}`
       )
 
       if (res.status == 404) {

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/BlockSelectorBig.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/BlockSelectorBig.tsx
@@ -167,6 +167,7 @@ export const BlockSelectorBig = ({
                         <CardColumns className="pt-3">
                           {uncategorized.map(([name, template]) => (
                             <BlockCard
+                              key={`${template}-${name}`}
                               close={close}
                               name={name}
                               template={template}


### PR DESCRIPTION
Basically uses `offset` and `limit` by treating the `offset` value like a `cursor`.

Tested with both 26 and 6 items and appears to be working correctly for both.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
