### PR TITLE
Do not redirect by to contextual editing by default. 

### DIFF
--- a/.changeset/flat-terms-fail.md
+++ b/.changeset/flat-terms-fail.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Only redirect to preview if the user is using a router

--- a/.changeset/flat-terms-fail.md
+++ b/.changeset/flat-terms-fail.md
@@ -2,4 +2,6 @@
 'tinacms': patch
 ---
 
-Only redirect to preview if the user is using a router
+Only redirect to preview if the user is using a router. 
+
+See [this video](https://www.loom.com/share/69345c21c3f94c57997ac0a19c9768a8) for more details.

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -25,6 +25,7 @@ import CollectionUpdatePage from './pages/CollectionUpdatePage'
 import ScreenPage from './pages/ScreenPage'
 
 import { useEditState } from '@tinacms/sharedctx'
+import { Client } from '../internalClient'
 
 const Redirect = () => {
   React.useEffect(() => {
@@ -130,6 +131,13 @@ export const TinaAdmin = ({
         const isTinaAdminEnabled =
           cms.flags.get('tina-admin') === false ? false : true
         if (isTinaAdminEnabled) {
+          const tinaClient: Client = cms.api?.tina
+          const collectionWithRouter =
+            tinaClient?.schema?.config?.collections.find((x) => {
+              return typeof x?.ui?.router === 'function'
+            })
+          const hasRouter = Boolean(collectionWithRouter)
+          console.log('hasRouter', hasRouter)
           return (
             <Router>
               {/* @ts-ignore */}
@@ -192,7 +200,7 @@ export const TinaAdmin = ({
                 <Route
                   path="/"
                   element={
-                    <MaybeRedirectToPreview redirect={!!preview}>
+                    <MaybeRedirectToPreview redirect={!!preview && hasRouter}>
                       <DefaultWrapper cms={cms}>
                         <DashboardPage />
                       </DefaultWrapper>

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -137,7 +137,6 @@ export const TinaAdmin = ({
               return typeof x?.ui?.router === 'function'
             })
           const hasRouter = Boolean(collectionWithRouter)
-          console.log('hasRouter', hasRouter)
           return (
             <Router>
               {/* @ts-ignore */}


### PR DESCRIPTION
Only redirect when the user has a `ui.router` in there collection.

See [this video](https://www.loom.com/share/69345c21c3f94c57997ac0a19c9768a8) for more details.
