### PR TITLE
Simplify formify resolve

### DIFF
--- a/.changeset/eleven-donkeys-allow.md
+++ b/.changeset/eleven-donkeys-allow.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Simplify the way form values are resolved into the data payload on iframe

--- a/examples/kitchen-sink/.tina/queries/documents.gql
+++ b/examples/kitchen-sink/.tina/queries/documents.gql
@@ -14,6 +14,17 @@ query CollectionQuery {
   }
 }
 
+query NodeQuery($id: String!) {
+  node(id: $id) {
+    ...on Document {
+      ...PageParts
+      ...PostParts
+      ...DocumentationParts
+      ...AuthorParts
+    }
+  }
+}
+
 query MenuQuery {
   collections {
     label
@@ -23,6 +34,7 @@ query MenuQuery {
         node {
           ...on Document {
             _sys {
+                path
                 filename
               }
             }

--- a/examples/kitchen-sink/content/post/tinacms-v0.69.7.mdx
+++ b/examples/kitchen-sink/content/post/tinacms-v0.69.7.mdx
@@ -1,5 +1,6 @@
 ---
 title: Some Title
+author: content/authors/napolean.md
 ---
 
 Here is some content
@@ -9,4 +10,3 @@ const ok = "test"
 
 export const MyReactComp = () = <div prop1={"hello"} >Hi</div>
 ```
-

--- a/examples/kitchen-sink/pages/collection/[collection]/[filename].tsx
+++ b/examples/kitchen-sink/pages/collection/[collection]/[filename].tsx
@@ -1,12 +1,13 @@
 import { InferGetServerSidePropsType } from 'next'
 import { useTina } from 'tinacms/dist/react'
 import client from '../../../.tina/__generated__/client'
+import { Json } from '../../../components/json'
 
 export default function Home(
   props: InferGetServerSidePropsType<typeof getServerSideProps>
 ) {
   const { data } = useTina(props)
-  return <pre>{JSON.stringify(data, null, 2)}</pre>
+  return <Json src={data} />
 }
 
 export const getServerSideProps = async ({

--- a/examples/kitchen-sink/pages/documentation/index.tsx
+++ b/examples/kitchen-sink/pages/documentation/index.tsx
@@ -1,0 +1,32 @@
+import { InferGetStaticPropsType } from 'next'
+import { Json } from '../../components/json'
+import { useTina } from 'tinacms/dist/react'
+import client from '../../.tina/__generated__/client'
+
+export default function Home(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
+  const { data } = useTina(props)
+
+  return (
+    <>
+      {data.documentationConnection.edges.map((edge) => {
+        return (
+          <div>
+            <div className="px-4">
+              <h1>{edge.node._sys.filename}</h1>
+            </div>
+            <Json src={edge.node} />
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export const getStaticProps = async () => {
+  const connection = await client.queries.documentationConnection()
+  return {
+    props: connection,
+  }
+}

--- a/examples/kitchen-sink/pages/node/[...filename].tsx
+++ b/examples/kitchen-sink/pages/node/[...filename].tsx
@@ -1,0 +1,20 @@
+import { InferGetServerSidePropsType } from 'next'
+import { Json } from '../../components/json'
+import { useTina } from 'tinacms/dist/react'
+import client from '../../.tina/__generated__/client'
+
+export default function Home(
+  props: InferGetServerSidePropsType<typeof getServerSideProps>
+) {
+  const { data } = useTina(props)
+
+  return <Json src={data} />
+}
+
+export const getServerSideProps = async ({ params }) => {
+  const variables = { id: `${params.filename.join('/')}.md` }
+  const props = await client.queries.NodeQuery(variables)
+  return {
+    props: { ...props, variables },
+  }
+}

--- a/examples/kitchen-sink/pages/node/[filename].test.ts
+++ b/examples/kitchen-sink/pages/node/[filename].test.ts
@@ -1,0 +1,26 @@
+import { test, expect } from 'vitest'
+import { getStaticProps } from './[filename]'
+import { printState, printBlueprints } from '@tinacms/app/dist/test-utils'
+import schema from '../../.tina/__generated__/_graphql.json'
+import client from '../../.tina/__generated__/client'
+import { DocumentNode, print } from 'graphql'
+import { toMatchFile } from 'jest-file-snapshot'
+expect.extend({ toMatchFile })
+import path from 'path'
+
+test('the query is formified for a documentation document', async () => {
+  const result = await getStaticProps({
+    params: { filename: 'tinacms-v0.69.7' },
+  })
+  const res = await printBlueprints({
+    schema: schema as DocumentNode,
+    client,
+    query: result.props.query,
+  })
+  expect(print(res.formifiedQuery)).toMatchFile(
+    path.join(__dirname, './formified-query.gql')
+  )
+  expect(JSON.stringify(printState(res.blueprints), null, 2)).toMatchFile(
+    path.join(__dirname, './blueprints.json')
+  )
+})

--- a/examples/kitchen-sink/pages/node/blueprints.json
+++ b/examples/kitchen-sink/pages/node/blueprints.json
@@ -1,0 +1,107 @@
+[
+  {
+    "name": "post",
+    "alias": "post",
+    "fields": [
+      {
+        "name": "title",
+        "alias": "title"
+      },
+      {
+        "name": "author",
+        "alias": "author",
+        "fields": [
+          {
+            "name": "name",
+            "alias": "name"
+          },
+          {
+            "name": "bio",
+            "alias": "bio"
+          },
+          {
+            "name": "hobbies",
+            "alias": "hobbies"
+          },
+          {
+            "name": "image",
+            "alias": "image"
+          },
+          {
+            "name": "id",
+            "alias": "id"
+          },
+          {
+            "name": "_sys",
+            "alias": "_internalSys",
+            "fields": [
+              {
+                "name": "path",
+                "alias": "path"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "categories",
+        "alias": "categories"
+      },
+      {
+        "name": "body",
+        "alias": "body"
+      },
+      {
+        "name": "image",
+        "alias": "image"
+      },
+      {
+        "name": "_sys",
+        "alias": "_sys",
+        "fields": [
+          {
+            "name": "filename",
+            "alias": "filename"
+          },
+          {
+            "name": "basename",
+            "alias": "basename"
+          },
+          {
+            "name": "breadcrumbs",
+            "alias": "breadcrumbs"
+          },
+          {
+            "name": "path",
+            "alias": "path"
+          },
+          {
+            "name": "relativePath",
+            "alias": "relativePath"
+          },
+          {
+            "name": "extension",
+            "alias": "extension"
+          }
+        ]
+      },
+      {
+        "name": "id",
+        "alias": "id"
+      },
+      {
+        "name": "_internalSys",
+        "alias": "_internalSys",
+        "fields": [
+          {
+            "name": "path",
+            "alias": "path"
+          }
+        ]
+      }
+    ],
+    "path": [
+      "post"
+    ]
+  }
+]

--- a/examples/kitchen-sink/pages/node/formified-query.gql
+++ b/examples/kitchen-sink/pages/node/formified-query.gql
@@ -1,0 +1,40 @@
+query post($relativePath: String!) {
+  post(relativePath: $relativePath) {
+    title
+    author {
+      ... on Author {
+        name
+        bio
+        hobbies
+        image
+      }
+      ... on Document {
+        id
+      }
+      ... on Document {
+        _internalSys: _sys {
+          path
+        }
+      }
+    }
+    categories
+    body
+    image
+    ... on Document {
+      _sys {
+        filename
+        basename
+        breadcrumbs
+        path
+        relativePath
+        extension
+      }
+      id
+    }
+    ... on Document {
+      _internalSys: _sys {
+        path
+      }
+    }
+  }
+}

--- a/examples/kitchen-sink/pages/page/index.tsx
+++ b/examples/kitchen-sink/pages/page/index.tsx
@@ -1,0 +1,32 @@
+import { InferGetStaticPropsType } from 'next'
+import { Json } from '../../components/json'
+import { useTina } from 'tinacms/dist/react'
+import client from '../../.tina/__generated__/client'
+
+export default function Home(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
+  const { data } = useTina(props)
+
+  return (
+    <>
+      {data.pageConnection.edges.map((edge) => {
+        return (
+          <div>
+            <div className="px-4">
+              <h1>{edge.node._sys.filename}</h1>
+            </div>
+            <Json src={edge.node} />
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export const getStaticProps = async () => {
+  const connection = await client.queries.pageConnection()
+  return {
+    props: connection,
+  }
+}

--- a/examples/kitchen-sink/pages/post/index.tsx
+++ b/examples/kitchen-sink/pages/post/index.tsx
@@ -1,0 +1,32 @@
+import { InferGetStaticPropsType } from 'next'
+import { Json } from '../../components/json'
+import { useTina } from 'tinacms/dist/react'
+import client from '../../.tina/__generated__/client'
+
+export default function Home(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
+  const { data } = useTina(props)
+
+  return (
+    <>
+      {data.postConnection.edges.map((edge) => {
+        return (
+          <div>
+            <div className="px-4">
+              <h1>{edge.node._sys.filename}</h1>
+            </div>
+            <Json src={edge.node} />
+          </div>
+        )
+      })}
+    </>
+  )
+}
+
+export const getStaticProps = async () => {
+  const connection = await client.queries.postConnection()
+  return {
+    props: connection,
+  }
+}

--- a/packages/@tinacms/app/appFiles/src/lib/formify/index.ts
+++ b/packages/@tinacms/app/appFiles/src/lib/formify/index.ts
@@ -304,8 +304,28 @@ export const formify = async ({
 const node = G.parse(`
  query Sample {
   ...on Document {
+    _internalValues: _values
     _internalSys: _sys {
+      breadcrumbs
+      basename
+      filename
       path
+      extension
+      relativePath
+      title
+      template
+      collection {
+        name
+        slug
+        label
+        path
+        format
+        matches
+        templates
+        fields
+        __typename
+      }
+      __typename
     }
   }
  }`)

--- a/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
+++ b/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
@@ -412,7 +412,6 @@ export const queryMachine =
         onChangeCallback: (context) => (callback, _onReceive) => {
           const schema = context.cms.api.tina.schema as TinaSchema
           Object.values(context.documentMap).forEach((documentMachine) => {
-            console.log('registerSubForms?', context.registerSubForms)
             if (!context.registerSubForms) {
               if (documentMachine.skipFormRegister) {
                 return

--- a/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
+++ b/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
@@ -10,12 +10,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { assign, ContextFrom, createMachine, spawn } from 'xstate'
+import { assign, createMachine, spawn } from 'xstate'
 import {
   Form,
   TinaCMS,
   NAMER,
-  Template,
   TinaFieldEnriched,
   TinaCollection,
   TinaSchema,
@@ -24,7 +23,7 @@ import {
 } from 'tinacms'
 import * as G from 'graphql'
 import { formify } from '../formify'
-import { documentMachine, FieldType, FormValues } from './document-machine'
+import { documentMachine } from './document-machine'
 import type { ActorRefFrom } from 'xstate'
 import { Blueprint2 } from '../formify'
 
@@ -43,6 +42,8 @@ type ContextType = {
   id: null | string
   data: null | DataType
   cms: TinaCMS
+  documentNode: G.DocumentNode
+  variables: object
   selectedDocument: string | null
   iframe: null | HTMLIFrameElement
   formifyCallback: (args: any) => Form
@@ -54,7 +55,9 @@ export const initialContext: Omit<ContextType, 'cms' | 'formifyCallback'> = {
   data: null,
   selectedDocument: null,
   blueprints: [],
+  variables: {},
   documentMap: {},
+  documentNode: { kind: 'Document', definitions: [] },
   iframe: null,
 }
 export const queryMachine =
@@ -214,10 +217,6 @@ export const queryMachine =
       actions: {
         handleError: (_context, event) => console.error(event.data),
         handleMissingDocument: assign((context, event) => {
-          count = count + 1
-          if (count > 50) {
-            throw new Error('infinite loop')
-          }
           if (event.data instanceof QueryError) {
             if (context.documentMap[event.data.id]) {
               // Already exists
@@ -299,29 +298,81 @@ export const queryMachine =
       },
       services: {
         setter: async (context) => {
-          const walk = (obj: unknown, path: string[] = []) => {
-            const accum: Record<string, unknown> = {}
-            if (isScalar(obj)) {
-              return obj
-            }
-            Object.entries(obj as object).map(([key, value]) => {
-              if (Array.isArray(value)) {
-                accum[key] = value.map((item) => walk(item, [...path, key]))
-              } else {
-                const blueprint = context.blueprints.find(
-                  (bp) => bp.path?.join('.') === [...path, key].join('.')
+          const tinaSchema = context.cms.api.tina.schema as TinaSchema
+          const gqlSchema = context.cms.api.tina.gqlSchema
+          const newData = await G.graphql({
+            schema: gqlSchema,
+            source: G.print(context.documentNode),
+            rootValue: context.data,
+            variableValues: context.variables,
+            fieldResolver: (source, args, _context, info) => {
+              const fieldNode = info.fieldNodes[0]
+              const fieldName = fieldNode.alias?.value || fieldNode.name.value
+              if (info.fieldNodes.length > 1) {
+                // Not sure this happens much https://github.com/graphql/graphql-js/issues/605
+                console.error(
+                  'Unexpected multiple field nodes, is the query optimized?'
                 )
-                if (blueprint) {
-                  accum[key] = setData(value, blueprint, context)
+              }
+              if (isNodeType(info.returnType)) {
+                const existingValue = source[fieldName]
+                if (!existingValue) {
+                  return null
+                }
+                let path: string = ''
+                if (typeof existingValue === 'string') {
+                  // this is a reference value (eg. post.author)
+                  path = existingValue
                 } else {
-                  accum[key] = walk(value, [...path, key])
+                  path = existingValue._internalSys.path
+                }
+                if (context.documentMap[path]) {
+                  const documentMachine = context.documentMap[path].ref
+                  const documentContext = documentMachine.getSnapshot()?.context
+                  if (!documentContext) {
+                    throw new QueryError(`MISSING_FORM:${path}`, path, false)
+                  }
+                  const { data, form } = documentContext
+                  const values = form?.values
+                  if (!data || !form || !values) {
+                    throw new QueryError(`MISSING_FORM:${path}`, path, false)
+                  }
+                  const collectionName = data._internalSys.collection.name
+                  const extraValues = documentContext.data
+                  const formVal = resolveFormValue({
+                    fields: form.fields,
+                    values: values,
+                    tinaSchema,
+                  })
+                  const template = tinaSchema.getTemplateForData({
+                    data: form.values,
+                    collection: tinaSchema.getCollection(collectionName),
+                  })
+                  return {
+                    ...extraValues,
+                    ...formVal,
+                    _sys: data._internalSys,
+                    id: path,
+                    __typename: NAMER.dataTypeName(template.namespace),
+                  }
+                } else {
+                  throw new QueryError(`MISSING_FORM:${path}`, path, false)
                 }
               }
-            })
-            return accum
+              return source[fieldName]
+            },
+          })
+          if (newData.errors?.length) {
+            console.log(newData.errors)
+            const error = newData.errors[0]
+            const id = error.message.split('MISSING_FORM:')[1]
+            throw new QueryError(
+              `Unable to resolve form for initial document`,
+              id,
+              false
+            )
           }
-          const accum = walk(context.data)
-          return { data: accum }
+          return { data: newData.data }
         },
         initializer: async (context, event) => {
           const tina = context.cms.api.tina as Client
@@ -343,7 +394,9 @@ export const queryMachine =
           )) as DataType
           return {
             data,
+            variables: event.value.variables,
             blueprints,
+            documentNode: formifiedQuery,
             id: event.value.id,
           }
         },
@@ -397,242 +450,121 @@ class QueryError extends Error {
     this.skipFormRegister = skipFormRegister
   }
 }
-let count = 0
 
-// https://github.com/oleics/node-is-scalar/blob/master/index.js
-const withSymbol = typeof Symbol !== 'undefined'
-function isScalar(value: unknown) {
-  const type = typeof value
-  if (type === 'string') return true
-  if (type === 'number') return true
-  if (type === 'boolean') return true
-  if (withSymbol === true && type === 'symbol') return true
-
-  if (value == null) return true
-  if (withSymbol === true && value instanceof Symbol) return true
-  if (value instanceof String) return true
-  if (value instanceof Number) return true
-  if (value instanceof Boolean) return true
-
-  return false
-}
-
-const setData = (
-  data: { [key: string]: unknown },
-  blueprint: Blueprint2,
-  context: ContextFrom<typeof queryMachine>
-) => {
-  if (data?._internalSys) {
-    const id = data._internalSys?.path
-    const doc = context.documentMap[id]
-    const docContext = doc?.ref?.getSnapshot()?.context
-    const form = docContext?.form
-    if (!form) {
-      const skipFormRegiester = (blueprint.path?.length || 0) > 2
-      throw new QueryError(
-        `Unable to resolve form for initial document`,
-        id,
-        skipFormRegiester
-      )
+const isNodeType = (type: G.GraphQLOutputType) => {
+  const namedType = G.getNamedType(type)
+  if (G.isInterfaceType(namedType)) {
+    if (namedType.name === 'Node') {
+      return true
     }
-    const _internalSys = docContext.data?._internalSys
-    if (!_internalSys) {
-      throw new Error(`No system information found for document ${id}`)
-    }
-
-    const fields = form.fields
-    const result = resolveForm({
-      id,
-      fields,
-      sys: _internalSys,
-      values: form.values,
-      fieldsToInclude: blueprint.fields,
-      context,
-    })
-    return { ...docContext.data, ...result }
-  } else {
-    // this isn't a node
   }
-  return data
-}
-
-const resolveForm = ({
-  id,
-  fields,
-  sys,
-  values,
-  fieldsToInclude,
-  context,
-}: {
-  id: string
-  fields: FieldType[]
-  sys: Record<string, unknown>
-  values: FormValues | undefined
-  fieldsToInclude: Blueprint2['fields']
-  context: ContextFrom<typeof queryMachine>
-}) => {
-  const accum: Record<string, unknown> = {}
-  if (!values) {
-    return accum
-  }
-
-  fieldsToInclude?.forEach((fieldToInclude) => {
-    const field = fields.find((field) => fieldToInclude.name === field.name)
-    if (!field) {
-      if (fieldToInclude.name === 'id') {
-        accum[fieldToInclude.alias] = id
-      } else if (fieldToInclude.name === '_sys') {
-        if (fieldToInclude.alias !== '_internalSys') {
-          const sysAccum: Record<string, unknown> = {}
-          // TODO: loop through these and actually use their alias values
-          fieldToInclude.fields?.forEach((field) => {
-            sysAccum[field.alias] = sys[field.name]
-          })
-          accum[fieldToInclude.alias] = sysAccum
-        }
-      } else if (fieldToInclude.name === '__typename') {
-        // field namespaces are one level deeper than what we need, so grab the first
-        // one and remove the last string on the namespace
-        accum[fieldToInclude.alias] = NAMER.dataTypeName(
-          fields[0].namespace.slice(0, fields[0].namespace.length - 1)
-        )
-      } else if (fieldToInclude.name === '_values') {
-        if (fieldToInclude.alias !== '_internalValues') {
-          accum[fieldToInclude.alias] = values
-        }
-      } else {
-      }
-    } else {
-      const result = resolveField({
-        id,
-        field,
-        sys,
-        value: values[field.name],
-        fieldsToInclude: fieldsToInclude.find(({ name }) => name === field.name)
-          ?.fields,
-        context,
+  if (G.isUnionType(namedType)) {
+    const types = namedType.getTypes()
+    if (
+      types.every((type) => {
+        return type.getInterfaces().some((intfc) => intfc.name === 'Node')
       })
-      if (result) {
-        accum[fieldToInclude.alias] = result
-      }
+    ) {
+      return true
     }
-  })
-
-  return accum
+  }
+  if (G.isObjectType(namedType)) {
+    if (namedType.getInterfaces().some((intfc) => intfc.name === 'Node')) {
+      return true
+    }
+  }
 }
-const resolveField = ({
-  id,
-  field,
-  sys,
-  value,
-  fieldsToInclude,
-  context,
+
+const resolveFormValue = <T extends Record<string, unknown>>({
+  fields,
+  values,
+  tinaSchema,
 }: {
-  id: string
+  fields: TinaFieldEnriched[]
+  values: T
+  tinaSchema: TinaSchema
+}): T & { __typename?: string } => {
+  const accum: Record<string, unknown> = {}
+  fields.forEach((field) => {
+    const v = values[field.name]
+    if (!v) {
+      return
+    }
+    accum[field.name] = resolveFieldValue({
+      field,
+      value: v,
+      tinaSchema,
+    })
+  })
+  return accum as T & { __typename?: string }
+}
+const resolveFieldValue = ({
+  field,
+  value,
+  tinaSchema,
+}: {
   field: TinaFieldEnriched
-  sys: Record<string, unknown>
   value: unknown
-  fieldsToInclude: Blueprint2['fields']
-  context: ContextFrom<typeof queryMachine>
+  tinaSchema: TinaSchema
 }) => {
   switch (field.type) {
-    case 'reference':
-      if (!value) {
-        return
-      }
-      if (typeof value === 'string') {
-        const doc = context.documentMap[value]
-        const docContext = doc?.ref?.getSnapshot()?.context
-        const form = docContext?.form
-        if (!form) {
-          throw new QueryError(
-            `Unable to resolve form for document`,
-            value,
-            true
-          )
-        }
-        const _internalSys = docContext.data?._internalSys
-        if (!_internalSys) {
-          throw new Error(`No system information found for document ${id}`)
-        }
-        return resolveForm({
-          id: value,
-          fields: form.fields,
-          sys: _internalSys,
-          values: form.values,
-          fieldsToInclude,
-          context,
-        })
-      }
-      throw new Error(`Unexpected value for type "reference"`)
-    case 'object':
-      if (field.fields) {
-        if (typeof field.fields === 'string') {
-          throw new Error('Global templates not supported')
-        }
-        field.fields
+    case 'object': {
+      if (field.templates) {
         if (field.list) {
           if (Array.isArray(value)) {
             return value.map((item) => {
-              if (typeof field.fields === 'string') {
+              const template = field.templates[item._template]
+              if (typeof template === 'string') {
                 throw new Error('Global templates not supported')
               }
-              return resolveForm({
-                id,
-                fields: field.fields,
-                sys,
-                values: item,
-                fieldsToInclude,
-                context,
-              })
+              return {
+                __typename: NAMER.dataTypeName(template.namespace),
+                ...resolveFormValue({
+                  fields: template.fields,
+                  values: item,
+                  tinaSchema,
+                }),
+              }
             })
           }
         } else {
-          return resolveForm({
-            id,
-            fields: field.fields,
-            sys,
-            values: value,
-            fieldsToInclude,
-            context,
-          })
+          // not implemented
         }
       }
-      if (field.templates) {
-        if (field.list) {
-          if (!value) {
-            return
-          }
-          if (!Array.isArray(value)) {
-            return
-          }
+
+      const templateFields = field.fields
+      if (typeof templateFields === 'string') {
+        throw new Error('Global templates not supported')
+      }
+      if (!templateFields) {
+        throw new Error(`Expected to find sub-fields on field ${field.name}`)
+      }
+      if (field.list) {
+        if (Array.isArray(value)) {
           return value.map((item) => {
-            let t: Template<true>
-            Object.entries(field.templates).forEach(([name, template]) => {
-              if (name === item._template) {
-                if (typeof template === 'string') {
-                  throw new Error('Global templates not supported')
-                }
-                t = template
-              }
-            })
             return {
-              _template: item._template,
-              ...resolveForm({
-                id,
-                fields: t.fields,
-                sys,
+              __typename: NAMER.dataTypeName(field.namespace),
+              ...resolveFormValue({
+                fields: templateFields,
                 values: item,
-                fieldsToInclude,
-                context,
+                tinaSchema,
               }),
             }
           })
-        } else {
-          // not supported yet
+        }
+      } else {
+        return {
+          __typename: NAMER.dataTypeName(field.namespace),
+          ...resolveFormValue({
+            fields: templateFields,
+            values: value as any,
+            tinaSchema,
+          }),
         }
       }
-    default:
+    }
+    default: {
       return value
+    }
   }
 }

--- a/packages/@tinacms/app/appFiles/src/preview.tsx
+++ b/packages/@tinacms/app/appFiles/src/preview.tsx
@@ -80,6 +80,8 @@ const QueryMachine = (props: {
       queryMachine.withContext({
         ...initialContext,
         cms,
+        // Enable registration of sub forms
+        // registerSubForms: true,
         // @ts-ignore FIXME: add formifyCallback args to Config type
         formifyCallback: props.formifyCallback,
       }),


### PR DESCRIPTION
The PR removes all of the logic around generating blueprints, and instead just calls the GraphQL `graphql` function client-side. This is the same function from GraphQL that we use on the backend, but instead of resolving the content from the database, we resolve it from the Tina forms. I realized I was basically recreating this logic with the blueprint stuff, and this is a much simpler approach which I think is a lot less error-prone. 

This should improve performance on formifying pages, which isn't really noticeable locally but makes a big difference on Tina cloud. Previously we were making the following queries before the user could see the forms in the sidebar:

Old pipeline
- Introspection query (we need the schema from the server)
- Optimize the query (this basically inlines fragments so it's one big query for easier parsing logic)
- Get the "formified" query (so the original content with the extra metadata we need)
- For each node we find in the query, go and refetch that

New pipeline
- Introspection query (we need the schema from the server)
- Get the "formified" query (so the original content with the extra metadata we need)

---

In the near future we can also skip the introspection query since we actually already build that during `tina build` (`.tina/__generated__/_graphql.json`) but I've left that out for now because that only runs on an actuall window page load, so once the SPA mounts it doesn't run again.
