### PR TITLE
fix timeouts

### DIFF
--- a/packages/@tinacms/datalayer/src/database/bridge/isomorphic.test.ts
+++ b/packages/@tinacms/datalayer/src/database/bridge/isomorphic.test.ts
@@ -16,7 +16,7 @@ import git from 'isomorphic-git'
 import { IsomorphicBridge } from './isomorphic'
 
 // Fix issue with test timing out
-jest.setTimeout(10000)
+jest.setTimeout(20000)
 
 describe('isomorphic bridge', () => {
   let contentMap: Record<string, string>


### PR DESCRIPTION
Some tests are failing on `main` because of a timeout issue (only happening on MacOS) this updates the timeout.