### PR TITLE
remove starters from changeset

### DIFF
--- a/.changeset/polite-poets-collect.md
+++ b/.changeset/polite-poets-collect.md
@@ -1,8 +1,6 @@
 ---
 "@tinacms/graphql": patch
 "@tinacms/schema-tools": patch
-"@tinacms/starter-iframe": patch
-"@tinacms/starter": patch
 ---
 
 feat: Allow adding aliases in field configs, to export special characters like names with dashes, or fields named "id"


### PR DESCRIPTION
There was a changeset that was added that included the starter packages. This caused an error to occur during publish. This PR should fix the error.