### PR TITLE
fix useEdit state from requiring querys to be active

### DIFF
--- a/.changeset/afraid-lions-stare.md
+++ b/.changeset/afraid-lions-stare.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Updated so that `useEditState` does not require `useTina` to be called first.

--- a/examples/basic-iframe/pages/index.js
+++ b/examples/basic-iframe/pages/index.js
@@ -1,7 +1,7 @@
 import { staticRequest } from 'tinacms'
 import { TinaMarkdown } from 'tinacms/dist/rich-text'
 import { Layout } from '../components/Layout'
-import { useEditState, useTina } from 'tinacms/dist/react'
+import { useTina } from 'tinacms/dist/react'
 
 const query = `query PageQuery {
   page(relativePath: "home.mdx"){
@@ -9,9 +9,6 @@ const query = `query PageQuery {
   }
 }`
 export default function Home(props) {
-  const { edit } = useEditState()
-  console.log('edit', edit)
-
   const { data } = useTina({
     query,
     variables: {},

--- a/examples/basic-iframe/pages/index.js
+++ b/examples/basic-iframe/pages/index.js
@@ -1,7 +1,7 @@
 import { staticRequest } from 'tinacms'
 import { TinaMarkdown } from 'tinacms/dist/rich-text'
 import { Layout } from '../components/Layout'
-import { useTina } from 'tinacms/dist/react'
+import { useEditState, useTina } from 'tinacms/dist/react'
 
 const query = `query PageQuery {
   page(relativePath: "home.mdx"){
@@ -9,6 +9,9 @@ const query = `query PageQuery {
   }
 }`
 export default function Home(props) {
+  const { edit } = useEditState()
+  console.log('edit', edit)
+
   const { data } = useTina({
     query,
     variables: {},

--- a/packages/@tinacms/app/appFiles/src/preview.tsx
+++ b/packages/@tinacms/app/appFiles/src/preview.tsx
@@ -39,6 +39,13 @@ export const Preview = (
           setActiveQuery(event.data)
         }
       })
+      window.addEventListener('message', (event: MessageEvent<PostMessage>) => {
+        if (event?.data?.type === 'isEditMode') {
+          props.iframeRef?.current?.contentWindow?.postMessage({
+            type: 'tina:editMode',
+          })
+        }
+      })
     }
   }, [props.iframeRef.current])
 
@@ -93,13 +100,6 @@ const QueryMachine = (props: {
 
   React.useEffect(() => {
     if (props.iframeRef.current) {
-      window.addEventListener('message', (event: MessageEvent<PostMessage>) => {
-        if (event?.data?.type === 'isEditMode') {
-          props.iframeRef?.current?.contentWindow?.postMessage({
-            type: 'tina:editMode',
-          })
-        }
-      })
       send({ type: 'IFRAME_MOUNTED', value: props.iframeRef.current })
       if (props.payload.type === 'open') {
         send({ type: 'ADD_QUERY', value: props.payload })


### PR DESCRIPTION
Previously, `useEditState` would not work if called before `useTina`. This PR fixes it so that `useEditState` work no matter what.