### PR TITLE
fix: When current branch doesn't exist, don't blow up

### DIFF
--- a/.changeset/sour-gifts-double.md
+++ b/.changeset/sour-gifts-double.md
@@ -1,0 +1,6 @@
+---
+"tinacms": patch
+"@tinacms/toolkit": patch
+---
+
+fix: When current branch doesn't exist, handle error more gracefully

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.test.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.test.tsx
@@ -1,0 +1,72 @@
+import { getFilteredBranchList } from './BranchSwitcher'
+import { Branch } from './types'
+
+const branches: Branch[] = [
+  { name: 'master', indexStatus: { status: 'complete' } },
+  { name: 'develop', indexStatus: { status: 'complete' } },
+  { name: 'feature/branch-1', indexStatus: { status: 'failed' } },
+  { name: 'feature/branch-2', indexStatus: { status: 'complete' } },
+  { name: 'feature/branch-3', indexStatus: { status: 'complete' } },
+]
+
+// test getFilteredBranchList to make sure it returns the correct list of branches
+describe('getFilteredBranchList', () => {
+  describe('with no filter', () => {
+    it('should return the correct list of branches', () => {
+      const filteredBranches = getFilteredBranchList(branches, '', 'master')
+      expect(filteredBranches.map((b) => b.name)).toEqual([
+        'master',
+        'develop',
+        'feature/branch-1',
+        'feature/branch-2',
+        'feature/branch-3',
+      ])
+    })
+  })
+  describe('with unknown branch', () => {
+    it('returns branch as unknown status', () => {
+      // test unknown branch
+      const filteredBranches = getFilteredBranchList(branches, '', 'foo')
+
+      console.log('filteredBranches:', filteredBranches)
+
+      expect(filteredBranches).toEqual([
+        { name: 'foo', indexStatus: { status: 'failed' } },
+        { name: 'master', indexStatus: { status: 'complete' } },
+        { name: 'develop', indexStatus: { status: 'complete' } },
+        { name: 'feature/branch-1', indexStatus: { status: 'failed' } },
+        { name: 'feature/branch-2', indexStatus: { status: 'complete' } },
+        { name: 'feature/branch-3', indexStatus: { status: 'complete' } },
+      ])
+    })
+  })
+  describe('with filter', () => {
+    // test filter filters list
+    it('should return the correct list of branches', () => {
+      const filteredBranches = getFilteredBranchList(
+        branches,
+        'feature',
+        'feature/branch-1'
+      )
+      expect(filteredBranches.map((b) => b.name)).toEqual([
+        'feature/branch-1',
+        'feature/branch-2',
+        'feature/branch-3',
+      ])
+    })
+
+    it('should add current branch to the top', () => {
+      const filteredBranches = getFilteredBranchList(
+        branches,
+        'feature',
+        'master'
+      )
+      expect(filteredBranches.map((b) => b.name)).toEqual([
+        'master',
+        'feature/branch-1',
+        'feature/branch-2',
+        'feature/branch-3',
+      ])
+    })
+  })
+})

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -230,7 +230,12 @@ const BranchSelector = ({
     (branch) => branch.name === currentBranch
   )
   filteredBranchList.splice(currentIndex, 1)
-  filteredBranchList.unshift(currentBranchItem)
+  filteredBranchList.unshift(
+    currentBranchItem || {
+      name: currentBranch,
+      indexStatus: { status: 'failed' },
+    }
+  )
 
   return (
     <div className="flex flex-col gap-3">

--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -206,6 +206,32 @@ export const BranchSwitcher = ({
   )
 }
 
+export const getFilteredBranchList = (
+  branchList: Branch[],
+  filter: string,
+  currentBranchName: string
+) => {
+  const filteredBranchList = branchList.filter(
+    (branch) =>
+      !filter ||
+      branch.name.includes(filter) ||
+      branch.name === currentBranchName
+  )
+  const currentBranchItem = branchList.find(
+    (branch) => branch.name === currentBranchName
+  )
+
+  // return list with current branch at top
+  return [
+    currentBranchItem ||
+      ({
+        name: currentBranchName,
+        indexStatus: { status: 'failed' },
+      } as Branch),
+    ...filteredBranchList.filter((branch) => branch.name !== currentBranchName),
+  ]
+}
+
 const BranchSelector = ({
   branchList,
   currentBranch,
@@ -219,22 +245,10 @@ const BranchSelector = ({
 }) => {
   const [newBranchName, setNewBranchName] = React.useState('')
   const [filter, setFilter] = React.useState('')
-  const filteredBranchList = branchList.filter(
-    (branch) =>
-      !filter || branch.name.includes(filter) || branch.name === currentBranch
-  )
-  const currentBranchItem = branchList.find(
-    (branch) => branch.name === currentBranch
-  )
-  const currentIndex = filteredBranchList.findIndex(
-    (branch) => branch.name === currentBranch
-  )
-  filteredBranchList.splice(currentIndex, 1)
-  filteredBranchList.unshift(
-    currentBranchItem || {
-      name: currentBranch,
-      indexStatus: { status: 'failed' },
-    }
+  const filteredBranchList = getFilteredBranchList(
+    branchList,
+    filter,
+    currentBranch
   )
 
   return (

--- a/packages/tinacms/src/admin/components/FullscreenError.tsx
+++ b/packages/tinacms/src/admin/components/FullscreenError.tsx
@@ -1,18 +1,21 @@
 import React from 'react'
+import { Button } from '@tinacms/toolkit'
+import { BiError, BiSync } from 'react-icons/bi'
 
 export const FullscreenError = ({
-  errorMessage = 'It looks like something went wrong',
+  title = 'Error',
+  errorMessage = 'It looks like something went wrong.',
 }) => {
   return (
     <div className="flex flex-col justify-center items-center h-screen bg-gray-100">
-      <div className="text-red-500 text-4xl mb-4">Error</div>
+      <div className="text-red-500 text-4xl mb-6 flex items-center">
+        <BiError className="w-12 h-auto fill-current text-red-400 opacity-70 mr-1" />{' '}
+        {title}
+      </div>
       <p className="text-gray-700 text-xl mb-8">{errorMessage}</p>
-      <button
-        className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
-        onClick={() => window.location.reload()}
-      >
-        Reload
-      </button>
+      <Button variant="danger" onClick={() => window.location.reload()}>
+        <BiSync className="w-7 h-auto fill-current opacity-70 mr-1" /> Reload
+      </Button>
     </div>
   )
 }

--- a/packages/tinacms/src/admin/components/FullscreenError.tsx
+++ b/packages/tinacms/src/admin/components/FullscreenError.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export const FullscreenError = ({
+  errorMessage = 'It looks like something went wrong',
+}) => {
+  return (
+    <div className="flex flex-col justify-center items-center h-screen bg-gray-100">
+      <div className="text-red-500 text-4xl mb-4">Error</div>
+      <p className="text-gray-700 text-xl mb-8">{errorMessage}</p>
+      <button
+        className="bg-red-500 hover:bg-red-600 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline"
+        onClick={() => window.location.reload()}
+      >
+        Reload
+      </button>
+    </div>
+  )
+}

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -8,6 +8,7 @@ import type { TinaSchema } from '@tinacms/schema-tools'
 import { FilterArgs, TinaAdminApi } from '../api'
 import LoadingPage from '../components/LoadingPage'
 import type { CollectionResponse } from '../types'
+import { FullscreenError } from './FullscreenError'
 
 export const useGetCollection = (
   cms: TinaCMS,
@@ -97,7 +98,7 @@ const GetCollection = ({
     ) || {}
 
   if (error) {
-    return null
+    return <FullscreenError />
   }
 
   if (loading) {

--- a/packages/tinacms/src/admin/components/GetDocument.tsx
+++ b/packages/tinacms/src/admin/components/GetDocument.tsx
@@ -7,7 +7,7 @@ import type { TinaCMS } from '@tinacms/toolkit'
 import { TinaAdminApi } from '../api'
 import type { DocumentForm } from '../types'
 import LoadingPage from './LoadingPage'
-
+import { FullscreenError } from './FullscreenError'
 export const useGetDocument = (
   cms: TinaCMS,
   collectionName: string,
@@ -62,7 +62,7 @@ const GetDocument = ({
   )
 
   if (error) {
-    return null
+    return <FullscreenError />
   }
 
   if (loading) {

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -207,76 +207,77 @@ const CollectionListPage = () => {
     <GetCMS>
       {(cms: TinaCMS) => {
         return (
-          <GetCollection
-            cms={cms}
-            collectionName={collectionName}
-            includeDocuments
-            startCursor={endCursor}
-            sortKey={sortKey}
-            filterArgs={
-              // only pass filter args if the collection is the same as the current route
-              // We need this hear because this runs before the useEffect above
-              collectionName === vars.collection
-                ? vars
-                : {
-                    collection: collectionName,
-                    relativePath: '',
-                    newRelativePath: '',
-                    filterField: '',
-                    startsWith: '',
-                    endsWith: '',
-                    before: '',
-                    after: '',
-                    booleanEquals: null,
-                  }
-            }
-          >
-            {(
-              collection: CollectionResponse,
-              _loading,
-              reFetchCollection,
-              collectionExtra: Collection<true>
-            ) => {
-              const totalCount = collection.documents.totalCount
-              const documents = collection.documents.edges
-              const admin: TinaAdminApi = cms.api.admin
-              const pageInfo = collection.documents.pageInfo
-              const fields = collectionExtra.fields?.filter((x) =>
-                // only allow sortable fields
-                ['string', 'number', 'datetime', 'boolean'].includes(x.type)
-              )
-
-              const filterFields = collectionExtra.fields?.filter((x) => {
-                // only allow fileable fields. Currently only string, datetime, and boolean of non-list type
-                return (
-                  ['string', 'datetime', 'boolean'].includes(x.type) && !x.list
+          <PageWrapper>
+            <GetCollection
+              cms={cms}
+              collectionName={collectionName}
+              includeDocuments
+              startCursor={endCursor}
+              sortKey={sortKey}
+              filterArgs={
+                // only pass filter args if the collection is the same as the current route
+                // We need this hear because this runs before the useEffect above
+                collectionName === vars.collection
+                  ? vars
+                  : {
+                      collection: collectionName,
+                      relativePath: '',
+                      newRelativePath: '',
+                      filterField: '',
+                      startsWith: '',
+                      endsWith: '',
+                      before: '',
+                      after: '',
+                      booleanEquals: null,
+                    }
+              }
+            >
+              {(
+                collection: CollectionResponse,
+                _loading,
+                reFetchCollection,
+                collectionExtra: Collection<true>
+              ) => {
+                const totalCount = collection.documents.totalCount
+                const documents = collection.documents.edges
+                const admin: TinaAdminApi = cms.api.admin
+                const pageInfo = collection.documents.pageInfo
+                const fields = collectionExtra.fields?.filter((x) =>
+                  // only allow sortable fields
+                  ['string', 'number', 'datetime', 'boolean'].includes(x.type)
                 )
-              })
 
-              const filterField = filterFields?.find(
-                (x) => x.name === vars.filterField
-              )
-              const showStartsWith =
-                filterField?.type === 'string' && !filterField.list
-              const showDateFilter = filterField?.type === 'datetime'
+                const filterFields = collectionExtra.fields?.filter((x) => {
+                  // only allow fileable fields. Currently only string, datetime, and boolean of non-list type
+                  return (
+                    ['string', 'datetime', 'boolean'].includes(x.type) &&
+                    !x.list
+                  )
+                })
 
-              const showBooleanToggle =
-                filterField?.type === 'boolean' && !filterField.list
+                const filterField = filterFields?.find(
+                  (x) => x.name === vars.filterField
+                )
+                const showStartsWith =
+                  filterField?.type === 'string' && !filterField.list
+                const showDateFilter = filterField?.type === 'datetime'
 
-              // TODO: add other fields
-              // const showNumberFilter = sortField?.type === 'number' && !sortField.list
+                const showBooleanToggle =
+                  filterField?.type === 'boolean' && !filterField.list
 
-              const collectionDefinition = cms.api.tina.schema.getCollection(
-                collection.name
-              )
+                // TODO: add other fields
+                // const showNumberFilter = sortField?.type === 'number' && !sortField.list
 
-              const allowCreate =
-                collectionDefinition?.ui?.allowedActions?.create ?? true
-              const allowDelete =
-                collectionDefinition?.ui?.allowedActions?.delete ?? true
+                const collectionDefinition = cms.api.tina.schema.getCollection(
+                  collection.name
+                )
 
-              return (
-                <PageWrapper>
+                const allowCreate =
+                  collectionDefinition?.ui?.allowedActions?.create ?? true
+                const allowDelete =
+                  collectionDefinition?.ui?.allowedActions?.delete ?? true
+
+                return (
                   <>
                     {deleteModalOpen && (
                       <DeleteModal
@@ -807,10 +808,10 @@ const CollectionListPage = () => {
                       </div>
                     </PageBody>
                   </>
-                </PageWrapper>
-              )
-            }}
-          </GetCollection>
+                )
+              }}
+            </GetCollection>
+          </PageWrapper>
         )
       }}
     </GetCMS>

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -60,22 +60,24 @@ const CollectionUpdatePage = () => {
             }
 
             return (
-              <GetDocument
-                cms={cms}
-                collectionName={collection.name}
-                relativePath={relativePath}
-              >
-                {(document) => (
-                  <RenderForm
-                    cms={cms}
-                    document={document}
-                    filename={filename}
-                    relativePath={relativePath}
-                    collection={collection}
-                    mutationInfo={mutationInfo}
-                  />
-                )}
-              </GetDocument>
+              <PageWrapper>
+                <GetDocument
+                  cms={cms}
+                  collectionName={collection.name}
+                  relativePath={relativePath}
+                >
+                  {(document) => (
+                    <RenderForm
+                      cms={cms}
+                      document={document}
+                      filename={filename}
+                      relativePath={relativePath}
+                      collection={collection}
+                      mutationInfo={mutationInfo}
+                    />
+                  )}
+                </GetDocument>
+              </PageWrapper>
             )
           }}
         </GetCollection>
@@ -141,33 +143,31 @@ const RenderForm = ({
   const headerPadding = renderNavToggle ? 'px-20' : 'px-6'
 
   return (
-    <PageWrapper>
-      <>
-        {cms?.api?.tina?.isLocalMode ? <LocalWarning /> : <BillingWarning />}
-        <div
-          className={`py-4 border-b border-gray-200 bg-white ${headerPadding}`}
-        >
-          <div className="max-w-form mx-auto">
-            <div className="mb-2">
-              <span className="block text-sm leading-tight uppercase text-gray-400 mb-1">
-                <Link
-                  to={`/collections/${collection.name}`}
-                  className="inline-block text-current hover:text-blue-400 focus:underline focus:outline-none focus:text-blue-400 font-medium transition-colors duration-150 ease-out"
-                >
-                  {collection.label ? collection.label : collection.name}
-                </Link>
-                <HiChevronRight className="inline-block -mt-0.5 opacity-50" />
-              </span>
-              <span className="text-xl text-gray-700 font-medium leading-tight">
-                Edit {`${filename}.${collection.format}`}
-              </span>
-            </div>
-            <FormStatus pristine={formIsPristine} />
+    <>
+      {cms?.api?.tina?.isLocalMode ? <LocalWarning /> : <BillingWarning />}
+      <div
+        className={`py-4 border-b border-gray-200 bg-white ${headerPadding}`}
+      >
+        <div className="max-w-form mx-auto">
+          <div className="mb-2">
+            <span className="block text-sm leading-tight uppercase text-gray-400 mb-1">
+              <Link
+                to={`/collections/${collection.name}`}
+                className="inline-block text-current hover:text-blue-400 focus:underline focus:outline-none focus:text-blue-400 font-medium transition-colors duration-150 ease-out"
+              >
+                {collection.label ? collection.label : collection.name}
+              </Link>
+              <HiChevronRight className="inline-block -mt-0.5 opacity-50" />
+            </span>
+            <span className="text-xl text-gray-700 font-medium leading-tight">
+              Edit {`${filename}.${collection.format}`}
+            </span>
           </div>
+          <FormStatus pristine={formIsPristine} />
         </div>
-        <FormBuilder form={form} onPristineChange={setFormIsPristine} />
-      </>
-    </PageWrapper>
+      </div>
+      <FormBuilder form={form} onPristineChange={setFormIsPristine} />
+    </>
   )
 }
 


### PR DESCRIPTION
Previously, when our locally cached branch doesn't exist, things kind of blow up in the CMS.
<img width="1063" alt="Screen Shot 2023-03-06 at 2 56 51 PM" src="https://user-images.githubusercontent.com/3323181/223205646-6741d08b-d912-41d7-b901-4ce9d38deeea.png">
I added a minimal error screen, but more importantly, the toolbar stays accessible (so the user can change branches and resolve the issue).

closes ENG-802