### PR TITLE
Revert "Fix rich text dropdown overlap issue"

### DIFF
--- a/.changeset/slow-clocks-play.md
+++ b/.changeset/slow-clocks-play.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/toolkit": patch
+---
+
+Revert "Fix rich text dropdown overlap issue" which was causing field labels to live underneath their inputs

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -95,7 +95,7 @@ export const FieldWrapper = ({
   children: React.ReactNode
 } & Partial<React.ComponentPropsWithoutRef<'div'>>) => {
   return (
-    <div className={`relative ${margin ? `mb-5 first:mb-0` : ``}`} {...props}>
+    <div className={`relative ${margin ? `mb-5 last:mb-0` : ``}`} {...props}>
       {children}
     </div>
   )

--- a/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/fields-builder.tsx
@@ -48,7 +48,7 @@ export function FieldsBuilder({
   return (
     // @ts-ignore FIXME twind
     <FieldsGroup padding={padding}>
-      {[...fields].reverse().map((field: Field) => (
+      {fields.map((field: Field) => (
         <InnerField
           key={field.name}
           field={field}
@@ -156,7 +156,7 @@ export const FieldsGroup = ({
 }) => {
   return (
     <div
-      className={`relative w-full h-full whitespace-nowrap overflow-x-visible flex flex-col-reverse ${
+      className={`relative block w-full h-full whitespace-nowrap overflow-x-visible ${
         padding ? `pb-5` : ``
       }`}
     >


### PR DESCRIPTION
Reverts tinacms/tinacms#3177

This seems to be causing some issues. The label is under the fields. 

<img width="482" alt="Screen Shot 2022-09-23 at 1 42 43 PM" src="https://user-images.githubusercontent.com/5414297/192054055-d047b4d2-7734-4d42-998b-89e641ecc370.png">


I'd like to know a bit more context about this PR and why it's necessary to reverse the fields and handle the order with `flex-col-reverse`

cc @Phoenix-Alpha 