### PR TITLE
Feat/always reset

### DIFF
--- a/.changeset/spotty-ads-help.md
+++ b/.changeset/spotty-ads-help.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Always reset the generated folder

--- a/packages/@tinacms/cli/src/buildTina/index.ts
+++ b/packages/@tinacms/cli/src/buildTina/index.ts
@@ -228,15 +228,13 @@ export const build = async ({
   }
 
   try {
-    if (!process.env.CI && !noWatch) {
-      await fs.mkdirp(tinaGeneratedPath)
-      await store.close()
-      await resetGeneratedFolder({
-        tinaGeneratedPath,
-        usingTs: ctx.usingTs,
-      })
-      await store.open()
-    }
+    await fs.mkdirp(tinaGeneratedPath)
+    await store.close()
+    await resetGeneratedFolder({
+      tinaGeneratedPath,
+      usingTs: ctx.usingTs,
+    })
+    await store.open()
     const cliFlags = []
     // always enable experimentalData and isomorphicGitBridge on the  backend
     cliFlags.push('experimentalData')


### PR DESCRIPTION
Always reset the generated folder even when using CI.


This is to fix an issue where the a "dummy" client.ts file was not being created and that would cause the the schema to not be able to compile.

