### PR TITLE
refactor: centralize LEVEL_NOT_FOUND error handling

### DIFF
--- a/.changeset/eleven-mice-kneel.md
+++ b/.changeset/eleven-mice-kneel.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix handling of level not found to centralize it

--- a/packages/@tinacms/graphql/src/database/level.ts
+++ b/packages/@tinacms/graphql/src/database/level.ts
@@ -81,8 +81,8 @@ const LevelProxyHandler = {
     } else if (property === 'sublevel') {
       // wrap sublevel in a proxy to intercept get
       return (...args) => {
-        // eslint-disable-next-line prefer-spread
         return new Proxy(
+          // eslint-disable-next-line prefer-spread
           target[property].apply(target, args),
           LevelProxyHandler
         )

--- a/packages/@tinacms/graphql/src/database/level.ts
+++ b/packages/@tinacms/graphql/src/database/level.ts
@@ -48,3 +48,54 @@ export const SUBLEVEL_OPTIONS: AbstractSublevelOptions<
   separator: INDEX_KEY_FIELD_SEPARATOR,
   valueEncoding: 'json',
 }
+
+export class LevelWrapper {
+  private level: Level
+  constructor(level: Level) {
+    this.level = level
+  }
+}
+
+const LevelProxyHandler = {
+  get: function (target, property) {
+    if (!target[property]) {
+      throw new Error(`The property, ${property.toString()}, doesn't exist`)
+    }
+    if (typeof target[property] !== 'function') {
+      throw new Error(`The property, ${property.toString()}, is not a function`)
+    }
+
+    if (property === 'get') {
+      return async (...args) => {
+        let result: any
+        try {
+          // eslint-disable-next-line prefer-spread
+          result = await target[property].apply(target, args)
+        } catch (e: any) {
+          if (e.code !== 'LEVEL_NOT_FOUND') {
+            throw e
+          }
+        }
+        return result
+      }
+    } else if (property === 'sublevel') {
+      // wrap sublevel in a proxy to intercept get
+      return (...args) => {
+        // eslint-disable-next-line prefer-spread
+        return new Proxy(
+          target[property].apply(target, args),
+          LevelProxyHandler
+        )
+      }
+    } else {
+      // eslint-disable-next-line prefer-spread
+      return (...args) => target[property].apply(target, args)
+    }
+  },
+}
+
+export class LevelProxy {
+  constructor(level: Level) {
+    return new Proxy(level as any, LevelProxyHandler)
+  }
+}


### PR DESCRIPTION
- use proxy to centralize the LEVEL_NOT_FOUND errors
- fix the database versioning logic