### PR TITLE
Automate Creating PRs to bump the Tina version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,3 +68,67 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  check-changeset-folder:
+    needs: build
+    name: a
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Check if a file has been deleted from the .changeset folder
+      - id: set
+        run: |
+          deleted_file=$(git diff-tree --no-commit-id --name-only -r HEAD | grep ".changeset/")
+          if [ -n "$deleted_file" ]; then
+             echo "::set-output name=run_job::yes"
+          else
+            echo "::set-output name=run_job::no"
+          fi
+    outputs:
+      run_job: ${{ steps.set.outputs.run_job }}
+
+  update-repos:
+    needs:
+      - check-changeset-folder
+      - build
+    if: needs.check-changeset-folder.outputs.run_job == 'yes'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repo: ['tinacms/tina-cloud-starter', 'tinacms/tina-barebones-starter']
+    steps:
+      - name: Check out repo to update
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: Install dependencies
+        run: yarn install
+      - name: Update Tina packages
+        run: yarn upgrade tinacms@latest @tinacms/cli@latest
+      - name: Update Schema
+        run: yarn tinacms audit
+      - name: Create and switch to new branch
+        run: |
+          current_date=$(date +"%Y-%m-%d")
+          branch_name="update-tina-$current_date"
+          git checkout -b $branch_name
+      - name: Commit and push changes
+        run: |
+          git config user.email "action@github.com"
+          git config user.name "GitHub Action"
+          git add .
+          git commit -m "Update from action"
+          git push origin $branch_name
+      - name: Create pull request
+        uses: actions/create-pull-request@v2
+        with:
+          title: 'Update from action'
+          head: $branch_name
+          base: main
+          body: 'This pull request was automatically created by a GitHub action.'
+          repository: ${{ matrix.repo }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a Github action that automates the creation of PRs to the starters. I am not 100% sure that this works (I am not sure of a good way to test it) but we can test it on the next release. 

