### PR TITLE
Fix/3127

### DIFF
--- a/.changeset/weak-turkeys-marry.md
+++ b/.changeset/weak-turkeys-marry.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': minor
+---
+
+Fix reference field loading only 10 first nodes in collection

--- a/packages/@tinacms/toolkit/src/packages/fields/components/Reference/ReferenceSelect.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/Reference/ReferenceSelect.tsx
@@ -17,11 +17,11 @@ limitations under the License.
 */
 
 import * as React from 'react'
-import type { TinaCMS } from '../../../../tina-cms'
-import type { ReferenceFieldProps } from './index'
-import { selectFieldClasses } from '../Select'
-import { LoadingDots } from '../../../form-builder'
 import { MdKeyboardArrowDown } from 'react-icons/md'
+import type { TinaCMS } from '../../../../tina-cms'
+import { LoadingDots } from '../../../form-builder'
+import { selectFieldClasses } from '../Select'
+import type { ReferenceFieldProps } from './index'
 
 interface ReferenceSelectProps {
   cms: TinaCMS
@@ -61,7 +61,7 @@ const useGetOptionSets = (cms: TinaCMS, collections: string[]) => {
               `#graphql
             query ($collection: String!){
               collection(collection: $collection) {
-                documents {
+                documents(first: -1) {
                   edges {
                     node {
                       ...on Node {


### PR DESCRIPTION
This pull request fixes an issue where reference field would show only 10 first nodes of collection in the CMS form. 

By querying `documents(first: -1)` we remove default pagination of the GraphQL request for the field. 

Fixes #3127