### PR TITLE
Fix ux for failed document creation 

### DIFF
--- a/.changeset/small-rings-knock.md
+++ b/.changeset/small-rings-knock.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/toolkit': patch
+'tinacms': patch
+---
+
+Better user experience when the document creation fails due to existing filename

--- a/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
@@ -143,7 +143,14 @@ export const FormBuilder: FC<FormBuilderProps> = ({
       key={`${i}: ${tinaForm.id}`}
       onSubmit={tinaForm.onSubmit}
     >
-      {({ handleSubmit, pristine, invalid, submitting }) => {
+      {({
+        handleSubmit,
+        pristine,
+        invalid,
+        submitting,
+        dirtySinceLastSubmit,
+        hasValidationErrors,
+      }) => {
         return (
           <>
             <DragDropContext onDragEnd={moveArrayItem}>
@@ -173,7 +180,12 @@ export const FormBuilder: FC<FormBuilderProps> = ({
                     )}
                     <Button
                       onClick={() => handleSubmit()}
-                      disabled={pristine || submitting || invalid}
+                      disabled={
+                        pristine ||
+                        submitting ||
+                        hasValidationErrors ||
+                        (invalid && !dirtySinceLastSubmit)
+                      }
                       busy={submitting}
                       variant="primary"
                       style={{ flexGrow: 3 }}

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -240,7 +240,14 @@ const RenderForm = ({ cms, collection, templateName, mutationInfo }) => {
           navigate(`/collections/${collection.name}`)
         } catch (error) {
           console.error(error)
-
+          const defaultErrorText = 'There was a problem saving your document.'
+          if (error.message.includes('already exists')) {
+            cms.alerts.error(
+              `${defaultErrorText} The "Filename" is alredy used for another document, please modify it.`
+            )
+          } else {
+            cms.alerts.error(defaultErrorText)
+          }
           throw new Error(
             `[${error.name}] CreateDocument failed: ${error.message}`
           )


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

As reported in the issue #3362 the creation of a post having a filename that already exists fails without giving a message to the user. After the failed submission if the user tries to edit the filename the submit button remains disabled.


## Button disabled after submission
 
In debugging why the button remains disabled, I found that: in case the submit response is an error the `invalid` property remains `true`.
In order for the button to be enabled again, I modified the condition for which it is considered disabled.
The new rule is: 
```
disabled={pristine ||  submitting || hasValidationErrors || (invalid && !dirtySinceLastSubmit)}
```
It will always be disabled in case there is a client validation error on one of the fileds. But it will be enabled if the form is invalid and after the last submission the user does some edits to the form.


## Error message not showed

Now when the creation fails the user will see the error dialog that will describe the issue to him.

I created a default error message, which is enriched in case the error indicates that the file already exists.

I haven't found a better way to figure out the type of error other than to go looking in the error sentence for the words `already exists`, so I'm open to advice on this.

You can see the new behavior in the next gif:
![create_post_filename_fix](https://user-images.githubusercontent.com/38522984/200131618-cb0b7cbf-2fa4-4eec-8f72-2849e6a93ee6.gif)

Closes #3362 

