### PR TITLE
ensure generated folder is created before building

### DIFF
--- a/.changeset/wicked-chefs-count.md
+++ b/.changeset/wicked-chefs-count.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+fix bug where tina init would error because there is no generated folder

--- a/packages/@tinacms/cli/src/buildTina/index.ts
+++ b/packages/@tinacms/cli/src/buildTina/index.ts
@@ -12,6 +12,7 @@
  */
 
 import retry from 'async-retry'
+import fs from 'fs-extra'
 
 import { Bridge, buildSchema, createDatabase, Database } from '@tinacms/graphql'
 import {
@@ -178,9 +179,11 @@ export const build = async ({
 
   try {
     if (!process.env.CI && !noWatch) {
+      const tinaGeneratedPath = path.join(rootPath, '.tina', '__generated__')
+      await fs.mkdirp(tinaGeneratedPath)
       await store.close()
       await resetGeneratedFolder({
-        tinaGeneratedPath: path.join(rootPath, '.tina', '__generated__'),
+        tinaGeneratedPath,
       })
       await store.open()
     }


### PR DESCRIPTION
Add a `mkdirp` command to ensure generated folder is present before trying to access it. 