### PR TITLE
Allow user to save an empty array

### DIFF
--- a/.changeset/smooth-jokes-work.md
+++ b/.changeset/smooth-jokes-work.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix usse where user could not save top level empty array

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -705,6 +705,7 @@ export class Resolver {
     Object.entries(fieldParams).forEach(([fieldName, fieldValue]) => {
       if (Array.isArray(fieldValue)) {
         if (fieldValue.length === 0) {
+          accum[fieldName] = []
           return
         }
       }


### PR DESCRIPTION
Fixes an issue that @jeffsee55 found where a user could not save a top level array that was empty.

Potential fix for #3536