### PR TITLE
Remove warning about TinaProvider

### DIFF
--- a/.changeset/dull-zebras-develop.md
+++ b/.changeset/dull-zebras-develop.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Remove warning about TinaProvider

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -181,12 +181,6 @@ export const TinaCMSProvider2 = ({
   schema,
   ...props
 }: TinaCMSProviderDefaultProps) => {
-  React.useEffect(() => {
-    console.warn(`
-    * Tina no longer requires wrapping your site in the TinaProvider
-    * See https://tina.io/blog/upgrading-to-iframe/ for full migration details
-    `)
-  }, [])
   if (props?.apiURL) {
     console.warn(
       'The apiURL prop is deprecated. Please see https://tina.io/blog/tina-v-0.68.14 for information on how to upgrade to the new API'


### PR DESCRIPTION
This warning shows up regardless of your config, it's also been a while since the alternate setup was used so probably safe to remove this.

Closes https://github.com/tinacms/tinacms/issues/3639.

