### PR TITLE
Filter UX

### DIFF
--- a/.changeset/silly-mice-think.md
+++ b/.changeset/silly-mice-think.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Groups filter inputs in a form so pressing 'enter' will filter the collection list

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -399,7 +399,7 @@ const CollectionListPage = () => {
                                   }}
                                 />
                               </div>
-                              <div className="flex flex-wrap gap-4 items-end">
+                              <form className="flex flex-wrap gap-4 items-end">
                                 <div className="flex flex-shrink-0 flex-col gap-2 items-start">
                                   <label
                                     htmlFor="filter"
@@ -557,6 +557,7 @@ const CollectionListPage = () => {
                                         reFetchCollection()
                                       }}
                                       variant="primary"
+                                      type="submit"
                                     >
                                       Search{' '}
                                       <BiSearch className="w-5 h-full ml-1.5 opacity-70" />
@@ -586,7 +587,7 @@ const CollectionListPage = () => {
                                     )}
                                   </div>
                                 )}
-                              </div>
+                              </form>
                             </div>
                           )}
                         </div>


### PR DESCRIPTION
This wraps the filter form inputs in a form and adds `type='submit'` to the button so that pressing `enter` filters the collection list.