### PR TITLE
Fix/children undefined

### DIFF
--- a/.changeset/rare-yaks-roll.md
+++ b/.changeset/rare-yaks-roll.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix error where children being undefined would cause an error

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/index.tsx
@@ -78,7 +78,12 @@ export const MdxFieldPlugin = {
 export const MdxFieldPluginExtendible = {
   name: 'rich-text',
   validate(value: any) {
-    if (value.children[0] && value.children[0].type === 'invalid_markdown') {
+    if (
+      typeof value !== 'undefined' &&
+      value !== null &&
+      value.children[0] &&
+      value.children[0].type === 'invalid_markdown'
+    ) {
       return 'Unable to parse rich-text'
     } else {
       return undefined


### PR DESCRIPTION
cc @jamespohalloran 

I noticed a bug that would break content creation. If you create a document with multiple rich-text components you would not be able to type or create a document. 