### PR TITLE
Fix issue with deeply nested object transforms

### DIFF
--- a/.changeset/brown-scissors-sneeze.md
+++ b/.changeset/brown-scissors-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/schema-tools': patch
+---
+
+Fix issue where deeply nested template objects inside field objects weren't transformed on save properly

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -315,7 +315,15 @@ export class TinaSchema {
           return { [_template]: this.transformCollectablePayload(rest, field) }
         }
       } else {
-        return value
+        if (field.list) {
+          assertShape<object[]>(value, (yup) => yup.array(yup.object()))
+          return value.map((item) => {
+            return this.transformCollectablePayload(item, field)
+          })
+        } else {
+          assertShape<object>(value, (yup) => yup.object())
+          return this.transformCollectablePayload(value, field)
+        }
       }
     else {
       return value


### PR DESCRIPTION
Fix issue where deeply nested template objects inside field objects weren't transformed on save properly

