### PR TITLE
fix: make rich text errors scrollable

### DIFF
--- a/.changeset/poor-wasps-cough.md
+++ b/.changeset/poor-wasps-cough.md
@@ -1,0 +1,7 @@
+---
+"@tinacms/app": patch
+"@tinacms/toolkit": patch
+"tinacms": patch
+---
+
+fix: make rich text errors scrollable

--- a/packages/@tinacms/app/appFiles/src/fields/rich-text/monaco/error-message.tsx
+++ b/packages/@tinacms/app/appFiles/src/fields/rich-text/monaco/error-message.tsx
@@ -101,7 +101,7 @@ export function ErrorMessage({ error }: { error: InvalidMarkdownElement }) {
           >
             <Popover.Panel className="absolute top-8 w-[300px] -right-3 z-10 mt-3 px-4 sm:px-0">
               <div className="overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
-                <div className="rounded-md bg-red-50 p-4">
+                <div className="rounded-md bg-red-50 p-4 overflow-scroll">
                   <div className="flex">
                     <div className="flex-shrink-0">
                       <XCircleIcon

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/monaco/error-message.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/monaco/error-message.tsx
@@ -101,7 +101,7 @@ export function ErrorMessage({ error }: { error: InvalidMarkdownElement }) {
           >
             <Popover.Panel className="absolute top-8 w-[300px] -right-3 z-10 mt-3 px-4 sm:px-0">
               <div className="overflow-hidden rounded-lg shadow-lg ring-1 ring-black ring-opacity-5">
-                <div className="rounded-md bg-red-50 p-4">
+                <div className="rounded-md bg-red-50 p-4 overflow-scroll">
                   <div className="flex">
                     <div className="flex-shrink-0">
                       <XCircleIcon


### PR DESCRIPTION
https://www.loom.com/share/cea9252a5c074f289fd4c84bef7c8ba0

The error wasn't always visible.
@spbyrne may want to take a peek