### PR TITLE
Feat/match in collection

### DIFF
--- a/.changeset/tricky-crabs-scream.md
+++ b/.changeset/tricky-crabs-scream.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Added match property for collections

--- a/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
@@ -19,10 +19,12 @@ export class FilesystemBridge implements Bridge {
   public addOutputPath(outputPath: string) {
     this.outputPath = outputPath
   }
-  public async glob(pattern: string, extension: string) {
-    const basePath = path.join(this.outputPath, ...pattern.split('/'))
+  public async glob(filePath: string, extension: string, match?: string) {
+    const basePath = path.join(this.outputPath, ...filePath.split('/'))
+    const realMatch = match ? match.replace(/\\/g, '/') : '**/*'
+
     const items = await fg(
-      path.join(basePath, '**', `/*${extension}`).replace(/\\/g, '/'),
+      path.join(basePath, `${realMatch}.${extension}`).replace(/\\/g, '/'),
       {
         dot: true,
       }

--- a/packages/@tinacms/graphql/src/database/bridge/index.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/index.ts
@@ -1,6 +1,6 @@
 export interface Bridge {
   rootPath: string
-  glob(pattern: string, extension: string): Promise<string[]>
+  glob(path: string, extension: string, match?: string): Promise<string[]>
   delete(filepath: string): Promise<void>
   get(filepath: string): Promise<string>
   put(filepath: string, data: string): Promise<void>

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1003,7 +1003,8 @@ export class Database {
     await sequential(tinaSchema.getCollections(), async (collection) => {
       const documentPaths = await this.bridge.glob(
         normalizePath(collection.path),
-        collection.format || 'md'
+        collection.format || 'md',
+        collection.match
       )
       await _indexContent(this, level, documentPaths, enqueueOps, collection)
     })


### PR DESCRIPTION
> This will be a draft until the work is done on Tina Cloud to support this.

Adds back the match property.  The glob that is used looks like this.

<collection.path>/<collection.match>.<collection.format> 

Demo: https://www.loom.com/share/e1e7bc3523164b029c09d7d9d81be80c