### PR TITLE
fix: ENG-415: fix data layer handling of null/undefined values

### DIFF
--- a/.changeset/dull-ads-enjoy.md
+++ b/.changeset/dull-ads-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/datalayer': patch
+---
+
+update key generation to gracefully handle null / undefined field values by skipping indexing

--- a/packages/@tinacms/datalayer/src/database/store/index.test.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.test.ts
@@ -103,6 +103,23 @@ describe('datalayer store helper functions', () => {
       )
       expect(result).toEqual(expected)
     })
+
+    it('fails with null field', () => {
+      const expected = null
+      const result = makeKeyForField(
+        {
+          fields: [
+            {
+              name: 'foo',
+              type: 'string',
+            },
+          ],
+        },
+        { foo: null },
+        escapeStr
+      )
+      expect(result).toEqual(expected)
+    })
   })
 
   describe('buildFilterSuffixes', () => {

--- a/packages/@tinacms/datalayer/src/database/store/index.ts
+++ b/packages/@tinacms/datalayer/src/database/store/index.ts
@@ -617,14 +617,19 @@ export const makeKeyForField = (
 ): string | null => {
   const valueParts = []
   for (const field of definition.fields) {
-    if (field.name in data) {
+    if (
+      field.name in data &&
+      data[field.name] !== undefined &&
+      data[field.name] !== null
+    ) {
       // TODO I think these dates are ISO 8601 so I don't think we need to convert to numbers
+      const rawValue = data[field.name]
       const resolvedValue = String(
         field.type === 'datetime'
-          ? new Date(data[field.name]).getTime()
+          ? new Date(rawValue).getTime()
           : field.type === 'string'
-          ? stringEscaper(data[field.name] as string | string[])
-          : data[field.name]
+          ? stringEscaper(rawValue as string | string[])
+          : rawValue
       ).substring(0, maxStringLength)
       valueParts.push(applyPadding(resolvedValue, field.pad))
     } else {


### PR DESCRIPTION
This PR fixes handling of null / undefined values when generates index keys in data layer. With this change, if a field is defined as null / undefined, a key will not be generated and it won't be included in the index for that field.
