### PR TITLE
fix: fs.rm "callback is not a function"

### DIFF
--- a/.changeset/wise-eels-hammer.md
+++ b/.changeset/wise-eels-hammer.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix for "callback is not a function" when running tinacms dev

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -48,7 +48,7 @@ export const buildSchema = async (
   const config = await fs
     .readFileSync(path.join(tempConfig, 'schema.json'))
     .toString()
-  fs.rmSync(tempConfig, { recursive: true, force: true })
+  await fs.remove(tempConfig)
 
   // only build the files, do not index
   const { graphQLSchema, tinaSchema } = await buildDotTinaFiles({

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -48,7 +48,7 @@ export const buildSchema = async (
   const config = await fs
     .readFileSync(path.join(tempConfig, 'schema.json'))
     .toString()
-  await fs.unlinkSync(tempConfig)
+  fs.rmSync(tempConfig, { recursive: true, force: true })
 
   // only build the files, do not index
   const { graphQLSchema, tinaSchema } = await buildDotTinaFiles({

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -48,7 +48,7 @@ export const buildSchema = async (
   const config = await fs
     .readFileSync(path.join(tempConfig, 'schema.json'))
     .toString()
-  await fs.rm(tempConfig, { recursive: true })
+  await fs.unlinkSync(tempConfig)
 
   // only build the files, do not index
   const { graphQLSchema, tinaSchema } = await buildDotTinaFiles({


### PR DESCRIPTION
Fix for "callback is not a function" when running tinacms dev