### PR TITLE
Fix admin list error on collections with templates

### DIFF
--- a/.changeset/shy-mirrors-laugh.md
+++ b/.changeset/shy-mirrors-laugh.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixes an issue where collections which used `templates` would error on the admin list page due to the recent addition of filters. Filters will only work for collections with `fields` at this time

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -40,7 +40,7 @@ export const useGetCollection = (
       if (await api.isAuthenticated()) {
         const { name, order } = JSON.parse(sortKey || '{}')
         const validSortKey = collectionExtra.fields
-          .map((x) => x.name)
+          ?.map((x) => x.name)
           .includes(name)
           ? name
           : undefined

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -178,7 +178,7 @@ const CollectionListPage = () => {
               const documents = collection.documents.edges
               const admin: TinaAdminApi = cms.api.admin
               const pageInfo = collection.documents.pageInfo
-              const fields = collectionExtra.fields.filter((x) =>
+              const fields = collectionExtra.fields?.filter((x) =>
                 // only allow sortable fields
                 ['string', 'number', 'datetime'].includes(x.type)
               )
@@ -215,7 +215,7 @@ const CollectionListPage = () => {
                               : collection.name}
                           </h3>
 
-                          {fields.length > 0 && (
+                          {fields?.length > 0 && (
                             <div className="flex gap-2 items-center">
                               <label
                                 htmlFor="sort"


### PR DESCRIPTION
Fixes an issue where collections which used  would error on the admin list page due to the recent addition of filters. Filters will only work for collections with  at this time

Closes https://github.com/tinacms/tinacms/issues/3132