### PR TITLE
Fix regression in handling images in rich-text

### DIFF
--- a/.changeset/many-gifts-dream.md
+++ b/.changeset/many-gifts-dream.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+Fix regression in handling images in rich-text

--- a/packages/@tinacms/mdx/src/parse/plate.ts
+++ b/packages/@tinacms/mdx/src/parse/plate.ts
@@ -96,6 +96,7 @@ export type BlockElement =
   | BlockquoteElement
   | MdxBlockElement
   | HTMLElement
+  | ImageElement
   | UnorderedListElement
   | OrderedListElement
   | ListItemElement

--- a/packages/@tinacms/mdx/src/stringify/index.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.ts
@@ -186,6 +186,13 @@ export const blockElement = (
         value: content.value,
       }
     }
+    case 'img':
+      return {
+        type: 'image',
+        url: imageCallback(content.url),
+        alt: content.alt,
+        title: content.caption,
+      }
     default:
       throw new Error(`BlockElement: ${content.type} is not yet supported`)
   }


### PR DESCRIPTION
In some cases the an image is dropped it without being wrapped in a `<p>`, we weren't handling that properly so this

Closes https://github.com/tinacms/tinacms/issues/3108