### PR TITLE
Fix/option label

### DIFF
--- a/.changeset/stale-colts-sleep.md
+++ b/.changeset/stale-colts-sleep.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix the option labels

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -255,7 +255,7 @@ const CollectionListPage = () => {
                                     .map((x) => [
                                       {
                                         label:
-                                          x.label || x.name + ' (Ascending)',
+                                          (x.label || x.name) + ' (Ascending)',
                                         value: JSON.stringify({
                                           name: x.name,
                                           order: 'asc',
@@ -263,7 +263,7 @@ const CollectionListPage = () => {
                                       },
                                       {
                                         label:
-                                          x.label || x.name + ' (Descending)',
+                                          (x.label || x.name) + ' (Descending)',
                                         value: JSON.stringify({
                                           name: x.name,
                                           order: 'desc',


### PR DESCRIPTION
Labels where only correct when there was no label on the field. This PR corrects that

Before
<img width="404" alt="Screen Shot 2022-10-26 at 4 34 54 PM" src="https://user-images.githubusercontent.com/43075109/198132147-b2b78594-11b1-4277-aff7-56faddedf445.png">
After
<img width="404" alt="Screen Shot 2022-10-26 at 4 37 39 PM" src="https://user-images.githubusercontent.com/43075109/198132587-4ef39afd-04ec-487e-a038-5388beef116f.png">

