### PR TITLE
Only format filter date when valid

### DIFF
--- a/.changeset/plenty-bottles-attend.md
+++ b/.changeset/plenty-bottles-attend.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixes the error when a user clears the date filter input

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -483,8 +483,12 @@ const CollectionListPage = () => {
                                         onChange={(e) => {
                                           setVars((old) => ({
                                             ...old,
-                                            // @ts-ignore
-                                            after: e.format(),
+                                            after:
+                                              // @ts-ignore
+                                              typeof e.format === 'function'
+                                                ? // @ts-ignore
+                                                  e.format()
+                                                : '',
                                             booleanEquals: null,
                                             startsWith: '',
                                           }))
@@ -506,8 +510,12 @@ const CollectionListPage = () => {
                                         onChange={(e) => {
                                           setVars((old) => ({
                                             ...old,
-                                            // @ts-ignore
-                                            before: e.format(),
+                                            before:
+                                              // @ts-ignore
+                                              typeof e.format === 'function'
+                                                ? // @ts-ignore
+                                                  e.format()
+                                                : '',
                                             booleanEquals: null,
                                             startsWith: '',
                                           }))


### PR DESCRIPTION
This fixes the error that happens when a user clears the date input from a valid date.