### PR TITLE
Fix issue with formify logic that returned undefined for falsy values

### DIFF
--- a/.changeset/lazy-cherries-serve.md
+++ b/.changeset/lazy-cherries-serve.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Fix issue with formify logic that returned undefined for falsy values like "" or 0

--- a/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
+++ b/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
@@ -630,7 +630,10 @@ const resolveFormValue = <T extends Record<string, unknown>>({
   const accum: Record<string, unknown> = {}
   fields.forEach((field) => {
     const v = values[field.name]
-    if (!v) {
+    if (typeof v === 'undefined') {
+      return
+    }
+    if (v === null) {
       return
     }
     accum[field.name] = resolveFieldValue({


### PR DESCRIPTION
Fix issue with formify logic that returned undefined for falsy values like "" or 0

