### PR TITLE
use mkdirp instead of mkdir

### DIFF
--- a/.changeset/unlucky-dots-end.md
+++ b/.changeset/unlucky-dots-end.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Update to use mkdirp to fix issue on windows

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -33,6 +33,7 @@ export const resetGeneratedFolder = async ({
   try {
     await fs.rm(tinaGeneratedPath, {
       recursive: true,
+      force: true,
     })
   } catch (e) {
     console.log(e)

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -37,7 +37,7 @@ export const resetGeneratedFolder = async ({
   } catch (e) {
     console.log(e)
   }
-  await fs.mkdir(tinaGeneratedPath)
+  await fs.mkdirp(tinaGeneratedPath)
   const ext = usingTs ? 'ts' : 'js'
   // temp types file to allows the client to build
   await fs.writeFile(

--- a/packages/@tinacms/cli/src/cmds/compile/index.ts
+++ b/packages/@tinacms/cli/src/cmds/compile/index.ts
@@ -31,10 +31,7 @@ export const resetGeneratedFolder = async ({
   usingTs: boolean
 }) => {
   try {
-    await fs.rm(tinaGeneratedPath, {
-      recursive: true,
-      force: true,
-    })
+    await fs.emptyDir(tinaGeneratedPath)
   } catch (e) {
     console.log(e)
   }


### PR DESCRIPTION
Mkdir was causing anyone using the windows OS to crash. This PR uses mkdirp instead

fixes #3076