### PR TITLE
port in use: CLI error handling

### DIFF
--- a/.changeset/fair-horses-yell.md
+++ b/.changeset/fair-horses-yell.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+fix: Don't run subprocess if main process fails with occupied port

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -124,8 +124,8 @@ export async function startServer(
       })
       state.server.on('error', function (e) {
         if (e.code === 'EADDRINUSE') {
-          logger.error(dangerText(`Port 4001 already in use`))
-          process.exit()
+          logger.error(dangerText(`Port ${port} already in use`))
+          process.exit(1)
         }
         throw e
       })


### PR DESCRIPTION
Fixes a few issues with the CLI error handling:
- Fixes issue where subprocess would still run if port was in use.
- Don't exist with success when initial build fails