### PR TITLE
Fix issue saving deeply nested objects in visual mode

### DIFF
--- a/.changeset/pretty-mails-pay.md
+++ b/.changeset/pretty-mails-pay.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/schema-tools': patch
+---
+
+Fix issue saving deeply nested objects in visual mode

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -252,14 +252,25 @@ export class TinaSchema {
           )
           return value.map((item) => {
             const { _template, ...rest } = item
-            return { [_template]: rest }
+            const template = field.templates.find((template) => {
+              if (typeof template === 'string') {
+                return false
+              }
+              return template.name === _template
+            })
+            if (typeof template === 'string') {
+              throw new Error('Global templates not supported')
+            }
+            return {
+              [_template]: this.transformCollectablePayload(rest, template),
+            }
           })
         } else {
           assertShape<{ _template: string }>(value, (yup) =>
             yup.object({ _template: yup.string().required() })
           )
           const { _template, ...rest } = value
-          return { [_template]: rest }
+          return { [_template]: this.transformCollectablePayload(rest, field) }
         }
       } else {
         return value


### PR DESCRIPTION
We weren't calling tthe transform recursively so deeper shapes didn't receive the transformed shape.

Closes https://github.com/tinacms/tinacms/issues/3338