### PR TITLE
fix: previous directory link in Tina MediaManager

### DIFF
--- a/.changeset/pink-wolves-boil.md
+++ b/.changeset/pink-wolves-boil.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/toolkit": patch
+---
+
+fix: previous directory link in Tina MediaManager

--- a/packages/@tinacms/toolkit/src/components/media/breadcrumb.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/breadcrumb.tsx
@@ -8,8 +8,9 @@ import React from 'react'
 import { LeftArrowIcon } from '../../packages/icons'
 
 // Fixed issue where dirname was being used in the frontend
-function dirname(path) {
-  return path.match(/.*\//)
+function dirname(path): string | undefined {
+  const pattern = new RegExp('(?<prevDir>.*)\/')
+  return path.match(pattern)?.groups?.prevDir
 }
 
 interface BreadcrumbProps {
@@ -30,7 +31,7 @@ const BreadcrumbButton = ({ className = '', ...props }) => (
 export function Breadcrumb({ directory = '', setDirectory }: BreadcrumbProps) {
   directory = directory.replace(/^\/|\/$/g, '')
 
-  let prevDir = dirname(directory) || ''
+  let prevDir: string = dirname(directory) || ''
   if (prevDir === '.') {
     prevDir = ''
   }


### PR DESCRIPTION
## Bug description:

- Previously the `dirname` function had a return value of type `RegExpMatchArray | null` - the result of calling `String.prototype.match()`
- However the `prevDir` variable must be of type `string` (or undefined or null) as it is passed directly to the `setDirectory` function
- Previously the media manager crashed when clicking the back link and threw a `TypeError` with the message `directory.replace is not a function` (given you can't call `replace` on a `RegExpMatchArray`)
- This fix extends the regex in the `dirname` function to use a capturing group and ensure it always returns a `string` or `undefined`
