### PR TITLE
feat: ENG-412: limit index values in keys to 100 characters

### DIFF
--- a/.changeset/happy-kids-rest.md
+++ b/.changeset/happy-kids-rest.md
@@ -1,5 +1,5 @@
 ---
-'@tinacms/graphql': patch
+'@tinacms/datalayer': patch
 ---
 
 limit db key values to 100 characters

--- a/.changeset/happy-kids-rest.md
+++ b/.changeset/happy-kids-rest.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+limit db key values to 100 characters

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -32,7 +32,7 @@ const escapeStr = makeStringEscaper(
 )
 
 describe('datalayer store helper functions', () => {
-  describe('buildKeyForField', () => {
+  describe('makeKeyForField', () => {
     it('succeeds with non-datetime', () => {
       const expected = 'bar'
       const result = makeKeyForField(
@@ -45,6 +45,25 @@ describe('datalayer store helper functions', () => {
           ],
         },
         { foo: expected },
+        escapeStr
+      )
+      expect(result).toEqual(expected)
+    })
+
+    it('succeeds with long string', () => {
+      const val =
+        'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz'
+      const expected = val.substring(0, 100)
+      const result = makeKeyForField(
+        {
+          fields: [
+            {
+              name: 'foo',
+              type: 'string',
+            },
+          ],
+        },
+        { foo: val },
         escapeStr
       )
       expect(result).toEqual(expected)

--- a/packages/@tinacms/datalayer/src/database/store/index.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.ts
@@ -612,7 +612,8 @@ export const makeFilterSuffixes = (
 export const makeKeyForField = (
   definition: IndexDefinition,
   data: object,
-  stringEscaper: StringEscaper
+  stringEscaper: StringEscaper,
+  maxStringLength: number = 100
 ): string | null => {
   const valueParts = []
   for (const field of definition.fields) {
@@ -624,7 +625,7 @@ export const makeKeyForField = (
           : field.type === 'string'
           ? stringEscaper(data[field.name] as string | string[])
           : data[field.name]
-      )
+      ).substring(0, maxStringLength)
       valueParts.push(applyPadding(resolvedValue, field.pad))
     } else {
       return null // tell caller that one of the fields is missing and we can't index


### PR DESCRIPTION
- limit the index value to 100 characters (maximum) when generating keys for store