### PR TITLE
Fix an issue where changes to a field weren't reflected on the page when typing quickly

### DIFF
--- a/.changeset/quiet-chairs-lay.md
+++ b/.changeset/quiet-chairs-lay.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix an issue where changes to a field weren't reflected on the page when typing quickly

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: pnpm/action-setup@v2.0.1
+        with:
+          version: 7.4.0
       - uses: actions/checkout@v1
       - name: Install
         run: pnpm install

--- a/packages/tinacms/src/hooks/formify/index.ts
+++ b/packages/tinacms/src/hooks/formify/index.ts
@@ -456,7 +456,7 @@ export const useFormify = ({
         }
       }
     })
-  }, [JSON.stringify(state.changeSets.length)])
+  }, [JSON.stringify(state.changeSets)])
 
   /**
    * NOTE: we're mimicking `componentWillUnmount` by keeping track of

--- a/packages/tinacms/src/hooks/formify/index.ts
+++ b/packages/tinacms/src/hooks/formify/index.ts
@@ -456,7 +456,7 @@ export const useFormify = ({
         }
       }
     })
-  }, [state.changeSets.length])
+  }, [JSON.stringify(state.changeSets.length)])
 
   /**
    * NOTE: we're mimicking `componentWillUnmount` by keeping track of


### PR DESCRIPTION
When a few changesets of the same field are batched by React the changeset length doesn't change. The `useEffect` dependency here isn't quite right, but stringifying instead of relying on the length does the job

Closes https://github.com/tinacms/tinacms/issues/3023