### PR TITLE
Fix issue resolving alias fields when passing through the `useTina` hook

### DIFF
--- a/.changeset/swift-pens-bow.md
+++ b/.changeset/swift-pens-bow.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Fix issue resolving alias fields when passing through the `useTina` hook

--- a/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
+++ b/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
@@ -399,7 +399,6 @@ export const queryMachine =
               return value
             },
           })
-          console.log(newData)
           if (missingForms.length > 0) {
             // Only run this one at a time
             const missingForm = missingForms[0]


### PR DESCRIPTION
How we're using graphql in the client is unconventional, and we actually need to look at `info.fieldNodes` to determine where the data might actually be. This isn't usually the way things work, but since we're resolving data from a _previous_ query (that ran before being passed to the `useTina` hook, our needs are a bit different, hence the awkward workaround.