### PR TITLE
Set input value even with errors in rawmode

### DIFF
--- a/packages/@tinacms/app/appFiles/src/fields/rich-text/monaco/index.tsx
+++ b/packages/@tinacms/app/appFiles/src/fields/rich-text/monaco/index.tsx
@@ -91,15 +91,16 @@ export const RawEditor = (props: RichTextType) => {
   React.useEffect(() => {
     // @ts-ignore no access to the rich-text type from this package
     const parsedValue = parseMDX(value, field, (value) => value)
-    if (parsedValue.children[0]) {
-      if (parsedValue.children[0].type === 'invalid_markdown') {
-        const invalidMarkdown = parsedValue.children[0]
-        setError(invalidMarkdown)
-        return
-      }
+    if (
+      parsedValue.children[0] &&
+      parsedValue.children[0].type === 'invalid_markdown'
+    ) {
+      const invalidMarkdown = parsedValue.children[0]
+      setError(invalidMarkdown)
+    } else {
+      setError(null)
     }
     props.input.onChange(parsedValue)
-    setError(null)
   }, [JSON.stringify(debouncedValue)])
 
   React.useEffect(() => {

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/index.tsx
@@ -77,6 +77,13 @@ export const MdxFieldPlugin = {
 
 export const MdxFieldPluginExtendible = {
   name: 'rich-text',
+  validate(value: any) {
+    if (value.children[0] && value.children[0].type === 'invalid_markdown') {
+      return 'Unable to parse rich-text'
+    } else {
+      return undefined
+    }
+  },
   Component: wrapFieldsWithMeta<InputProps, { templates: MdxTemplate[] }>(
     (props) => {
       const [key, setKey] = React.useState(0)

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/create-invalid-markdown-plugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/create-invalid-markdown-plugin/index.tsx
@@ -44,10 +44,13 @@ export function ErrorMessage({ error }) {
         </h3>
         <div className="mt-2 max-w-xl text-sm text-red-800 space-y-4">
           <p>{message}</p>
-          <p>
-            To fix these errors, edit your content locally and then restart the
-            Tina server.
-          </p>
+          <p>To fix these errors, edit the content in raw-mode.</p>
+          <button
+            onClick={() => setRawMode(true)}
+            className="rounded-l-md border-r-0 shadow rounded-md bg-white cursor-pointer relative inline-flex items-center px-2 py-2 border border-gray-200 hover:text-white text-sm font-medium transition-all ease-out duration-150 hover:bg-gray-500 focus:z-10 focus:outline-none focus:ring-1 focus:ring-gray-500 focus:border-gray-500"
+          >
+            Switch to raw-mode
+          </button>
         </div>
         {/* <div className="mt-5">
           <button


### PR DESCRIPTION
Currently, when you make a change in raw-mode with an error, when you switch to the rich-text editor, your changes are quietly wiped. Saving also quietly omits any changes after you introduced a rich-text editor. 

This changes that behaviour a bit:
- Changes to raw-mode / rich-text-editor are always persisted in the form state (even with an error)
- The form now gets a validation error when we can't parse rich-text (to block saving)
- I added a button to jump to the raw mode if there's an error (@spbyrne may want to take a look at the styling)

https://www.loom.com/share/040cbb84408a442b93f60c9b0731cca6

fixes ENG-778
fixes ENG-784
fixes ENG-776
fixes ENG-781