### PR TITLE
revert styling that broke tests

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
+++ b/packages/@tinacms/toolkit/src/packages/form-builder/FormBuilder.tsx
@@ -381,7 +381,7 @@ export const FormWrapper = ({ children, id }) => {
   return (
     <div
       data-test={`form:${id?.replace(/\\/g, '/')}`}
-      className="h-full overflow-y-auto max-h-full bg-gray-50 pt-6 px-6 pb-2"
+      className="h-full overflow-y-auto max-h-full bg-gray-50 py-5 px-6"
     >
       <div className="w-full flex justify-center">
         <div className="w-full max-w-form">{children}</div>


### PR DESCRIPTION
There was some styling that added some padding to the bottom that prevented the e2e tests from finding the element. 

I tried to update the tests to be more robust but was having difficulty getting it all to work properly. We can undo the small style update so the tests pass and look into updating the e2e tests in the future. 
