### PR TITLE
Fix dot menu popover displayed under blocks

### DIFF
--- a/.changeset/nine-boxes-pretend.md
+++ b/.changeset/nine-boxes-pretend.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+fix DotMenu Popover displayed under blocks

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/create-mdx-plugins/component.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/create-mdx-plugins/component.tsx
@@ -215,8 +215,8 @@ const DotMenu = ({ onOpen, onRemove }) => {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <Popover.Panel>
-          <div className="z-30 origin-top-right absolute right-0 mt-2 -mr-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
+        <Popover.Panel className="z-30 absolute origin-top-right right-0">
+          <div className="mt-2 -mr-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none">
             <div className="py-1">
               <span
                 onClick={onOpen}


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

As reported on the following issue: #3309 When two blocks having the "DotMenu" are below each other, if you try to open the menu of the first block it will be shown below the second block.

The issue was solved by moving the classes that are defining the position of the element from the `div` that is setting its appearance to the `Popover.Panel` element.

Before: 
![image](https://user-images.githubusercontent.com/38522984/198149845-156f53fb-cd81-4b74-9c0e-1d8f3222eb8d.png)


After:
![image](https://user-images.githubusercontent.com/38522984/198149467-78477f3c-a17c-45de-8224-d537da0bc7ac.png)
