### PR TITLE
fix: ENG-484: null check in markdown to ast to fix new doc creation

### DIFF
--- a/.changeset/red-moose-grin.md
+++ b/.changeset/red-moose-grin.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+Add null check in markdownToAst to fix error during new doc creation

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ packages/cli/forestry/.env
 .idea/
 **/.cache/
 **/package-lock.json
+tsconfig.tsbuildinfo
 
 .npmrc
 

--- a/packages/@tinacms/mdx/src/parse/index.ts
+++ b/packages/@tinacms/mdx/src/parse/index.ts
@@ -81,16 +81,18 @@ export const markdownToAst = (value: string, field: RichTypeInner) => {
       throw new Error('Global templates are not supported')
     }
     if (template.match) {
-      preprocessedString = replaceAll(
-        preprocessedString,
-        template.match.start,
-        `<${template.name}>\``
-      )
-      preprocessedString = replaceAll(
-        preprocessedString,
-        template.match.end,
-        `\`</${template.name}>`
-      )
+      if (preprocessedString) {
+        preprocessedString = replaceAll(
+          preprocessedString,
+          template.match.start,
+          `<${template.name}>\``
+        )
+        preprocessedString = replaceAll(
+          preprocessedString,
+          template.match.end,
+          `\`</${template.name}>`
+        )
+      }
     }
   })
   try {


### PR DESCRIPTION
# what

In `experimental-examples/tina-cloud-starter` new document creation was resulting in this error:

```
GraphQL request:3:9
2 |       mutation($collection: String!, $relativePath: String!, $params: DocumentMutation!) {
3 |         createDocument(
  |         ^
4 |           collection: $collection,
More error context below
Error Parsing file test1.mdx collection posts. Please run "tinacms audit" or add the --verbose option  for more info
TypeError: Cannot read property 'valueOf' of undefined
    at replaceAll (/Users/kldavis/projects/tinacms/packages/@tinacms/mdx/dist/index.js:244727:18)
    at /Users/kldavis/projects/tinacms/packages/@tinacms/mdx/dist/index.js:244677:28
    at Array.forEach (<anonymous>)
    at markdownToAst (/Users/kldavis/projects/tinacms/packages/@tinacms/mdx/dist/index.js:244672:66)
    at parseMDX (/Users/kldavis/projects/tinacms/packages/@tinacms/mdx/dist/index.js:244695:12)
    at Resolver.resolveFieldData (/Users/kldavis/projects/tinacms/packages/@tinacms/graphql/dist/index.js:3461:48)
    at /Users/kldavis/projects/tinacms/packages/@tinacms/graphql/dist/index.js:3099:25
    at reducePromises (/Users/kldavis/projects/tinacms/packages/@tinacms/graphql/dist/index.js:95:12)
    at async sequential (/Users/kldavis/projects/tinacms/packages/@tinacms/graphql/dist/index.js:97:18)
    at async Resolver.getDocument (/Users/kldavis/projects/tinacms/packages/@tinacms/graphql/dist/index.js:3098:11) {
  message: 'Error Parsing file test1.mdx collection posts. Please run "tinacms audit" or add the --verbose option  for more info',
  locations: [ { line: 3, column: 9 } ],
  path: [ 'createDocument' ]
}
```

This was traced to a undefined value being passed to markdownToAst followed by a call to valueOf on that undefined value. This PR adds a truthy check and only does the replace if the value is truthy.

(Also does a gitignore on tsconfig.tsbuildinfo)