### PR TITLE
Enable custom text component

### DIFF
--- a/.changeset/fast-apples-promise.md
+++ b/.changeset/fast-apples-promise.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+Enable custom component for text in TinaMarkdown

--- a/packages/tinacms/src/rich-text/index.tsx
+++ b/packages/tinacms/src/rich-text/index.tsx
@@ -27,6 +27,7 @@ type BaseComponents = {
   strikethrough?: { children: JSX.Element }
   underline?: { children: JSX.Element }
   code?: { children: JSX.Element }
+  text?: { children: string }
   ul?: { children: JSX.Element }
   ol?: { children: JSX.Element }
   li?: { children: JSX.Element }
@@ -123,7 +124,7 @@ const Leaf = (props: {
   code?: boolean
   components: Pick<
     BaseComponentSignature,
-    'bold' | 'italic' | 'underline' | 'strikethrough' | 'code'
+    'bold' | 'italic' | 'underline' | 'strikethrough' | 'code' | 'text'
   >
 }) => {
   if (props.bold) {
@@ -205,6 +206,10 @@ const Leaf = (props: {
         <Leaf {...rest} />
       </code>
     )
+  }
+  if (props.components.text) {
+    const Component = props.components.text
+    return <Component>{props.text}</Component>
   }
   return <>{props.text}</>
 }


### PR DESCRIPTION
This enables the consumer to post-process the text before rendering.

For context, I'd like to enable `smartypants` on the text but there isn't a great place to hook into the text to call the function. Feasibly, I could walk the tree myself & call it on the text elements, but this seemed simpler. Obviously, totally understandable if you don't want this added upstream.