### PR TITLE
fix: detect LevelDB initialization error and throw a meaningful error

### DIFF
--- a/.changeset/beige-brooms-camp.md
+++ b/.changeset/beige-brooms-camp.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix LevelDB initialization to throw a GraphQL error that can be handled correctly in Tina Cloud

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -189,6 +189,11 @@ export class Database {
         this.level = this.rootLevel.sublevel(version, SUBLEVEL_OPTIONS)
       }
     }
+
+    // Make sure this error bubbles up to the user
+    if (!this.level) {
+      throw new GraphQLError('Error initializing LevelDB instance')
+    }
   }
 
   public get = async <T extends object>(filepath: string): Promise<T> => {


### PR DESCRIPTION
Fixes issue where database was failing to check if a level instance was set resulting in null error. This catches the condition and throws a more user friendly error.