### PR TITLE
Include node_modules as part of the build in @tinacms/app

### DIFF
--- a/.changeset/calm-planes-join.md
+++ b/.changeset/calm-planes-join.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Include dependencies as part of the build artifacts for @tinacms/app

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "MONOREPO_DEV=true tinacms dev -c \"next dev\"",
+    "dev2": "tinacms dev -c \"next dev\"",
     "dev-sandbox": "MONOREPO_DEV=true tinacms dev -c \"next dev\" --sandbox",
     "test": "MONOREPO_DEV=true tinacms dev -c \"vitest\"",
     "test:dev": "vitest",

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "types": "rm dist/index.d.ts && touch dist/index.d.ts && echo \"export declare const viteBuild: (args: any) => any\" > dist/index.d.ts",
-    "build": "tinacms-scripts build",
+    "build": "tinacms-scripts build && npm --prefix ./appFiles i --legacy-peer-deps --omit=dev --no-package-lock",
     "inline": "cd appFiles && npm --prefix ./ i --legacy-peer-deps --omit=dev --no-package-lock && cd .. && npm run unlink",
     "unlink": "cd appFiles && cp -RL node_modules node_modules2 && rm -rf node_modules && mv node_modules2 node_modules"
   },

--- a/packages/@tinacms/app/src/index.ts
+++ b/packages/@tinacms/app/src/index.ts
@@ -174,9 +174,9 @@ export const viteBuild = async ({
       await fs.copy(appCopyPath, appRootPath)
     }
 
-    await execShellCommand(
-      `npm --prefix ${appRootPath} i --legacy-peer-deps --omit=dev --no-package-lock`
-    )
+    // await execShellCommand(
+    //   `npm --prefix ${appRootPath} i --legacy-peer-deps --omit=dev --no-package-lock`
+    // )
     await fs.outputFile(
       path.join(outputPath, '.gitignore'),
       `index.html


### PR DESCRIPTION
Previously we were running a special `npm install` command whenever we started the Tina dev server to get the `@tinacms/app` dependencies in the right location. However that command has failed for some users for reasons that aren't super clear. It also feels a little bit brittle to run `npm install` and aside from a larger bundle for the `@tinacms/app` I don't see any downsides.