### PR TITLE
fix OverflowMenu of collection items not correctly placed on top of other elements

### DIFF
--- a/.changeset/three-phones-fix.md
+++ b/.changeset/three-phones-fix.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix elements displayed above the OverflowMenu

--- a/packages/@tinacms/toolkit/src/packages/styles/OverflowMenu.tsx
+++ b/packages/@tinacms/toolkit/src/packages/styles/OverflowMenu.tsx
@@ -63,9 +63,9 @@ export const OverflowMenu = ({ toolbarItems }) => {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <Popover.Panel>
+            <Popover.Panel className="absolute z-20 origin-top-right right-0">
               {({ close }) => (
-                <div className="z-20 origin-top-right absolute right-0 mt-0 -mr-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1">
+                <div className="mt-0 -mr-1 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1">
                   {toolbarItems.map((toolbarItem) => {
                     return (
                       <span


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

## Issue description

The `OverflowMenu` of collection items is not correctly placed on top of the other elements.
When the popover is open, some of the elements that should be under it are visible and clickable.

You can see the issue here: https://www.loom.com/share/f0fcb48284374cbe889da8bda0ae1ba2

## Solution

I have fixed the issue by moving the classes that are defining the position of the element from the div that is setting its appearance to the `Popover.Panel` element.

You can see the working solution here: https://www.loom.com/share/c6011fe901794771a784419d8e45bc9a

This issue was similar to the one I have already solved in this PR #3317 