### PR TITLE
Example page accounts for apps that use the src dir

### DIFF
--- a/.changeset/shy-crabs-retire.md
+++ b/.changeset/shy-crabs-retire.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Example page accounts for apps that use the src dir

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -239,7 +239,7 @@ export async function tinaSetup(_ctx: any, next: () => void, _options) {
   const tinaBlogPagePathFile = p.join(tinaBlogPagePath, '[filename].js')
   if (!fs.pathExistsSync(tinaBlogPagePathFile)) {
     fs.mkdirpSync(tinaBlogPagePath)
-    fs.writeFileSync(tinaBlogPagePathFile, nextPostPage())
+    fs.writeFileSync(tinaBlogPagePathFile, nextPostPage({ usingSrc }))
   }
   logger.info('Adding a content folder... ✅')
   // 4. update the users package.json

--- a/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/setup-files/index.ts
@@ -44,15 +44,20 @@ mille rigidi sub taurum.
 
 `
 
-export const nextPostPage =
-  () => `// THIS FILE HAS BEEN GENERATED WITH THE TINA CLI.
+export const nextPostPage = ({
+  usingSrc,
+}: {
+  usingSrc: boolean
+}) => `// THIS FILE HAS BEEN GENERATED WITH THE TINA CLI.
   // This is a demo file once you have tina setup feel free to delete this file
   
   import Head from 'next/head'
   import { createGlobalStyle } from 'styled-components'
   import { useTina } from 'tinacms/dist/edit-state'
   import { TinaMarkdown } from 'tinacms/dist/rich-text'
-  import client from '../../../.tina/__generated__/client'
+  import client from '${
+    usingSrc ? '../' : ''
+  }../../../.tina/__generated__/client'
   
   // Styles for markdown
   const GlobalStyle = createGlobalStyle\`


### PR DESCRIPTION
Fixes issue where init would setup the wrong path if the user had there app in a `src` dir