### PR TITLE
Fix rich text focus styles

### DIFF
--- a/.changeset/tiny-bobcats-jog.md
+++ b/.changeset/tiny-bobcats-jog.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix rich text field focus styles

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/index.tsx
@@ -66,13 +66,14 @@ export const RichEditor = wrapFieldsWithMeta<
   const withToolbar = true
   const tempId = [props.tinaForm.id, props.input.name].join('.')
   const id = React.useMemo(() => uuid(), [tempId])
+
   return (
     <EditorContext.Provider value={{ templates: props.field.templates }}>
       <div className={withToolbar ? 'with-toolbar' : ''}>
         <div
           className={classNames(
             withToolbar ? 'min-h-[100px]' : 'min-h-auto',
-            'max-w-full tina-prose relative shadow-inner focus:shadow-outline focus:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus:text-gray-900 rounded-md px-3 py-2 mb-5'
+            'max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded-md px-3 py-2 mb-5'
           )}
         >
           <Plate
@@ -84,6 +85,7 @@ export const RichEditor = wrapFieldsWithMeta<
               props.input.onChange({ type: 'root', children: value })
             }}
           >
+            {}
             {withToolbar ? (
               <Toolbar templates={props.field.templates} inlineOnly={false} />
             ) : (


### PR DESCRIPTION
Given the rich text input styles are provided by a wrapper div, I've changed `focus` for `focus-within` so the styles will work properly. 

<img width="384" alt="Screen Shot 2022-06-23 at 2 52 46 PM" src="https://user-images.githubusercontent.com/5075484/175363185-99f99fb2-0b3b-4d8e-9441-ec40ba478f35.png">
