### PR TITLE
Filename UI

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/fields/components/TextField.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/TextField.tsx
@@ -29,13 +29,14 @@ export interface TextFieldProps extends a {
 
 export const textFieldClasses =
   'shadow-inner focus:shadow-outline focus:border-blue-500 focus:outline-none block text-base px-3 py-2 text-gray-600 w-full bg-white border border-gray-200 transition-all ease-out duration-150 focus:text-gray-900 rounded-md'
-const disabledClasses =
-  'bg-gray-100 pointer-events-none	opacity-30 cursor-not-allowed'
+const disabledClasses = 'opacity-50 pointer-events-none cursor-not-allowed'
 export const BaseTextField = ({ ...props }) => {
   return (
     <input
       type="text"
-      className={`${textFieldClasses}${props?.disabled ? disabledClasses : ''}`}
+      className={`${textFieldClasses} ${
+        props?.disabled ? disabledClasses : ''
+      }`}
       {...props}
     />
   )

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -11,7 +11,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { Form, FormBuilder, FormStatus } from '@tinacms/toolkit'
+import {
+  BaseTextField,
+  Form,
+  FormBuilder,
+  FormStatus,
+  wrapFieldsWithMeta,
+} from '@tinacms/toolkit'
 import { Link, useNavigate, useParams } from 'react-router-dom'
 import React, { useMemo, useState } from 'react'
 import { TinaSchema, resolveForm } from '@tinacms/schema-tools'
@@ -26,6 +32,7 @@ import { TinaAdminApi } from '../api'
 import type { TinaCMS } from '@tinacms/toolkit'
 import { transformDocumentIntoMutationRequestPayload } from '../../hooks/use-graphql-forms'
 import { useWindowWidth } from '@react-hook/window-size'
+import { BiPencil } from 'react-icons/bi'
 
 const createDocument = async (
   cms: TinaCMS,
@@ -93,6 +100,37 @@ const CollectionCreatePage = () => {
   )
 }
 
+const FilenameInput = (props) => {
+  const [filenameTouched, setFilenameTouched] = React.useState(false)
+
+  return (
+    <div
+      className="group relative block cursor-pointer"
+      onClick={() => {
+        setFilenameTouched(true)
+      }}
+    >
+      <input
+        type="text"
+        className={`shadow-inner focus:shadow-outline focus:border-blue-500 focus:outline-none block text-base pl-3 truncate py-2 w-full border transition-all ease-out duration-150 focus:text-gray-900 rounded-md ${
+          props.readonly || !filenameTouched
+            ? 'bg-gray-50 text-gray-300  border-gray-100 pointer-events-none pr-8'
+            : 'bg-white text-gray-600  border-gray-200 pr-3'
+        }`}
+        {...props}
+        disabled={props.readonly || !filenameTouched}
+      />
+      <BiPencil
+        className={`absolute top-1/2 right-2 -translate-y-1/2 h-6 w-auto transition-opacity duration-150 ease-out ${
+          !filenameTouched && !props.readonly
+            ? 'opacity-30 group-hover:opacity-80'
+            : 'opacity-0'
+        }`}
+      />
+    </div>
+  )
+}
+
 const RenderForm = ({ cms, collection, templateName, mutationInfo }) => {
   const navigate = useNavigate()
   const [formIsPristine, setFormIsPristine] = useState(true)
@@ -151,7 +189,14 @@ const RenderForm = ({ cms, collection, templateName, mutationInfo }) => {
         {
           name: 'filename',
           label: 'Filename',
-          component: 'text',
+          component: wrapFieldsWithMeta(({ field, input, meta }) => {
+            return (
+              <FilenameInput
+                readonly={template?.ui?.filename?.readonly}
+                {...input}
+              />
+            )
+          }),
           disabled: template?.ui?.filename?.readonly,
           description: (
             <span>

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -123,7 +123,7 @@ const FilenameInput = (props) => {
       <BiPencil
         className={`absolute top-1/2 right-2 -translate-y-1/2 h-6 w-auto transition-opacity duration-150 ease-out ${
           !filenameTouched && !props.readonly
-            ? 'opacity-30 group-hover:opacity-80'
+            ? 'opacity-20 group-hover:opacity-80'
             : 'opacity-0'
         }`}
       />
@@ -189,14 +189,16 @@ const RenderForm = ({ cms, collection, templateName, mutationInfo }) => {
         {
           name: 'filename',
           label: 'Filename',
-          component: wrapFieldsWithMeta(({ field, input, meta }) => {
-            return (
-              <FilenameInput
-                readonly={template?.ui?.filename?.readonly}
-                {...input}
-              />
-            )
-          }),
+          component: slugFunction
+            ? wrapFieldsWithMeta(({ field, input, meta }) => {
+                return (
+                  <FilenameInput
+                    readonly={template?.ui?.filename?.readonly}
+                    {...input}
+                  />
+                )
+              })
+            : 'text',
           disabled: template?.ui?.filename?.readonly,
           description: (
             <span>


### PR DESCRIPTION
Replaces standard textfield with a custom filename component if a slugFunction is provided. The component renders like a disabled text field but with a little edit icon to indicate it can be edited. If it's clicked it enables the field for editing.

<img width="671" alt="Screen Shot 2022-10-03 at 5 19 33 PM" src="https://user-images.githubusercontent.com/5075484/193672849-632ab9e9-9f0f-4c1a-90b5-20bcf0e6a854.png">
