### PR TITLE
fix unbound tinaAPI bug

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
@@ -169,6 +169,8 @@ export const FormBuilder: FC<FormBuilderProps> = ({
   //   })
   // }
 
+  const tinaApi = cms.api.tina
+
   return (
     <FinalForm
       form={finalForm}
@@ -224,9 +226,11 @@ export const FormBuilder: FC<FormBuilderProps> = ({
                         (invalid && !dirtySinceLastSubmit)
                       }
                       busy={submitting}
-                      createPullRequest={cms.api.tina.createPullRequest}
-                      indexStatus={cms.api.tina.indexStatus}
-                      vercelStatus={cms.api.tina.vercelStatus}
+                      createPullRequest={tinaApi.createPullRequest.bind(
+                        tinaApi
+                      )}
+                      indexStatus={tinaApi.indexStatus.bind(tinaApi)}
+                      vercelStatus={tinaApi.vercelStatus.bind(tinaApi)}
                     >
                       {submitting && <LoadingDots />}
                       {!submitting && tinaForm.buttons.save}


### PR DESCRIPTION
Hopeful fix for: 

> Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'contentApiBase')
>     at createPullRequest (index.es.js:2427:25)
>     at index.es.js:5227:11
>     at onClick (index.es.js:5282:20)
>     at Object.mQ (react-dom.production.min.js:52:317)
>     at wQ (react-dom.production.min.js:52:471)
>     at bQ (react-dom.production.min.js:53:35)
>     at a3 (react-dom.production.min.js:100:68)
>     at D8 (react-dom.production.min.js:101:380)
>     at react-dom.production.min.js:113:65
>     at n8 (react-dom.production.min.js:292:189)