### PR TITLE
Unwrap image block

### DIFF
--- a/.changeset/slow-eyes-pretend.md
+++ b/.changeset/slow-eyes-pretend.md
@@ -1,0 +1,8 @@
+---
+'@tinacms/mdx': patch
+---
+
+Treat images as block-level when they're isolated in a paragraph.
+
+Previously all images were nested inside `<p>` elements when coming from the server, but treated as block level by the rich-text editor. This resulted in a scenario where new paragraphs adjacent to images were nested
+in parent `<p>` tags, which caused an error.

--- a/packages/@tinacms/mdx/package.json
+++ b/packages/@tinacms/mdx/package.json
@@ -36,6 +36,7 @@
     "prettier": "^2.7.1",
     "remark": "^14.0.2",
     "remark-mdx": "^2.1.2",
+    "remark-unwrap-images": "^3.0.1",
     "unist-util-visit": "^4.1.0",
     "vfile": "^4.2.0"
   },

--- a/packages/@tinacms/mdx/src/parse/index.ts
+++ b/packages/@tinacms/mdx/src/parse/index.ts
@@ -18,6 +18,7 @@ limitations under the License.
 
 import { remark } from 'remark'
 import remarkMdx from 'remark-mdx'
+import remarkUnwrapImages from 'remark-unwrap-images'
 import { remarkToSlate, RichTextParseError } from './remarkToPlate'
 import type { RichTypeInner } from '@tinacms/schema-tools'
 import type * as Md from 'mdast'
@@ -101,12 +102,8 @@ export const markdownToAst = (value: string, field: RichTypeInner) => {
     if (!tree) {
       throw new Error('Error parsing markdown')
     }
-    // NOTE: if we want to provide error highlighing in the raw editor
-    // we could keep this info around in edit mode
-    // Delete useless position info
-    // visit(tree, (node) => {
-    //   delete node.position
-    // })
+    // @ts-ignore Not really how plugins are designed in remark https://github.com/remarkjs/remark/discussions/1014#discussioncomment-3139992
+    remarkUnwrapImages({})(tree)
     return tree
   } catch (e) {
     // @ts-ignore VMessage is the error type but it's not accessible

--- a/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
+++ b/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
@@ -64,6 +64,8 @@ export const remarkToSlate = (
         return code(content)
       case 'paragraph':
         return paragraph(content)
+      case 'image':
+        return image(content)
       case 'mdxJsxFlowElement':
         return mdxJsxElement(content, field, imageCallback)
       case 'thematicBreak':

--- a/packages/@tinacms/mdx/src/tests/autotest/image.test.ts
+++ b/packages/@tinacms/mdx/src/tests/autotest/image.test.ts
@@ -23,40 +23,25 @@ const out = output({
   type: 'root',
   children: [
     {
-      type: 'p',
-      children: [
-        {
-          type: 'img',
-          url: 'https://some-image.jpg',
-          alt: 'alt description',
-          caption: 'Some Title',
-          children: [{ type: 'text', text: '' }],
-        },
-      ],
+      type: 'img',
+      url: 'https://some-image.jpg',
+      alt: 'alt description',
+      caption: 'Some Title',
+      children: [{ type: 'text', text: '' }],
     },
     {
-      type: 'p',
-      children: [
-        {
-          type: 'img',
-          url: 'https://some-image.jpg',
-          alt: '',
-          caption: 'Some title',
-          children: [{ type: 'text', text: '' }],
-        },
-      ],
+      type: 'img',
+      url: 'https://some-image.jpg',
+      alt: '',
+      caption: 'Some title',
+      children: [{ type: 'text', text: '' }],
     },
     {
-      type: 'p',
-      children: [
-        {
-          type: 'img',
-          url: 'https://some-image.jpg',
-          alt: '',
-          caption: null,
-          children: [{ type: 'text', text: '' }],
-        },
-      ],
+      type: 'img',
+      url: 'https://some-image.jpg',
+      alt: '',
+      caption: null,
+      children: [{ type: 'text', text: '' }],
     },
   ],
 })

--- a/packages/@tinacms/mdx/src/tests/autotest/kitchen sink.test.ts
+++ b/packages/@tinacms/mdx/src/tests/autotest/kitchen sink.test.ts
@@ -139,16 +139,11 @@ const out = output({
       ],
     },
     {
-      type: 'p',
-      children: [
-        {
-          type: 'img',
-          url: 'https://get.svg.workers.dev',
-          alt: 'Alt Text',
-          caption: 'Image Title',
-          children: [{ type: 'text', text: '' }],
-        },
-      ],
+      type: 'img',
+      url: 'https://get.svg.workers.dev',
+      alt: 'Alt Text',
+      caption: 'Image Title',
+      children: [{ type: 'text', text: '' }],
     },
     {
       type: 'p',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -804,6 +804,7 @@ importers:
       prettier: ^2.7.1
       remark: ^14.0.2
       remark-mdx: ^2.1.2
+      remark-unwrap-images: ^3.0.1
       ts-node: ^10.8.2
       typescript: ^4.7.4
       unist-util-visit: ^4.1.0
@@ -819,6 +820,7 @@ importers:
       prettier: 2.7.1
       remark: 14.0.2
       remark-mdx: 2.1.2
+      remark-unwrap-images: 3.0.1
       unist-util-visit: 4.1.0
       vfile: 4.2.1
     devDependencies:
@@ -18284,6 +18286,13 @@ packages:
       }
     dev: false
 
+  /hast-util-whitespace/2.0.0:
+    resolution:
+      {
+        integrity: sha512-Pkw+xBHuV6xFeJprJe2BBEoDV+AvQySaz3pPDRUs5PNZEMQjpXJJueqrpcHIXxnWTcAGi/UOCgVShlkY6kLoqg==,
+      }
+    dev: false
+
   /hasurl/1.0.0:
     resolution:
       {
@@ -25969,6 +25978,18 @@ packages:
       }
     dependencies:
       mdast-util-to-markdown: 0.6.5
+    dev: false
+
+  /remark-unwrap-images/3.0.1:
+    resolution:
+      {
+        integrity: sha512-5VUY0n+J9lPTPfkct5S3/SbutryBjp8J/4mbgtlkDrOk3h8jde0hyqdYUJOoJKherZezS08tjd6i4+nnQ+wl5w==,
+      }
+    dependencies:
+      '@types/mdast': 3.0.10
+      hast-util-whitespace: 2.0.0
+      unified: 10.1.2
+      unist-util-visit: 4.1.0
     dev: false
 
   /remark/13.0.0:


### PR DESCRIPTION
Closes https://github.com/tinacms/tinacms/issues/3310
closes ENG-3310

Treat images as block-level when they're isolated in a paragraph.

Previously all images were nested inside `<p>` elements when coming from the server, but treated as block level by the rich-text editor. This resulted in a scenario where new paragraphs adjacent to images were nested
in parent `<p>` tags, which caused an error.