### PR TITLE
fix: bullet/numbered list overflow out of text field (#3253)

### DIFF
--- a/.changeset/soft-forks-exist.md
+++ b/.changeset/soft-forks-exist.md
@@ -1,0 +1,11 @@
+---
+'@tinacms/toolkit': minor
+---
+
+Fix #3253 bullet/numbered list items overflow out of text fields
+
+# Change
+
+- Add `w-full` class to list item content to prevent text overflow to the right of sidebar as shown in #3253.
+- Also change `<ol></ol>` element class from `pl-2` to `pl-4` to fix numbered list's marker overflow to the left of text field.
+

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/components.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/components.tsx
@@ -205,7 +205,7 @@ export const components = () => {
         className={classNames(
           blockClasses,
           className,
-          'mb-4 pl-2 list-decimal list-inside last:mb-0'
+          'mb-4 pl-4 list-decimal list-inside last:mb-0'
         )}
         {...attributes}
         {...props}
@@ -222,7 +222,7 @@ export const components = () => {
     [ELEMENT_LIC]: ({ attributes, editor, element, className, ...props }) => (
       <span
         // without a min-width the cursor is hidden when the list is empty
-        className={classNames(className, 'inline-block align-top mb-2')}
+        className={classNames(className, 'w-full inline-block align-top mb-2')}
         {...attributes}
         {...props}
       />


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

Fix #3253 bullet/numbered list items overflow out of text fields

# Change

- Add `w-full` class to list item content to prevent text overflow to the right of sidebar as shown in #3253.
- Also change `<ol></ol>` element class from `pl-2` to `pl-4` to fix numbered list's marker overflow to the left of text field.


