### PR TITLE
Fix issue where `getTemplatesForCollectable` was being called with a nullable value

### DIFF
--- a/.changeset/silver-pianos-joke.md
+++ b/.changeset/silver-pianos-joke.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix issue where getTemplatesForCollectable was being called with a nullable value

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1105,7 +1105,10 @@ const _indexContent = async (
   }
 
   const tinaSchema = await database.getSchema()
-  const templateInfo = await tinaSchema.getTemplatesForCollectable(collection)
+  let templateInfo: CollectionTemplateable | null = null
+  if (collection) {
+    templateInfo = await tinaSchema.getTemplatesForCollectable(collection)
+  }
 
   await sequential(documentPaths, async (filepath) => {
     try {
@@ -1121,10 +1124,12 @@ const _indexContent = async (
       )
       const normalizedPath = normalizePath(filepath)
 
-      const aliasedData = replaceNameOverrides(
-        getTemplateForFile(templateInfo, data as any),
-        data
-      )
+      const aliasedData = templateInfo
+        ? replaceNameOverrides(
+            getTemplateForFile(templateInfo, data as any),
+            data
+          )
+        : data
 
       await enqueueOps([
         ...makeIndexOpsForDocument<Record<string, any>>(


### PR DESCRIPTION
I'm not sure what the circumstances are for when `collection` is null, but I ran into it calling `database.indexContentByPaths`, and it looks like Tina Cloud would see the same issue [here](https://github.com/tinacms/tina-cloud/blob/16e2d4e8db11201874ac7b7753cf1e1aaecdf083/js/content-api/src/database/index.ts#L164)