### PR TITLE
Feat/use gql version in request

### DIFF
--- a/.changeset/large-eyes-study.md
+++ b/.changeset/large-eyes-study.md
@@ -1,0 +1,12 @@
+---
+'@tinacms/schema-tools': minor
+'@tinacms/datalayer': minor
+'@tinacms/graphql': minor
+'@tinacms/scripts': minor
+'@tinacms/toolkit': minor
+'@tinacms/app': minor
+'@tinacms/cli': minor
+'tinacms': minor
+---
+
+Use new API endpoint in content api reqests

--- a/packages/@tinacms/app/src/App.tsx
+++ b/packages/@tinacms/app/src/App.tsx
@@ -43,7 +43,13 @@ export const TinaAdminWrapper = () => {
   const schema = { ...config?.schema, config }
   return (
     // @ts-ignore JSX element type 'TinaCMS' does not have any construct or call signatures.ts(2604)
-    <TinaCMS {...config} schema={schema} client={{ apiUrl: __API_URL__ }}>
+    <TinaCMS
+      {...config}
+      schema={schema}
+      client={{ apiUrl: __API_URL__ }}
+      // THis will be replaced by the version of the graphql package or --garphql-version flag. It is replaced by vite at compile time
+      tinaGraphQLVersion={__TINA_GRAPHQL_VERSION__}
+    >
       <SetPreview outputFolder={config.build.outputFolder} />
       <TinaAdmin
         preview={Preview}

--- a/packages/@tinacms/app/src/vite-env.d.ts
+++ b/packages/@tinacms/app/src/vite-env.d.ts
@@ -4,3 +4,4 @@
 
 /// <reference types="vite/client" />
 declare const __API_URL__: string
+declare const __TINA_GRAPHQL_VERSION__: string

--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -105,6 +105,7 @@ export class Codegen {
     const branch = this.configManager.config?.branch
     const clientId = this.configManager.config?.clientId
     const token = this.configManager.config?.token
+    const version = this.configManager.getTinaGraphQLVersion()
     const baseUrl =
       this.configManager.config.tinaioConfig?.contentApiUrlOverride ||
       `https://${TINA_HOST}`
@@ -128,7 +129,7 @@ export class Codegen {
 
     let apiURL = this.port
       ? `http://localhost:${this.port}/graphql`
-      : `${baseUrl}/content/${clientId}/github/${branch}`
+      : `${baseUrl}/${version}/content/${clientId}/github/${branch}`
 
     if (this.configManager.config.contentApiUrlOverride) {
       apiURL = this.configManager.config.contentApiUrlOverride

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -32,6 +32,10 @@ export class BuildCommand extends Command {
   noTelemetry = Option.Boolean('--noTelemetry', false, {
     description: 'Disable anonymous telemetry that is collected',
   })
+  tinaGraphQLVersion = Option.String('--tina-graphql-version', {
+    description:
+      'Specify the root directory to run the CLI from (defaults to current working directory)',
+  })
 
   static usage = Command.Usage({
     category: `Commands`,
@@ -46,7 +50,10 @@ export class BuildCommand extends Command {
   }
 
   async execute(): Promise<number | void> {
-    const configManager = new ConfigManager(this.rootPath)
+    const configManager = new ConfigManager(
+      this.rootPath,
+      this.tinaGraphQLVersion
+    )
     logger.info('Starting Tina build')
 
     try {

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -46,9 +46,11 @@ export class ConfigManager {
   selfHostedDatabaseFilePath?: string
   spaRootPath: string
   spaHTMLPath: string
+  tinaGraphQLVersionFromCLI?: string
 
-  constructor(rootPath: string = process.cwd()) {
+  constructor(rootPath: string = process.cwd(), tinaGraphQLVersion?: string) {
     this.rootPath = normalizePath(rootPath)
+    this.tinaGraphQLVersionFromCLI = tinaGraphQLVersion
   }
 
   isUsingTs() {
@@ -188,6 +190,24 @@ export class ConfigManager {
     throw new Error(
       `Unable to find Tina folder, if you're working in folder outside of the Tina config be sure to specify --rootPath`
     )
+  }
+
+  getTinaGraphQLVersion() {
+    if (this.tinaGraphQLVersionFromCLI) {
+      return this.tinaGraphQLVersionFromCLI
+    }
+    const generatedSchema = fs.readJSONSync(this.generatedSchemaJSONPath)
+    if (
+      !generatedSchema ||
+      !(typeof generatedSchema?.version !== 'undefined') ||
+      !(typeof generatedSchema?.version?.major === 'string') ||
+      !(typeof generatedSchema?.version?.minor === 'string')
+    ) {
+      throw new Error(
+        `Can not find Tina GraphQL version in ${this.generatedSchemaJSONPath}`
+      )
+    }
+    return `${generatedSchema.version.major}.${generatedSchema.version.minor}`
   }
 
   printGeneratedClientFilePath() {

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -82,6 +82,7 @@ export const createConfig = async (
       'process.env': `new Object(${JSON.stringify(publicEnv)})`,
       __API_URL__: `"${apiURL}"`,
       __TOKEN__: `"${configManager.config.token}"`,
+      __TINA_GRAPHQL_VERSION__: `"${configManager.getTinaGraphQLVersion()}"`,
     },
     server: {
       watch: noWatch

--- a/packages/@tinacms/schema-tools/src/util/parseURL.spec.ts
+++ b/packages/@tinacms/schema-tools/src/util/parseURL.spec.ts
@@ -6,11 +6,12 @@ import { parseURL, TINA_HOST } from './parseURL'
 const MOCK_HOST_PROD = `https://${TINA_HOST}`
 const MOCK_HOST_LOCAL = `https://localhost:4001`
 const MOCK_CLIENT_ID = '1234'
+const MOCK_VERSION = 'beta'
 const MOCK_BRANCH = 'main'
 
 describe('parseUrl', () => {
   it('returns the branch, client, ID and isLocalClient from a valid production URL', () => {
-    const correctURL = `${MOCK_HOST_PROD}/content/${MOCK_CLIENT_ID}/github/${MOCK_BRANCH}`
+    const correctURL = `${MOCK_HOST_PROD}/${MOCK_VERSION}/content/${MOCK_CLIENT_ID}/github/${MOCK_BRANCH}`
     const { branch, clientId, isLocalClient } = parseURL(correctURL)
     expect(branch).toBe(MOCK_BRANCH)
     expect(clientId).toBe(MOCK_CLIENT_ID)
@@ -25,7 +26,7 @@ describe('parseUrl', () => {
   })
   it('handles when branch name contains a "/"', () => {
     const MOCK_BRANCH = 'foo/bar'
-    const correctURL = `${MOCK_HOST_PROD}/content/${MOCK_CLIENT_ID}/github/${MOCK_BRANCH}`
+    const correctURL = `${MOCK_HOST_PROD}/${MOCK_VERSION}/content/${MOCK_CLIENT_ID}/github/${MOCK_BRANCH}`
     const { branch, clientId, isLocalClient } = parseURL(correctURL)
     expect(branch).toBe(MOCK_BRANCH)
     expect(clientId).toBe(MOCK_CLIENT_ID)

--- a/packages/@tinacms/schema-tools/src/util/parseURL.ts
+++ b/packages/@tinacms/schema-tools/src/util/parseURL.ts
@@ -48,8 +48,10 @@ export const parseURL = (
     }
   }
 
-  const pattern = new UrlPattern('/content/:clientId/github/*', {
+  const pattern = new UrlPattern('/:v/content/:clientId/github/*', {
     escapeChar: ' ',
+    // extend to allow `.` in version
+    segmentValueCharset: 'a-zA-Z0-9-_~ %.',
   })
   const result = pattern.match(params.pathname)
   const branch = result?._
@@ -57,7 +59,7 @@ export const parseURL = (
 
   if (!branch || !clientId) {
     throw new Error(
-      `Invalid URL format provided. Expected: https://content.tinajs.io/content/<ClientID>/github/<Branch> but but received ${url}`
+      `Invalid URL format provided. Expected: https://content.tinajs.io/<Verion>/content/<ClientID>/github/<Branch> but but received ${url}`
     )
   }
 

--- a/packages/@tinacms/schema-tools/src/util/parseURL.ts
+++ b/packages/@tinacms/schema-tools/src/util/parseURL.ts
@@ -59,7 +59,7 @@ export const parseURL = (
 
   if (!branch || !clientId) {
     throw new Error(
-      `Invalid URL format provided. Expected: https://content.tinajs.io/<Verion>/content/<ClientID>/github/<Branch> but but received ${url}`
+      `Invalid URL format provided. Expected: https://content.tinajs.io/<Version>/content/<ClientID>/github/<Branch> but but received ${url}`
     )
   }
 

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -27,6 +27,7 @@ interface ServerOptions {
   schema?: Schema
   clientId: string
   branch: string
+  tinaGraphQLVersion: string
   customContentApiUrl?: string
   getTokenFn?: () => Promise<TokenObject>
   tinaioConfig?: TinaIOConfig
@@ -178,6 +179,7 @@ export class Client {
   clientId: string
   contentApiBase: string
   query: string
+  tinaGraphQLVersion: string
   setToken: (_token: TokenObject) => void
   private getToken: () => Promise<TokenObject>
   private token: string // used with memory storage
@@ -186,6 +188,7 @@ export class Client {
   events = new EventBus() // automatically hooked into global event bus when attached via cms.registerApi
 
   constructor({ tokenStorage = 'MEMORY', ...options }: ServerOptions) {
+    this.tinaGraphQLVersion = options.tinaGraphQLVersion
     this.onLogin = options.schema?.config?.admin?.auth?.onLogin
     this.onLogout = options.schema?.config?.admin?.auth?.onLogout
     if (options.schema?.config?.admin?.auth?.logout) {
@@ -289,7 +292,7 @@ export class Client {
       `https://content.tinajs.io`
     this.contentApiUrl =
       this.options.customContentApiUrl ||
-      `${this.contentApiBase}/content/${this.options.clientId}/github/${encodedBranch}`
+      `${this.contentApiBase}/${this.tinaGraphQLVersion}/content/${this.options.clientId}/github/${encodedBranch}`
   }
 
   addPendingContent = async (props) => {
@@ -716,12 +719,13 @@ export class LocalClient extends Client {
     props?: {
       customContentApiUrl?: string
       schema?: Schema
-    } & Omit<ServerOptions, 'clientId' | 'branch'>
+    } & Omit<ServerOptions, 'clientId' | 'branch' | 'tinaGraphQLVersion'>
   ) {
     const clientProps = {
       ...props,
       clientId: '',
       branch: '',
+      tinaGraphQLVersion: '',
       customContentApiUrl:
         props && props.customContentApiUrl
           ? props.customContentApiUrl

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -238,6 +238,7 @@ export const TinaCMSProvider2 = ({
         // Not ideal but we need this for backwards compatibility for now. We can clean this up when we require a config.{js,ts} file
         // @ts-ignore
         schema={{ ...schema, config: { ...schema.config, ...props } }}
+        tinaGraphQLVersion={props.tinaGraphQLVersion}
       >
         <style>{styles}</style>
         <ErrorBoundary>{props.children}</ErrorBoundary>

--- a/packages/tinacms/src/types/cms.ts
+++ b/packages/tinacms/src/types/cms.ts
@@ -64,4 +64,6 @@ type QueryProviderProps =
 export type TinaCMSProviderDefaultProps = QueryProviderProps &
   APIProviderProps &
   BaseProviderProps &
-  Config
+  Config & {
+    tinaGraphQLVersion: string
+  }

--- a/packages/tinacms/src/utils/index.ts
+++ b/packages/tinacms/src/utils/index.ts
@@ -16,6 +16,7 @@ export interface CreateClientProps {
   branch?: string
   schema?: Schema
   apiUrl?: string
+  tinaGraphQLVersion: string
 }
 export const createClient = ({
   clientId,
@@ -24,6 +25,7 @@ export const createClient = ({
   tinaioConfig,
   schema,
   apiUrl,
+  tinaGraphQLVersion,
 }: CreateClientProps) => {
   return isLocalClient
     ? new LocalClient({ customContentApiUrl: apiUrl, schema })
@@ -33,6 +35,7 @@ export const createClient = ({
         tokenStorage: 'LOCAL_STORAGE',
         tinaioConfig,
         schema,
+        tinaGraphQLVersion,
       })
 }
 


### PR DESCRIPTION
Uses new API endpoint. 

Depends on #3659  to be merged first.

What was `/content/<ClientID>/github/<Branch>` is now  `/<Version>/content/<ClientID>/github/<Branch>`

Fixes ENG-852