### PR TITLE
no long express all env vars to the frontend

### DIFF
--- a/.changeset/nasty-tigers-own.md
+++ b/.changeset/nasty-tigers-own.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Fix issue where all env vars where send to the admin

--- a/packages/@tinacms/app/src/index.ts
+++ b/packages/@tinacms/app/src/index.ts
@@ -119,6 +119,19 @@ export const viteBuild = async ({
     TINA_IMPORT: configPrebuildPath,
   }
 
+  // TODO: make this configurable
+  const publicEnv: Record<string, string> = {}
+  Object.keys(process.env).forEach((key) => {
+    if (
+      key.startsWith('TINA_PUBLIC_') ||
+      key.startsWith('NEXT_PUBLIC_') ||
+      key === 'NODE_ENV' ||
+      key === 'HEAD'
+    ) {
+      publicEnv[key] = JSON.stringify(process.env[key])
+    }
+  })
+
   const config: InlineConfig = {
     root: appRootPath,
     base: `/${outputFolder}/`,
@@ -143,7 +156,7 @@ export const viteBuild = async ({
        * `process.env` with `{}` are problematic, because browsers don't understand the `{}.` syntax,
        * but node does. This was a surprise, but using `new Object()` seems to do the trick.
        */
-      'process.env': `new Object(${JSON.stringify(process.env)})`,
+      'process.env': `new Object(${JSON.stringify(publicEnv)})`,
       __API_URL__: `"${apiUrl}"`,
     },
     // NextJS forces es5 on tsconfig, specifying it here ignores that


### PR DESCRIPTION
Fixes #3579 by exposing `NODE_ENV`, `NEXT_PUBLIC_*`, `TINA_PUBLIC_*`, and `HEAD` (for integration with Netifly) environment vars in the admin. 
