### PR TITLE
Add support for rootPath option in CLI

### DIFF
--- a/.changeset/fast-pugs-join.md
+++ b/.changeset/fast-pugs-join.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/app': patch
+'@tinacms/cli': patch
+---
+
+Add support for --rootPath argument in CLI commands

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -44,6 +44,7 @@
     "@types/react-dom": "17.0.2",
     "@tinacms/scripts": "workspace:*",
     "tinacms": "workspace:*",
+    "@tinacms/toolkit": "workspace:*",
     "@tinacms/mdx": "workspace:*",
     "jest": "^27.0.6"
   },

--- a/packages/@tinacms/app/src/index.ts
+++ b/packages/@tinacms/app/src/index.ts
@@ -160,7 +160,7 @@ export const viteBuild = async ({
     },
     resolve: {
       alias,
-      dedupe: ['graphql'],
+      dedupe: ['graphql', 'tinacms', '@tinacms/toolkit'],
     },
     build: {
       sourcemap: true,

--- a/packages/@tinacms/cli/package.json
+++ b/packages/@tinacms/cli/package.json
@@ -48,6 +48,7 @@
     "test": "jest --passWithNoTests",
     "types": "pnpm tsc",
     "test-watch": "jest  --passWithNoTests --watch",
+    "tinacms": "MONOREPO_DEV=true node ./bin/tinacms",
     "generate:schema": "yarn node scripts/generateSchema.js"
   },
   "dependencies": {

--- a/packages/@tinacms/cli/src/buildTina/attachPath.ts
+++ b/packages/@tinacms/cli/src/buildTina/attachPath.ts
@@ -14,8 +14,8 @@
 import { pathExists } from 'fs-extra'
 import path from 'path'
 
-export const attachPath = async (ctx: any, next: () => void, _options: any) => {
-  ctx.rootPath = process.cwd()
+export const attachPath = async (ctx: any, next: () => void, options: any) => {
+  ctx.rootPath = options.rootPath || process.cwd()
 
   ctx.usingTs = await isProjectTs(ctx.rootPath)
   next()

--- a/packages/@tinacms/cli/src/buildTina/index.ts
+++ b/packages/@tinacms/cli/src/buildTina/index.ts
@@ -41,6 +41,7 @@ interface ClientGenOptions {
   local?: boolean
   verbose?: boolean
   port?: number
+  rootPath?: string
 }
 
 interface BuildOptions {
@@ -271,19 +272,20 @@ export class ConfigBuilder {
     verbose,
     local,
     port,
+    rootPath,
   }: ClientGenOptions & {
     usingTs: boolean
     compiledSchema: any
   }) {
     const astSchema = await getASTSchema(this.database)
 
-    await genTypes({ schema: astSchema, usingTs }, () => {}, {
+    await genTypes({ schema: astSchema, usingTs, rootPath }, () => {}, {
       noSDK,
       verbose,
     })
 
     return genClient(
-      { tinaSchema: compiledSchema, usingTs },
+      { tinaSchema: compiledSchema, usingTs, rootPath },
       {
         local,
         port,

--- a/packages/@tinacms/cli/src/cmds/baseCmds.ts
+++ b/packages/@tinacms/cli/src/cmds/baseCmds.ts
@@ -43,6 +43,11 @@ const startServerPortOption = {
   name: '--port <port>',
   description: 'Specify a port to run the server on. (default 4001)',
 }
+const rootPathOption = {
+  name: '--rootPath <rootPath>',
+  description:
+    'Specify the root directory to run the CLI from (defaults to current working directory)',
+}
 const experimentalDatalayer = {
   name: '--experimentalData',
   description: 'Build the server with additional data querying capabilities',
@@ -161,6 +166,7 @@ export const baseCmds: Command[] = [
       noTelemetryOption,
       watchFileOption,
       verboseOption,
+      rootPathOption,
     ],
     action: (options) =>
       chain(
@@ -185,6 +191,7 @@ export const baseCmds: Command[] = [
       verboseOption,
       developmentOption,
       localOption,
+      rootPathOption,
     ],
     action: (options) =>
       chain(
@@ -202,6 +209,7 @@ export const baseCmds: Command[] = [
   {
     command: INIT,
     options: [
+      rootPathOption,
       experimentalDatalayer,
       isomorphicGitBridge,
       noTelemetryOption,
@@ -214,6 +222,7 @@ export const baseCmds: Command[] = [
   },
   {
     options: [
+      rootPathOption,
       cleanOption,
       useDefaultValuesOption,
       noTelemetryOption,

--- a/packages/@tinacms/cli/src/cmds/query-gen/genTypes.ts
+++ b/packages/@tinacms/cli/src/cmds/query-gen/genTypes.ts
@@ -21,16 +21,20 @@ import { logText, warnText } from '../../utils/theme'
 import { logger } from '../../logger'
 import { transform } from 'esbuild'
 export const TINA_HOST = 'content.tinajs.io'
-const root = process.cwd()
-const generatedPath = p.join(root, '.tina', '__generated__')
 
 export async function genClient(
   {
     tinaSchema,
     usingTs,
-  }: { tinaSchema: TinaCloudSchema<false>; usingTs?: boolean },
+    rootPath,
+  }: {
+    tinaSchema: TinaCloudSchema<false>
+    usingTs?: boolean
+    rootPath: string
+  },
   options
 ) {
+  const generatedPath = p.join(rootPath, '.tina', '__generated__')
   const branch = tinaSchema?.config?.branch
   const clientId = tinaSchema?.config?.clientId
   const token = tinaSchema.config?.token
@@ -68,15 +72,19 @@ export default client;
 }
 
 export async function genTypes(
-  { schema, usingTs }: { schema: GraphQLSchema; usingTs?: boolean },
+  {
+    schema,
+    usingTs,
+    rootPath,
+  }: { schema: GraphQLSchema; usingTs?: boolean; rootPath: string },
   next: () => void,
   options
 ) {
-  const typesPath = process.cwd() + '/.tina/__generated__/types.ts'
-  const typesJSPath = process.cwd() + '/.tina/__generated__/types.js'
-  const typesDPath = process.cwd() + '/.tina/__generated__/types.d.ts'
-  const fragPath = process.cwd() + '/.tina/__generated__/*.{graphql,gql}'
-  const queryPathGlob = process.cwd() + '/.tina/queries/**/*.{graphql,gql}'
+  const typesPath = rootPath + '/.tina/__generated__/types.ts'
+  const typesJSPath = rootPath + '/.tina/__generated__/types.js'
+  const typesDPath = rootPath + '/.tina/__generated__/types.d.ts'
+  const fragPath = rootPath + '/.tina/__generated__/*.{graphql,gql}'
+  const queryPathGlob = rootPath + '/.tina/queries/**/*.{graphql,gql}'
 
   const typescriptTypes = await generateTypes(
     schema,
@@ -104,7 +112,7 @@ export async function genTypes(
   }
 
   const schemaString = await printSchema(schema)
-  const schemaPath = process.cwd() + '/.tina/__generated__/schema.gql'
+  const schemaPath = rootPath + '/.tina/__generated__/schema.gql'
 
   await fs.outputFile(
     schemaPath,

--- a/packages/@tinacms/cli/src/cmds/start-server/index.ts
+++ b/packages/@tinacms/cli/src/cmds/start-server/index.ts
@@ -199,6 +199,7 @@ export async function startServer(
         verbose,
         usingTs: ctx.usingTs,
         port,
+        rootPath: ctx.rootPath,
       })
 
       await spin({

--- a/packages/@tinacms/cli/src/server/models/media.ts
+++ b/packages/@tinacms/cli/src/server/models/media.ts
@@ -40,21 +40,25 @@ interface ListMediaRes {
   error?: string
 }
 export interface PathConfig {
+  rootPath: string
   publicFolder: string
   mediaRoot: string
 }
 
 type SuccessRecord = { ok: true } | { ok: false; message: string }
 export class MediaModel {
+  public readonly rootPath: string
   public readonly publicFolder: string
   public readonly mediaRoot: string
-  constructor({ publicFolder, mediaRoot }: PathConfig) {
+  constructor({ rootPath, publicFolder, mediaRoot }: PathConfig) {
+    this.rootPath = rootPath
     this.mediaRoot = mediaRoot
     this.publicFolder = publicFolder
   }
   async listMedia(args: MediaArgs): Promise<ListMediaRes> {
     try {
       const folderPath = join(
+        this.rootPath,
         this.publicFolder,
         this.mediaRoot,
         args.searchPath
@@ -130,7 +134,12 @@ export class MediaModel {
   }
   async deleteMedia(args: MediaArgs): Promise<SuccessRecord> {
     try {
-      const file = join(this.publicFolder, this.mediaRoot, args.searchPath)
+      const file = join(
+        this.rootPath,
+        this.publicFolder,
+        this.mediaRoot,
+        args.searchPath
+      )
       // ensure the file exists because fs.remove does not throw an error if the file does not exist
       await fs.stat(file)
       await fs.remove(file)

--- a/packages/@tinacms/cli/src/server/routes/index.ts
+++ b/packages/@tinacms/cli/src/server/routes/index.ts
@@ -17,7 +17,11 @@ import multer from 'multer'
 import { MediaModel, PathConfig } from '../models/media'
 
 export const createMediaRouter = (config: PathConfig): Router => {
-  const mediaFolder = join(process.cwd(), config.publicFolder, config.mediaRoot)
+  const mediaFolder = join(
+    config.rootPath,
+    config.publicFolder,
+    config.mediaRoot
+  )
   const storage = multer.diskStorage({
     destination: function (req, file, cb) {
       cb(null, mediaFolder)

--- a/packages/@tinacms/cli/src/server/server.ts
+++ b/packages/@tinacms/cli/src/server/server.ts
@@ -75,6 +75,7 @@ export const gqlServer = async (database, verbose: boolean) => {
   app.use(
     '/media',
     createMediaRouter({
+      rootPath: db.bridge.rootPath,
       publicFolder: parseMediaFolder(mediaPaths?.publicFolder || ''),
       mediaRoot: parseMediaFolder(mediaPaths?.mediaRoot || ''),
     })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -329,6 +329,7 @@ importers:
       '@tailwindcss/typography': ^0.5.4
       '@tinacms/mdx': workspace:*
       '@tinacms/scripts': workspace:*
+      '@tinacms/toolkit': workspace:*
       '@types/fs-extra': ^9.0.1
       '@types/react': 17.0.2
       '@types/react-dom': 17.0.2
@@ -382,6 +383,7 @@ importers:
     devDependencies:
       '@tinacms/mdx': link:../mdx
       '@tinacms/scripts': link:../scripts
+      '@tinacms/toolkit': link:../toolkit
       '@types/fs-extra': 9.0.13
       '@types/react': 17.0.2
       '@types/react-dom': 17.0.2
@@ -500,7 +502,7 @@ importers:
       zod: ^3.14.3
     dependencies:
       '@graphql-codegen/core': 2.5.1_graphql@15.8.0
-      '@graphql-codegen/plugin-helpers': 3.1.1_graphql@15.8.0
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@15.8.0
       '@graphql-codegen/typescript': 2.5.1_graphql@15.8.0
       '@graphql-codegen/typescript-generic-sdk': 2.3.12_graphql@15.8.0
       '@graphql-codegen/typescript-operations': 2.4.2_graphql@15.8.0
@@ -5630,15 +5632,15 @@ packages:
       tslib: 2.4.0
     dev: false
 
-  /@graphql-codegen/plugin-helpers/3.1.1_graphql@15.8.0:
+  /@graphql-codegen/plugin-helpers/3.1.2_graphql@15.8.0:
     resolution:
       {
-        integrity: sha512-+V1WK4DUhejVSbkZrAsyv9gA4oQABVrtEUkT7vWq7gSf7Ln6OEM59lDUDsjp5wpLPTBIDJANbAe3qEd+iCB3Ow==,
+        integrity: sha512-emOQiHyIliVOIjKVKdsI5MXj312zmRDwmHpyUTZMjfpvxq/UVAHUJIVdVf+lnjjrI+LXBTgMlTWTgHQfmICxjg==,
       }
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
-      '@graphql-tools/utils': 8.8.0_graphql@15.8.0
+      '@graphql-tools/utils': 9.1.3_graphql@15.8.0
       change-case-all: 1.0.15
       common-tags: 1.8.2
       graphql: 15.8.0
@@ -5871,6 +5873,18 @@ packages:
     dependencies:
       graphql: 15.8.0
       tslib: 2.4.0
+
+  /@graphql-tools/utils/9.1.3_graphql@15.8.0:
+    resolution:
+      {
+        integrity: sha512-bbJyKhs6awp1/OmP+WKA1GOyu9UbgZGkhIj5srmiMGLHohEOKMjW784Sk0BZil1w2x95UPu0WHw6/d/HVCACCg==,
+      }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      graphql: 15.8.0
+      tslib: 2.4.0
+    dev: false
 
   /@headlessui/react/1.6.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution:


### PR DESCRIPTION
This is a precursor to the separate content repos work, but it has a nice side-effect in that it allows us to use Tina modules from the monorepo while developing without `npm link`.

Run the normal watch command from the `tinacms` root:
```
pnpm watch
```

From the `packages/@tinacms/cli` root:

```
pnpm tinacms dev --rootPath /Users/jeffsee/code/my-tina-site
```
`tinacms dev` can be whatever command you need.

