### PR TITLE
feat: allow paths to start with numeric characters

### DIFF
--- a/.changeset/tall-forks-travel.md
+++ b/.changeset/tall-forks-travel.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Allow paths to start with numeric characters

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -137,9 +137,9 @@ const RenderForm = ({ cms, collection, templateName, mutationInfo }) => {
               return true
             }
 
-            const isValid = /^[_a-zA-Z][\.\-_\/a-zA-Z0-9]*$/.test(value)
+            const isValid = /^[_a-zA-Z0-9][\.\-_\/a-zA-Z0-9]*$/.test(value)
             if (value && !isValid) {
-              return 'Must begin with a-z, A-Z, or _ and contain only a-z, A-Z, 0-9, -, _, ., or /.'
+              return 'Must begin with a-z, A-Z, 0-9, or _ and contain only a-z, A-Z, 0-9, -, _, ., or /.'
             }
           },
         },

--- a/packages/tinacms/src/hooks/use-content-creator.tsx
+++ b/packages/tinacms/src/hooks/use-content-creator.tsx
@@ -159,9 +159,9 @@ export const useDocumentCreatorPlugin = (args?: DocumentCreatorArgs) => {
                  * https://github.com/tinacms/tina-graphql-gateway/blob/682e2ed54c51520d1a87fac2887950839892f465/packages/tina-graphql-gateway-cli/src/cmds/compile/index.ts#L296
                  * */
 
-                const isValid = /^[_a-zA-Z][-,_a-zA-Z0-9]*$/.test(value)
+                const isValid = /^[_a-zA-Z0-9][\-_a-zA-Z0-9]*$/.test(value)
                 if (value && !isValid) {
-                  return 'Must begin with a-z, A-Z, or _ and contain only a-z, A-Z, 0-9, - or _'
+                  return 'Must begin with a-z, A-Z, 0-9, or _ and contain only a-z, A-Z, 0-9, - or _'
                 }
               },
             },


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

Allows numeric characters at the start of filenames to facilitate existing practices which include storing blog posts with the date prefixed or date based folder hierarchies. (e.g. Jekyll style `2022-08-21-blog-title-slug.md` files)

also updated a regex that appeared to be malformed and did not match the error description by allowing `,` characters.