### PR TITLE
Fix list page breaking for templates on collection

### DIFF
--- a/.changeset/quick-seas-eat.md
+++ b/.changeset/quick-seas-eat.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix list page breaking for templates on collection

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -40,7 +40,7 @@ export const useGetCollection = (
       if (await api.isAuthenticated()) {
         const { name, order } = JSON.parse(sortKey || '{}')
         const validSortKey = collectionExtra.fields
-          .map((x) => x.name)
+          ?.map((x) => x.name)
           .includes(name)
           ? name
           : undefined

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -178,7 +178,7 @@ const CollectionListPage = () => {
               const documents = collection.documents.edges
               const admin: TinaAdminApi = cms.api.admin
               const pageInfo = collection.documents.pageInfo
-              const fields = collectionExtra.fields.filter((x) =>
+              const fields = collectionExtra.fields?.filter((x) =>
                 // only allow sortable fields
                 ['string', 'number', 'datetime'].includes(x.type)
               )


### PR DESCRIPTION
A collection doesn't have to have fields, so optional chain off the `fields` property.
This does mean collections with `templates` aren't sortable.

Fixes #3087.