### PR TITLE
Pass `config.formifyCallback` to `<QueryMachine>`

### DIFF
--- a/packages/@tinacms/app/appFiles/src/preview.tsx
+++ b/packages/@tinacms/app/appFiles/src/preview.tsx
@@ -14,6 +14,7 @@ import React from 'react'
 import { useMachine } from '@xstate/react'
 import { queryMachine, initialContext } from './lib/machines/query-machine'
 import { useCMS, defineConfig } from 'tinacms'
+import type { formifyCallback as FormifyCallback } from 'tinacms/dist/hooks/use-graphql-forms'
 
 type Config = Parameters<typeof defineConfig>[0]
 
@@ -48,6 +49,7 @@ export const Preview = (
           key={activeQuery.id}
           payload={activeQuery}
           iframeRef={props.iframeRef}
+          formifyCallback={props.formifyCallback}
         />
       )}
       <div className="h-full overflow-scroll">
@@ -72,6 +74,7 @@ export const Preview = (
 const QueryMachine = (props: {
   payload: PostMessage
   iframeRef: React.MutableRefObject<HTMLIFrameElement>
+  formifyCallback: FormifyCallback
 }) => {
   const cms = useCMS()
 


### PR DESCRIPTION
## Implementation notes

The `formifyCallback` is expected by the `<QueryMachine />` machine as you can see on this line, which accesses the `props.formifyCallback` value: https://github.com/tinacms/tinacms/blob/main/packages/@tinacms/app/appFiles/src/preview.tsx#L86. And that `formifyCallback` function is a valid option on the `Config` object: https://github.com/tinacms/tinacms/blob/main/packages/tinacms/src/index.ts#L96-L109, however it wasn't being passed through to the component that was attempting to use it. This update fixes that bug by ensuring the `formifyCallback` function is properly passed through, making it available within the `context` for the `query-machine` and `document-machine` respectively.

## Problem description

Using the latest version of TinaCMS, you can see this issue by setting a `formifyCallback` like the following within the config object passed to Tina's `defineConfig` function:

```typescript
formifyCallback: (
  { formConfig, createForm, createGlobalForm, skip },
  cms
) => {
  console.log('This message will never get logged cos the formifyCallback isn't being passed through!')
  console.log('formConfig', formConfig)

  return createForm(formConfig)
}
```

We would expect to see a message printed to the console, but it doesn't happen as the custom `formifyCallback` is not passed through to the `<QueryMachine />` component, so it never gets invoked (the default `formify` function runs instead)

Let me know if you need me to make any changes to this PR. Given it's a bug fix I figured we probably don't need to update the README or docs, but happy to tweak the implementation or make other updates where you need 👍 

PS: Amazing work on Tina - it's an incredibly powerful tool! 🎉 