### PR TITLE
Fix/better name error

### DIFF
--- a/.changeset/tall-rockets-behave.md
+++ b/.changeset/tall-rockets-behave.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/schema-tools': patch
+---
+
+Better error message on the name field

--- a/packages/@tinacms/schema-tools/src/validate/fields.ts
+++ b/packages/@tinacms/schema-tools/src/validate/fields.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod'
 import type { TinaField as TinaFieldType } from '../types/index'
 import { findDuplicates } from '../util'
+import { name } from './properties'
 
 const TypeName = [
   'string',
@@ -22,20 +23,6 @@ const typeRequiredError = `type is required and must be one of ${TypeName.join(
   ', '
 )}`
 
-const nameProp = z
-  .string({
-    required_error: 'name must be provided',
-    invalid_type_error: 'name must be a sting',
-  })
-  .superRefine((val, ctx) => {
-    if (val.includes(' '))
-      ctx.addIssue({
-        message: `name "${val}" cannot contain spaces`,
-        code: z.ZodIssueCode.custom,
-        fatal: true,
-      })
-  })
-
 const Option = z.union(
   [
     z.string(),
@@ -52,7 +39,7 @@ const Option = z.union(
   }
 )
 const TinaField = z.object({
-  name: nameProp,
+  name,
   label: z.string().or(z.boolean()).optional(),
   description: z.string().optional(),
   required: z.boolean().optional(),
@@ -118,7 +105,7 @@ export const TinaFieldZod: z.ZodType<TinaFieldType> = z.lazy(() => {
   const TemplateTemp = z
     .object({
       label: z.string().optional(),
-      name: nameProp,
+      name,
       fields: z.array(TinaFieldZod),
       match: z
         .object({

--- a/packages/@tinacms/schema-tools/src/validate/index.ts
+++ b/packages/@tinacms/schema-tools/src/validate/index.ts
@@ -1,7 +1,3 @@
-/**
-
-*/
-
 import { ZodError } from 'zod'
 import type { Schema } from '../types/index'
 import { parseZodError } from '../util/parseZodErrors'

--- a/packages/@tinacms/schema-tools/src/validate/properties.ts
+++ b/packages/@tinacms/schema-tools/src/validate/properties.ts
@@ -13,7 +13,7 @@ export const name = z
       ctx.addIssue({
         code: 'custom',
         message: `name, "${val}" must be alphanumeric and can only contain underscores. (No spaces, dashes, special characters, etc.)
-If you only wan to display this value in the CMS UI, you can use the label property to customize it.
+If you only want to display this value in the CMS UI, you can use the label property to customize it.
 
 If you need to use this value in your content you can use the \`nameOverride\` property to customize the value. For example:
 \`\`\`

--- a/packages/@tinacms/schema-tools/src/validate/properties.ts
+++ b/packages/@tinacms/schema-tools/src/validate/properties.ts
@@ -8,9 +8,20 @@ export const name = z
     required_error: 'Name is required but not provided',
     invalid_type_error: 'Name must be a string',
   })
-  .refine(
-    (val) => val.match(/^[a-zA-Z0-9_]*$/) !== null,
-    (val) => ({
-      message: `name, "${val}" must be alphanumeric and can only contain underscores`,
-    })
-  )
+  .superRefine((val, ctx) => {
+    if (val.match(/^[a-zA-Z0-9_]*$/) === null) {
+      ctx.addIssue({
+        code: 'custom',
+        message: `name, "${val}" must be alphanumeric and can only contain underscores. (No spaces, dashes, special characters, etc.)
+If you display the name in the UI, you can use the label property to customize the display name.
+If you need to use this value you can use the\`nameOverride\` property to customize the value. For example:
+\`\`\`
+{
+  "name": ${val.replace(/[^a-zA-Z0-9]/g, '_')},
+  "nameOverride": ${val},
+  // ...
+}
+\`\`\``,
+      })
+    }
+  })

--- a/packages/@tinacms/schema-tools/src/validate/properties.ts
+++ b/packages/@tinacms/schema-tools/src/validate/properties.ts
@@ -13,8 +13,9 @@ export const name = z
       ctx.addIssue({
         code: 'custom',
         message: `name, "${val}" must be alphanumeric and can only contain underscores. (No spaces, dashes, special characters, etc.)
-If you display the name in the UI, you can use the label property to customize the display name.
-If you need to use this value you can use the\`nameOverride\` property to customize the value. For example:
+If you only wan to display this value in the CMS UI, you can use the label property to customize it.
+
+If you need to use this value in your content you can use the \`nameOverride\` property to customize the value. For example:
 \`\`\`
 {
   "name": ${val.replace(/[^a-zA-Z0-9]/g, '_')},

--- a/packages/@tinacms/schema-tools/src/validate/schema.ts
+++ b/packages/@tinacms/schema-tools/src/validate/schema.ts
@@ -36,7 +36,7 @@ const Template = z
     }
   })
 
-const TinaCloudCollectionBase = z.object({
+export const CollectionBaseSchema = z.object({
   label: z.string().optional(),
   name: name.superRefine((val, ctx) => {
     if (val === 'relativePath') {
@@ -46,11 +46,12 @@ const TinaCloudCollectionBase = z.object({
       })
     }
   }),
+  path: z.string().transform((val) => val.replace(/^\/|\/$/g, '')),
   format: z.enum(FORMATS).optional(),
 })
 
 // Zod did not handel this union very well so we will handle it ourselves
-const TinaCloudCollection = TinaCloudCollectionBase.extend({
+const TinaCloudCollection = CollectionBaseSchema.extend({
   fields: z
     .array(TinaFieldZod)
     .min(1)


### PR DESCRIPTION
Fixes ENG-836

The error message looks like this.

```
TinaSchemaValidationError: Error name, "sub-title" must be alphanumeric and can only contain underscores. (No spaces, dashes, special characters, etc.)
If you only wan to display this value in the CMS UI, you can use the label property to customize it.

If you need to use this value in your content you can use the `nameOverride` property to customize the value. For example:
\```
{
  "name": sub_title,
  "nameOverride": sub-title,
  // ...
}
\```
```