### PR TITLE
Throw an error when client not configured properly in production

### DIFF
--- a/.changeset/real-dots-build.md
+++ b/.changeset/real-dots-build.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Throw an error message when the client is not setup properly in production

--- a/experimental-examples/tina-cloud-starter/package.json
+++ b/experimental-examples/tina-cloud-starter/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "tinacms dev --noTelemetry -c \"next dev\"",
     "build": "tinacms dev --noWatch  --noTelemetry -c\"next build\"",
+    "build:prod": "tinacms build && next build",
     "start": "tinacms dev --noWatch  --noTelemetry -c\"next start\""
   },
   "devDependencies": {

--- a/packages/@tinacms/cli/src/cmds/query-gen/genTypes.ts
+++ b/packages/@tinacms/cli/src/cmds/query-gen/genTypes.ts
@@ -37,11 +37,16 @@ export async function genClient(
   const token = tinaSchema.config?.token
 
   if ((!branch || !clientId || !token) && !options?.local) {
-    logger.warn(
-      // TODO: add link to docs
-      warnText('Client not configured properly. Skipping client generation.')
+    const missing = []
+    if (!branch) missing.push('branch')
+    if (!clientId) missing.push('clientId')
+    if (!token) missing.push('token')
+
+    throw new Error(
+      `Client not configured properly. Missing ${missing.join(
+        ', '
+      )}. Please visit https://tina.io/docs/tina-cloud/connecting-site/ for more information`
     )
-    return next()
   }
 
   const apiURL = options.local


### PR DESCRIPTION
-  We should only do that check when the `local` flag isn't set.
-  When local isn't set, throw an error instead of a warning.
- It would be helpful if it told you exactly what was not configured properly (E.g, clientId missing)