### PR TITLE
BREAKING CHANGE: Deprecate dated defineConfig use

### DIFF
--- a/.changeset/moody-masks-confess.md
+++ b/.changeset/moody-masks-confess.md
@@ -1,0 +1,8 @@
+---
+"tinacms": patch
+---
+
+BREAKING CHANGE: Deprecate dated defineConfig use:
+- clientId & branch should instead be passed to defineSchema. 
+- defineConfig now needs to take in the client. 
+See tina.io for upgrade details: https://tina.io/blog/tina-v-0.69.0

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -250,37 +250,6 @@ type APIProviderProps =
        */
       clientId?: never
     }
-  | {
-      /**
-       * Content API URL
-       *
-       */
-      apiURL?: never
-      /**
-       * Point to the local version of GraphQL instead of tina.io
-       * https://tina.io/docs/tinacms-context/#adding-tina-to-the-sites-frontend
-       *
-       * @deprecated use apiURL instead
-       */
-      isLocalClient?: boolean
-      /**
-       * The base branch to pull content from. Note that this is ignored for local development
-       *
-       * @deprecated use apiURL instead
-       */
-      branch?: string
-      /**
-       * Your clientId from tina.io
-       *
-       * @deprecated use apiURL instead
-       */
-      clientId?: string
-      /**
-       * The API url From this client will be used to make requests.
-       *
-       */
-      client: never
-    }
 
 interface BaseProviderProps {
   /** Callback if you need access to the TinaCMS instance */


### PR DESCRIPTION
Remove one of the type options for defineConfig. 
Small breaking change for anyone using the fairly dated config. 
As a result of this, our types become more strict to that `client` will be required when `apiURL` isn't provided
