### PR TITLE
fix: handle LEVEL_NOT_FOUND when fetching from level

### DIFF
--- a/.changeset/five-socks-argue.md
+++ b/.changeset/five-socks-argue.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix update Database.get to properly handle LEVEL_NOT_FOUND errors

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -203,12 +203,19 @@ export class Database {
     } else {
       const tinaSchema = await this.getSchema(this.level)
       const extension = path.extname(filepath)
-      const contentObject = await this.level
-        .sublevel<string, Record<string, any>>(
-          CONTENT_ROOT_PREFIX,
-          SUBLEVEL_OPTIONS
-        )
-        .get(normalizePath(filepath))
+      let contentObject
+      try {
+        contentObject = await this.level
+          .sublevel<string, Record<string, any>>(
+            CONTENT_ROOT_PREFIX,
+            SUBLEVEL_OPTIONS
+          )
+          .get(normalizePath(filepath))
+      } catch (e: any) {
+        if (e.code !== 'LEVEL_NOT_FOUND') {
+          throw e
+        }
+      }
       if (!contentObject) {
         throw new GraphQLError(`Unable to find record ${filepath}`)
       }


### PR DESCRIPTION
Fix `Could not get value` error when querying non-existent content