### PR TITLE
Fix Cloud Sidebar Links

### DIFF
--- a/.changeset/twelve-geese-prove.md
+++ b/.changeset/twelve-geese-prove.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix links to Tina Cloud

--- a/packages/@tinacms/toolkit/src/tina-cms.ts
+++ b/packages/@tinacms/toolkit/src/tina-cms.ts
@@ -132,7 +132,7 @@ export class TinaCMS extends CMS {
             name: 'Project Config',
             link: {
               text: 'Project Config',
-              href: `https://app.tina.io/projects/${clientId}/0`,
+              href: `https://app.tina.io/projects/${clientId}/overview`,
             },
           })
         )
@@ -141,7 +141,7 @@ export class TinaCMS extends CMS {
             name: 'User Management',
             link: {
               text: 'User Management',
-              href: `https://app.tina.io/projects/${clientId}/3`,
+              href: `https://app.tina.io/projects/${clientId}/collaborators`,
             },
           })
         )


### PR DESCRIPTION
The cloud project UI received an update that added semantic routing, so the old `/0` and `/3` type links don't work, this updates them.