### PR TITLE
fix: Exit init on dep install error

### DIFF
--- a/.changeset/gold-guests-notice.md
+++ b/.changeset/gold-guests-notice.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Exit tinacms init when there's an error with dependency install

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -39,10 +39,10 @@ import { defaultSchema } from '../compile/defaultSchema'
  */
 export function execShellCommand(cmd): Promise<string> {
   const exec = require('child_process').exec
-  return new Promise((resolve, _reject) => {
+  return new Promise((resolve, reject) => {
     exec(cmd, (error, stdout, stderr) => {
       if (error) {
-        console.warn(error)
+        reject(error)
       }
       resolve(stdout ? stdout : stderr)
     })


### PR DESCRIPTION
Exit tinacms init when there's an error with dependency install

Exit with an error when a dependency error occurs:

<img width="614" alt="Screen Shot 2022-10-05 at 2 07 17 PM" src="https://user-images.githubusercontent.com/3323181/194120086-4e7b714f-de6b-4555-adba-3f0e104f8465.png">

Instead of:

<img width="594" alt="Screen Shot 2022-10-05 at 1 48 18 PM" src="https://user-images.githubusercontent.com/3323181/194120159-bfbac576-8bd7-4746-b0be-e443edffbf8e.png">

