### PR TITLE
List Field Meta Wrapper, Form Improvements

### DIFF
--- a/.changeset/young-turtles-check.md
+++ b/.changeset/young-turtles-check.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/schema-tools': patch
+'@tinacms/scripts': patch
+'@tinacms/toolkit': patch
+---
+
+Adds meta wrapper for list-type fields that displays errors. Adds optional min/max for list-type fields that controls add/remove UI. Removes duplicate label from group field.

--- a/packages/@tinacms/schema-tools/src/types.ts
+++ b/packages/@tinacms/schema-tools/src/types.ts
@@ -115,6 +115,8 @@ type Component<Type, List> = (props: {
 }) => any
 
 type UIField<Type, List extends boolean> = {
+  max?: List extends true ? number : never
+  min?: List extends true ? number : never
   /**
    * Override the label from parent object
    */

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -342,7 +342,20 @@ const config = (cwd = '') => {
         auto: 'auto',
       },
       extend: {
+        keyframes: {
+          slideIn: {
+            '0%': {
+              opacity: '0',
+              transform: 'translateY(-1rem)',
+            },
+            '100%': {
+              opacity: '1',
+              transform: 'translateY(0)',
+            },
+          },
+        },
         animation: {
+          'slide-in': 'slideIn 150ms ease-out 1 normal forwards',
           'spin-reverse': 'spin 1s linear infinite reverse',
         },
         scale: {

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
@@ -21,17 +21,12 @@ import { Field, Form } from '../../../forms'
 import { FieldsBuilder, useFormPortal } from '../../../form-builder'
 import { Droppable, Draggable } from 'react-beautiful-dnd'
 import { GroupPanel, PanelHeader, PanelBody } from '../GroupFieldPlugin'
-import { FieldDescription } from '../wrapFieldWithMeta'
 import {
-  GroupListHeader,
-  GroupListMeta,
   GroupLabel,
   ItemDeleteButton,
   ItemHeader,
-  ListPanel,
   DragHandle,
   ItemClickTarget,
-  EmptyState,
 } from '../GroupListFieldPlugin'
 import { useCMS } from '../../../react-core/use-cms'
 import { useEvent } from '../../../react-core'
@@ -39,6 +34,7 @@ import { FieldHoverEvent, FieldFocusEvent } from '../../field-events'
 import { BlockSelector } from './BlockSelector'
 import { BlockSelectorBig } from './BlockSelectorBig'
 import { BiPencil } from 'react-icons/bi'
+import { EmptyList, ListFieldMeta, ListPanel } from '../ListFieldMeta'
 
 export interface BlocksFieldDefinititon extends Field {
   component: 'blocks'
@@ -79,9 +75,17 @@ interface BlockFieldProps {
   field: BlocksFieldDefinititon
   form: any
   tinaForm: Form
+  index?: number
 }
 
-const Blocks = ({ tinaForm, form, field, input }: BlockFieldProps) => {
+const Blocks = ({
+  tinaForm,
+  form,
+  field,
+  input,
+  meta,
+  index,
+}: BlockFieldProps) => {
   const addItem = React.useCallback(
     (name: string, template: BlockTemplate) => {
       let obj: any = {}
@@ -99,34 +103,31 @@ const Blocks = ({ tinaForm, form, field, input }: BlockFieldProps) => {
   const items = input.value || []
 
   return (
-    <>
-      <GroupListHeader>
-        <GroupListMeta>
-          {field.label !== false && (
-            <GroupLabel>{field.label || field.name}</GroupLabel>
-          )}
-          {field.description && (
-            <FieldDescription>{field.description}</FieldDescription>
-          )}
-        </GroupListMeta>
-        {/* @ts-ignore */}
-        {!field.visualSelector && (
+    <ListFieldMeta
+      name={input.name}
+      label={field.label}
+      description={field.description}
+      error={meta.error}
+      index={index}
+      tinaForm={tinaForm}
+      actions={
+        // @ts-ignore
+        !field.visualSelector ? (
           <BlockSelector templates={field.templates} addItem={addItem} />
-        )}
-        {/* @ts-ignore */}
-        {field.visualSelector && (
+        ) : (
           <BlockSelectorBig
             label={field.label || field.name}
             templates={field.templates}
             addItem={addItem}
           />
-        )}
-      </GroupListHeader>
+        )
+      }
+    >
       <ListPanel>
         <Droppable droppableId={field.name} type={field.name}>
           {(provider) => (
             <div ref={provider.innerRef} className="edit-page--list-parent">
-              {items.length === 0 && <EmptyState />}
+              {items.length === 0 && <EmptyList />}
               {items.map((block: any, index: any) => {
                 const template = field.templates[block._template]
 
@@ -164,7 +165,7 @@ const Blocks = ({ tinaForm, form, field, input }: BlockFieldProps) => {
           )}
         </Droppable>
       </ListPanel>
-    </>
+    </ListFieldMeta>
   )
 }
 

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
@@ -105,7 +105,7 @@ const Blocks = ({
   // @ts-ignore
   const isMax = items.length >= (field.max || Infinity)
   // @ts-ignore
-  const isMin = items.length <= (field.min || Infinity)
+  const isMin = items.length <= (field.min || 0)
   // @ts-ignore
   const fixedLength = field.min === field.max
 

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
@@ -102,6 +102,13 @@ const Blocks = ({
 
   const items = input.value || []
 
+  // @ts-ignore
+  const isMax = items.length >= (field.max || Infinity)
+  // @ts-ignore
+  const isMin = items.length <= (field.min || Infinity)
+  // @ts-ignore
+  const fixedLength = field.min === field.max
+
   return (
     <ListFieldMeta
       name={input.name}
@@ -111,8 +118,9 @@ const Blocks = ({
       index={index}
       tinaForm={tinaForm}
       actions={
+        (!fixedLength || (fixedLength && !isMax)) &&
         // @ts-ignore
-        !field.visualSelector ? (
+        (!field.visualSelector ? (
           <BlockSelector templates={field.templates} addItem={addItem} />
         ) : (
           <BlockSelectorBig
@@ -120,7 +128,7 @@ const Blocks = ({
             templates={field.templates}
             addItem={addItem}
           />
-        )
+        ))
       }
     >
       <ListPanel>
@@ -156,6 +164,8 @@ const Blocks = ({
                     index={index}
                     field={field}
                     tinaForm={tinaForm}
+                    isMin={isMin}
+                    fixedLength={fixedLength}
                     {...itemProps(block)}
                   />
                 )
@@ -176,6 +186,8 @@ interface BlockListItemProps {
   block: any
   template: BlockTemplate
   label?: string
+  isMin?: boolean
+  fixedLength?: boolean
 }
 
 const BlockListItem = ({
@@ -185,6 +197,8 @@ const BlockListItem = ({
   index,
   template,
   block,
+  isMin,
+  fixedLength,
 }: BlockListItemProps) => {
   const cms = useCMS()
   const FormPortal = useFormPortal()
@@ -234,7 +248,9 @@ const BlockListItem = ({
               <GroupLabel>{label || template.label}</GroupLabel>
               <BiPencil className="h-5 w-auto fill-current text-gray-200 group-hover:text-inherit transition-colors duration-150 ease-out" />
             </ItemClickTarget>
-            <ItemDeleteButton onClick={removeItem} />
+            {(!fixedLength || (fixedLength && !isMin)) && (
+              <ItemDeleteButton disabled={isMin} onClick={removeItem} />
+            )}
           </ItemHeader>
           <FormPortal>
             {({ zIndexShift }) => (

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
@@ -22,7 +22,7 @@ import { FieldsBuilder, useFormPortal, FormWrapper } from '../../form-builder'
 import { useCMS } from '../../react-core/use-cms'
 import { BiPencil } from 'react-icons/bi'
 import { IoMdClose } from 'react-icons/io'
-import { wrapFieldsWithMeta } from './wrapFieldWithMeta'
+import { wrapFieldsWithMeta, wrapFieldWithError } from './wrapFieldWithMeta'
 
 export interface GroupFieldDefinititon extends Field {
   component: 'group'
@@ -37,7 +37,7 @@ export interface GroupProps {
   tinaForm: Form
 }
 
-export const Group = wrapFieldsWithMeta(({ tinaForm, field }: GroupProps) => {
+export const Group = wrapFieldWithError(({ tinaForm, field }: GroupProps) => {
   const cms = useCMS()
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
   return (

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupFieldPlugin.tsx
@@ -22,7 +22,7 @@ import { FieldsBuilder, useFormPortal, FormWrapper } from '../../form-builder'
 import { useCMS } from '../../react-core/use-cms'
 import { BiPencil } from 'react-icons/bi'
 import { IoMdClose } from 'react-icons/io'
-import { wrapFieldsWithMeta, wrapFieldWithError } from './wrapFieldWithMeta'
+import { wrapFieldWithError } from './wrapFieldWithMeta'
 
 export interface GroupFieldDefinititon extends Field {
   component: 'group'

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
@@ -84,6 +84,13 @@ const Group = ({ tinaForm, form, field, input, meta, index }: GroupProps) => {
     [field.itemProps]
   )
 
+  // @ts-ignore
+  const isMax = items.length >= (field.max || Infinity)
+  // @ts-ignore
+  const isMin = items.length <= (field.min || Infinity)
+  // @ts-ignore
+  const fixedLength = field.min === field.max
+
   return (
     <ListFieldMeta
       name={input.name}
@@ -93,9 +100,16 @@ const Group = ({ tinaForm, form, field, input, meta, index }: GroupProps) => {
       index={index}
       tinaForm={tinaForm}
       actions={
-        <IconButton onClick={addItem} variant="primary" size="small">
-          <AddIcon className="w-5/6 h-auto" />
-        </IconButton>
+        (!fixedLength || (fixedLength && !isMax)) && (
+          <IconButton
+            onClick={addItem}
+            disabled={isMax}
+            variant="primary"
+            size="small"
+          >
+            <AddIcon className="w-5/6 h-auto" />
+          </IconButton>
+        )
       }
     >
       <ListPanel>
@@ -112,6 +126,8 @@ const Group = ({ tinaForm, form, field, input, meta, index }: GroupProps) => {
                     field={field}
                     item={item}
                     index={index}
+                    isMin={isMin}
+                    fixedLength={fixedLength}
                     {...itemProps(item)}
                   />
                 ))}
@@ -131,9 +147,20 @@ interface ItemProps {
   index: number
   item: any
   label?: string
+  isMin: boolean
+  fixedLength: boolean
 }
 
-const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
+const Item = ({
+  tinaForm,
+  field,
+  index,
+  item,
+  label,
+  isMin,
+  fixedLength,
+  ...p
+}: ItemProps) => {
   const cms = useCMS()
   const FormPortal = useFormPortal()
   const [isExpanded, setExpanded] = React.useState<boolean>(false)
@@ -184,7 +211,9 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
               <GroupLabel>{title}</GroupLabel>
               <BiPencil className="h-5 w-auto fill-current text-gray-200 group-hover:text-inherit transition-colors duration-150 ease-out" />
             </ItemClickTarget>
-            <ItemDeleteButton onClick={removeItem} />
+            {(!fixedLength || (fixedLength && !isMin)) && (
+              <ItemDeleteButton disabled={isMin} onClick={removeItem} />
+            )}
           </ItemHeader>
           <FormPortal>
             {({ zIndexShift }) => (
@@ -261,10 +290,12 @@ export const ItemHeader = ({
   )
 }
 
-export const ItemDeleteButton = ({ onClick }) => {
+export const ItemDeleteButton = ({ onClick, disabled = false }) => {
   return (
     <button
-      className="w-8 px-1 py-2.5 flex items-center justify-center hover:bg-gray-50 text-gray-200 hover:text-red-500"
+      className={`w-8 px-1 py-2.5 flex items-center justify-center hover:bg-gray-50 text-gray-200 hover:text-red-500 ${
+        disabled && 'pointer-events-none opacity-30 cursor-not-allowed'
+      }`}
       onClick={onClick}
     >
       <TrashIcon className="fill-current transition-colors ease-out duration-100" />

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
@@ -23,11 +23,11 @@ import { IconButton } from '../../styles'
 import { Droppable, Draggable } from 'react-beautiful-dnd'
 import { AddIcon, DragIcon, ReorderIcon, TrashIcon } from '../../icons'
 import { GroupPanel, PanelHeader, PanelBody } from './GroupFieldPlugin'
-import { FieldDescription } from './wrapFieldWithMeta'
 import { useEvent } from '../../react-core/use-cms-event'
 import { FieldHoverEvent, FieldFocusEvent } from '../field-events'
 import { useCMS } from '../../react-core/use-cms'
 import { BiPencil } from 'react-icons/bi'
+import { EmptyList, ListFieldMeta, ListPanel } from './ListFieldMeta'
 
 interface GroupFieldDefinititon extends Field {
   component: 'group'
@@ -61,9 +61,10 @@ interface GroupProps {
   field: GroupFieldDefinititon
   form: any
   tinaForm: Form
+  index?: number
 }
 
-const Group = ({ tinaForm, form, field, input }: GroupProps) => {
+const Group = ({ tinaForm, form, field, input, meta, index }: GroupProps) => {
   const addItem = React.useCallback(() => {
     let obj = {}
     if (typeof field.defaultItem === 'function') {
@@ -84,28 +85,25 @@ const Group = ({ tinaForm, form, field, input }: GroupProps) => {
   )
 
   return (
-    <>
-      <GroupListHeader>
-        <GroupListMeta>
-          {field.label !== false && (
-            <GroupLabel>{field.label || field.name}</GroupLabel>
-          )}
-          {field.description && (
-            <FieldDescription className="whitespace-nowrap text-ellipsis overflow-hidden">
-              {field.description}
-            </FieldDescription>
-          )}
-        </GroupListMeta>
+    <ListFieldMeta
+      name={input.name}
+      label={field.label}
+      description={field.description}
+      error={meta.error}
+      index={index}
+      tinaForm={tinaForm}
+      actions={
         <IconButton onClick={addItem} variant="primary" size="small">
           <AddIcon className="w-5/6 h-auto" />
         </IconButton>
-      </GroupListHeader>
+      }
+    >
       <ListPanel>
         <div>
           <Droppable droppableId={field.name} type={field.name}>
             {(provider) => (
               <div ref={provider.innerRef}>
-                {items.length === 0 && <EmptyState />}
+                {items.length === 0 && <EmptyList />}
                 {items.map((item: any, index: any) => (
                   <Item
                     // NOTE: Supressing warnings, but not helping with render perf
@@ -123,11 +121,9 @@ const Group = ({ tinaForm, form, field, input }: GroupProps) => {
           </Droppable>
         </div>
       </ListPanel>
-    </>
+    </ListFieldMeta>
   )
 }
-
-export const EmptyState = () => <EmptyList>There are no items</EmptyList>
 
 interface ItemProps {
   tinaForm: Form
@@ -235,34 +231,6 @@ export const GroupLabel = ({
     >
       {children}
     </span>
-  )
-}
-
-export const GroupListHeader = ({ children }: { children?: any }) => {
-  return (
-    <span className="relative flex gap-2 w-full justify-between items-center mb-2">
-      {children}
-    </span>
-  )
-}
-
-export const GroupListMeta = ({ children }: { children?: any }) => {
-  return <div className="flex-1 truncate">{children}</div>
-}
-
-export const ListPanel = ({ children }) => {
-  return (
-    <div className="relative mb-6 rounded-md bg-gray-100 shadow">
-      {children}
-    </div>
-  )
-}
-
-export const EmptyList = ({ children }) => {
-  return (
-    <div className="text-center rounded bg-gray-100 text-gray-400 p-3 text-sm italic font-regular">
-      {children}
-    </div>
   )
 }
 

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldMeta.tsx
@@ -1,0 +1,115 @@
+/**
+
+Copyright 2021 Forestry.io Holdings, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+*/
+
+import * as React from 'react'
+import { useEvent } from '../../react-core/use-cms-event'
+import { FieldHoverEvent, FieldFocusEvent } from '../field-events'
+import { Form } from '../../forms'
+import { FieldDescription, FieldError, FieldWrapper } from './wrapFieldWithMeta'
+
+interface FieldMetaProps extends React.HTMLAttributes<HTMLElement> {
+  name: string
+  children: any
+  actions?: any
+  label?: string | boolean
+  description?: string
+  error?: string
+  margin?: boolean
+  index?: number
+  tinaForm: Form
+}
+
+export const ListFieldMeta = ({
+  name,
+  label,
+  description,
+  error,
+  margin = true,
+  children,
+  actions,
+  index,
+  tinaForm,
+  ...props
+}: FieldMetaProps) => {
+  const { dispatch: setHoveredField } = useEvent<FieldHoverEvent>('field:hover')
+  const { dispatch: setFocusedField } = useEvent<FieldFocusEvent>('field:focus')
+  return (
+    <FieldWrapper
+      margin={margin}
+      onMouseOver={() => setHoveredField({ id: tinaForm.id, fieldName: name })}
+      onMouseOut={() => setHoveredField({ id: null, fieldName: null })}
+      onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
+      style={{ zIndex: index ? 1000 - index : undefined }}
+      {...props}
+    >
+      <ListHeader>
+        <ListMeta>
+          {label !== false && <ListLabel>{label || name}</ListLabel>}
+          {description && (
+            <FieldDescription className="whitespace-nowrap text-ellipsis overflow-hidden">
+              {description}
+            </FieldDescription>
+          )}
+        </ListMeta>
+        {actions && actions}
+      </ListHeader>
+      {children}
+      {/*
+      FIXME: when a object field has a sub-field with a validation (eg. required)
+             AND the object field is not pristine (eg. you've touched other fields)
+             the error will be an object (eg {mySubField: "required"}).
+     */}
+      {error && typeof error === 'string' && <FieldError>{error}</FieldError>}
+    </FieldWrapper>
+  )
+}
+
+export const ListHeader = ({ children }: { children?: any }) => {
+  return (
+    <span className="relative flex gap-2 w-full justify-between items-center mb-2">
+      {children}
+    </span>
+  )
+}
+
+export const ListMeta = ({ children }: { children?: any }) => {
+  return <div className="flex-1 truncate">{children}</div>
+}
+
+export const ListLabel = ({ children }: { children?: any }) => {
+  return (
+    <span
+      className={`m-0 text-xs font-semibold flex-1 text-ellipsis overflow-hidden transition-all ease-out duration-100 text-left`}
+    >
+      {children}
+    </span>
+  )
+}
+
+export const ListPanel = ({ className = '', ...props }) => (
+  <div
+    className={`max-h-[initial] relative h-auto rounded-md shadow bg-gray-100 ${className}`}
+    {...props}
+  />
+)
+
+export const EmptyList = ({ message = 'There are no items' }) => (
+  <div className="text-center bg-gray-100 text-gray-300 leading-[1.35] py-3 text-[15px] font-normal">
+    {message}
+  </div>
+)

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
@@ -92,7 +92,7 @@ const List = ({ tinaForm, form, field, input, meta, index }: ListProps) => {
   // @ts-ignore
   const isMax = items.length >= (field.max || Infinity)
   // @ts-ignore
-  const isMin = items.length <= (field.min || Infinity)
+  const isMin = items.length <= (field.min || 0)
   // @ts-ignore
   const fixedLength = field.min === field.max
 

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldPlugin.tsx
@@ -89,6 +89,13 @@ const List = ({ tinaForm, form, field, input, meta, index }: ListProps) => {
     [field.itemProps]
   )
 
+  // @ts-ignore
+  const isMax = items.length >= (field.max || Infinity)
+  // @ts-ignore
+  const isMin = items.length <= (field.min || Infinity)
+  // @ts-ignore
+  const fixedLength = field.min === field.max
+
   return (
     <ListFieldMeta
       name={input.name}
@@ -98,9 +105,11 @@ const List = ({ tinaForm, form, field, input, meta, index }: ListProps) => {
       index={index}
       tinaForm={tinaForm}
       actions={
-        <IconButton onClick={addItem} variant="primary" size="small">
-          <AddIcon className="w-5/6 h-auto" />
-        </IconButton>
+        (!fixedLength || (fixedLength && !isMax)) && (
+          <IconButton onClick={addItem} variant="primary" size="small">
+            <AddIcon className="w-5/6 h-auto" />
+          </IconButton>
+        )
       }
     >
       <ListPanel>
@@ -117,6 +126,8 @@ const List = ({ tinaForm, form, field, input, meta, index }: ListProps) => {
                     field={field}
                     item={item}
                     index={index}
+                    isMin={isMin}
+                    fixedLength={fixedLength}
                     {...itemProps(item)}
                   />
                 ))}
@@ -136,9 +147,20 @@ interface ItemProps {
   index: number
   item: any
   label?: string
+  isMin?: boolean
+  fixedLength?: boolean
 }
 
-const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
+const Item = ({
+  tinaForm,
+  field,
+  index,
+  item,
+  label,
+  isMin,
+  fixedLength,
+  ...p
+}: ItemProps) => {
   const removeItem = React.useCallback(() => {
     tinaForm.mutators.remove(field.name, index)
   }, [tinaForm, field, index])
@@ -165,7 +187,9 @@ const Item = ({ tinaForm, field, index, item, label, ...p }: ItemProps) => {
           <ItemClickTarget>
             <FieldsBuilder padding={false} form={tinaForm} fields={fields} />
           </ItemClickTarget>
-          <ItemDeleteButton onClick={removeItem} />
+          {(!fixedLength || (fixedLength && !isMin)) && (
+            <ItemDeleteButton disabled={isMin} onClick={removeItem} />
+          )}
         </ItemHeader>
       )}
     </Draggable>

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/index.tsx
@@ -63,7 +63,7 @@ export const MdxFieldPlugin = {
         >
           <div
             className={
-              'min-h-[100px] max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded-md px-3 py-2 mb-5'
+              'min-h-[100px] max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded-md px-3 py-2'
             }
           >
             {/* {rawMode ? <RawEditor {...props} /> : <RichEditor {...props} />} */}
@@ -106,7 +106,7 @@ export const MdxFieldPluginExtendible = {
         >
           <div
             className={
-              'min-h-[100px] max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded-md px-3 py-2 mb-5'
+              'min-h-[100px] max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded-md px-3 py-2'
             }
           >
             {props.rawMode ? props.rawEditor : <RichEditor {...props} />}

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -48,6 +48,28 @@ export function wrapFieldsWithMeta<ExtraFieldProps = {}, InputProps = {}>(
   }
 }
 
+// Same as above but excludes the label, useful for fields that have their own label
+export function wrapFieldWithError<ExtraFieldProps = {}, InputProps = {}>(
+  Field:
+    | React.FunctionComponent<InputFieldType<ExtraFieldProps, InputProps>>
+    | React.ComponentClass<InputFieldType<ExtraFieldProps, InputProps>>
+) {
+  return (props: InputFieldType<ExtraFieldProps, InputProps>) => {
+    return (
+      <FieldMeta
+        name={props.input.name}
+        label={false}
+        description={props.field.description}
+        error={props.meta.error}
+        index={props.index}
+        tinaForm={props.tinaForm}
+      >
+        <Field {...props} />
+      </FieldMeta>
+    )
+  }
+}
+
 interface FieldMetaProps extends React.HTMLAttributes<HTMLElement> {
   name: string
   children: any

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/wrapFieldWithMeta.tsx
@@ -164,7 +164,7 @@ export const FieldError = ({
 }) => {
   return (
     <span
-      className={`block font-sans text-xs font-normal text-red-500 pt-2 whitespace-normal m-0 ${className}`}
+      className={`block font-sans text-xs font-normal text-red-500 pt-3 animate-slide-in whitespace-normal m-0  ${className}`}
       {...props}
     >
       {children}

--- a/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
@@ -340,7 +340,7 @@ export const FormWrapper = ({ children, id }) => {
   return (
     <div
       data-test={`form:${id?.replace(/\\/g, '/')}`}
-      className="h-full overflow-y-auto max-h-full bg-gray-50 pt-6 px-6 pb-2"
+      className="h-full overflow-y-auto max-h-full bg-gray-50 py-5 px-6"
     >
       <div className="w-full flex justify-center">
         <div className="w-full max-w-form">{children}</div>


### PR DESCRIPTION
### Video Demo -- Shows both list errors and min/max:
https://user-images.githubusercontent.com/5075484/211587949-a19681e1-f8c9-4f91-820a-f7f55eeb0e6d.mp4

## Fixes Errors

The List, Group List and Block fields weren't displaying errors. I've created a list meta wrapper component that provides the label, description, and error UI. It accepts an 'actions' prop that allows each field to control that logic.

This also updates the error styles to give it a bit more whitespace and a quick slide-in animation.

Fixes #3495

## Adds Min/Max Support

The field UI object now accepts a min and max when the field is `list: true`. If the list/group list/block field is at the max or min value, the add or remove buttons are disabled. If the min and max values are the same, the field is considered 'fixed length' and the add/remove buttons are removed entirely, unless the data is invalid (you can still add items if there's not enough to satisfy the validation).

<img width="608" alt="Screenshot 2023-01-06 at 2 20 47 PM" src="https://user-images.githubusercontent.com/5075484/211074258-3bc93d4d-5e22-4b13-9a2b-9612884865f2.png">

Here's a field with min and max set to the same number: (no add/remove buttons)
<img width="537" alt="Screenshot 2023-01-10 at 10 39 19 AM" src="https://user-images.githubusercontent.com/5075484/211580526-6df4288e-33a3-465f-a028-5190c80c51b5.png">

### Fix Form Whitespace

Adds padding at the bottom of forms and removes unnecessary margin from the MDX component (this is provided by the field wrapper). 

<img width="582" alt="Screenshot 2023-01-10 at 10 59 17 AM" src="https://user-images.githubusercontent.com/5075484/211585393-e5ed8fb6-12b3-4581-ae74-0a192a3b4b3d.png">
