### PR TITLE
Logan/eng 447 payload too large error for large

### DIFF
--- a/.changeset/swift-flies-bathe.md
+++ b/.changeset/swift-flies-bathe.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Update default reference depth to 2 and give warning when a large file is produced.

--- a/packages/@tinacms/graphql/src/build.ts
+++ b/packages/@tinacms/graphql/src/build.ts
@@ -108,6 +108,26 @@ const _buildFragments = async (
   const fragPath = path.join(rootPath, '.tina', '__generated__')
 
   await fs.outputFile(path.join(fragPath, 'frags.gql'), print(fragDoc))
+  // is the file bigger then 100kb?
+  if (
+    (await (await fs.stat(path.join(fragPath, 'frags.gql'))).size) >
+    // convert to 100 kb to bytes
+    100 * 1024
+  ) {
+    console.warn(
+      'Warning: frags.gql is very large (>100kb). Consider setting the reference dept to 1 or 0. See code snippet below.'
+    )
+    console.log(
+      `const schema = defineSchema({
+        config: {
+            client: {
+                referenceDepth: 1,
+            },
+        }
+        // ...
+    })`
+    )
+  }
   //   await fs.outputFileSync(
   //     path.join(fragPath, 'frags.json'),
   //     JSON.stringify(fragDoc, null, 2)

--- a/packages/@tinacms/graphql/src/build.ts
+++ b/packages/@tinacms/graphql/src/build.ts
@@ -115,7 +115,7 @@ const _buildFragments = async (
     100 * 1024
   ) {
     console.warn(
-      'Warning: frags.gql is very large (>100kb). Consider setting the reference dept to 1 or 0. See code snippet below.'
+      'Warning: frags.gql is very large (>100kb). Consider setting the reference depth to 1 or 0. See code snippet below.'
     )
     console.log(
       `const schema = defineSchema({

--- a/packages/@tinacms/graphql/src/builder/index.ts
+++ b/packages/@tinacms/graphql/src/builder/index.ts
@@ -69,7 +69,7 @@ export class Builder {
   ) {
     this.maxDepth =
       // @ts-ignore
-      config?.tinaSchema.schema?.config?.client?.referenceDepth ?? 5
+      config?.tinaSchema.schema?.config?.client?.referenceDepth ?? 2
     this.tinaSchema = config.tinaSchema
     this.database = config.database
   }


### PR DESCRIPTION
- update default reference depth to 2
- add a warning message when frags.gql is bigger then 100kb
