### PR TITLE
Alert Improvements

### DIFF
--- a/.changeset/wild-cobras-beam.md
+++ b/.changeset/wild-cobras-beam.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+Errors are now blocking modals.

--- a/packages/@tinacms/toolkit/src/packages/alerts/alerts.ts
+++ b/packages/@tinacms/toolkit/src/packages/alerts/alerts.ts
@@ -74,7 +74,7 @@ export class Alerts {
       this.dismiss(alert)
     }
 
-    timeoutId = setTimeout(dismiss, alert.timeout)
+    timeoutId = level !== 'error' ? setTimeout(dismiss, alert.timeout) : null
 
     return dismiss
   }

--- a/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.test.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.test.tsx
@@ -58,7 +58,7 @@ describe('Alerts', () => {
         const alerts = createMockAlerts([alert])
         const output = render(<Alerts alerts={alerts} />)
 
-        output.getByText(alert.message).click()
+        output.getByRole('button').click()
 
         expect(alerts.dismiss).toHaveBeenCalledWith(alert)
       })

--- a/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.tsx
@@ -22,6 +22,14 @@ import {
   CloseIcon,
 } from '../icons'
 import { useSubscribable } from '../react-core'
+import {
+  Modal,
+  ModalActions,
+  ModalBody,
+  ModalHeader,
+  PopupModal,
+} from '../react-modals'
+import { Button } from '../styles'
 
 export interface AlertsProps {
   alerts: AlertsCollection
@@ -35,27 +43,67 @@ export function Alerts({ alerts }: AlertsProps) {
   }
 
   return (
-    <AlertContainer>
-      {alerts.all.map((alert, i) => {
-        return (
-          <Alert
-            key={alert.id}
-            index={i}
-            level={alert.level}
-            onClick={() => {
-              alerts.dismiss(alert)
-            }}
-          >
-            {alert.level === 'info' && <InfoIcon />}
-            {alert.level === 'success' && <AlertIcon />}
-            {alert.level === 'warn' && <WarningIcon />}
-            {alert.level === 'error' && <ErrorIcon />}
-            <p>{alert.message}</p>
-            <CloseAlert />
-          </Alert>
-        )
-      })}
-    </AlertContainer>
+    <>
+      <AlertContainer>
+        {alerts.all
+          .filter((alert) => {
+            return alert.level !== 'error'
+          })
+          .map((alert, i) => {
+            return (
+              <Alert key={alert.id} index={i} level={alert.level}>
+                {alert.level === 'info' && <InfoIcon />}
+                {alert.level === 'success' && <AlertIcon />}
+                {alert.level === 'warn' && <WarningIcon />}
+                <p>{alert.message}</p>
+                <CloseAlert
+                  onClick={() => {
+                    alerts.dismiss(alert)
+                  }}
+                />
+              </Alert>
+            )
+          })}
+      </AlertContainer>
+      {alerts.all
+        .filter((alert) => {
+          return alert.level === 'error'
+        })
+        .map((alert, i) => {
+          const AlertMessage = alert.message
+
+          return (
+            <Modal>
+              <PopupModal>
+                <ModalHeader
+                  close={() => {
+                    alerts.dismiss(alert)
+                  }}
+                >
+                  <ErrorIcon className="mr-1 w-6 h-auto fill-current inline-block text-red-600" />{' '}
+                  Error
+                </ModalHeader>
+                <ModalBody padded={true}>
+                  <div className="tina-prose">
+                    <AlertMessage />
+                  </div>
+                </ModalBody>
+                <ModalActions>
+                  <div className="flex-1"></div>
+                  <Button
+                    style={{ flexGrow: 1 }}
+                    onClick={() => {
+                      alerts.dismiss(alert)
+                    }}
+                  >
+                    Close
+                  </Button>
+                </ModalActions>
+              </PopupModal>
+            </Modal>
+          )
+        })}
+    </>
   )
 }
 

--- a/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.tsx
@@ -112,7 +112,9 @@ const Alert = styled.div<{ level: AlertLevel; index: number }>`
 
   p {
     margin: 0;
-    flex: 1 0 auto;
+    flex: 1 1 auto;
+    white-space: wrap;
+    max-width: 680px;
     text-align: left;
   }
 

--- a/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.tsx
+++ b/packages/@tinacms/toolkit/src/packages/react-alerts/Alerts.tsx
@@ -69,11 +69,16 @@ export function Alerts({ alerts }: AlertsProps) {
         .filter((alert) => {
           return alert.level === 'error'
         })
-        .map((alert, i) => {
-          const AlertMessage = alert.message
+        .map((alert) => {
+          const AlertMessage =
+            typeof alert.message === 'string'
+              ? () => {
+                  return <p className="text-base mb-3">{alert.message}</p>
+                }
+              : alert.message
 
           return (
-            <Modal>
+            <Modal key={alert.id}>
               <PopupModal>
                 <ModalHeader
                   close={() => {

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -55,8 +55,7 @@ export const useGetCollection = (
           setCollection(collection)
         } catch (error) {
           cms.alerts.error(
-            `[${error.name}] GetCollection failed: ${error.message}`,
-            30 * 1000 // 30 seconds
+            `[${error.name}] GetCollection failed: ${error.message}`
           )
           console.error(error)
           setCollection(undefined)

--- a/packages/tinacms/src/admin/components/GetDocument.tsx
+++ b/packages/tinacms/src/admin/components/GetDocument.tsx
@@ -35,8 +35,7 @@ export const useGetDocument = (
           setDocument(response.document)
         } catch (error) {
           cms.alerts.error(
-            `[${error.name}] GetDocument failed: ${error.message}`,
-            30 * 1000 // 30 seconds
+            `[${error.name}] GetDocument failed: ${error.message}`
           )
           console.error(error)
           setDocument(undefined)

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -53,8 +53,8 @@ const createDocument = async (
   if (await api.isAuthenticated()) {
     await api.createDocument(collection.name, relativePath, params)
   } else {
-    const authMessage = `[Error] CreateDocument failed: User is no longer authenticated; please login and try again.`
-    cms.alerts.error(authMessage, 30 * 1000)
+    const authMessage = `CreateDocument failed: User is no longer authenticated; please login and try again.`
+    cms.alerts.error(authMessage)
     console.error(authMessage)
     return false
   }

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -42,8 +42,8 @@ const updateDocument = async (
   if (await api.isAuthenticated()) {
     await api.updateDocument(collection.name, relativePath, params)
   } else {
-    const authMessage = `[Error] UpdateDocument failed: User is no longer authenticated; please login and try again.`
-    cms.alerts.error(authMessage, 30 * 1000)
+    const authMessage = `UpdateDocument failed: User is no longer authenticated; please login and try again.`
+    cms.alerts.error(authMessage)
     console.error(authMessage)
     return false
   }

--- a/packages/tinacms/src/hooks/formify/index.ts
+++ b/packages/tinacms/src/hooks/formify/index.ts
@@ -447,7 +447,7 @@ export const useFormify = ({
                 })
               })
               .catch((e) => {
-                cms.alerts.error(`Unexpected error fetching reference`)
+                cms.alerts.error(`Unexpected error fetching reference.`)
                 console.log(e)
               })
           }

--- a/packages/tinacms/src/hooks/formify/util.ts
+++ b/packages/tinacms/src/hooks/formify/util.ts
@@ -223,13 +223,13 @@ export const buildForm = (
             })
             cms.alerts.success('Document saved!')
           } catch (e) {
-            cms.alerts.error('There was a problem saving your document')
+            cms.alerts.error('There was a problem saving your document.')
             console.error(e)
           }
         }
       } catch (e) {
         console.error(e)
-        cms.alerts.error('There was a problem saving your document')
+        cms.alerts.error('There was a problem saving your document.')
       }
     },
   }


### PR DESCRIPTION
- Fixes alerts so only the close button dismisses them (or the timeout) and text wraps, allowing for longer alert messages.
- Converts error alerts to a blocking modal that doesn't have a timeout.
- Error modal supports providing a component instead of a string so that formatting and links can be provided, but it will render out strings inside a paragraph so that it's compatible with existing errors.

Fixes #3101

Example:

Code: 

```
cms.alerts.error(() => {
  return (
    <>
      <p className="text-base mb-3">
        This is an example error with a link. You can click the link
        without dismissing it.
      </p>
      <a
        className="flex items-center transition-all duration-150 ease-out text-blue-600 hover:text-blue-400 hover:underline no-underline"
        href="#"
      >
        Example Link{' '}
        <MdArrowForward className="w-4 h-auto ml-1.5 opacity-80" />
      </a>
    </>
  )
})
```

How it's rendered:

<img width="1002" alt="Screen Shot 2022-08-24 at 2 44 14 PM" src="https://user-images.githubusercontent.com/5075484/186487472-5ce793fa-712b-4352-acdc-b6a4f2429886.png">

Right now a lot of code is needed to render a pretty trivial error, given you have to provide your own styling. There's a few ways I could possibly improve the DX but I'm not sure what approach to take.

closes ENG-488