### PR TITLE
use Tina url override in generated client

### DIFF
--- a/.changeset/spicy-poems-jog.md
+++ b/.changeset/spicy-poems-jog.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/cli': patch
+'@tinacms/schema-tools': patch
+'tinacms': patch
+---
+
+Use tinaio url config override in the client

--- a/experimental-examples/tina-cloud-starter/.tina/config.ts
+++ b/experimental-examples/tina-cloud-starter/.tina/config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
   //   outputFolder: "tina",
   //   publicFolder: "public",
   // },
+  // tinaioConfig: {
+  //   contentApiUrlOverride: "foo.io",
+  // },
   branch: "main",
   clientId: "foobar",
   token: "foo",

--- a/packages/@tinacms/cli/src/cmds/query-gen/genTypes.ts
+++ b/packages/@tinacms/cli/src/cmds/query-gen/genTypes.ts
@@ -34,6 +34,9 @@ export async function genClient(
   const branch = tinaSchema?.config?.branch
   const clientId = tinaSchema?.config?.clientId
   const token = tinaSchema.config?.token
+  const baseUrl =
+    tinaSchema?.config?.tinaioConfig?.contentApiUrlOverride ||
+    `https://${TINA_HOST}`
 
   if ((!branch || !clientId || !token) && !options?.local) {
     const missing = []
@@ -50,7 +53,7 @@ export async function genClient(
 
   const apiURL = options.local
     ? 'http://localhost:4001/graphql'
-    : `https://${TINA_HOST}/content/${clientId}/github/${branch}`
+    : `${baseUrl}/content/${clientId}/github/${branch}`
 
   const clientPath = p.join(generatedPath, `client.${usingTs ? 'ts' : 'js'}`)
   fs.writeFileSync(

--- a/packages/@tinacms/schema-tools/src/types/config.ts
+++ b/packages/@tinacms/schema-tools/src/types/config.ts
@@ -39,4 +39,14 @@ export interface TinaCloudSchemaConfig<Store = any> {
       mediaRoot: string
     }
   }
+
+  /**
+   * Used to override the default Tina Cloud API URL
+   */
+  tinaioConfig?: {
+    assetsApiUrlOverride?: string // https://assets.tinajs.io
+    frontendUrlOverride?: string // https://app.tina.io
+    identityApiUrlOverride?: string // https://identity.tinajs.io
+    contentApiUrlOverride?: string // https://content.tinajs.io
+  }
 }

--- a/packages/tinacms/src/unifiedClient/index.ts
+++ b/packages/tinacms/src/unifiedClient/index.ts
@@ -122,12 +122,6 @@ export class TinaClient<GenQueries> {
 
     // TODO if !result || !result.clientId || !result.branch, throw an error
 
-    if (params.host !== TINA_HOST) {
-      throw new Error(
-        `The only supported hosts are ${TINA_HOST} or localhost, but received ${params.host}.`
-      )
-    }
-
     return {
       host: params.host,
       clientId,

--- a/packages/tinacms/src/utils/parseUrl.ts
+++ b/packages/tinacms/src/utils/parseUrl.ts
@@ -35,12 +35,6 @@ export const parseURL = (url: string): { branch; isLocalClient; clientId } => {
 
   // TODO if !result || !result.clientId || !result.branch, throw an error
 
-  if (params.host !== TINA_HOST) {
-    throw new Error(
-      `The only supported hosts are ${TINA_HOST} or localhost, but received ${params.host}.`
-    )
-  }
-
   return {
     branch,
     clientId,


### PR DESCRIPTION
- remove the check for the correct domain name (we are generating this so it should never be incorrect)
- use the override url if it is provided
