### PR TITLE
fix: ENG-502: fix subfolder matching document name issue

### DIFF
--- a/.changeset/clean-pets-poke.md
+++ b/.changeset/clean-pets-poke.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/datalayer': patch
+---
+
+Fix issue where if a subfolder exists in a collection that matches a document, editing that document creates null commits

--- a/packages/@tinacms/datalayer/src/database/bridge/isomorphic.ts
+++ b/packages/@tinacms/datalayer/src/database/bridge/isomorphic.ts
@@ -23,6 +23,7 @@ import type { Bridge } from './index'
 import globParent from 'glob-parent'
 import normalize from 'normalize-path'
 import { GraphQLError } from 'graphql'
+import { dirname } from 'path'
 
 const flat =
   typeof Array.prototype.flat === 'undefined'
@@ -196,8 +197,18 @@ export class IsomorphicBridge implements Bridge {
     const result = await git.walk({
       ...this.isomorphicConfig,
       map: async (filepath, [head]) => {
-        if ((head as any)._fullpath === '.' || path.startsWith(filepath)) {
+        if ((head as any)._fullpath === '.') {
           return head
+        }
+        if (path.startsWith(filepath)) {
+          if (dirname(path) === dirname(filepath)) {
+            if (path === filepath) {
+              // same parent directory so this is the entry
+              return head
+            }
+          } else {
+            return head
+          }
         }
       },
       cache: this.cache,


### PR DESCRIPTION
# what

Fix issue where if a subfolder exists in a collection that matches a document, editing that document creates null commits.

The logic in the git tree walker was treating a subfolder matching the path of the file as a parent path of that file. This is fixed by adding an additional check such that when the parent directories are the same, it requires an exact match instead of a startsWith.