### PR TITLE
Fix drag-n-drop on local dev

### DIFF
--- a/.changeset/polite-mails-smile.md
+++ b/.changeset/polite-mails-smile.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix issue where drag-n-drop on image fields wasn't working with the repo-based media on local dev

--- a/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
+++ b/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
@@ -171,6 +171,7 @@ export class TinaMediaStore implements MediaStore {
           filename: file.name,
           directory,
           previewSrc: path,
+          src: path,
         }
 
         newFiles.push(parsedRes)


### PR DESCRIPTION
Fix issue where drag-n-drop on image fields wasn't working with the repo-based media on local dev.

I think some of us saw it working and not working at times, I assume that's because the `persist_cloud` returns a `src` attribute so things are fine there.
