### PR TITLE
rm broken line from changeset

### DIFF
--- a/.changeset/gorgeous-donkeys-itch.md
+++ b/.changeset/gorgeous-donkeys-itch.md
@@ -1,5 +1,4 @@
 ---
-'@tinacms/starter': patch
 '@tinacms/cli': patch
 '@tinacms/schema-tools': patch
 'create-tina-app': patch


### PR DESCRIPTION
I see a line in the latest changeset may have blocked the builds. (Mixing ignored and unignored changesets?)

https://github.com/tinacms/tinacms/actions/runs/3586233293/jobs/6035177827#step:12:42

Not 100% if removing that line retroactively fixes things or not. 