### PR TITLE
Fix wrong background when hovering "Embed" button inside the toolbar

### DIFF
--- a/.changeset/strange-items-cheat.md
+++ b/.changeset/strange-items-cheat.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+fix wrong background when hovering the "Embed" button inside the toolbar

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/toolbar/toolbar-item.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/toolbar/toolbar-item.tsx
@@ -208,7 +208,7 @@ export const EmbedButton = ({
             onMouseDown={(e) => {
               e.preventDefault()
             }}
-            className={`cursor-pointer relative inline-flex items-center px-2 py-2 rounded-r-md border  text-sm font-medium transition-all ease-out duration-150 hover:bg-blue-500 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${
+            className={`cursor-pointer relative inline-flex items-center px-2 py-2 rounded-r-md border text-sm font-medium transition-all ease-out duration-150 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500 ${
               open
                 ? `bg-gray-50 border-gray-200 text-blue-500`
                 : `text-white border-blue-500 bg-blue-500`


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

As described in the issue opened earlier #3324 : The toolbar "embed" button shows a wrong background when opened and hovered.
Under these conditions the background turns blue and hides the text, since the text has the same color.

The issue was solved by removing the `hover:bg-blue-500` class from the always applied classes of the button, since it has the `bg-blue-500` class when the open state is `false`. 

Let me know if this behavior is the correct one, if not, I will fix it by changing the text color.


Before: 

This is a GIF click on it please.
![toolbar-embed-button-bug](https://user-images.githubusercontent.com/38522984/198158818-56dc3b87-f2e3-4594-a073-ed4d7fd78312.gif)

After:

This is a GIF click on it please.
![background-embed-button-fix](https://user-images.githubusercontent.com/38522984/198163758-40981229-c85e-4b18-8e65-4feedb913952.gif)

