### PR TITLE
Fix stringification of code element nested in link

### DIFF
--- a/.changeset/fuzzy-students-trade.md
+++ b/.changeset/fuzzy-students-trade.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+Fix stringification of code element nested in link

--- a/packages/@tinacms/mdx/src/stringify/marks.ts
+++ b/packages/@tinacms/mdx/src/stringify/marks.ts
@@ -77,7 +77,7 @@ const replaceLinksWithTextNodes = (content: Plate.InlineElement[]) => {
                 type: 'link',
                 url: item.url,
                 title: item.title,
-                children: [text({ text: a.value })],
+                children: [a],
               }
             },
           })
@@ -225,11 +225,12 @@ export const eat = (
     if (nonMatchingSiblingIndex) {
       throw new Error(`Marks inside inline code are not supported`)
     }
+    const node = {
+      type: markToProcess,
+      value: first.text,
+    }
     return [
-      {
-        type: markToProcess,
-        value: first.text,
-      },
+      first.linkifyTextNode?.(node) ?? node,
       ...eat(content.slice(nonMatchingSiblingIndex + 1), field, imageCallback),
     ]
   }

--- a/packages/@tinacms/mdx/src/tests/autotest/kitchen sink.md
+++ b/packages/@tinacms/mdx/src/tests/autotest/kitchen sink.md
@@ -41,3 +41,7 @@ This is [an example](http://example.com "Example") link.
 This paragraph has some `code` in it.
 
 ![Alt Text](https://get.svg.workers.dev "Image Title")
+
+This is a **paragraph with *nested* emphasis**.
+
+This is a [`link in code`](http://example.com)

--- a/packages/@tinacms/mdx/src/tests/autotest/kitchen sink.test.ts
+++ b/packages/@tinacms/mdx/src/tests/autotest/kitchen sink.test.ts
@@ -150,6 +150,27 @@ const out = output({
         },
       ],
     },
+    {
+      type: 'p',
+      children: [
+        { type: 'text', text: 'This is a ' },
+        { type: 'text', text: 'paragraph with ', bold: true },
+        { type: 'text', text: 'nested', bold: true, italic: true },
+        { type: 'text', text: ' emphasis', bold: true },
+        { type: 'text', text: '.' },
+      ],
+    },
+    {
+      type: 'p',
+      children: [
+        { type: 'text', text: 'This is a ' },
+        {
+          type: 'a',
+          url: 'http://example.com',
+          children: [{ type: 'text', text: 'link in code', code: true }],
+        },
+      ],
+    },
   ],
 })
 


### PR DESCRIPTION
Add missing call to `linkifyTextNode` when handling `inlineCode` elements.
Also add a test case for #3078.