### PR TITLE
fix: use type field on file object instead of mime-types library due to issue discovered via #3254

### DIFF
--- a/.changeset/tough-lemons-ring.md
+++ b/.changeset/tough-lemons-ring.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix to use mime-type from file object instead of mime-types library

--- a/packages/@tinacms/toolkit/package.json
+++ b/packages/@tinacms/toolkit/package.json
@@ -83,7 +83,6 @@
     "final-form-set-field-data": "^1.0.2",
     "is-hotkey": "^0.2.0",
     "lodash.get": "^4.4.2",
-    "mime-types": "^2.1.24",
     "moment": "2.29.4",
     "monaco-editor": "0.31.0",
     "prism-react-renderer": "^1.3.5",

--- a/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
+++ b/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
@@ -26,7 +26,6 @@ import {
   E_BAD_ROUTE,
 } from './media'
 import { CMS } from './cms'
-import mime from 'mime-types'
 
 const s3ErrorRegex = /<Error>.*<Code>(.+)<\/Code>.*<Message>(.+)<\/Message>.*/
 
@@ -120,8 +119,7 @@ export class TinaMediaStore implements MediaStore {
           method: 'PUT',
           body: item.file,
           headers: {
-            'Content-Type':
-              mime.contentType(item.file.name) || 'application/octet-stream',
+            'Content-Type': item.file.type || 'application/octet-stream',
             'Content-Length': String(item.file.size),
           },
         })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -909,7 +909,6 @@ importers:
       is-hotkey: ^0.2.0
       jest: ^27.0.6
       lodash.get: ^4.4.2
-      mime-types: ^2.1.24
       moment: 2.29.4
       monaco-editor: 0.31.0
       prism-react-renderer: ^1.3.5
@@ -954,7 +953,6 @@ importers:
       final-form-set-field-data: 1.0.2_final-form@4.20.7
       is-hotkey: 0.2.0
       lodash.get: 4.4.2
-      mime-types: 2.1.35
       moment: 2.29.4
       monaco-editor: 0.31.0
       prism-react-renderer: 1.3.5_react@17.0.2


### PR DESCRIPTION
The contentType function in mime-types is no longer working (suspect a bundling issue). This is not necessary, though, since the mime type is already supplied on the file object. This PR removes the library and switches to using that field.
