### PR TITLE
ui.itemProps on collections

### DIFF
--- a/.changeset/shiny-steaks-joke.md
+++ b/.changeset/shiny-steaks-joke.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/schema-tools': minor
+'tinacms': minor
+---
+
+add ui.itemProps on collections

--- a/packages/@tinacms/schema-tools/src/types.ts
+++ b/packages/@tinacms/schema-tools/src/types.ts
@@ -73,6 +73,15 @@ export interface UICollection {
     create?: boolean
     delete?: boolean
   }
+  /**
+   * An optional function to override the properties of the collecion table
+   * row component. Except for the `label` property:
+   * that is used as the title of the collection element.
+   */
+  itemProps?: (item: Record<string, any>) => {
+    key?: string
+    label?: string
+  } & Record<string, any>
 }
 export type Option =
   | string

--- a/packages/@tinacms/schema-tools/src/types/SchemaTypes.ts
+++ b/packages/@tinacms/schema-tools/src/types/SchemaTypes.ts
@@ -131,6 +131,15 @@ export interface UICollection {
     document: Document
     collection: TinaCloudCollection<true>
   }) => string | undefined
+  /**
+   * An optional function to override the properties of the collecion table
+   * row component. Except for the `label` property:
+   * that is used as the title of the collection element.
+   */
+  itemProps?: (item: Record<string, any>) => {
+    key?: string
+    label?: string
+  } & Record<string, any>
 }
 
 export type DefaultItem<ReturnType> = ReturnType | (() => ReturnType)

--- a/packages/tinacms/src/admin/api.ts
+++ b/packages/tinacms/src/admin/api.ts
@@ -97,6 +97,7 @@ export class TinaAdminApi {
                     filename
                     extension
                   }
+                  _values
                 }
               }
             }
@@ -142,6 +143,7 @@ export class TinaAdminApi {
                     filename
                     extension
                   }
+                  _values
                 }
               }
             }

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -205,6 +205,7 @@ const CollectionListPage = () => {
                 collectionDefinition?.ui?.allowedActions?.create ?? true
               const allowDelete =
                 collectionDefinition?.ui?.allowedActions?.delete ?? true
+              const itemPropsFunction = collectionDefinition?.ui?.itemProps
 
               return (
                 <PageWrapper>
@@ -317,9 +318,10 @@ const CollectionListPage = () => {
                           <table className="table-auto shadow bg-white border-b border-gray-200 w-full max-w-full rounded-lg">
                             <tbody className="divide-y divide-gray-150">
                               {documents.map((document) => {
-                                const hasTitle = Boolean(
-                                  document.node._sys.title
-                                )
+                                const { label, ...rowProps } =
+                                  itemPropsFunction?.(document.node._values) ||
+                                  {}
+                                const title = label ?? document.node._sys.title
                                 const subfolders =
                                   document.node._sys.breadcrumbs
                                     .slice(0, -1)
@@ -329,6 +331,7 @@ const CollectionListPage = () => {
                                   <tr
                                     key={`document-${document.node._sys.relativePath}`}
                                     className=""
+                                    {...rowProps}
                                   >
                                     <td className="pl-5 pr-3 py-2 truncate max-w-0">
                                       <a
@@ -346,7 +349,7 @@ const CollectionListPage = () => {
                                         <BiEdit className="inline-block h-6 w-auto flex-shrink-0 opacity-70" />
                                         <span className="truncate block">
                                           <span className="block text-xs text-gray-400 mb-1 uppercase">
-                                            {hasTitle ? 'Title' : 'Filename'}
+                                            {!!title ? 'Title' : 'Filename'}
                                           </span>
                                           <span className="h-5 leading-5 block truncate">
                                             {subfolders && (
@@ -355,15 +358,14 @@ const CollectionListPage = () => {
                                               </span>
                                             )}
                                             <span>
-                                              {hasTitle
-                                                ? document.node._sys?.title
-                                                : document.node._sys.filename}
+                                              {title ||
+                                                document.node._sys.filename}
                                             </span>
                                           </span>
                                         </span>
                                       </a>
                                     </td>
-                                    {hasTitle && (
+                                    {!!title && (
                                       <td className="px-3 py-4 truncate max-w-0 ">
                                         <span className="block text-xs text-gray-400 mb-1 uppercase">
                                           Filename

--- a/packages/tinacms/src/admin/types.ts
+++ b/packages/tinacms/src/admin/types.ts
@@ -29,6 +29,7 @@ export interface DocumentNode {
       extension: string
       title?: string
     }
+    _values: Record<string, any>
   }
 }
 


### PR DESCRIPTION
Hello!

I created this PR for #3389 

I tried it with `experimental-examples/tina-cloud-starter` adding the `draft` field and the `ui.itemProps` to the collection schema:

```js
...
const schema = defineSchema({
  collections: [
    {
      label: "Blog Posts",
      name: "posts",
      path: "content/posts",
      format: "mdx",
      ui: {
        router: ({ document, collection }) => {
          return `/${collection.name}/${document._sys.filename}`;
        },
        itemProps: (item) => ({
          label: item.draft ? `🚧 ${item.title}` : item.title,
          className: item.draft ? 'bg-blue-50' : ''
        })
      },
      fields: [
        {
          type: "boolean",
          name: "draft",
          label: "Draft",
        },
...
```

and could produce this:

![2022-11-20_15h58_05](https://user-images.githubusercontent.com/4682432/202909342-a510b546-bccd-4097-a8e6-3c6bb46592da.png)

---

I'm not sure though if both `packages/@tinacms/schema-tools/src/types.ts` and `packages/@tinacms/schema-tools/src/types/SchemaTypes.ts` file needed to be updated, or one would have been enough.

I also haven't looked into your tests, so I'm not sure about the necessary tests either.