### PR TITLE
Improved MDX & Audit error handling

### DIFF
--- a/.changeset/chilled-moose-breathe.md
+++ b/.changeset/chilled-moose-breathe.md
@@ -1,0 +1,11 @@
+---
+'@tinacms/cli': patch
+'@tinacms/mdx': patch
+---
+
+fix(CLI audit): Audit all files instead of first 10
+
+feat(CLI audit): Show clearer errors/warning in CLI audit
+
+fix(ContentAPI): Improved error boundary when a document contains unsupported rich-text
+

--- a/packages/@tinacms/cli/src/cmds/audit/audit.test.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.test.ts
@@ -1,3 +1,16 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { auditDocuments } from './audit'
 import { AuditError } from './issue'
 

--- a/packages/@tinacms/cli/src/cmds/audit/audit.test.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.test.ts
@@ -1,0 +1,115 @@
+import { auditDocuments } from './audit'
+import { AuditError } from './issue'
+
+jest.mock('./validations/validateRichText', () => {
+  return {
+    validateRichText: jest.fn(() => [new AuditError('oops', '')]),
+  }
+})
+jest.mock('./validations/validateMutations', () => {
+  return {
+    validateMutations: jest.fn(() => [new AuditError('oops', '')]),
+  }
+})
+
+const emptyCollectionResponse = {
+  data: {
+    postConnection: {
+      edges: [],
+      pageInfo: {
+        endCursor: 'foo',
+        hasNextPage: false,
+      },
+    },
+  },
+}
+
+const firstPageResponse = {
+  data: {
+    postConnection: {
+      edges: [
+        {
+          node: {
+            _values: {
+              date: '2021-07-12T07:00:00.000Z',
+            },
+          },
+        },
+        {
+          node: {
+            _values: {
+              date: '2021-07-12T07:00:00.000Z',
+            },
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: 'foo',
+        hasNextPage: true,
+      },
+    },
+  },
+}
+
+const lastPageResponse = {
+  data: {
+    postConnection: {
+      edges: [
+        {
+          node: {
+            _values: {
+              date: '2021-07-12T07:00:00.000Z',
+            },
+          },
+        },
+      ],
+      pageInfo: {
+        endCursor: 'foo2',
+        hasNextPage: false,
+      },
+    },
+  },
+}
+
+describe('audit', () => {
+  describe('with no documents', () => {
+    test('reports no issues', async () => {
+      const result = await auditDocuments({
+        collection: {
+          name: 'post',
+          templates: [],
+          path: 'content/posts',
+        },
+        resolve: jest
+          .fn()
+          .mockImplementationOnce(() =>
+            Promise.resolve(emptyCollectionResponse)
+          ),
+        rootPath: 'posts/foo',
+        useDefaultValues: false,
+      })
+
+      expect(result.length).toEqual(0) // 2 errors per document, 3 documents
+    })
+  })
+
+  describe('with paged collection', () => {
+    test('audits every document', async () => {
+      const result = await auditDocuments({
+        collection: {
+          name: 'post',
+          templates: [],
+          path: 'content/posts',
+        },
+        resolve: jest
+          .fn()
+          .mockImplementationOnce(() => Promise.resolve(firstPageResponse))
+          .mockImplementationOnce(() => Promise.resolve(lastPageResponse)),
+        rootPath: 'posts/foo',
+        useDefaultValues: false,
+      })
+
+      expect(result.length).toEqual(6) // 2 errors per document, 3 documents
+    })
+  })
+})

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -15,46 +15,11 @@ import { resolve } from '@tinacms/graphql'
 import type { Database, TinaCloudCollection } from '@tinacms/graphql'
 import p from 'path'
 import { logger } from '../../logger'
-import { assertShape } from '@tinacms/graphql'
-import chalk from 'chalk'
+import { AuditIssue } from './issue'
+import { validateRichText } from './validations/validateRichText'
+import { validateMutations } from './validations/validateMutations'
 
-export interface AuditIssue {
-  level: 'error' | 'warning'
-  print: () => void
-}
-
-abstract class BaseAuditIssue implements AuditIssue {
-  message: string
-  level: 'error' | 'warning'
-  constructor(message: string, level: 'error' | 'warning') {
-    this.level = level
-    this.message = message
-  }
-
-  print() {
-    throw new Error('Not Implemented')
-  }
-}
-
-class AuditError extends BaseAuditIssue {
-  constructor(message) {
-    super(message, 'error')
-  }
-  public print() {
-    logger.error(chalk.red(this.message))
-  }
-}
-
-class AuditWarning extends BaseAuditIssue {
-  constructor(message) {
-    super(message, 'warning')
-  }
-  public print() {
-    logger.warn(chalk.yellowBright(this.message))
-  }
-}
-
-type AuditArgs = {
+export type AuditArgs = {
   collection: TinaCloudCollection
   database: Database
   rootPath: string
@@ -109,75 +74,6 @@ const interateCollectionDocuments = async (
   } while (hasNextPage)
 }
 
-const validateRichText = (node) => {
-  let issues: AuditIssue[] = []
-  Object.keys(node._values)
-    .map((fieldName) => node._values[fieldName])
-    .filter((field) => {
-      return field?.type == 'root'
-    })
-    .forEach((field) => {
-      const errorMessages = field.children
-        .filter((f) => f.type == 'invalid_markdown')
-        .map((f) => f.message)
-
-      errorMessages.forEach((errorMessage) => {
-        issues.push(new AuditWarning(errorMessage))
-      })
-    })
-
-  return issues
-}
-
-const validateMutations = async (
-  node,
-  args: AuditArgs
-): Promise<AuditIssue[]> => {
-  const topLevelDefaults = {}
-
-  // TODO: account for when collection is a string
-  if (args.useDefaultValues && typeof args.collection.fields !== 'string') {
-    args.collection.fields
-      .filter((x) => !x.list)
-      .forEach((x) => {
-        const value = x.ui as any
-        if (typeof value !== 'undefined') {
-          topLevelDefaults[x.name] = value.defaultValue
-        }
-      })
-  }
-  const params = transformDocumentIntoMutationRequestPayload(
-    node._values,
-    {
-      includeCollection: true,
-      includeTemplate: typeof args.collection.templates !== 'undefined',
-    },
-    topLevelDefaults
-  )
-
-  const mutation = `mutation($collection: String!, $relativePath: String!, $params: DocumentMutation!) {
-        updateDocument(
-          collection: $collection,
-          relativePath: $relativePath,
-          params: $params
-        ){__typename}
-      }`
-
-  const mutationRes = await resolve({
-    database: args.database,
-    query: mutation,
-    variables: {
-      params,
-      collection: args.collection.name,
-      relativePath: node._sys.relativePath,
-    },
-    silenceErrors: true,
-    verbose: true,
-  })
-
-  return (mutationRes.errors || []).map((err) => new AuditError(err.message))
-}
-
 const auditDocument = async (node, args: AuditArgs): Promise<AuditIssue[]> => {
   const richTextIssues = validateRichText(node)
   const mutationIssues = await validateMutations(node, args)
@@ -201,73 +97,4 @@ export const auditDocuments = async (args: AuditArgs) => {
   })
 
   return issues
-}
-
-// TODO: move this to its own package
-export const transformDocumentIntoMutationRequestPayload = (
-  document: {
-    _collection: string
-    __typename?: string
-    _template: string
-    [key: string]: unknown
-  },
-  /** Whether to include the collection and template names as top-level keys in the payload */
-  instructions: { includeCollection?: boolean; includeTemplate?: boolean },
-  defaults?: any
-) => {
-  const { _collection, __typename, _template, ...rest } = document
-
-  const params = transformParams(rest)
-  const paramsWithTemplate = instructions.includeTemplate
-    ? { [_template]: params }
-    : params
-
-  return instructions.includeCollection
-    ? { [_collection]: { ...defaults, ...filterObject(paramsWithTemplate) } }
-    : { ...defaults, ...filterObject(paramsWithTemplate) }
-}
-
-const transformParams = (data: unknown) => {
-  if (['string', 'number', 'boolean'].includes(typeof data)) {
-    return data
-  }
-  if (Array.isArray(data)) {
-    return data.map((item) => transformParams(item))
-  }
-  try {
-    assertShape<{ _template: string; __typename?: string }>(data, (yup) =>
-      // @ts-ignore No idea what yup is trying to tell me:  Type 'RequiredStringSchema<string, Record<string, any>>' is not assignable to type 'AnySchema<any, any, any>
-      yup.object({ _template: yup.string().required() })
-    )
-    const { _template, __typename, ...rest } = data
-    const nested = transformParams(rest)
-    return { [_template]: nested }
-  } catch (e) {
-    if (e.message === 'Failed to assertShape - _template is a required field') {
-      if (!data) {
-        return undefined
-        return []
-      }
-      const accum = {}
-      Object.entries(data).map(([keyName, value]) => {
-        accum[keyName] = transformParams(value)
-      })
-      return accum
-    } else {
-      if (!data) {
-        return undefined
-        return []
-      }
-      throw e
-    }
-  }
-}
-
-// SRC: https://stackoverflow.com/questions/39977214/merge-in-es6-es7object-assign-without-overriding-undefined-values
-function filterObject(obj) {
-  const ret = {}
-  Object.keys(obj)
-    .filter((key) => obj[key] !== undefined)
-    .forEach((key) => (ret[key] = obj[key]))
-  return ret
 }

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -18,7 +18,7 @@ import { logger } from '../../logger'
 import { assertShape } from '@tinacms/graphql'
 import chalk from 'chalk'
 
-interface AuditIssue {
+export interface AuditIssue {
   level: 'error' | 'warning'
   print: () => void
 }

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -16,7 +16,7 @@ import { validateRichText } from './validations/validateRichText'
 import { validateMutations } from './validations/validateMutations'
 import { AuditArgs, Resolver } from './auditArgs'
 
-const interateCollectionDocuments = async (
+const iterateCollectionDocuments = async (
   collectionName: string,
   resolve: Resolver,
   action: (doc) => Promise<void>
@@ -71,7 +71,7 @@ export const auditDocuments = async (args: AuditArgs) => {
 
   let issues: AuditIssue[] = []
 
-  await interateCollectionDocuments(collection.name, resolve, async (doc) => {
+  await iterateCollectionDocuments(collection.name, resolve, async (doc) => {
     const docIssues = await auditDocument(doc, args)
     issues = [...issues, ...docIssues]
   })

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -73,8 +73,8 @@ export const auditDocuments = async (args: AuditArgs) => {
           .map((f) => f.message)
 
         errorMessages.forEach((errorMessage) => {
-          error = true
-          logger.error(chalk.red(errorMessage))
+          warning = true
+          logger.warn(chalk.yellowBright(errorMessage))
         })
       })
 

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -80,9 +80,6 @@ const auditDocument = async (
   let errors: string[] = []
   let warnings: string[] = []
 
-  const fullPath = p.join(args.rootPath, node._sys.path)
-  logger.info(`Checking document: ${fullPath}`)
-
   Object.keys(node._values)
     .map((fieldName) => node._values[fieldName])
     .filter((field) => {
@@ -95,7 +92,6 @@ const auditDocument = async (
 
       errorMessages.forEach((errorMessage) => {
         warnings.push(errorMessage)
-        logger.warn(chalk.yellowBright(errorMessage))
       })
     })
 
@@ -143,7 +139,6 @@ const auditDocument = async (
   if (mutationRes.errors) {
     mutationRes.errors.forEach((err) => {
       errors.push(err.message)
-      logger.error(chalk.red(err.message))
     })
   }
 
@@ -157,7 +152,16 @@ export const auditDocuments = async (args: AuditArgs) => {
   let warning = false
 
   await interateCollectionDocuments(collection.name, database, async (doc) => {
+    const fullPath = p.join(args.rootPath, doc._sys.path)
+    logger.info(`Checking document: ${fullPath}`)
+
     const auditResult = await auditDocument(doc, args)
+    auditResult.warnings.forEach((errMessage) => {
+      logger.warn(chalk.yellowBright(errMessage))
+    })
+    auditResult.errors.forEach((errMessage) => {
+      logger.error(chalk.red(errMessage))
+    })
 
     error = error || auditResult.errors.length > 0
     warning = warning || auditResult.warnings.length > 0

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -121,6 +121,24 @@ export const auditDocuments = async (args: AuditArgs) => {
       query: documentQuery,
       variables: {},
     })
+
+    Object.keys(docResult.data.document._values)
+      .filter((fieldName) => {
+        return docResult.data.document._values[fieldName]?.type == 'root'
+      })
+      .forEach((fieldName) => {
+        const errorMessages = docResult.data.document._values[
+          fieldName
+        ].children
+          .filter((f) => f.type == 'invalid_markdown')
+          .map((f) => f.message)
+
+        errorMessages.forEach((errorMessage) => {
+          error = true
+          logger.error(chalk.red(errorMessage))
+        })
+      })
+
     const topLevelDefaults = {}
 
     // TODO: account for when collection is a string

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -86,14 +86,8 @@ export const auditDocuments = async (args: AuditArgs) => {
   let issues: AuditIssue[] = []
 
   await interateCollectionDocuments(collection.name, database, async (doc) => {
-    const fullPath = p.join(args.rootPath, doc._sys.path)
-    logger.info(`Checking document: ${fullPath}`)
-
     const docIssues = await auditDocument(doc, args)
     issues = [...issues, ...docIssues]
-    docIssues.forEach((issue) => {
-      issue.print()
-    })
   })
 
   return issues

--- a/packages/@tinacms/cli/src/cmds/audit/audit.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/audit.ts
@@ -185,28 +185,22 @@ const auditDocument = async (node, args: AuditArgs): Promise<AuditIssue[]> => {
 }
 
 export const auditDocuments = async (args: AuditArgs) => {
-  const { collection, database, rootPath, useDefaultValues } = args
+  const { collection, database } = args
 
-  let error = false
-  let warning = false
+  let issues: AuditIssue[] = []
 
   await interateCollectionDocuments(collection.name, database, async (doc) => {
     const fullPath = p.join(args.rootPath, doc._sys.path)
     logger.info(`Checking document: ${fullPath}`)
 
-    const auditIssues = await auditDocument(doc, args)
-    auditIssues.forEach((issue) => {
+    const docIssues = await auditDocument(doc, args)
+    issues = [...issues, ...docIssues]
+    docIssues.forEach((issue) => {
       issue.print()
     })
-
-    error =
-      error || auditIssues.filter((issue) => issue.level == 'error').length > 0
-    warning =
-      warning ||
-      auditIssues.filter((issue) => issue.level == 'warning').length > 0
   })
 
-  return { error, warning }
+  return issues
 }
 
 // TODO: move this to its own package

--- a/packages/@tinacms/cli/src/cmds/audit/auditArgs.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/auditArgs.ts
@@ -1,0 +1,13 @@
+import type { TinaCloudCollection } from '@tinacms/graphql'
+import type { resolve } from '@tinacms/graphql'
+
+type ResolveParams = Parameters<typeof resolve>[0]
+export type Resolver = (
+  params: Omit<ResolveParams, 'database'>
+) => ReturnType<typeof resolve>
+export type AuditArgs = {
+  collection: TinaCloudCollection
+  resolve: Resolver
+  rootPath: string
+  useDefaultValues: boolean
+}

--- a/packages/@tinacms/cli/src/cmds/audit/auditArgs.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/auditArgs.ts
@@ -1,3 +1,16 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import type { TinaCloudCollection } from '@tinacms/graphql'
 import type { resolve } from '@tinacms/graphql'
 

--- a/packages/@tinacms/cli/src/cmds/audit/index.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/index.ts
@@ -11,15 +11,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { auditDocuments } from './audit'
+import { auditDocuments, AuditIssue } from './audit'
 import { logger } from '../../logger'
 import chalk from 'chalk'
 import prompts from 'prompts'
 import { Telemetry } from '@tinacms/metrics'
+import { Database } from '@tinacms/graphql'
 
 const rootPath = process.cwd()
 
-export const audit = async (ctx: any, next: () => void, options) => {
+interface AuditCtx {
+  issues: AuditIssue[]
+  database: Database
+}
+
+export const audit = async (ctx: AuditCtx, next: () => void, options) => {
   const telemetry = new Telemetry({ disabled: options.noTelemetry })
   await telemetry.submitRecord({
     event: {
@@ -73,7 +79,7 @@ export const audit = async (ctx: any, next: () => void, options) => {
 }
 
 export const printFinalMessage = async (
-  ctx: any,
+  ctx: AuditCtx,
   next: () => void,
   _options
 ) => {

--- a/packages/@tinacms/cli/src/cmds/audit/index.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/index.ts
@@ -11,12 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { auditDocuments, AuditIssue } from './audit'
+import { auditDocuments } from './audit'
 import { logger } from '../../logger'
 import chalk from 'chalk'
 import prompts from 'prompts'
 import { Telemetry } from '@tinacms/metrics'
 import { Database } from '@tinacms/graphql'
+import { AuditIssue } from './issue'
 
 const rootPath = process.cwd()
 

--- a/packages/@tinacms/cli/src/cmds/audit/index.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/index.ts
@@ -16,7 +16,7 @@ import { logger } from '../../logger'
 import chalk from 'chalk'
 import prompts from 'prompts'
 import { Telemetry } from '@tinacms/metrics'
-import { Database } from '@tinacms/graphql'
+import { Database, resolve } from '@tinacms/graphql'
 import { AuditIssue } from './issue'
 
 const rootPath = process.cwd()
@@ -68,7 +68,9 @@ export const audit = async (ctx: AuditCtx, next: () => void, options) => {
   for (let i = 0; i < collections.length; i++) {
     const collectionIssues = await auditDocuments({
       collection: collections[i],
-      database,
+      resolve: (args) => {
+        return resolve({ ...args, database })
+      },
       rootPath,
       useDefaultValues: options.useDefaultValues,
     })

--- a/packages/@tinacms/cli/src/cmds/audit/index.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/index.ts
@@ -79,11 +79,11 @@ export const audit = async (ctx: AuditCtx, next: () => void, options) => {
   next()
 }
 
-export const printFinalMessage = async (
-  ctx: AuditCtx,
-  next: () => void,
-  _options
-) => {
+export const printAudit = async (ctx: AuditCtx, next: () => void, _options) => {
+  ctx.issues.forEach((issue) => {
+    issue.print()
+  })
+
   const warnings = ctx.issues.filter((issue) => issue.level == 'warning')
   const errors = ctx.issues.filter((issue) => issue.level == 'error')
 

--- a/packages/@tinacms/cli/src/cmds/audit/index.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/index.ts
@@ -11,15 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { createDatabase } from '@tinacms/graphql'
-
-import {
-  AuditFileSystemBridge,
-  FilesystemBridge,
-  AuditFilesystemStore,
-  FilesystemStore,
-} from '@tinacms/datalayer'
-import { auditCollection, auditDocuments } from './audit'
+import { auditDocuments } from './audit'
 import { logger } from '../../logger'
 import chalk from 'chalk'
 import prompts from 'prompts'
@@ -63,25 +55,19 @@ export const audit = async (ctx: any, next: () => void, options) => {
   const database = ctx.database
   const schema = await database.getSchema()
   const collections = schema.getCollections()
+
   let warning = false
   let error = false
 
   for (let i = 0; i < collections.length; i++) {
-    const collection = collections[i]
-    const returnWarning = await auditCollection({
-      collection,
+    const auditResult = await auditDocuments({
+      collection: collections[i],
       database,
       rootPath,
       useDefaultValues: options.useDefaultValues,
     })
-    const returnError = await auditDocuments({
-      collection,
-      database,
-      rootPath,
-      useDefaultValues: options.useDefaultValues,
-    })
-    warning = warning || returnWarning
-    error = error || returnError
+    warning = warning || auditResult.warning
+    error = error || auditResult.error
   }
   ctx.warning = warning
   ctx.error = error

--- a/packages/@tinacms/cli/src/cmds/audit/issue.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/issue.ts
@@ -3,13 +3,16 @@ import chalk from 'chalk'
 
 export interface AuditIssue {
   level: 'error' | 'warning'
+  docPath: string
   print: () => void
 }
 
 abstract class BaseAuditIssue implements AuditIssue {
   message: string
   level: 'error' | 'warning'
-  constructor(message: string, level: 'error' | 'warning') {
+  docPath: string
+  constructor(message: string, level: 'error' | 'warning', docPath: string) {
+    this.docPath = docPath
     this.level = level
     this.message = message
   }
@@ -17,22 +20,26 @@ abstract class BaseAuditIssue implements AuditIssue {
   print() {
     throw new Error('Not Implemented')
   }
+
+  protected formatOutput() {
+    return `${this.docPath}: ${this.message}`
+  }
 }
 
 export class AuditError extends BaseAuditIssue {
-  constructor(message) {
-    super(message, 'error')
+  constructor(message: string, docPath: string) {
+    super(message, 'error', docPath)
   }
   public print() {
-    logger.error(chalk.red(this.message))
+    logger.error(chalk.red(this.formatOutput()))
   }
 }
 
 export class AuditWarning extends BaseAuditIssue {
-  constructor(message) {
-    super(message, 'warning')
+  constructor(message: string, docPath: string) {
+    super(message, 'warning', docPath)
   }
   public print() {
-    logger.warn(chalk.yellowBright(this.message))
+    logger.warn(chalk.yellowBright(this.formatOutput()))
   }
 }

--- a/packages/@tinacms/cli/src/cmds/audit/issue.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/issue.ts
@@ -1,0 +1,38 @@
+import { logger } from '../../logger'
+import chalk from 'chalk'
+
+export interface AuditIssue {
+  level: 'error' | 'warning'
+  print: () => void
+}
+
+abstract class BaseAuditIssue implements AuditIssue {
+  message: string
+  level: 'error' | 'warning'
+  constructor(message: string, level: 'error' | 'warning') {
+    this.level = level
+    this.message = message
+  }
+
+  print() {
+    throw new Error('Not Implemented')
+  }
+}
+
+export class AuditError extends BaseAuditIssue {
+  constructor(message) {
+    super(message, 'error')
+  }
+  public print() {
+    logger.error(chalk.red(this.message))
+  }
+}
+
+export class AuditWarning extends BaseAuditIssue {
+  constructor(message) {
+    super(message, 'warning')
+  }
+  public print() {
+    logger.warn(chalk.yellowBright(this.message))
+  }
+}

--- a/packages/@tinacms/cli/src/cmds/audit/issue.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/issue.ts
@@ -1,3 +1,16 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { logger } from '../../logger'
 import chalk from 'chalk'
 

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
@@ -48,7 +48,9 @@ export const validateMutations = async (
     verbose: true,
   })
 
-  return (mutationRes.errors || []).map((err) => new AuditError(err.message))
+  return (mutationRes.errors || []).map(
+    (err) => new AuditError(err.message, node._sys.path)
+  )
 }
 
 // TODO: move this to its own package

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
@@ -1,0 +1,121 @@
+import { AuditError, AuditIssue } from '../issue'
+import { assertShape, resolve } from '@tinacms/graphql'
+import { AuditArgs } from '../audit'
+
+export const validateMutations = async (
+  node,
+  args: AuditArgs
+): Promise<AuditIssue[]> => {
+  const topLevelDefaults = {}
+
+  // TODO: account for when collection is a string
+  if (args.useDefaultValues && typeof args.collection.fields !== 'string') {
+    args.collection.fields
+      .filter((x) => !x.list)
+      .forEach((x) => {
+        const value = x.ui as any
+        if (typeof value !== 'undefined') {
+          topLevelDefaults[x.name] = value.defaultValue
+        }
+      })
+  }
+  const params = transformDocumentIntoMutationRequestPayload(
+    node._values,
+    {
+      includeCollection: true,
+      includeTemplate: typeof args.collection.templates !== 'undefined',
+    },
+    topLevelDefaults
+  )
+
+  const mutation = `mutation($collection: String!, $relativePath: String!, $params: DocumentMutation!) {
+        updateDocument(
+          collection: $collection,
+          relativePath: $relativePath,
+          params: $params
+        ){__typename}
+      }`
+
+  const mutationRes = await resolve({
+    database: args.database,
+    query: mutation,
+    variables: {
+      params,
+      collection: args.collection.name,
+      relativePath: node._sys.relativePath,
+    },
+    silenceErrors: true,
+    verbose: true,
+  })
+
+  return (mutationRes.errors || []).map((err) => new AuditError(err.message))
+}
+
+// TODO: move this to its own package
+export const transformDocumentIntoMutationRequestPayload = (
+  document: {
+    _collection: string
+    __typename?: string
+    _template: string
+    [key: string]: unknown
+  },
+  /** Whether to include the collection and template names as top-level keys in the payload */
+  instructions: { includeCollection?: boolean; includeTemplate?: boolean },
+  defaults?: any
+) => {
+  const { _collection, __typename, _template, ...rest } = document
+
+  const params = transformParams(rest)
+  const paramsWithTemplate = instructions.includeTemplate
+    ? { [_template]: params }
+    : params
+
+  return instructions.includeCollection
+    ? { [_collection]: { ...defaults, ...filterObject(paramsWithTemplate) } }
+    : { ...defaults, ...filterObject(paramsWithTemplate) }
+}
+
+const transformParams = (data: unknown) => {
+  if (['string', 'number', 'boolean'].includes(typeof data)) {
+    return data
+  }
+  if (Array.isArray(data)) {
+    return data.map((item) => transformParams(item))
+  }
+  try {
+    assertShape<{ _template: string; __typename?: string }>(data, (yup) =>
+      // @ts-ignore No idea what yup is trying to tell me:  Type 'RequiredStringSchema<string, Record<string, any>>' is not assignable to type 'AnySchema<any, any, any>
+      yup.object({ _template: yup.string().required() })
+    )
+    const { _template, __typename, ...rest } = data
+    const nested = transformParams(rest)
+    return { [_template]: nested }
+  } catch (e) {
+    if (e.message === 'Failed to assertShape - _template is a required field') {
+      if (!data) {
+        return undefined
+        return []
+      }
+      const accum = {}
+      Object.entries(data).map(([keyName, value]) => {
+        accum[keyName] = transformParams(value)
+      })
+      return accum
+    } else {
+      if (!data) {
+        return undefined
+        return []
+      }
+      throw e
+    }
+  }
+}
+
+// SRC: https://stackoverflow.com/questions/39977214/merge-in-es6-es7object-assign-without-overriding-undefined-values
+function filterObject(obj) {
+  const ret = {}
+  Object.keys(obj)
+    .filter((key) => obj[key] !== undefined)
+    .forEach((key) => (ret[key] = obj[key]))
+  return ret
+}

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
@@ -1,3 +1,16 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { AuditError, AuditIssue } from '../issue'
 import { assertShape } from '@tinacms/graphql'
 import { AuditArgs } from '../auditArgs'

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateMutations.ts
@@ -1,6 +1,6 @@
 import { AuditError, AuditIssue } from '../issue'
-import { assertShape, resolve } from '@tinacms/graphql'
-import { AuditArgs } from '../audit'
+import { assertShape } from '@tinacms/graphql'
+import { AuditArgs } from '../auditArgs'
 
 export const validateMutations = async (
   node,
@@ -36,8 +36,7 @@ export const validateMutations = async (
         ){__typename}
       }`
 
-  const mutationRes = await resolve({
-    database: args.database,
+  const mutationRes = await args.resolve({
     query: mutation,
     variables: {
       params,

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
@@ -58,6 +58,9 @@ describe('validateRichText', () => {
           group: {
             date: '2021-07-12T07:00:00.000Z',
             foo: null,
+            emptyArray: [],
+            objArray: [{ title: 'foo' }],
+            strArray: ['foo', 'bar'],
             nestedBody: {
               type: 'root',
               children: [

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
@@ -1,0 +1,94 @@
+import { validateRichText } from './validateRichText'
+
+describe('validateRichText', () => {
+  describe('with no issues', () => {
+    const dummyDoc = {
+      _sys: {
+        extension: 'md',
+        path: 'content/posts/hello-world.md',
+        relativePath: 'posts/md',
+      },
+      _values: {
+        date: '2021-07-12T07:00:00.000Z',
+        _body: {
+          type: 'root',
+          children: [
+            {
+              type: 'p',
+              children: [
+                {
+                  type: 'text',
+                  text: 'Lorem markdownum evinctus ut cape adhaeret gravis licet progenies ut haesit maxima ille. Est scorpius, mori vel in visaeque Haemoniis viperei furoris e ad vasti, distulit. Crudus sub coniuge iam: dea propera sive',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }
+
+    test('returns empty array', () => {
+      const result = validateRichText(dummyDoc)
+      expect(result.length).toEqual(0)
+    })
+  })
+  describe('with rich text issue', () => {
+    const dummyDoc = {
+      _sys: {
+        extension: 'md',
+        path: 'content/posts/hello-world.md',
+        relativePath: 'posts/md',
+      },
+      _values: {
+        pageBlocks3: null,
+        title: 'Just Another Blog Post',
+        heroImg: null,
+        excerpt: {
+          type: 'root',
+          children: [
+            {
+              type: 'p',
+              children: [
+                {
+                  type: 'text',
+                  text: 'Lorem markdownum evinctus ut cape adhaeret gravis licet progenies ut haesit maxima ille. Est scorpius, mori vel in visaeque Haemoniis viperei furoris e ad vasti, distulit. Crudus sub coniuge iam: dea propera sive',
+                },
+              ],
+            },
+          ],
+        },
+        author: {
+          name: 'Napolean',
+          avatar:
+            'https://images.unsplash.com/photo-1606721977440-13e6c3a3505a?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=344&q=80',
+          id: 'content/authors/napolean.md',
+        },
+        date: '2021-07-12T07:00:00.000Z',
+        _body: {
+          type: 'root',
+          children: [
+            {
+              type: 'invalid_markdown',
+              value:
+                '\n\n## Overarching Process\n\nTina has three main branches:\n\n- **master:** The bleeding edge of tinacms\n- **next:** A preview of the next release\n- **latest:** The current stable release\n\nThe flow of changes therefore looks like:\n\n> `fix-some-bug` => `master` => `next` => `latest`\n\nThe process happens over a week:\n\n- On Monday\n  1. `next` is merged into `latest`; then `latest` is published to npm\n  2. `master` is merged into `next`; then `next` is published to npm\n- Any hot fixes for bugs will be cherry picked into `next` and `latest`\n  and the published accordingly.\n- Every pull request merged to `master` automatically triggers a\n  `canary` release.\n\nWith this process:\n\n- all accepted changes are available as `canary` releases for early testing\n- critical fixes are published as soon as possible\n- new features and minor fixes take ~1.5 weeks to be published\n\n## Steps to Release\n\nThe general release process looks like this:\n\n1. **Build the source files:**\n\n   The source must be compiled, minified, and uglified in preparation for release.\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   We use `lerna` to generate CHANGELOG files automatically from our commit messages.\n\n1. **Clean the CHANGELOGs**\n\n   Lerna sometimes adds empty changelog entries. For example, if `react-tinacms` is changed\n   then `tinacms` will get get a patch update with only the dependency updated. Make sure to install `lerna-clean-changelog-cli`:\n\n   ```\n   npm i -g lerna-clean-changelogs-cli\n   ```\n\n1. **Publish to NPM:**\n\n   You must have an NPM_TOKEN set locally that has access to the `@tinacms` organization\n\n1. **Push CHANGELOGs and Git tags to Github:**\n\n   Let everyone know!\n\nThe exact commands vary slightly depending on the type of release being made.\n\n### Prerelease\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-prerelease \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): prerelease"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package --dist-tag next\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Graduating Prereleases\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-graduate \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): graduation"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1) **Publish to NPM:**\n\n   ```\n   lerna publish from-package\n   ```\n\n1) **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Release\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --no-push \\\n     --allow-branch master \\\n     -m "chore(publish): release"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n',
+              message: 'Error: listItem inside list item is not supported',
+              children: [
+                {
+                  type: 'text',
+                  text: '',
+                },
+              ],
+            },
+          ],
+        },
+      },
+    }
+
+    test('returns warning', () => {
+      const result = validateRichText(dummyDoc)
+      expect(result.filter((r) => r.level == 'warning')).toHaveLength(1)
+      expect(result.filter((r) => r.level == 'error')).toHaveLength(0)
+      expect(result[0].docPath == 'content/posts/hello-world.md')
+    })
+  })
+})

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
@@ -1,3 +1,16 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { validateRichText } from './validateRichText'
 
 describe('validateRichText', () => {

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.test.ts
@@ -46,62 +46,82 @@ describe('validateRichText', () => {
     })
   })
   describe('with rich text issue', () => {
-    const dummyDoc = {
-      _sys: {
-        extension: 'md',
-        path: 'content/posts/hello-world.md',
-        relativePath: 'posts/md',
-      },
-      _values: {
-        pageBlocks3: null,
-        title: 'Just Another Blog Post',
-        heroImg: null,
-        excerpt: {
-          type: 'root',
-          children: [
-            {
-              type: 'p',
+    describe('as nested field', () => {
+      const dummyDoc = {
+        _sys: {
+          extension: 'md',
+          path: 'content/posts/hello-world.md',
+          relativePath: 'posts/md',
+        },
+        _values: {
+          date: '2021-07-12T07:00:00.000Z',
+          group: {
+            date: '2021-07-12T07:00:00.000Z',
+            foo: null,
+            nestedBody: {
+              type: 'root',
               children: [
                 {
-                  type: 'text',
-                  text: 'Lorem markdownum evinctus ut cape adhaeret gravis licet progenies ut haesit maxima ille. Est scorpius, mori vel in visaeque Haemoniis viperei furoris e ad vasti, distulit. Crudus sub coniuge iam: dea propera sive',
+                  type: 'invalid_markdown',
+                  value:
+                    '\n\n## Overarching Process\n\nTina has three main branches:\n\n- **master:** The bleeding edge of tinacms\n- **next:** A preview of the next release\n- **latest:** The current stable release\n\nThe flow of changes therefore looks like:\n\n> `fix-some-bug` => `master` => `next` => `latest`\n\nThe process happens over a week:\n\n- On Monday\n  1. `next` is merged into `latest`; then `latest` is published to npm\n  2. `master` is merged into `next`; then `next` is published to npm\n- Any hot fixes for bugs will be cherry picked into `next` and `latest`\n  and the published accordingly.\n- Every pull request merged to `master` automatically triggers a\n  `canary` release.\n\nWith this process:\n\n- all accepted changes are available as `canary` releases for early testing\n- critical fixes are published as soon as possible\n- new features and minor fixes take ~1.5 weeks to be published\n\n## Steps to Release\n\nThe general release process looks like this:\n\n1. **Build the source files:**\n\n   The source must be compiled, minified, and uglified in preparation for release.\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   We use `lerna` to generate CHANGELOG files automatically from our commit messages.\n\n1. **Clean the CHANGELOGs**\n\n   Lerna sometimes adds empty changelog entries. For example, if `react-tinacms` is changed\n   then `tinacms` will get get a patch update with only the dependency updated. Make sure to install `lerna-clean-changelog-cli`:\n\n   ```\n   npm i -g lerna-clean-changelogs-cli\n   ```\n\n1. **Publish to NPM:**\n\n   You must have an NPM_TOKEN set locally that has access to the `@tinacms` organization\n\n1. **Push CHANGELOGs and Git tags to Github:**\n\n   Let everyone know!\n\nThe exact commands vary slightly depending on the type of release being made.\n\n### Prerelease\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-prerelease \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): prerelease"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package --dist-tag next\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Graduating Prereleases\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-graduate \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): graduation"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1) **Publish to NPM:**\n\n   ```\n   lerna publish from-package\n   ```\n\n1) **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Release\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --no-push \\\n     --allow-branch master \\\n     -m "chore(publish): release"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n',
+                  message: 'Error: listItem inside list item is not supported',
+                  children: [
+                    {
+                      type: 'text',
+                      text: '',
+                    },
+                  ],
                 },
               ],
             },
-          ],
+          },
         },
-        author: {
-          name: 'Napolean',
-          avatar:
-            'https://images.unsplash.com/photo-1606721977440-13e6c3a3505a?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=344&q=80',
-          id: 'content/authors/napolean.md',
-        },
-        date: '2021-07-12T07:00:00.000Z',
-        _body: {
-          type: 'root',
-          children: [
-            {
-              type: 'invalid_markdown',
-              value:
-                '\n\n## Overarching Process\n\nTina has three main branches:\n\n- **master:** The bleeding edge of tinacms\n- **next:** A preview of the next release\n- **latest:** The current stable release\n\nThe flow of changes therefore looks like:\n\n> `fix-some-bug` => `master` => `next` => `latest`\n\nThe process happens over a week:\n\n- On Monday\n  1. `next` is merged into `latest`; then `latest` is published to npm\n  2. `master` is merged into `next`; then `next` is published to npm\n- Any hot fixes for bugs will be cherry picked into `next` and `latest`\n  and the published accordingly.\n- Every pull request merged to `master` automatically triggers a\n  `canary` release.\n\nWith this process:\n\n- all accepted changes are available as `canary` releases for early testing\n- critical fixes are published as soon as possible\n- new features and minor fixes take ~1.5 weeks to be published\n\n## Steps to Release\n\nThe general release process looks like this:\n\n1. **Build the source files:**\n\n   The source must be compiled, minified, and uglified in preparation for release.\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   We use `lerna` to generate CHANGELOG files automatically from our commit messages.\n\n1. **Clean the CHANGELOGs**\n\n   Lerna sometimes adds empty changelog entries. For example, if `react-tinacms` is changed\n   then `tinacms` will get get a patch update with only the dependency updated. Make sure to install `lerna-clean-changelog-cli`:\n\n   ```\n   npm i -g lerna-clean-changelogs-cli\n   ```\n\n1. **Publish to NPM:**\n\n   You must have an NPM_TOKEN set locally that has access to the `@tinacms` organization\n\n1. **Push CHANGELOGs and Git tags to Github:**\n\n   Let everyone know!\n\nThe exact commands vary slightly depending on the type of release being made.\n\n### Prerelease\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-prerelease \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): prerelease"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package --dist-tag next\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Graduating Prereleases\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-graduate \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): graduation"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1) **Publish to NPM:**\n\n   ```\n   lerna publish from-package\n   ```\n\n1) **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Release\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --no-push \\\n     --allow-branch master \\\n     -m "chore(publish): release"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n',
-              message: 'Error: listItem inside list item is not supported',
-              children: [
-                {
-                  type: 'text',
-                  text: '',
-                },
-              ],
-            },
-          ],
-        },
-      },
-    }
+      }
 
-    test('returns warning', () => {
-      const result = validateRichText(dummyDoc)
-      expect(result.filter((r) => r.level == 'warning')).toHaveLength(1)
-      expect(result.filter((r) => r.level == 'error')).toHaveLength(0)
-      expect(result[0].docPath == 'content/posts/hello-world.md')
+      test('returns warning', () => {
+        const result = validateRichText(dummyDoc)
+        expect(result.filter((r) => r.level == 'warning')).toHaveLength(1)
+        expect(result.filter((r) => r.level == 'error')).toHaveLength(0)
+        expect(result[0].docPath == 'content/posts/hello-world.md')
+      })
+    })
+
+    describe('as root field', () => {
+      const dummyDoc = {
+        _sys: {
+          extension: 'md',
+          path: 'content/posts/hello-world.md',
+          relativePath: 'posts/md',
+        },
+        _values: {
+          date: '2021-07-12T07:00:00.000Z',
+          _body: {
+            type: 'root',
+            children: [
+              {
+                type: 'invalid_markdown',
+                value:
+                  '\n\n## Overarching Process\n\nTina has three main branches:\n\n- **master:** The bleeding edge of tinacms\n- **next:** A preview of the next release\n- **latest:** The current stable release\n\nThe flow of changes therefore looks like:\n\n> `fix-some-bug` => `master` => `next` => `latest`\n\nThe process happens over a week:\n\n- On Monday\n  1. `next` is merged into `latest`; then `latest` is published to npm\n  2. `master` is merged into `next`; then `next` is published to npm\n- Any hot fixes for bugs will be cherry picked into `next` and `latest`\n  and the published accordingly.\n- Every pull request merged to `master` automatically triggers a\n  `canary` release.\n\nWith this process:\n\n- all accepted changes are available as `canary` releases for early testing\n- critical fixes are published as soon as possible\n- new features and minor fixes take ~1.5 weeks to be published\n\n## Steps to Release\n\nThe general release process looks like this:\n\n1. **Build the source files:**\n\n   The source must be compiled, minified, and uglified in preparation for release.\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   We use `lerna` to generate CHANGELOG files automatically from our commit messages.\n\n1. **Clean the CHANGELOGs**\n\n   Lerna sometimes adds empty changelog entries. For example, if `react-tinacms` is changed\n   then `tinacms` will get get a patch update with only the dependency updated. Make sure to install `lerna-clean-changelog-cli`:\n\n   ```\n   npm i -g lerna-clean-changelogs-cli\n   ```\n\n1. **Publish to NPM:**\n\n   You must have an NPM_TOKEN set locally that has access to the `@tinacms` organization\n\n1. **Push CHANGELOGs and Git tags to Github:**\n\n   Let everyone know!\n\nThe exact commands vary slightly depending on the type of release being made.\n\n### Prerelease\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-prerelease \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): prerelease"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package --dist-tag next\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Graduating Prereleases\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --conventional-graduate \\\n     --no-push \\\n     --allow-branch next \\\n     -m "chore(publish): graduation"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1) **Publish to NPM:**\n\n   ```\n   lerna publish from-package\n   ```\n\n1) **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n\n### Release\n\n1. **Build the source files:**\n\n   ```\n   npm run build\n   ```\n\n1. **Generate CHANGELOGs and Git tags:**\n\n   ```\n   lerna version \\\n     --conventional-commits \\\n     --no-push \\\n     --allow-branch master \\\n     -m "chore(publish): release"\n   ```\n\n1. **Clean the CHANGELOGs**\n\n   ```\n   lcc ** && git commit -am "chore: clean changelogs"\n   ```\n\n1. **Publish to NPM:**\n   ```\n   lerna publish from-package\n   ```\n1. **Push CHANGELOGs and Git tags to Github:**\n   ```\n   git push && git push --tags\n   ```\n',
+                message: 'Error: listItem inside list item is not supported',
+                children: [
+                  {
+                    type: 'text',
+                    text: '',
+                  },
+                ],
+              },
+            ],
+          },
+        },
+      }
+
+      test('returns warning', () => {
+        const result = validateRichText(dummyDoc)
+        expect(result.filter((r) => r.level == 'warning')).toHaveLength(1)
+        expect(result.filter((r) => r.level == 'error')).toHaveLength(0)
+        expect(result[0].docPath == 'content/posts/hello-world.md')
+      })
     })
   })
 })

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
@@ -18,21 +18,18 @@ const validateValues = (values, addWarning: (message: string) => void) => {
     .map((fieldName) => values[fieldName])
     .filter((field) => typeof field === 'object')
 
-  fields
-    .filter((field) => field?.type == 'root')
-    .forEach((field) => {
-      const errorMessages = field.children
-        .filter((f) => f.type == 'invalid_markdown')
-        .map((f) => f.message)
-
-      errorMessages.forEach((errorMessage) => {
-        addWarning(errorMessage)
-      })
-    })
-
-  //check nested values
   fields.forEach((field) => {
     if (field) {
+      if (field?.type == 'root') {
+        const errorMessages = field.children
+          .filter((f) => f.type == 'invalid_markdown')
+          .map((f) => f.message)
+
+        errorMessages.forEach((errorMessage) => {
+          addWarning(errorMessage)
+        })
+      }
+
       validateValues(field, addWarning)
     }
   })

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
@@ -13,7 +13,7 @@ export const validateRichText = (node) => {
         .map((f) => f.message)
 
       errorMessages.forEach((errorMessage) => {
-        issues.push(new AuditWarning(errorMessage))
+        issues.push(new AuditWarning(errorMessage, node._sys.path))
       })
     })
 

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
@@ -1,3 +1,16 @@
+/**
+Copyright 2021 Forestry.io Holdings, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import { AuditIssue, AuditWarning } from '../issue'
 
 export const validateRichText = (node) => {

--- a/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
+++ b/packages/@tinacms/cli/src/cmds/audit/validations/validateRichText.ts
@@ -1,0 +1,21 @@
+import { AuditIssue, AuditWarning } from '../issue'
+
+export const validateRichText = (node) => {
+  let issues: AuditIssue[] = []
+  Object.keys(node._values)
+    .map((fieldName) => node._values[fieldName])
+    .filter((field) => {
+      return field?.type == 'root'
+    })
+    .forEach((field) => {
+      const errorMessages = field.children
+        .filter((f) => f.type == 'invalid_markdown')
+        .map((f) => f.message)
+
+      errorMessages.forEach((errorMessage) => {
+        issues.push(new AuditWarning(errorMessage))
+      })
+    })
+
+  return issues
+}

--- a/packages/@tinacms/cli/src/cmds/baseCmds.ts
+++ b/packages/@tinacms/cli/src/cmds/baseCmds.ts
@@ -11,7 +11,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { audit, printFinalMessage } from './audit'
+import { audit, printAudit } from './audit'
 import {
   checkDeps,
   initTina,
@@ -249,7 +249,7 @@ export const baseCmds: Command[] = [
             next()
           },
           audit,
-          printFinalMessage,
+          printAudit,
         ],
         options
       ),

--- a/packages/@tinacms/mdx/src/parse/index.ts
+++ b/packages/@tinacms/mdx/src/parse/index.ts
@@ -132,11 +132,11 @@ export const parseMDX = (
     } else {
       return { type: 'root', children: [] }
     }
-  } catch (e) {
+  } catch (e: any) {
     if (e instanceof RichTextParseError) {
       return invalidMarkdown(e, value)
     }
-    throw e
+    return invalidMarkdown(new RichTextParseError(e, e.position), value)
   }
 }
 


### PR DESCRIPTION
Currently, the document list blows up if there's an unexpected error in the body of any individual document's rich-text. 
This will handle those unexpected errors that we aren't specifically handling better, so we'll display an error instead in the rich-text field.

<img width="1013" alt="Screen Shot 2022-08-17 at 3 29 35 PM" src="https://user-images.githubusercontent.com/3323181/185215792-d24fae34-147e-43cb-ab77-ad3e84f30309.png">

<img width="687" alt="Screen Shot 2022-08-17 at 3 26 24 PM" src="https://user-images.githubusercontent.com/3323181/185215182-b4de2ac5-3838-41cd-b796-555bf8acf142.png">

To test, Add this invalid rich-text body to a markdown file:
https://github.com/tinacms/tina.io/blob/master/content/docs/contributing/releasing.md

---

Update: the audit functionality also needed to be updated with this change. Since we were letting requests with rich-text issues move the content api, we needed to update to CLI audit to still capture these issues.

Other than some general refactoring, the user-facing changes to audit:
- Fixed a bug where we were only auditing first 10 docs per collection
- Now that collection lists can be long, I'm only printing the actual warnings/errors
- We're now more likely to log ALL the document's issues, and not just break & stop on the first issue.
- We display the count of errors/warnings

<img width="1075" alt="Screen Shot 2022-08-23 at 3 44 42 PM" src="https://user-images.githubusercontent.com/3323181/186240449-6cace27c-b26f-427d-a238-fed6cd12f19f.png">

fixes ENG-497
fixes ENG-489
