### PR TITLE
added more context to error message

### DIFF
--- a/.changeset/red-moose-search.md
+++ b/.changeset/red-moose-search.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Update the error message to include context from the server

--- a/packages/@tinacms/cli/src/cmds/statusChecks/checkClientInformation.ts
+++ b/packages/@tinacms/cli/src/cmds/statusChecks/checkClientInformation.ts
@@ -44,20 +44,22 @@ async function request<DataType extends Record<string, any> = any>(args: {
     body: bodyString,
     redirect: 'follow',
   })
+  const json = await res.json()
   if (!res.ok) {
     let additionalInfo = ''
     if (res.status === 401) {
       additionalInfo =
         'Please check that your client ID, URL and read only token are configured properly.'
     }
-
+    if (json) {
+      additionalInfo += `\n\nMessage from server: ${json.message}`
+    }
     throw new Error(
       `Server responded with status code ${res.status}, ${res.statusText}. ${
         additionalInfo ? additionalInfo : ''
       } Please see our FAQ for more information: https://tina.io/docs/errors/faq/`
     )
   }
-  const json = await res.json()
   if (json.errors) {
     throw new Error(
       `Unable to fetch, please see our FAQ for more information: https://tina.io/docs/errors/faq/
@@ -118,6 +120,7 @@ export const checkClientInfo = async (
         2
       )}\n\n Please check you have the correct "clientId", "branch" and "token" configured. For more information see https://tina.io/docs/tina-cloud/connecting-site/`
     )
+
     throw e
   }
 


### PR DESCRIPTION
Add's more context to the error message.

This will tell the user the `.tina/__generated__/_schema.json` is not on Github. 

Looks like this.
![Screen Shot 2022-12-06 at 1 56 30 PM](https://user-images.githubusercontent.com/43075109/205998005-d217563a-bbba-45f2-8058-683f9c0418b6.png)

