### PR TITLE
Feat/add client build

### DIFF
--- a/.changeset/polite-balloons-vanish.md
+++ b/.changeset/polite-balloons-vanish.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/cli': patch
+---
+
+Adds adds a new command, `tinacms build:client`, that builds the only the client and types file. This use useful for CI type checks and other situations where you need the client and types file but not the admin UI.
+
+

--- a/packages/@tinacms/cli/src/buildTina/index.ts
+++ b/packages/@tinacms/cli/src/buildTina/index.ts
@@ -185,6 +185,10 @@ export const buildCmdBuild = async (
     usingTs: ctx.usingTs,
     port: options.port,
   })
+  // @ts-ignore
+  if (ctx?.skipBuild) {
+    return next()
+  }
   await buildAdmin({
     local: options.local,
     rootPath: ctx.rootPath,

--- a/packages/@tinacms/cli/src/buildTina/index.ts
+++ b/packages/@tinacms/cli/src/buildTina/index.ts
@@ -186,7 +186,7 @@ export const buildCmdBuild = async (
     port: options.port,
   })
   // @ts-ignore
-  if (ctx?.skipBuild) {
+  if (ctx?.skipAdminBuild) {
     return next()
   }
   await buildAdmin({

--- a/packages/@tinacms/cli/src/cmds/baseCmds.ts
+++ b/packages/@tinacms/cli/src/cmds/baseCmds.ts
@@ -218,7 +218,7 @@ export const baseCmds: Command[] = [
         [
           attachPath,
           async (ctx, next, _options) => {
-            ctx.skipBuild = true
+            ctx.skipAdminBuild = true
             next()
           },
           checkOptions,


### PR DESCRIPTION
Adds adds a new command, `tinacms build:client`, that builds the only the client and types file. This use useful for CI type checks and other situations where you need the client and types file but not the admin UI.