### PR TITLE
 Fix a bug where meta data was added to the form values payload

### DIFF
--- a/.changeset/happy-pillows-suffer.md
+++ b/.changeset/happy-pillows-suffer.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Fix a bug where meta data was added to the form values payload

--- a/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
+++ b/packages/@tinacms/app/appFiles/src/lib/machines/query-machine.ts
@@ -425,7 +425,14 @@ export const queryMachine =
                 const itemPath = path.concat(i)
                 yield [i, o[i], itemPath, o]
                 if (o[i] !== null && typeof o[i] == 'object') {
-                  if (i !== META_KEY) {
+                  if (
+                    [
+                      '_internalSys',
+                      '_internalValues',
+                      '_sys',
+                      META_KEY,
+                    ].includes(i)
+                  ) {
                     //going one step down in the object tree!!
                     yield* innerTraversal(o[i], itemPath)
                   }


### PR DESCRIPTION
The `__meta__` stuff recently added was making it's way into the form values, this PR stops those values from being populated