### PR TITLE
Bump esbuild versions in graphql/scripts

### DIFF
--- a/.changeset/clever-emus-notice.md
+++ b/.changeset/clever-emus-notice.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/graphql': patch
+'@tinacms/scripts': patch
+---
+
+Bump esbuild versions in graphql/scripts

--- a/packages/@tinacms/graphql/package.json
+++ b/packages/@tinacms/graphql/package.json
@@ -41,7 +41,7 @@
     "dataloader": "^2.0.0",
     "date-fns": "^2.21.1",
     "encoding-down": "^7.1.0",
-    "esbuild": "^0.12.25",
+    "esbuild": "^0.15.5",
     "esbuild-jest": "^0.5.0",
     "estree-walker": "^3.0.0",
     "fast-glob": "^3.2.5",

--- a/packages/@tinacms/scripts/package.json
+++ b/packages/@tinacms/scripts/package.json
@@ -28,7 +28,7 @@
     "chalk": "^4.1.1",
     "chokidar": "^3.5.2",
     "commander": "^7.2.0",
-    "esbuild": "^0.12.9",
+    "esbuild": "^0.15.5",
     "esbuild-jest": "^0.5.0",
     "execa": "^5.1.1",
     "express": "^4.17.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 overrides:
   '@types/react': 17.0.47
@@ -27,9 +27,9 @@ importers:
       workspace: ^0.0.1-preview.1
     dependencies:
       '@changesets/cli': 2.26.0
-      '@typescript-eslint/eslint-plugin': 2.34.0_771580faa0a2a8e0660942a0650f3bdf
-      '@typescript-eslint/parser': 5.15.0_eslint@6.8.0+typescript@4.3.5
-      '@yarnpkg/pnpify': 2.4.0_eslint@6.8.0+typescript@4.3.5
+      '@typescript-eslint/eslint-plugin': 2.34.0_o4kyb6vaukuoazqjikqgkdz334
+      '@typescript-eslint/parser': 5.15.0_ormy72tqrapqsntr3tx5lktgaq
+      '@yarnpkg/pnpify': 2.4.0_ormy72tqrapqsntr3tx5lktgaq
       danger: 11.2.3
       eslint: 6.8.0
       eslint-config-prettier: 6.15.0_eslint@6.8.0
@@ -58,7 +58,7 @@ importers:
       react-is: ^17.0.2
       tinacms: workspace:*
     dependencies:
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
@@ -67,7 +67,7 @@ importers:
       '@tinacms/cli': link:../../packages/@tinacms/cli
       '@types/node': 17.0.45
       eslint: 7.32.0
-      eslint-config-next: 13.2.1_eslint@7.32.0+typescript@4.3.5
+      eslint-config-next: 13.2.1_eslint@7.32.0
 
   examples/basic-iframe:
     specifiers:
@@ -91,7 +91,7 @@ importers:
       '@tinacms/graphql': link:../../packages/@tinacms/graphql
       dotenv: 16.0.3
       js-base64: 3.7.5
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
@@ -100,7 +100,7 @@ importers:
       '@tinacms/cli': link:../../packages/@tinacms/cli
       '@types/node': 17.0.45
       eslint: 7.32.0
-      eslint-config-next: 13.2.1_eslint@7.32.0+typescript@4.3.5
+      eslint-config-next: 13.2.1_eslint@7.32.0
 
   examples/empty:
     specifiers:
@@ -115,7 +115,7 @@ importers:
       tinacms: workspace:*
     dependencies:
       '@tinacms/cli': link:../../packages/@tinacms/cli
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
@@ -123,7 +123,7 @@ importers:
     devDependencies:
       '@types/node': 17.0.45
       eslint: 7.32.0
-      eslint-config-next: 13.2.1_eslint@7.32.0+typescript@4.3.5
+      eslint-config-next: 13.2.1_eslint@7.32.0
 
   examples/kitchen-sink:
     specifiers:
@@ -154,16 +154,16 @@ importers:
       vitest: ^0.18.0
     dependencies:
       '@cypress/chrome-recorder': 2.2.0
-      '@headlessui/react': 1.7.3_react-dom@18.2.0+react@18.2.0
+      '@headlessui/react': 1.7.3_biqbaboplfbrettd7655fr4n2y
       '@heroicons/react': 2.0.12_react@18.2.0
       '@tailwindcss/typography': 0.5.7_tailwindcss@3.1.8
       graphql: 15.8.0
       jest-file-snapshot: 0.5.0
-      next: 12.2.4_react-dom@18.2.0+react@18.2.0
+      next: 12.2.4_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-icons: 4.7.1_react@18.2.0
-      react-json-view: 1.21.3_react-dom@18.2.0+react@18.2.0
+      react-json-view: 1.21.3_biqbaboplfbrettd7655fr4n2y
       tinacms: link:../../packages/tinacms
       vite: 3.1.3
       vitest: 0.18.1
@@ -174,10 +174,10 @@ importers:
       autoprefixer: 10.4.7_postcss@8.4.18
       cypress: 10.10.0
       eslint: 8.24.0
-      eslint-config-next: 13.2.1_eslint@8.24.0+typescript@4.8.4
+      eslint-config-next: 13.2.1_ypn2ylkkyfa5i233caldtndbqa
       postcss: 8.4.18
       puppeteer: 18.2.1
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
       typescript: 4.8.4
 
   examples/tina-self-hosted-demo:
@@ -213,21 +213,21 @@ importers:
       tinacms: workspace:*
       typescript: ^4.5.2
     dependencies:
-      '@headlessui/react': 1.7.5_react-dom@17.0.2+react@17.0.2
+      '@headlessui/react': 1.7.5_sfoxds7t5ydpegc3knd667wn6m
       '@octokit/rest': 19.0.7
       '@tailwindcss/typography': 0.5.9_tailwindcss@3.2.4
       '@tinacms/datalayer': link:../../packages/@tinacms/datalayer
       date-fns: 2.28.0
       js-base64: 3.7.5
       mongodb-level: 0.0.2
-      next: 12.3.4_react-dom@17.0.2+react@17.0.2
+      next: 12.3.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-icons: 4.7.1_react@17.0.2
       react-is: 17.0.2
-      styled-components: 5.3.5_281a4fa50a045c9112baf635f3bc27a7
+      styled-components: 5.3.5_fane7jikarojcev26y27hpbhu4
       styled-jsx: 5.1.2_react@17.0.2
-      tailwindcss: 3.2.4
+      tailwindcss: 3.2.4_postcss@8.4.18
       tinacms: link:../../packages/tinacms
       typescript: 4.8.4
     devDependencies:
@@ -237,8 +237,8 @@ importers:
       '@types/node': 16.11.41
       '@types/react': 17.0.47
       '@types/styled-components': 5.1.25
-      '@typescript-eslint/eslint-plugin': 5.53.0_d3de6e120ef40116095f98e4b4bc1f84
-      '@typescript-eslint/parser': 5.53.0_eslint@8.24.0+typescript@4.8.4
+      '@typescript-eslint/eslint-plugin': 5.53.0_2ppg4eqo6qarmck7tdsljpa7qq
+      '@typescript-eslint/parser': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
       autoprefixer: 10.4.7_postcss@8.4.18
       eslint: 8.24.0
       postcss: 8.4.18
@@ -256,7 +256,7 @@ importers:
       react-is: ^17.0.2
       tinacms: workspace:*
     dependencies:
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
@@ -264,7 +264,7 @@ importers:
     devDependencies:
       '@tinacms/cli': link:../../packages/@tinacms/cli
       eslint: 7.32.0
-      eslint-config-next: 13.2.1_eslint@7.32.0+typescript@4.3.5
+      eslint-config-next: 13.2.1_eslint@7.32.0
 
   experimental-examples/tina-cloud-starter:
     specifiers:
@@ -294,13 +294,13 @@ importers:
       tinacms: workspace:*
       typescript: 4.3.5
     dependencies:
-      '@headlessui/react': 1.6.5_react-dom@17.0.2+react@17.0.2
+      '@headlessui/react': 1.6.5_sfoxds7t5ydpegc3knd667wn6m
       '@tailwindcss/typography': 0.4.1_tailwindcss@2.2.19
       '@tinacms/auth': link:../../packages/@tinacms/auth
       '@tinacms/datalayer': link:../../packages/@tinacms/datalayer
       '@tinacms/graphql': link:../../packages/@tinacms/graphql
       date-fns: 2.28.0
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       next-tinacms-cloudinary: link:../../packages/next-tinacms-cloudinary
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -319,7 +319,7 @@ importers:
       postcss: 8.4.14
       postcss-import: 14.1.0_postcss@8.4.14
       postcss-nesting: 10.1.9_postcss@8.4.14
-      tailwindcss: 2.2.19_a191cbaa25c4a0a9f05cc78eac153be7
+      tailwindcss: 2.2.19_ugi4xkrfysqkt4c4y6hkyfj344
 
   experimental-examples/tina-cloud-starter-iframe:
     specifiers:
@@ -349,17 +349,17 @@ importers:
       tinacms: workspace:*
       typescript: 4.3.5
     dependencies:
-      '@headlessui/react': 1.6.6_react-dom@17.0.2+react@17.0.2
+      '@headlessui/react': 1.6.6_sfoxds7t5ydpegc3knd667wn6m
       '@tailwindcss/typography': 0.4.1_tailwindcss@2.2.19
       '@tinacms/auth': link:../../packages/@tinacms/auth
       date-fns: 2.28.0
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       next-tinacms-cloudinary: link:../../packages/next-tinacms-cloudinary
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-icons: 4.4.0_react@17.0.2
       react-is: 17.0.2
-      styled-components: 5.3.5_281a4fa50a045c9112baf635f3bc27a7
+      styled-components: 5.3.5_fane7jikarojcev26y27hpbhu4
       styled-jsx: 5.1.2_react@17.0.2
       tinacms: link:../../packages/tinacms
       typescript: 4.3.5
@@ -374,7 +374,7 @@ importers:
       postcss: 8.4.16
       postcss-import: 14.1.0_postcss@8.4.16
       postcss-nesting: 10.1.9_postcss@8.4.16
-      tailwindcss: 2.2.19_dd5b83115bc64f84aeac6195b940d961
+      tailwindcss: 2.2.19_3vnygek3yzhyjlvmmgk3sqgzme
 
   packages/@tinacms/app:
     specifiers:
@@ -412,14 +412,14 @@ importers:
       webfontloader: 1.6.28
       xstate: 4.32.1
     dependencies:
-      '@headlessui/react': 1.6.6_react-dom@17.0.2+react@17.0.2
+      '@headlessui/react': 1.6.6_sfoxds7t5ydpegc3knd667wn6m
       '@heroicons/react': 1.0.6_react@17.0.2
-      '@monaco-editor/react': 4.4.5_42c17ac666de4a81a5f889e41c4e1ae7
+      '@monaco-editor/react': 4.4.5_ilaxvrtg3zfidjpyrhsbytq244
       '@tailwindcss/aspect-ratio': 0.4.0_tailwindcss@3.1.8
       '@tailwindcss/line-clamp': 0.3.1_tailwindcss@3.1.8
       '@tailwindcss/typography': 0.5.4_tailwindcss@3.1.8
       '@vitejs/plugin-react': 2.1.0_vite@3.1.8
-      '@xstate/react': 3.0.0_83b3e746b3d7a44f199627017eaaa2a3
+      '@xstate/react': 3.0.0_qoz6orvt26se6gmwe4ax5kvcum
       autoprefixer: 10.4.7_postcss@8.4.14
       final-form: 4.20.7
       fs-extra: 9.1.0
@@ -430,9 +430,9 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
-      react-router-dom: 6.3.0_react-dom@17.0.2+react@17.0.2
-      styled-components: 5.3.5_281a4fa50a045c9112baf635f3bc27a7
-      tailwindcss: 3.1.8
+      react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
+      styled-components: 5.3.5_fane7jikarojcev26y27hpbhu4
+      tailwindcss: 3.1.8_postcss@8.4.14
       typescript: 4.7.4
       vite: 3.1.8
       webfontloader: 1.6.28
@@ -700,7 +700,7 @@ importers:
       dataloader: ^2.0.0
       date-fns: ^2.21.1
       encoding-down: ^7.1.0
-      esbuild: ^0.12.25
+      esbuild: ^0.15.5
       esbuild-jest: ^0.5.0
       estree-walker: ^3.0.0
       fast-glob: ^3.2.5
@@ -758,8 +758,8 @@ importers:
       dataloader: 2.1.0
       date-fns: 2.28.0
       encoding-down: 7.1.0
-      esbuild: 0.12.29
-      esbuild-jest: 0.5.0_esbuild@0.12.29
+      esbuild: 0.15.12
+      esbuild-jest: 0.5.0_esbuild@0.15.12
       estree-walker: 3.0.1
       fast-glob: 3.2.11
       flat: 5.0.2
@@ -983,7 +983,7 @@ importers:
       '@vitejs/plugin-react': 2.1.0_vite@3.0.2
       c8: 7.11.3
       estree-jsx: 0.0.1
-      jest: 28.1.3_635e6337f05c348d75a1fd7f673a4111
+      jest: 28.1.3_mnpggn7qlq2i25nb7v7woosbce
       jest-diff: 28.1.3
       jest-file-snapshot: 0.5.0
       jest-matcher-utils: 28.1.3
@@ -991,9 +991,9 @@ importers:
       postcss: 8.4.21
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      react-monaco-editor: 0.51.0_44a4ff1120eec37d4c08627d30e9aebe
-      tailwindcss: 3.2.7_ts-node@10.9.1
-      ts-node: 10.9.1_dce5d793216ec5b06690943fcc406465
+      react-monaco-editor: 0.51.0_issp6eja53bx2taimj6tb2noxy
+      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
+      ts-node: 10.9.1_3ts5pezbn3c3azuqsq74yqdemu
       typedoc: 0.23.21_typescript@4.7.4
       typedoc-plugin-markdown: 3.13.6_typedoc@0.23.21
       typescript: 4.7.4
@@ -1052,7 +1052,7 @@ importers:
       chalk: ^4.1.1
       chokidar: ^3.5.2
       commander: ^7.2.0
-      esbuild: ^0.12.9
+      esbuild: ^0.15.5
       esbuild-jest: ^0.5.0
       execa: ^5.1.1
       express: ^4.17.1
@@ -1080,8 +1080,8 @@ importers:
       chalk: 4.1.2
       chokidar: 3.5.3
       commander: 7.2.0
-      esbuild: 0.12.29
-      esbuild-jest: 0.5.0_esbuild@0.12.29
+      esbuild: 0.15.12
+      esbuild-jest: 0.5.0_esbuild@0.15.12
       execa: 5.1.1
       express: 4.18.1
       fs-extra: 9.1.0
@@ -1091,8 +1091,8 @@ importers:
       normalize-path: 3.0.0
       postcss: 8.4.14
       postcss-nested: 5.0.6_postcss@8.4.14
-      tailwindcss: 3.1.4
-      tsup: 4.14.0_postcss@8.4.14+typescript@4.7.4
+      tailwindcss: 3.1.4_postcss@8.4.14
+      tsup: 4.14.0_m3gf5jmpd2aiwepqhoxxcqgnwi
       typescript: 4.7.4
       vite: 2.9.14
       vite-plugin-dts: 0.5.3_vite@2.9.14
@@ -1174,10 +1174,10 @@ importers:
       webfontloader: 1.6.28
     dependencies:
       '@floating-ui/dom': 0.1.10
-      '@floating-ui/react-dom': 0.3.4_6b79dcf651fa0d4fc8b46fa68013a7bf
-      '@headlessui/react': 1.6.5_react-dom@17.0.2+react@17.0.2
+      '@floating-ui/react-dom': 0.3.4_nn45z5sr7igu7sfun6tiae5hx4
+      '@headlessui/react': 1.6.5_sfoxds7t5ydpegc3knd667wn6m
       '@heroicons/react': 1.0.6_react@17.0.2
-      '@monaco-editor/react': 4.4.5_42c17ac666de4a81a5f889e41c4e1ae7
+      '@monaco-editor/react': 4.4.5_ilaxvrtg3zfidjpyrhsbytq244
       '@react-aria/i18n': 3.4.1_react@17.0.2
       '@react-aria/listbox': 3.3.0_react@17.0.2
       '@react-hook/window-size': 3.0.7_react@17.0.2
@@ -1185,7 +1185,7 @@ importers:
       '@react-types/shared': 3.13.1_react@17.0.2
       '@sambego/storybook-styles': 1.0.0
       '@tinacms/sharedctx': link:../sharedctx
-      '@udecode/plate-headless': 14.4.3_09d299f50cb82e75cff2c2c5480a011b
+      '@udecode/plate-headless': 14.4.3_bhjjt5imxaxhlt7sylcuqcqbdm
       atob: 2.1.2
       color-string: 1.9.1
       final-form: 4.20.7
@@ -1198,21 +1198,21 @@ importers:
       prism-react-renderer: 1.3.5_react@17.0.2
       prismjs: 1.28.0
       prop-types: 15.7.2
-      react-beautiful-dnd: 13.1.0_react-dom@17.0.2+react@17.0.2
+      react-beautiful-dnd: 13.1.0_sfoxds7t5ydpegc3knd667wn6m
       react-color: 2.19.3_react@17.0.2
-      react-datetime: 2.16.3_9b9afce5b760d4382de297dd21b1d59c
+      react-datetime: 2.16.3_tonpzznxmdkdqlpcs7osdmovtq
       react-dropzone: 14.2.3_react@17.0.2
-      react-final-form: 6.5.9_final-form@4.20.7+react@17.0.2
+      react-final-form: 6.5.9_s44h3cxpdxv6cks4bnqewerqda
       react-icons: 4.4.0_react@17.0.2
-      react-onclickoutside: 6.12.2_react-dom@17.0.2+react@17.0.2
+      react-onclickoutside: 6.12.2_sfoxds7t5ydpegc3knd667wn6m
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
       slate-hyperscript: 0.77.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
       webfontloader: 1.6.28
     devDependencies:
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 12.1.5_react-dom@17.0.2+react@17.0.2
+      '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
       '@testing-library/user-event': 12.8.3
       '@tinacms/scripts': link:../scripts
       '@types/atob': 2.1.2
@@ -1338,7 +1338,7 @@ importers:
       tinacms: workspace:*
       typescript: 4.3.5
     dependencies:
-      '@aws-sdk/client-s3': 3.150.0_8819a27328893df3e2254a910e04770d
+      '@aws-sdk/client-s3': 3.150.0_ram2e4zire67hyrfjkiq4bdxbu
       '@aws-sdk/signature-v4-crt': 3.163.0
       multer: 1.4.5-lts.1
     devDependencies:
@@ -1396,8 +1396,8 @@ importers:
       zod: ^3.14.3
     dependencies:
       '@graphql-inspector/core': 4.0.0_graphql@15.8.0
-      '@graphql-tools/relay-operation-optimizer': 6.5.0_encoding@0.1.13+graphql@15.8.0
-      '@headlessui/react': 1.7.5_react-dom@17.0.2+react@17.0.2
+      '@graphql-tools/relay-operation-optimizer': 6.5.0_qyboaezk4cm6zsf5jfobzggyaa
+      '@headlessui/react': 1.7.5_sfoxds7t5ydpegc3knd667wn6m
       '@heroicons/react': 1.0.6_react@17.0.2
       '@react-hook/window-size': 3.0.7_react@17.0.2
       '@tinacms/schema-tools': link:../@tinacms/schema-tools
@@ -1412,14 +1412,14 @@ importers:
       lodash.set: 4.3.2
       prism-react-renderer: 1.3.5_react@17.0.2
       react-icons: 4.4.0_react@17.0.2
-      react-router-dom: 6.3.0_react-dom@17.0.2+react@17.0.2
+      react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
       yup: 0.32.11
       zod: 3.17.3
     devDependencies:
       '@graphql-tools/utils': 8.8.0_graphql@15.8.0
       '@testing-library/jest-dom': 5.16.4
-      '@testing-library/react': 12.1.5_react-dom@17.0.2+react@17.0.2
-      '@testing-library/react-hooks': 7.0.2_react-dom@17.0.2+react@17.0.2
+      '@testing-library/react': 12.1.5_sfoxds7t5ydpegc3knd667wn6m
+      '@testing-library/react-hooks': 7.0.2_sfoxds7t5ydpegc3knd667wn6m
       '@testing-library/user-event': 12.8.3
       '@tinacms/scripts': link:../@tinacms/scripts
       '@types/jest': 27.5.2
@@ -1431,7 +1431,7 @@ importers:
       isomorphic-fetch: 3.0.0_encoding@0.1.13
       jest: 27.5.1
       jest-file-snapshot: 0.5.0
-      next: 12.2.4_react-dom@17.0.2+react@17.0.2
+      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-is: 17.0.2
@@ -1455,38 +1455,6 @@ packages:
       }
     dependencies:
       grapheme-splitter: 1.0.4
-    dev: false
-
-  /@ardatan/relay-compiler/12.0.0_encoding@0.1.13+graphql@15.8.0:
-    resolution:
-      {
-        integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==,
-      }
-    hasBin: true
-    peerDependencies:
-      graphql: '*'
-    dependencies:
-      '@babel/core': 7.21.0
-      '@babel/generator': 7.18.13
-      '@babel/parser': 7.18.13
-      '@babel/runtime': 7.21.0
-      '@babel/traverse': 7.18.13
-      '@babel/types': 7.18.13
-      babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
-      chalk: 4.1.2
-      fb-watchman: 2.0.1
-      fbjs: 3.0.4_encoding@0.1.13
-      glob: 7.2.3
-      graphql: 15.8.0
-      immutable: 3.7.6
-      invariant: 2.2.4
-      nullthrows: 1.1.1
-      relay-runtime: 12.0.0_encoding@0.1.13
-      signedsource: 1.0.0
-      yargs: 15.4.1
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
     dev: false
 
   /@ardatan/relay-compiler/12.0.0_graphql@15.8.0:
@@ -1514,6 +1482,38 @@ packages:
       invariant: 2.2.4
       nullthrows: 1.1.1
       relay-runtime: 12.0.0
+      signedsource: 1.0.0
+      yargs: 15.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@ardatan/relay-compiler/12.0.0_qyboaezk4cm6zsf5jfobzggyaa:
+    resolution:
+      {
+        integrity: sha512-9anThAaj1dQr6IGmzBMcfzOQKTa5artjuPmw8NYK/fiGEMjADbSguBY2FMDykt+QhilR3wc9VA/3yVju7JHg7Q==,
+      }
+    hasBin: true
+    peerDependencies:
+      graphql: '*'
+    dependencies:
+      '@babel/core': 7.21.0
+      '@babel/generator': 7.18.13
+      '@babel/parser': 7.18.13
+      '@babel/runtime': 7.21.0
+      '@babel/traverse': 7.18.13
+      '@babel/types': 7.18.13
+      babel-preset-fbjs: 3.4.0_@babel+core@7.21.0
+      chalk: 4.1.2
+      fb-watchman: 2.0.1
+      fbjs: 3.0.4_encoding@0.1.13
+      glob: 7.2.3
+      graphql: 15.8.0
+      immutable: 3.7.6
+      invariant: 2.2.4
+      nullthrows: 1.1.1
+      relay-runtime: 12.0.0_encoding@0.1.13
       signedsource: 1.0.0
       yargs: 15.4.1
     transitivePeerDependencies:
@@ -1828,7 +1828,7 @@ packages:
       - aws-crt
     dev: false
 
-  /@aws-sdk/client-s3/3.150.0_8819a27328893df3e2254a910e04770d:
+  /@aws-sdk/client-s3/3.150.0_ram2e4zire67hyrfjkiq4bdxbu:
     resolution:
       {
         integrity: sha512-vUW/+9TM3vl6cofqP7HYtisX/fnu2KlnPjDYzhwbezcoAAXL4aZOVqMHpZqcr8fZytFsfSl5FcZvi4x2c/TTlw==,
@@ -1868,7 +1868,7 @@ packages:
       '@aws-sdk/node-config-provider': 3.127.0
       '@aws-sdk/node-http-handler': 3.127.0
       '@aws-sdk/protocol-http': 3.127.0
-      '@aws-sdk/signature-v4-multi-region': 3.130.0_8819a27328893df3e2254a910e04770d
+      '@aws-sdk/signature-v4-multi-region': 3.130.0_ram2e4zire67hyrfjkiq4bdxbu
       '@aws-sdk/smithy-client': 3.142.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/url-parser': 3.127.0
@@ -2066,7 +2066,7 @@ packages:
       '@aws-sdk/util-utf8-node': 3.109.0
       entities: 2.2.0
       fast-xml-parser: 3.19.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2130,7 +2130,7 @@ packages:
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-config-provider': 3.109.0
       '@aws-sdk/util-middleware': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/config-resolver/3.272.0:
@@ -2274,7 +2274,7 @@ packages:
       '@aws-sdk/property-provider': 3.127.0
       '@aws-sdk/shared-ini-file-loader': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2409,7 +2409,7 @@ packages:
       '@aws-sdk/property-provider': 3.272.0
       '@aws-sdk/shared-ini-file-loader': 3.272.0
       '@aws-sdk/types': 3.272.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     transitivePeerDependencies:
       - aws-crt
     dev: false
@@ -2436,7 +2436,7 @@ packages:
     dependencies:
       '@aws-sdk/eventstream-serde-universal': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/eventstream-serde-config-resolver/3.127.0:
@@ -2447,7 +2447,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/eventstream-serde-node/3.127.0:
@@ -2459,7 +2459,7 @@ packages:
     dependencies:
       '@aws-sdk/eventstream-serde-universal': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/eventstream-serde-universal/3.127.0:
@@ -2484,7 +2484,7 @@ packages:
       '@aws-sdk/querystring-builder': 3.127.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-base64-browser': 3.109.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/fetch-http-handler/3.272.0:
@@ -2510,7 +2510,7 @@ packages:
       '@aws-sdk/chunked-blob-reader': 3.55.0
       '@aws-sdk/chunked-blob-reader-native': 3.109.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/hash-node/3.127.0:
@@ -2522,7 +2522,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-buffer-from': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/hash-node/3.272.0:
@@ -2547,7 +2547,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/invalid-dependency/3.127.0:
@@ -2557,7 +2557,7 @@ packages:
       }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/invalid-dependency/3.272.0:
@@ -2601,7 +2601,7 @@ packages:
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-utf8-browser': 3.109.0
       '@aws-sdk/util-utf8-node': 3.109.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-bucket-endpoint/3.127.0:
@@ -2615,7 +2615,7 @@ packages:
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-arn-parser': 3.55.0
       '@aws-sdk/util-config-provider': 3.109.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-content-length/3.127.0:
@@ -2627,7 +2627,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-content-length/3.272.0:
@@ -2670,7 +2670,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-flexible-checksums/3.127.0:
@@ -2685,7 +2685,7 @@ packages:
       '@aws-sdk/is-array-buffer': 3.55.0
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-host-header/3.127.0:
@@ -2697,7 +2697,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-host-header/3.272.0:
@@ -2721,7 +2721,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-logger/3.127.0:
@@ -2732,7 +2732,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-logger/3.272.0:
@@ -2756,7 +2756,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-recursion-detection/3.272.0:
@@ -2783,7 +2783,7 @@ packages:
       '@aws-sdk/service-error-classification': 3.127.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-middleware': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
       uuid: 8.3.2
     dev: false
 
@@ -2815,7 +2815,7 @@ packages:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-arn-parser': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-sdk-sts/3.130.0:
@@ -2857,7 +2857,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-serde/3.272.0:
@@ -2883,7 +2883,7 @@ packages:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/signature-v4': 3.130.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-signing/3.272.0:
@@ -2910,7 +2910,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-stack/3.127.0:
@@ -2920,7 +2920,7 @@ packages:
       }
     engines: { node: '>= 12.0.0' }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-stack/3.272.0:
@@ -2943,7 +2943,7 @@ packages:
     dependencies:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/middleware-user-agent/3.272.0:
@@ -2969,7 +2969,7 @@ packages:
       '@aws-sdk/property-provider': 3.127.0
       '@aws-sdk/shared-ini-file-loader': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/node-config-provider/3.272.0:
@@ -2997,7 +2997,7 @@ packages:
       '@aws-sdk/protocol-http': 3.127.0
       '@aws-sdk/querystring-builder': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/node-http-handler/3.272.0:
@@ -3046,7 +3046,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/protocol-http/3.272.0:
@@ -3205,10 +3205,10 @@ packages:
       '@aws-sdk/signature-v4-crt': 3.163.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-arn-parser': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
-  /@aws-sdk/signature-v4-multi-region/3.130.0_8819a27328893df3e2254a910e04770d:
+  /@aws-sdk/signature-v4-multi-region/3.130.0_ram2e4zire67hyrfjkiq4bdxbu:
     resolution:
       {
         integrity: sha512-ZRRoPRoCVdkGDtjuog81pqHsSLfnXK6ELrWm4Dq8xdcHQGbEDNdYmeXARXG9yPAO42x9yIJXHNutMz5Y/P64cw==,
@@ -3225,7 +3225,7 @@ packages:
       '@aws-sdk/signature-v4-crt': 3.163.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-arn-parser': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/signature-v4/3.130.0:
@@ -3284,7 +3284,7 @@ packages:
     dependencies:
       '@aws-sdk/middleware-stack': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/smithy-client/3.272.0:
@@ -3351,7 +3351,7 @@ packages:
     dependencies:
       '@aws-sdk/querystring-parser': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/url-parser/3.272.0:
@@ -3382,7 +3382,7 @@ packages:
         integrity: sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==,
       }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-base64-node/3.55.0:
@@ -3393,7 +3393,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/util-buffer-from': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-base64/3.208.0:
@@ -3424,7 +3424,7 @@ packages:
         integrity: sha512-Ei2OCzXQw5N6ZkTMZbamUzc1z+z1R1Ja5tMEagz5BxuX4vWdBObT+uGlSzL8yvTbjoPjnxWA2aXyEqaUP3JS8Q==,
       }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-body-length-node/3.208.0:
@@ -3445,7 +3445,7 @@ packages:
       }
     engines: { node: '>= 12.0.0' }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-buffer-from/3.208.0:
@@ -3502,7 +3502,7 @@ packages:
       '@aws-sdk/property-provider': 3.127.0
       '@aws-sdk/types': 3.127.0
       bowser: 2.11.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-defaults-mode-browser/3.272.0:
@@ -3531,7 +3531,7 @@ packages:
       '@aws-sdk/node-config-provider': 3.127.0
       '@aws-sdk/property-provider': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-defaults-mode-node/3.272.0:
@@ -3647,7 +3647,7 @@ packages:
       '@aws-sdk/util-base64-browser': 3.109.0
       '@aws-sdk/util-hex-encoding': 3.109.0
       '@aws-sdk/util-utf8-browser': 3.109.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-stream-node/3.129.0:
@@ -3660,7 +3660,7 @@ packages:
       '@aws-sdk/node-http-handler': 3.127.0
       '@aws-sdk/types': 3.127.0
       '@aws-sdk/util-buffer-from': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-uri-escape/3.201.0:
@@ -3692,7 +3692,7 @@ packages:
     dependencies:
       '@aws-sdk/types': 3.127.0
       bowser: 2.11.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-user-agent-browser/3.272.0:
@@ -3721,7 +3721,7 @@ packages:
     dependencies:
       '@aws-sdk/node-config-provider': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-user-agent-node/3.272.0:
@@ -3748,7 +3748,7 @@ packages:
         integrity: sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==,
       }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
 
   /@aws-sdk/util-utf8-node/3.109.0:
     resolution:
@@ -3758,7 +3758,7 @@ packages:
     engines: { node: '>= 12.0.0' }
     dependencies:
       '@aws-sdk/util-buffer-from': 3.55.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/util-utf8/3.254.0:
@@ -3782,7 +3782,7 @@ packages:
     dependencies:
       '@aws-sdk/abort-controller': 3.127.0
       '@aws-sdk/types': 3.127.0
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@aws-sdk/xml-builder/3.142.0:
@@ -3792,7 +3792,7 @@ packages:
       }
     engines: { node: '>= 12.0.0' }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@babel/code-frame/7.12.11:
@@ -6725,7 +6725,21 @@ packages:
       '@jridgewell/trace-mapping': 0.3.9
     dev: true
 
-  /@csstools/selector-specificity/2.0.1_1d546e2941f6b4ca889831b9fbdc79d8:
+  /@csstools/selector-specificity/2.0.1_444rcjjorr3kpoqtvoodsr46pu:
+    resolution:
+      {
+        integrity: sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==,
+      }
+    engines: { node: ^12 || ^14 || >=16 }
+    peerDependencies:
+      postcss: ^8.3
+      postcss-selector-parser: ^6.0.10
+    dependencies:
+      postcss: 8.4.14
+      postcss-selector-parser: 6.0.10
+    dev: true
+
+  /@csstools/selector-specificity/2.0.1_dvkg4kkb622mvceygg47xxdz3a:
     resolution:
       {
         integrity: sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==,
@@ -6739,7 +6753,7 @@ packages:
       postcss-selector-parser: 6.0.10
     dev: true
 
-  /@csstools/selector-specificity/2.0.1_7b6fee2724f05f3c8883c74281a3791a:
+  /@csstools/selector-specificity/2.0.1_pnx64jze6bptzcedy5bidi3zdi:
     resolution:
       {
         integrity: sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==,
@@ -6750,20 +6764,6 @@ packages:
       postcss-selector-parser: ^6.0.10
     dependencies:
       postcss: 8.4.16
-      postcss-selector-parser: 6.0.10
-    dev: true
-
-  /@csstools/selector-specificity/2.0.1_e73911252e8c76a7ba13ab9c39479e7d:
-    resolution:
-      {
-        integrity: sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==,
-      }
-    engines: { node: ^12 || ^14 || >=16 }
-    peerDependencies:
-      postcss: ^8.3
-      postcss-selector-parser: ^6.0.10
-    dependencies:
-      postcss: 8.4.14
       postcss-selector-parser: 6.0.10
     dev: true
 
@@ -6816,14 +6816,16 @@ packages:
       uuid: 8.3.2
     dev: true
 
-  /@cypress/xvfb/1.2.4:
+  /@cypress/xvfb/1.2.4_supports-color@8.1.1:
     resolution:
       {
         integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==,
       }
     dependencies:
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@8.1.1
       lodash.once: 4.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@emotion/is-prop-valid/1.1.3:
@@ -6972,7 +6974,7 @@ packages:
       '@floating-ui/core': 0.3.1
     dev: false
 
-  /@floating-ui/react-dom/0.3.4_6b79dcf651fa0d4fc8b46fa68013a7bf:
+  /@floating-ui/react-dom/0.3.4_nn45z5sr7igu7sfun6tiae5hx4:
     resolution:
       {
         integrity: sha512-/rnS+pXHLQC+q/koZD8f2O1utyJJCAzOvhxDfKBUUiEzVZmZE0ryzmpIcvs+3zUudpv8xP7cmWWSRi7Y1DsSdg==,
@@ -6984,7 +6986,7 @@ packages:
       '@floating-ui/dom': 0.1.10
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      use-isomorphic-layout-effect: 1.1.2_9506f604383c27787a7cb97c95a04323
+      use-isomorphic-layout-effect: 1.1.2_sudpmbbyhqtxq6t4xf6jlicdem
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -7305,23 +7307,6 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@graphql-tools/relay-operation-optimizer/6.5.0_encoding@0.1.13+graphql@15.8.0:
-    resolution:
-      {
-        integrity: sha512-snqmdPiM2eBex6pijRFx4H9MPumVd8ZWM3y+aaRwzc73VUNnjHE4NyVZEEIdlbmJ2HoQ9Zrm9aFlHVMK7B59zg==,
-      }
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-    dependencies:
-      '@ardatan/relay-compiler': 12.0.0_encoding@0.1.13+graphql@15.8.0
-      '@graphql-tools/utils': 8.8.0_graphql@15.8.0
-      graphql: 15.8.0
-      tslib: 2.4.0
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
   /@graphql-tools/relay-operation-optimizer/6.5.0_graphql@15.8.0:
     resolution:
       {
@@ -7331,6 +7316,23 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@ardatan/relay-compiler': 12.0.0_graphql@15.8.0
+      '@graphql-tools/utils': 8.8.0_graphql@15.8.0
+      graphql: 15.8.0
+      tslib: 2.4.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@graphql-tools/relay-operation-optimizer/6.5.0_qyboaezk4cm6zsf5jfobzggyaa:
+    resolution:
+      {
+        integrity: sha512-snqmdPiM2eBex6pijRFx4H9MPumVd8ZWM3y+aaRwzc73VUNnjHE4NyVZEEIdlbmJ2HoQ9Zrm9aFlHVMK7B59zg==,
+      }
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@ardatan/relay-compiler': 12.0.0_qyboaezk4cm6zsf5jfobzggyaa
       '@graphql-tools/utils': 8.8.0_graphql@15.8.0
       graphql: 15.8.0
       tslib: 2.4.0
@@ -7377,7 +7379,7 @@ packages:
       tslib: 2.5.0
     dev: false
 
-  /@headlessui/react/1.6.5_react-dom@17.0.2+react@17.0.2:
+  /@headlessui/react/1.6.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-3VkKteDxlxf3fE0KbfO9t60KC1lM7YNpZggLpwzVNg1J/zwL+h+4N7MBlFDVpInZI3rKlZGpNx0PWsG/9c2vQg==,
@@ -7391,7 +7393,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@headlessui/react/1.6.6_react-dom@17.0.2+react@17.0.2:
+  /@headlessui/react/1.6.6_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-MFJtmj9Xh/hhBMhLccGbBoSk+sk61BlP6sJe4uQcVMtXZhCgGqd2GyIQzzmsdPdTEWGSF434CBi8mnhR6um46Q==,
@@ -7405,7 +7407,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@headlessui/react/1.7.3_react-dom@18.2.0+react@18.2.0:
+  /@headlessui/react/1.7.3_biqbaboplfbrettd7655fr4n2y:
     resolution:
       {
         integrity: sha512-LGp06SrGv7BMaIQlTs8s2G06moqkI0cb0b8stgq7KZ3xcHdH3qMP+cRyV7qe5x4XEW/IGY48BW4fLesD6NQLng==,
@@ -7419,7 +7421,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /@headlessui/react/1.7.5_react-dom@17.0.2+react@17.0.2:
+  /@headlessui/react/1.7.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-UZSxOfA0CYKO7QDT5OGlFvesvlR1SKkawwSjwQJwt7XQItpzRKdE3ZUQxHcg4LEz3C0Wler2s9psdb872ynwrQ==,
@@ -7691,7 +7693,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       jest-changed-files: 28.1.3
-      jest-config: 28.1.3_91a8f49a6a0ffd6e1e554100fd5d58fa
+      jest-config: 28.1.3_sgupjgtkb76w4hsvieap2xky7i
       jest-haste-map: 28.1.3
       jest-message-util: 28.1.3
       jest-regex-util: 28.0.2
@@ -8229,7 +8231,7 @@ packages:
       state-local: 1.0.7
     dev: false
 
-  /@monaco-editor/react/4.4.5_42c17ac666de4a81a5f889e41c4e1ae7:
+  /@monaco-editor/react/4.4.5_ilaxvrtg3zfidjpyrhsbytq244:
     resolution:
       {
         integrity: sha512-IImtzU7sRc66OOaQVCG+5PFHkSWnnhrUWGBuH6zNmH2h0YgmAhcjHZQc/6MY9JWEbUtVF1WPBMJ9u1XuFbRrVA==,
@@ -9701,7 +9703,7 @@ packages:
         integrity: sha512-rEUrBSGIoSFuYxwBYtlUFMlE2CwGhmW+w9355/5oduSw8e5h2+Tj4UrAGNNgP9915++wj5vkQo0UuOBqOAq4nw==,
       }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
     dev: false
 
   /@swc/helpers/0.4.3:
@@ -9710,7 +9712,7 @@ packages:
         integrity: sha512-6JrF+fdUK2zbGpJIlN7G3v966PQjyx/dPt1T9km2wj+EUBqgrxCk3uX4Kct16MIm9gGxfKRcfax2hVf5jvlTzA==,
       }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
 
   /@swc/jest/0.2.21_@swc+core@1.2.215:
     resolution:
@@ -9743,7 +9745,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.1.4
+      tailwindcss: 3.1.4_postcss@8.4.14
     dev: false
 
   /@tailwindcss/aspect-ratio/0.4.0_tailwindcss@3.1.8:
@@ -9754,7 +9756,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.14
     dev: false
 
   /@tailwindcss/forms/0.5.3_tailwindcss@3.2.7:
@@ -9766,7 +9768,7 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.2.7_ts-node@10.9.1
+      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
     dev: true
 
   /@tailwindcss/line-clamp/0.3.1_tailwindcss@3.1.4:
@@ -9777,7 +9779,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.1.4
+      tailwindcss: 3.1.4_postcss@8.4.14
     dev: false
 
   /@tailwindcss/line-clamp/0.3.1_tailwindcss@3.1.8:
@@ -9788,7 +9790,7 @@ packages:
     peerDependencies:
       tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
     dependencies:
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.14
     dev: false
 
   /@tailwindcss/typography/0.4.1_tailwindcss@2.2.19:
@@ -9803,7 +9805,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       lodash.uniq: 4.5.0
-      tailwindcss: 2.2.19_a191cbaa25c4a0a9f05cc78eac153be7
+      tailwindcss: 2.2.19_ugi4xkrfysqkt4c4y6hkyfj344
     dev: false
 
   /@tailwindcss/typography/0.5.2_tailwindcss@3.1.4:
@@ -9817,7 +9819,7 @@ packages:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
-      tailwindcss: 3.1.4
+      tailwindcss: 3.1.4_postcss@8.4.14
     dev: false
 
   /@tailwindcss/typography/0.5.4_tailwindcss@3.1.8:
@@ -9831,7 +9833,7 @@ packages:
       lodash.castarray: 4.4.0
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.14
     dev: false
 
   /@tailwindcss/typography/0.5.7_tailwindcss@3.1.8:
@@ -9846,7 +9848,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.1.8
+      tailwindcss: 3.1.8_postcss@8.4.18
     dev: false
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.2.4:
@@ -9861,7 +9863,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.4
+      tailwindcss: 3.2.4_postcss@8.4.18
     dev: false
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.2.7:
@@ -9876,7 +9878,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.7_ts-node@10.9.1
+      tailwindcss: 3.2.7_aesdjsunmf4wiehhujt67my7tu
     dev: true
 
   /@testing-library/dom/8.14.0:
@@ -9914,7 +9916,7 @@ packages:
       redent: 3.0.0
     dev: true
 
-  /@testing-library/react-hooks/7.0.2_react-dom@17.0.2+react@17.0.2:
+  /@testing-library/react-hooks/7.0.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==,
@@ -9939,7 +9941,7 @@ packages:
       react-error-boundary: 3.1.4_react@17.0.2
     dev: true
 
-  /@testing-library/react/12.1.5_react-dom@17.0.2+react@17.0.2:
+  /@testing-library/react/12.1.5_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-OfTXCJUFgjd/digLUuPxa0+/3ZxsQmE7ub9kcbW/wi96Bh3o/p5vrETcBGfP17NWPGqeYYl5LTRpwyGoMC4ysg==,
@@ -10776,7 +10778,6 @@ packages:
       {
         integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==,
       }
-    dev: true
 
   /@types/prettier/2.6.3:
     resolution:
@@ -11136,7 +11137,7 @@ packages:
       }
     dev: true
 
-  /@typescript-eslint/eslint-plugin/2.34.0_771580faa0a2a8e0660942a0650f3bdf:
+  /@typescript-eslint/eslint-plugin/2.34.0_o4kyb6vaukuoazqjikqgkdz334:
     resolution:
       {
         integrity: sha512-4zY3Z88rEE99+CNvTbXSyovv2z9PNOVffTWD2W8QF5s2prBQtwN2zadqERcrHpcR7O/+KMI3fcTAmUUhK/iQcQ==,
@@ -11150,8 +11151,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 2.34.0_eslint@6.8.0+typescript@4.3.5
-      '@typescript-eslint/parser': 5.15.0_eslint@6.8.0+typescript@4.3.5
+      '@typescript-eslint/experimental-utils': 2.34.0_ormy72tqrapqsntr3tx5lktgaq
+      '@typescript-eslint/parser': 5.15.0_ormy72tqrapqsntr3tx5lktgaq
       eslint: 6.8.0
       functional-red-black-tree: 1.0.1
       regexpp: 3.2.0
@@ -11161,7 +11162,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.53.0_d3de6e120ef40116095f98e4b4bc1f84:
+  /@typescript-eslint/eslint-plugin/5.53.0_2ppg4eqo6qarmck7tdsljpa7qq:
     resolution:
       {
         integrity: sha512-alFpFWNucPLdUOySmXCJpzr6HKC3bu7XooShWM+3w/EL6J2HIoB2PFxpLnq4JauWVk6DiVeNKzQlFEaE+X9sGw==,
@@ -11175,10 +11176,10 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.53.0_eslint@8.24.0+typescript@4.8.4
+      '@typescript-eslint/parser': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
       '@typescript-eslint/scope-manager': 5.53.0
-      '@typescript-eslint/type-utils': 5.53.0_eslint@8.24.0+typescript@4.8.4
-      '@typescript-eslint/utils': 5.53.0_eslint@8.24.0+typescript@4.8.4
+      '@typescript-eslint/type-utils': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
+      '@typescript-eslint/utils': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
       debug: 4.3.4
       eslint: 8.24.0
       grapheme-splitter: 1.0.4
@@ -11192,7 +11193,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/2.34.0_eslint@6.8.0+typescript@4.3.5:
+  /@typescript-eslint/experimental-utils/2.34.0_ormy72tqrapqsntr3tx5lktgaq:
     resolution:
       {
         integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==,
@@ -11211,7 +11212,7 @@ packages:
       - typescript
     dev: false
 
-  /@typescript-eslint/parser/5.15.0_eslint@6.8.0+typescript@4.3.5:
+  /@typescript-eslint/parser/5.15.0_ormy72tqrapqsntr3tx5lktgaq:
     resolution:
       {
         integrity: sha512-NGAYP/+RDM2sVfmKiKOCgJYPstAO40vPAgACoWPO/+yoYKSgAXIFaBKsV8P0Cc7fwKgvj27SjRNX4L7f4/jCKQ==,
@@ -11234,7 +11235,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.53.0_eslint@7.32.0+typescript@4.3.5:
+  /@typescript-eslint/parser/5.53.0_eslint@7.32.0:
     resolution:
       {
         integrity: sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==,
@@ -11249,15 +11250,14 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.53.0
       '@typescript-eslint/types': 5.53.0
-      '@typescript-eslint/typescript-estree': 5.53.0_typescript@4.3.5
+      '@typescript-eslint/typescript-estree': 5.53.0
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 4.3.5
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/parser/5.53.0_eslint@8.24.0+typescript@4.8.4:
+  /@typescript-eslint/parser/5.53.0_ypn2ylkkyfa5i233caldtndbqa:
     resolution:
       {
         integrity: sha512-MKBw9i0DLYlmdOb3Oq/526+al20AJZpANdT6Ct9ffxcV8nKCHz63t/S0IhlTFNsBIHJv+GY5SFJ0XfqVeydQrQ==,
@@ -11302,7 +11302,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.53.0
     dev: true
 
-  /@typescript-eslint/type-utils/5.53.0_eslint@8.24.0+typescript@4.8.4:
+  /@typescript-eslint/type-utils/5.53.0_ypn2ylkkyfa5i233caldtndbqa:
     resolution:
       {
         integrity: sha512-HO2hh0fmtqNLzTAme/KnND5uFNwbsdYhCZghK2SoxGp3Ifn2emv+hi0PBUjzzSh0dstUIFqOj3bp0AwQlK4OWw==,
@@ -11316,7 +11316,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.53.0_typescript@4.8.4
-      '@typescript-eslint/utils': 5.53.0_eslint@8.24.0+typescript@4.8.4
+      '@typescript-eslint/utils': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
       debug: 4.3.4
       eslint: 8.24.0
       tsutils: 3.21.0_typescript@4.8.4
@@ -11389,7 +11389,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.53.0_typescript@4.3.5:
+  /@typescript-eslint/typescript-estree/5.53.0:
     resolution:
       {
         integrity: sha512-eKmipH7QyScpHSkhbptBBYh9v8FxtngLquq292YTEQ1pxVs39yFBlLC1xeIZcPPz1RWGqb7YgERJRGkjw8ZV7w==,
@@ -11407,8 +11407,7 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.3.5
-      typescript: 4.3.5
+      tsutils: 3.21.0
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -11437,7 +11436,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.53.0_eslint@8.24.0+typescript@4.8.4:
+  /@typescript-eslint/utils/5.53.0_ypn2ylkkyfa5i233caldtndbqa:
     resolution:
       {
         integrity: sha512-VUOOtPv27UNWLxFwQK/8+7kvxVC+hPHNsJjzlJyotlaHjLSIgOCKj9I0DBUjwOOA64qjBwx5afAPjksqOxMO0g==,
@@ -11482,7 +11481,7 @@ packages:
       eslint-visitor-keys: 3.3.0
     dev: true
 
-  /@udecode/plate-alignment/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-alignment/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-J9+AQRW4CnTHiik6axrRiotk2T98/bAVx+DJq/AJ31LqjIcEZKubyfIq8WPXPA2nIefNhK29/ml8ZF48JHgfcg==,
@@ -11494,12 +11493,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11514,7 +11513,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-autoformat/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-autoformat/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-74b3y1UxsHrl6a0ZCuBTRlXhyBzQL2zhiQizyBzpPXgXXq+3/jjW8YusGnyC4Tfgyfe4/a8aLJjo+lLn2WWUwg==,
@@ -11526,12 +11525,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11546,7 +11545,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-elements/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-basic-elements/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-FGtqKuYaDdevPlNHV4ZMtnTp3QOkHah6end00ThIb6O48Bef+YeVEeGfY5mwg2xZHOOIU3H2J68sKsAw1g/81A==,
@@ -11558,16 +11557,16 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-block-quote': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-code-block': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-heading': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-paragraph': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-block-quote': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-code-block': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-heading': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-paragraph': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11582,7 +11581,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-basic-marks/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-basic-marks/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-plLDPjQ+VPiiSV43V5dzMCiEAsO/O5pdXUeJao36kQ0tLtWicthq5G/43sHYkATDaXn3UuYMZOqxiGr/AlsvzA==,
@@ -11594,12 +11593,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11614,7 +11613,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-block-quote/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-block-quote/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-FbWXGaRlaQGd3lkYt0RiL/CfjjQaZ9lbPZMB69z7jc9+HrY89CkOhCJRvGyzEGUjf7V4Ct8dRfMmVwghkiERZA==,
@@ -11626,12 +11625,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11646,7 +11645,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-break/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-break/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-1+K9CCooO+4iYNN+aIzh6eTw5CmgchhllDw0o2PMwhcUSAO1meVxX+CC0Rnxa00UoWAp1SThzKOlhr19f2x48Q==,
@@ -11658,12 +11657,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11678,7 +11677,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-code-block/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-code-block/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-UiLYSyPWavnLIL2MtCu0PXiMqnLyLwfBvUdwpj6+eoR+bdXQMiKXvJZBu09wLHzbjjizRslrHT8Q6bTd/7Meig==,
@@ -11690,13 +11689,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       prismjs: 1.28.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11711,7 +11710,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-combobox/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-combobox/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-HLcb0S39vtH15Ijh/UqzH8uA47anggxc2z7DnagQ+cRX+0Vfpfo5sysOkm96Qkk0gel/0iQnODosZwUwffePKg==,
@@ -11723,13 +11722,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       downshift: 6.1.7_react@17.0.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11744,7 +11743,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-core/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-core/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-0aMwC/uoLbjBkI5k2X0kTqoU94j4Vm7kWSiQqJGp3nL+1wgJi17cAJDy4Fcx85Mh25k+mkcU8Uxr91yrVptZNA==,
@@ -11757,7 +11756,7 @@ packages:
       slate-react: '>=0.74.2'
     dependencies:
       '@radix-ui/react-slot': 0.1.2_react@17.0.2
-      '@udecode/zustood': 1.1.1_0d0a9a542565185d959e64f8eb38b1e9
+      '@udecode/zustood': 1.1.1_bufjuvbfmumf3fm6mt4owofr5e
       clsx: 1.1.1
       jotai: 1.7.5_react@17.0.2
       lodash: 4.17.21
@@ -11765,7 +11764,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
       use-deep-compare: 1.1.0_react@17.0.2
       zustand: 3.7.2_react@17.0.2
     transitivePeerDependencies:
@@ -11782,7 +11781,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-find-replace/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-find-replace/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-3W5f6A/S+o9rWOZL7hdC/MjcjgPNmZj0QZV5t17X0SY9vG93rkk3P7/KE/CbxeiWp27ygzntvK1FOls67Z1aNA==,
@@ -11794,12 +11793,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11814,7 +11813,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-font/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-font/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-jVLJQshXVn14L3qE+0y04gCWK26BpOX2hcOOmR+rfTNZc9fceak0sc1V1CyzmFEB37OejliIJTJZPICNFAA9FA==,
@@ -11826,12 +11825,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11846,7 +11845,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-heading/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-heading/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-p7nf5F3q7R6BxHtJ2aPS9Kp56zQtQ7QVO9qG7cFJ0wEo47bsvzVC1uGF24le/SLuqVAwI81MbuRsoTi29fu50Q==,
@@ -11858,12 +11857,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11878,7 +11877,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-headless/14.4.3_09d299f50cb82e75cff2c2c5480a011b:
+  /@udecode/plate-headless/14.4.3_bhjjt5imxaxhlt7sylcuqcqbdm:
     resolution:
       {
         integrity: sha512-HAewyjqndw3jI0exw21yo8//X2xeAwxiJ0yNDyNpE5GygeMv2gPcAXLCTtfPhPzwTpuc2l3+Y1IZ8G41Jfh8nQ==,
@@ -11891,46 +11890,46 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-alignment': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-autoformat': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-basic-elements': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-basic-marks': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-block-quote': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-break': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-code-block': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-combobox': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-find-replace': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-font': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-heading': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-highlight': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-horizontal-rule': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-image': 14.4.2_646f040a1a634c32573c8e264e4e1886
-      '@udecode/plate-indent': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-indent-list': 14.4.3_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-kbd': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-line-height': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-link': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-list': 14.4.3_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-media-embed': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-mention': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-node-id': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-normalizers': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-paragraph': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-reset-node': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-select': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-serializer-csv': 14.4.2_c440c04e44dd0dd80f1d87a53cbc8124
-      '@udecode/plate-serializer-docx': 14.4.3_09d299f50cb82e75cff2c2c5480a011b
-      '@udecode/plate-serializer-html': 14.4.2_c440c04e44dd0dd80f1d87a53cbc8124
-      '@udecode/plate-serializer-md': 14.4.3_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-table': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-trailing-block': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-alignment': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-autoformat': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-basic-elements': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-basic-marks': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-block-quote': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-break': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-code-block': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-combobox': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-find-replace': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-font': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-heading': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-highlight': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-horizontal-rule': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-image': 14.4.2_mrxqicq2mngdevz4ryte4tqyqy
+      '@udecode/plate-indent': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-indent-list': 14.4.3_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-kbd': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-line-height': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-link': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-list': 14.4.3_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-media-embed': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-mention': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-node-id': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-normalizers': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-paragraph': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-reset-node': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-select': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-serializer-csv': 14.4.2_yramatse3ug5qdy5q6stzpebeq
+      '@udecode/plate-serializer-docx': 14.4.3_bhjjt5imxaxhlt7sylcuqcqbdm
+      '@udecode/plate-serializer-html': 14.4.2_yramatse3ug5qdy5q6stzpebeq
+      '@udecode/plate-serializer-md': 14.4.3_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-table': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-trailing-block': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
       slate-hyperscript: 0.77.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11947,7 +11946,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-highlight/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-highlight/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-7k+mTBgAVTxh4k19T/KkNMzOn19RmwoyvoRiqSReruGZZa3mgOQ+MELH6OHlUlJprq+lxuolDysVq4HTdWLkyA==,
@@ -11959,12 +11958,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -11979,7 +11978,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-horizontal-rule/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-horizontal-rule/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-pkrtkgpll4vXAlVl/F6/JzI86oBGnaU43K1YIToZMGJqL172HQnkwiypEEdEfIx+L/Qrod7/jmtcyNnZ2gbLgg==,
@@ -11991,12 +11990,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12011,7 +12010,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-image/14.4.2_646f040a1a634c32573c8e264e4e1886:
+  /@udecode/plate-image/14.4.2_mrxqicq2mngdevz4ryte4tqyqy:
     resolution:
       {
         integrity: sha512-NzTCo+wIgMFVj1JRZiORF/0pHX5R7cIkAnOcLr405Gz6Lk7CMzIWooeT5P4UbT61Z3RnJ0yebIityV2BZrprdQ==,
@@ -12023,14 +12022,14 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      re-resizable: 6.9.9_react-dom@17.0.2+react@17.0.2
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      re-resizable: 6.9.9_sfoxds7t5ydpegc3knd667wn6m
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-textarea-autosize: 8.3.4_9506f604383c27787a7cb97c95a04323
+      react-textarea-autosize: 8.3.4_sudpmbbyhqtxq6t4xf6jlicdem
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12046,7 +12045,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent-list/14.4.3_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-indent-list/14.4.3_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-e3aymnRLVioJglANMC5utoM3c896XkqsT1Zv0RN7uWqFQuDuQt2XEc2E+6XeZnG4+TC25qXcKBEw1aRl6xyJdA==,
@@ -12058,14 +12057,14 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-indent': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-list': 14.4.3_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-indent': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-list': 14.4.3_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12080,7 +12079,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-indent/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-indent/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-cL7FlQ1LnctwaQ8QshRx+PFzz9QvLncaBbyLvDJK3gAPp/WlaDmHvsk/CSw60gH2+wCnSCaucSrZ/zBlwJn+Ig==,
@@ -12092,12 +12091,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12112,7 +12111,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-kbd/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-kbd/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-Fu32jeiLEEm1RHI0Nq+XSN5J3xIRefGT/pzJMPIyCBaq2QB9w/oD+rXjV3jiVJI7Y+ACYMQmgkjLIODr1+tfKQ==,
@@ -12124,12 +12123,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12144,7 +12143,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-line-height/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-line-height/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-KPEuhKpCcdbQ+2YyP4BPfInz9RsI9bLeE0hUtMrz6DoO2rNdGTWeP2BlgLdxT6GtS69epn4XrfLr0+hqamw1Zw==,
@@ -12156,12 +12155,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12176,7 +12175,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-link/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-link/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-p49z5pyXRbL5pAuHEyPQRU+Q5JvMYSVNLxF9uHBCbQH3rQIb/Kl3dVloKyTmB/tQl0zl6AW6UWqn0/PfGQlMnw==,
@@ -12188,13 +12187,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-normalizers': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-normalizers': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12209,7 +12208,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-list/14.4.3_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-list/14.4.3_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-JwFxpbXSRRnmKC/5uD8YJyme5oXOyyIopdjElZjQ1ig7BB/PMj86NmdgvtLKqauGULf09bTB2SRQmE+6HP+P1A==,
@@ -12221,13 +12220,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-reset-node': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-reset-node': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12242,7 +12241,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-media-embed/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-media-embed/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-/fPHg0Orb6eyc7o7vd0vO2K6tIM3KDKmEhR0+l8AGDRXQiUt5OXyftAJkvvVBJGgarYB2Yu9m6bFljPJvJLyHQ==,
@@ -12254,12 +12253,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12274,7 +12273,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-mention/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-mention/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-Nt3+AUNfjaWKNCYxJwmp5dykqpheCcmihbj5vkqnADjmx4Dkhql1Shj0GamHLwLxUpZzXBRs/vXbErSrKPI3yA==,
@@ -12286,13 +12285,13 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-combobox': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-combobox': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12307,7 +12306,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-node-id/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-node-id/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-GVWt2KhRpma07CYk6DhUDvFRSZFdQ5vETDVUclJPDlA+5o9G1R8ExnpiqW9pf+xLz+j8n5VPphHoETJzCdHMmQ==,
@@ -12319,12 +12318,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12339,7 +12338,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-normalizers/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-normalizers/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-4NeFrHzOa+jjLz6aqDUetdxYwFMnxzaCsCeqESANoLKhN6GycVqCuaBSY6IZ887YTJbCKxE7jtxPC5QrRqznWQ==,
@@ -12351,12 +12350,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12371,7 +12370,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-paragraph/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-paragraph/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-9RgGei6/fWbdgpdbGzdNi1sjS1zKK53ZSzcSJymv11v9XCGYvzWGO6VzCnxpEhtGLpq9I8hJK/mFhHxlRPVllw==,
@@ -12383,12 +12382,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12403,7 +12402,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-reset-node/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-reset-node/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-6/3pb7Tkc8sHmpSGF0zoPUnQ0uLccaAoJA+ytHfBO6ITTcEisFxDsHla5BKR2XqBMq4aK8dqrY3fCgwg6S5ktA==,
@@ -12415,12 +12414,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12435,7 +12434,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-select/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-select/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-NDdyScKVG5dBXfCSvPvZNvsaxo+8YUqApuaMzztogdRJHLQ84QXGamrovxwtJmiOY7gptYrF4UsgJCQKrYmHQg==,
@@ -12447,12 +12446,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12467,7 +12466,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-csv/14.4.2_c440c04e44dd0dd80f1d87a53cbc8124:
+  /@udecode/plate-serializer-csv/14.4.2_yramatse3ug5qdy5q6stzpebeq:
     resolution:
       {
         integrity: sha512-GM0lkF1Mne8IWSufBdmkXUu6bGwK8DdFzK3aBQ7nLn0S/N6evXHTXR5ox3+nyZbrEtG+SZooA5ZIJLoTZTY/yA==,
@@ -12479,14 +12478,14 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-table': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-table': 14.4.2_osox4cvcdffivfm2442l6silnq
       papaparse: 5.3.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-hyperscript: 0.77.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12502,7 +12501,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-docx/14.4.3_09d299f50cb82e75cff2c2c5480a011b:
+  /@udecode/plate-serializer-docx/14.4.3_bhjjt5imxaxhlt7sylcuqcqbdm:
     resolution:
       {
         integrity: sha512-XEzjDIL2yIA7qPd334KjT1nK0fr+zwd4uDqbIUFakeFv9JDoXA7hL1l4rQWtx8RqBVfpY2hqjiqGOLcj+L5rHA==,
@@ -12515,19 +12514,19 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-heading': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-image': 14.4.2_646f040a1a634c32573c8e264e4e1886
-      '@udecode/plate-indent': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-indent-list': 14.4.3_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-paragraph': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-table': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-heading': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-image': 14.4.2_mrxqicq2mngdevz4ryte4tqyqy
+      '@udecode/plate-indent': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-indent-list': 14.4.3_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-paragraph': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-table': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
       slate-hyperscript: 0.77.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
       validator: 13.7.0
     transitivePeerDependencies:
       - '@babel/core'
@@ -12544,7 +12543,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-html/14.4.2_c440c04e44dd0dd80f1d87a53cbc8124:
+  /@udecode/plate-serializer-html/14.4.2_yramatse3ug5qdy5q6stzpebeq:
     resolution:
       {
         integrity: sha512-BSISkeOBLmG0oIs07EFSLFxr412L8h0u7lUqnNEljQTYsEFnYChz45xVOhlqZOc/2xCcnUUBwO3CtNFCXVeVUg==,
@@ -12556,13 +12555,13 @@ packages:
       slate-hyperscript: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       html-entities: 2.3.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-hyperscript: 0.77.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12578,7 +12577,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-serializer-md/14.4.3_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-serializer-md/14.4.3_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-VRK5p09bJXz5f676f70lce9XDE37nLNQFX+oyuvB12OfOIIAXSZY+73YzdJaAPO29vTjfLoTOToRcGbX9INBmQ==,
@@ -12590,20 +12589,20 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-block-quote': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-code-block': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-heading': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-link': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-list': 14.4.3_749d7e0aa2194a8a959ae734bf490b6c
-      '@udecode/plate-paragraph': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-block-quote': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-code-block': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-heading': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-link': 14.4.2_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-list': 14.4.3_osox4cvcdffivfm2442l6silnq
+      '@udecode/plate-paragraph': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       remark-parse: 9.0.0
       remark-slate: 1.8.6
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
       unified: 9.2.2
     transitivePeerDependencies:
       - '@babel/core'
@@ -12620,7 +12619,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-table/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-table/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-4oXPDeA8CGckFTXXiu9uWqgm1vLnYjqcg42T7Bgx2nKZFbfLOZwWj2OtlrBicd+5ClYl8flXQMrraQsShHB0pg==,
@@ -12632,12 +12631,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.79.0'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12652,7 +12651,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/plate-trailing-block/14.4.2_749d7e0aa2194a8a959ae734bf490b6c:
+  /@udecode/plate-trailing-block/14.4.2_osox4cvcdffivfm2442l6silnq:
     resolution:
       {
         integrity: sha512-FuSVBnZIga8crcEcvRfVbOpSl9AHt7MBI88M1XosqO8XKuKsqiGtEBZbBfgvbvrwMrrNnVcZ0fIZeGN+/DaMow==,
@@ -12664,12 +12663,12 @@ packages:
       slate-history: '>=0.66.0'
       slate-react: '>=0.74.2'
     dependencies:
-      '@udecode/plate-core': 14.4.2_749d7e0aa2194a8a959ae734bf490b6c
+      '@udecode/plate-core': 14.4.2_osox4cvcdffivfm2442l6silnq
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       slate: 0.81.1
       slate-history: 0.66.0_slate@0.81.1
-      slate-react: 0.81.0_a934eed243d776c7f849b0091a69bb7e
+      slate-react: 0.81.0_ve2o5usd253mp6cjwaeru2n3py
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/template'
@@ -12684,7 +12683,7 @@ packages:
       - xstate
     dev: false
 
-  /@udecode/zustood/1.1.1_0d0a9a542565185d959e64f8eb38b1e9:
+  /@udecode/zustood/1.1.1_bufjuvbfmumf3fm6mt4owofr5e:
     resolution:
       {
         integrity: sha512-EupPWrLliymKLMIdU1SavDQjuqsjGePT5cQwXgq+os3DgF6aU+Xq6XBFT9FkkNOw1KZ2bOy67pA6HOtvgTY4dg==,
@@ -12693,7 +12692,7 @@ packages:
       zustand: '>=3.5.10'
     dependencies:
       immer: 9.0.15
-      react-tracked: 1.7.9_react-dom@17.0.2+react@17.0.2
+      react-tracked: 1.7.9_sfoxds7t5ydpegc3knd667wn6m
       zustand: 3.7.2_react@17.0.2
     transitivePeerDependencies:
       - react
@@ -12756,7 +12755,7 @@ packages:
       varint: 5.0.2
     dev: false
 
-  /@xstate/react/3.0.0_83b3e746b3d7a44f199627017eaaa2a3:
+  /@xstate/react/3.0.0_qoz6orvt26se6gmwe4ax5kvcum:
     resolution:
       {
         integrity: sha512-KHSCfwtb8gZ7QH2luihvmKYI+0lcdHQOmGNRUxUEs4zVgaJCyd8csCEmwPsudpliLdUmyxX2pzUBojFkINpotw==,
@@ -12772,7 +12771,7 @@ packages:
         optional: true
     dependencies:
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2_9506f604383c27787a7cb97c95a04323
+      use-isomorphic-layout-effect: 1.1.2_sudpmbbyhqtxq6t4xf6jlicdem
       use-sync-external-store: 1.2.0_react@17.0.2
       xstate: 4.32.1
     transitivePeerDependencies:
@@ -12875,7 +12874,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/pnpify/2.4.0_eslint@6.8.0+typescript@4.3.5:
+  /@yarnpkg/pnpify/2.4.0_ormy72tqrapqsntr3tx5lktgaq:
     resolution:
       {
         integrity: sha512-Ibu94L2jjgijPI3TjhJAv2RJdO1p/BVADM8H5kxTE6sCvRq0d1/mV7+lsc4hB/6jjzl3dckPHJiIaJoo4/aCBA==,
@@ -13128,6 +13127,8 @@ packages:
     dependencies:
       altair-static: 4.5.1
       express: 4.18.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /altair-static/4.5.1:
@@ -13233,6 +13234,8 @@ packages:
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /anymatch/3.1.2:
@@ -13928,7 +13931,7 @@ packages:
       babel-plugin-syntax-jsx: 6.18.0
       lodash: 4.17.21
       picomatch: 2.3.1
-      styled-components: 5.3.5_281a4fa50a045c9112baf635f3bc27a7
+      styled-components: 5.3.5_fane7jikarojcev26y27hpbhu4
     dev: false
 
   /babel-plugin-syntax-jsx/6.18.0:
@@ -14228,6 +14231,8 @@ packages:
       raw-body: 2.5.1
       type-is: 1.6.18
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /boolbase/1.0.0:
@@ -14278,6 +14283,8 @@ packages:
       snapdragon-node: 2.1.1
       split-string: 3.1.0
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /braces/3.0.2:
@@ -15198,7 +15205,6 @@ packages:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    dev: true
 
   /colorette/2.0.19:
     resolution:
@@ -15497,7 +15503,6 @@ packages:
       parse-json: 5.2.0
       path-type: 4.0.0
       yaml: 1.10.2
-    dev: true
 
   /crc-32/1.2.2:
     resolution:
@@ -15622,7 +15627,6 @@ packages:
       {
         integrity: sha512-zj5D7X1U2h2zsXOAM8EyUREBnnts6H+Jm+d1M2DbiQQcUtnqgQsMrdo8JW9R80YFUmIdBZeMu5wvYM7hcgWP/Q==,
       }
-    dev: true
 
   /css-select/4.3.0:
     resolution:
@@ -15664,7 +15668,6 @@ packages:
       {
         integrity: sha512-IiJwMC8rdZE0+xiEZHeru6YoONC4rfPMqGm2W85jMIbkFvv5nFTwJVFHam2eFrN6txmoUYFAFXiv8ICVeTO0MA==,
       }
-    dev: true
 
   /css-what/6.1.0:
     resolution:
@@ -15781,7 +15784,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@cypress/request': 2.88.10
-      '@cypress/xvfb': 1.2.4
+      '@cypress/xvfb': 1.2.4_supports-color@8.1.1
       '@types/node': 14.18.29
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
@@ -15834,7 +15837,7 @@ packages:
     requiresBuild: true
     dependencies:
       '@cypress/request': 2.88.10
-      '@cypress/xvfb': 1.2.4
+      '@cypress/xvfb': 1.2.4_supports-color@8.1.1
       '@types/node': 14.18.29
       '@types/sinonjs__fake-timers': 8.1.1
       '@types/sizzle': 2.3.3
@@ -15998,6 +16001,11 @@ packages:
       {
         integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
       }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
 
@@ -16006,8 +16014,43 @@ packages:
       {
         integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
       }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
+    dev: true
+
+  /debug/3.2.7_supports-color@5.5.0:
+    resolution:
+      {
+        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+      }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 5.5.0
+    dev: true
+
+  /debug/3.2.7_supports-color@8.1.1:
+    resolution:
+      {
+        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+      }
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 8.1.1
     dev: true
 
   /debug/4.3.4:
@@ -16695,7 +16738,6 @@ packages:
       }
     dependencies:
       iconv-lite: 0.6.3
-    dev: false
 
   /end-of-stream/1.1.0:
     resolution:
@@ -17113,7 +17155,7 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-jest/0.5.0_esbuild@0.12.29:
+  /esbuild-jest/0.5.0_esbuild@0.15.12:
     resolution:
       {
         integrity: sha512-AMZZCdEpXfNVOIDvURlqYyHwC8qC1/BFjgsrOiSL1eyiIArVtHL8YAC83Shhn16cYYoAWEW17yZn0W/RJKJKHQ==,
@@ -17124,7 +17166,7 @@ packages:
       '@babel/core': 7.18.6
       '@babel/plugin-transform-modules-commonjs': 7.18.6_@babel+core@7.18.6
       babel-jest: 26.6.3_@babel+core@7.18.6
-      esbuild: 0.12.29
+      esbuild: 0.15.12
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -17788,6 +17830,7 @@ packages:
       {
         integrity: sha512-w/XuoBCSwepyiZtIRsKsetiLDUVGPVw1E/R3VTFSecIy8UR7Cq3SOtwKHJMFoVqqVG36aGkzh4e8BvpO1Fdc7g==,
       }
+    hasBin: true
     requiresBuild: true
     dev: false
 
@@ -17993,7 +18036,7 @@ packages:
     optionalDependencies:
       source-map: 0.6.1
 
-  /eslint-config-next/13.2.1_eslint@7.32.0+typescript@4.3.5:
+  /eslint-config-next/13.2.1_eslint@7.32.0:
     resolution:
       {
         integrity: sha512-2GAx7EjSiCzJN6H2L/v1kbYrNiwQxzkyjy6eWSjuhAKt+P6d3nVNHGy9mON8ZcYd72w/M8kyMjm4UB9cvijgrw==,
@@ -18007,20 +18050,20 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.2.1
       '@rushstack/eslint-patch': 1.1.3
-      '@typescript-eslint/parser': 5.53.0_eslint@7.32.0+typescript@4.3.5
+      '@typescript-eslint/parser': 5.53.0_eslint@7.32.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.3_3bd94fa9be989baab6ef2e6b5dec3766
-      eslint-plugin-import: 2.26.0_eslint@7.32.0
+      eslint-import-resolver-typescript: 3.5.3_hpmu7kn6tcn2vnxpfzvv33bxmy
+      eslint-plugin-import: 2.26.0_4tg6za7ba6fx3td7qt4pxqlpxa
       eslint-plugin-jsx-a11y: 6.6.0_eslint@7.32.0
       eslint-plugin-react: 7.32.2_eslint@7.32.0
       eslint-plugin-react-hooks: 4.6.0_eslint@7.32.0
-      typescript: 4.3.5
     transitivePeerDependencies:
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
-  /eslint-config-next/13.2.1_eslint@8.24.0+typescript@4.8.4:
+  /eslint-config-next/13.2.1_ypn2ylkkyfa5i233caldtndbqa:
     resolution:
       {
         integrity: sha512-2GAx7EjSiCzJN6H2L/v1kbYrNiwQxzkyjy6eWSjuhAKt+P6d3nVNHGy9mON8ZcYd72w/M8kyMjm4UB9cvijgrw==,
@@ -18034,16 +18077,17 @@ packages:
     dependencies:
       '@next/eslint-plugin-next': 13.2.1
       '@rushstack/eslint-patch': 1.1.3
-      '@typescript-eslint/parser': 5.53.0_eslint@8.24.0+typescript@4.8.4
+      '@typescript-eslint/parser': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-typescript: 3.5.3_19b4f2795054463b84ba2d1a1feb6aa1
-      eslint-plugin-import: 2.26.0_eslint@8.24.0
+      eslint-import-resolver-typescript: 3.5.3_dg2pe6kqkrddxbf2funb723kue
+      eslint-plugin-import: 2.26.0_udyfursvxhlygebee5nma5vkaq
       eslint-plugin-jsx-a11y: 6.6.0_eslint@8.24.0
       eslint-plugin-react: 7.32.2_eslint@8.24.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.24.0
       typescript: 4.8.4
     transitivePeerDependencies:
+      - eslint-import-resolver-webpack
       - supports-color
     dev: true
 
@@ -18068,9 +18112,11 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.22.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.3_19b4f2795054463b84ba2d1a1feb6aa1:
+  /eslint-import-resolver-typescript/3.5.3_dg2pe6kqkrddxbf2funb723kue:
     resolution:
       {
         integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==,
@@ -18083,7 +18129,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 8.24.0
-      eslint-plugin-import: 2.26.0_eslint@8.24.0
+      eslint-plugin-import: 2.26.0_udyfursvxhlygebee5nma5vkaq
       get-tsconfig: 4.4.0
       globby: 13.1.2
       is-core-module: 2.10.0
@@ -18093,7 +18139,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-import-resolver-typescript/3.5.3_3bd94fa9be989baab6ef2e6b5dec3766:
+  /eslint-import-resolver-typescript/3.5.3_hpmu7kn6tcn2vnxpfzvv33bxmy:
     resolution:
       {
         integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==,
@@ -18106,7 +18152,7 @@ packages:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
       eslint: 7.32.0
-      eslint-plugin-import: 2.26.0_eslint@7.32.0
+      eslint-plugin-import: 2.26.0_4tg6za7ba6fx3td7qt4pxqlpxa
       get-tsconfig: 4.4.0
       globby: 13.1.2
       is-core-module: 2.10.0
@@ -18116,33 +18162,57 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.3:
+  /eslint-module-utils/2.7.3_mt5m6g4252lmspi2hfl5yvgj4m:
     resolution:
       {
         integrity: sha512-088JEC7O3lDZM9xGe0RerkOMd0EjFl+Yvd1jPWIkMT5u3H9+HC34mWWPnqPrN13gieT9pBOO+Qt07Nb/6TresQ==,
       }
     engines: { node: '>=4' }
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.53.0_eslint@7.32.0
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
+      eslint-import-resolver-typescript: 3.5.3_hpmu7kn6tcn2vnxpfzvv33bxmy
       find-up: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_eslint@7.32.0:
+  /eslint-plugin-import/2.26.0_4tg6za7ba6fx3td7qt4pxqlpxa:
     resolution:
       {
         integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==,
       }
     engines: { node: '>=4' }
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.53.0_eslint@7.32.0
       array-includes: 3.1.6
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_mt5m6g4252lmspi2hfl5yvgj4m
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -18150,24 +18220,33 @@ packages:
       object.values: 1.1.6
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
-  /eslint-plugin-import/2.26.0_eslint@8.24.0:
+  /eslint-plugin-import/2.26.0_udyfursvxhlygebee5nma5vkaq:
     resolution:
       {
         integrity: sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==,
       }
     engines: { node: '>=4' }
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.53.0_ypn2ylkkyfa5i233caldtndbqa
       array-includes: 3.1.6
       array.prototype.flat: 1.3.0
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.24.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.3
+      eslint-module-utils: 2.7.3_mt5m6g4252lmspi2hfl5yvgj4m
       has: 1.0.3
       is-core-module: 2.10.0
       is-glob: 4.0.3
@@ -18175,6 +18254,10 @@ packages:
       object.values: 1.1.6
       resolve: 1.22.1
       tsconfig-paths: 3.14.1
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-jsx-a11y/6.6.0_eslint@7.32.0:
@@ -18846,6 +18929,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /expand-tilde/2.0.2:
@@ -18938,6 +19023,8 @@ packages:
       type-is: 1.6.18
       utils-merge: 1.0.1
       vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /extend-shallow/2.0.1:
@@ -19001,6 +19088,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /extract-zip/2.0.1:
@@ -19380,6 +19469,8 @@ packages:
       parseurl: 1.3.3
       statuses: 2.0.1
       unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /find-up/2.1.0:
@@ -20165,7 +20256,6 @@ packages:
         integrity: sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==,
       }
     engines: { node: '>= 10.x' }
-    dev: false
 
   /gray-matter/4.0.3:
     resolution:
@@ -20431,7 +20521,6 @@ packages:
       {
         integrity: sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ==,
       }
-    dev: true
 
   /history/5.3.0:
     resolution:
@@ -20482,14 +20571,12 @@ packages:
       {
         integrity: sha512-M5ezZw4LzXbBKMruP+BNANf0k+19hDQMgpzBIYnya//Al+fjNct9Wf3b1WedLqdEs2hKBvxq/jh+DsHJLj0F9A==,
       }
-    dev: true
 
   /hsla-regex/1.0.0:
     resolution:
       {
         integrity: sha512-7Wn5GMLuHBjZCb2bTmnDOycho0p/7UVaAeqXZGbHrBCl6Yd/xDhQJAXe6Ga9AXJH2I5zY1dEdYw2u1UptnSBJA==,
       }
-    dev: true
 
   /html-encoding-sniffer/2.0.1:
     resolution:
@@ -20519,7 +20606,6 @@ packages:
         integrity: sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==,
       }
     engines: { node: '>=8' }
-    dev: true
 
   /html-void-elements/1.0.5:
     resolution:
@@ -20706,7 +20792,6 @@ packages:
     engines: { node: '>=0.10.0' }
     dependencies:
       safer-buffer: 2.1.2
-    dev: false
 
   /identity-obj-proxy/3.0.0:
     resolution:
@@ -21141,7 +21226,6 @@ packages:
       hsla-regex: 1.0.0
       rgb-regex: 1.0.1
       rgba-regex: 1.0.0
-    dev: true
 
   /is-core-module/2.10.0:
     resolution:
@@ -21899,7 +21983,7 @@ packages:
       - ts-node
       - utf-8-validate
 
-  /jest-cli/28.1.3_635e6337f05c348d75a1fd7f673a4111:
+  /jest-cli/28.1.3_mnpggn7qlq2i25nb7v7woosbce:
     resolution:
       {
         integrity: sha512-roY3kvrv57Azn1yPgdTebPAXvdR2xfezaKKYzVxZ6It/5NCxzJym6tUI5P1zkdWhfUYkxEI9uZWcQdaFLo8mJQ==,
@@ -21919,7 +22003,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 28.1.3_635e6337f05c348d75a1fd7f673a4111
+      jest-config: 28.1.3_mnpggn7qlq2i25nb7v7woosbce
       jest-util: 28.1.3
       jest-validate: 28.1.3
       prompts: 2.4.2
@@ -21972,7 +22056,7 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /jest-config/28.1.3_635e6337f05c348d75a1fd7f673a4111:
+  /jest-config/28.1.3_mnpggn7qlq2i25nb7v7woosbce:
     resolution:
       {
         integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==,
@@ -22010,12 +22094,12 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_dce5d793216ec5b06690943fcc406465
+      ts-node: 10.9.1_3ts5pezbn3c3azuqsq74yqdemu
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /jest-config/28.1.3_91a8f49a6a0ffd6e1e554100fd5d58fa:
+  /jest-config/28.1.3_sgupjgtkb76w4hsvieap2xky7i:
     resolution:
       {
         integrity: sha512-MG3INjByJ0J4AsNBm7T3hsuxKQqFIiRo/AUqb1q9LRKI5UU6Aar9JHbr9Ivn1TVwfUD9KirRoM/T6u8XlcQPHQ==,
@@ -22053,7 +22137,7 @@ packages:
       pretty-format: 28.1.3
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.9.1_dce5d793216ec5b06690943fcc406465
+      ts-node: 10.9.1_3ts5pezbn3c3azuqsq74yqdemu
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -22279,6 +22363,8 @@ packages:
       walker: 1.0.8
     optionalDependencies:
       fsevents: 2.3.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /jest-haste-map/27.5.1:
@@ -22999,7 +23085,7 @@ packages:
       - ts-node
       - utf-8-validate
 
-  /jest/28.1.3_635e6337f05c348d75a1fd7f673a4111:
+  /jest/28.1.3_mnpggn7qlq2i25nb7v7woosbce:
     resolution:
       {
         integrity: sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==,
@@ -23015,7 +23101,7 @@ packages:
       '@jest/core': 28.1.3_ts-node@10.9.1
       '@jest/types': 28.1.3
       import-local: 3.1.0
-      jest-cli: 28.1.3_635e6337f05c348d75a1fd7f673a4111
+      jest-cli: 28.1.3_mnpggn7qlq2i25nb7v7woosbce
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -23804,7 +23890,6 @@ packages:
       {
         integrity: sha512-1/W4dM+35DwvE/iEd1M9ekewOSTlpFekhw9mhAtrwjVqUr83/ilQiyAvmg4tVX7Unkcfl1KC+i9WdaT4B6aQcg==,
       }
-    dev: true
 
   /lodash.truncate/4.4.2:
     resolution:
@@ -25352,6 +25437,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /micromatch/4.0.5:
@@ -25578,7 +25665,6 @@ packages:
         integrity: sha512-2lMlY1Yc1+CUy0gw4H95uNN7vjbpoED7NNRSBHE25nWfLBdmMzFCsPshlzbxHz+gYMcBEUN8V4pU16prcdPSgA==,
       }
     engines: { node: '>=6' }
-    dev: true
 
   /module-error/1.0.2:
     resolution:
@@ -25804,6 +25890,8 @@ packages:
       regex-not: 1.0.2
       snapdragon: 0.8.2
       to-regex: 3.0.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /napi-macros/2.0.0:
@@ -25895,54 +25983,7 @@ packages:
       - babel-plugin-macros
     dev: true
 
-  /next/12.2.4_react-dom@17.0.2+react@17.0.2:
-    resolution:
-      {
-        integrity: sha512-b1xlxEozmAWokAXzXsi5vlmU/IfJcFNIJA8dpU5UdkFbyDPio8wwb8mAQ/Y7rGtfTgG/t/u49BiyEA+xAgFvow==,
-      }
-    engines: { node: '>=12.22.0' }
-    hasBin: true
-    peerDependencies:
-      fibers: '>= 3.1.0'
-      node-sass: ^6.0.0 || ^7.0.0
-      react: ^17.0.2 || ^18.0.0-0
-      react-dom: ^17.0.2 || ^18.0.0-0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      fibers:
-        optional: true
-      node-sass:
-        optional: true
-      sass:
-        optional: true
-    dependencies:
-      '@next/env': 12.2.4
-      '@swc/helpers': 0.4.3
-      caniuse-lite: 1.0.30001359
-      postcss: 8.4.14
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      styled-jsx: 5.0.2_react@17.0.2
-      use-sync-external-store: 1.2.0_react@17.0.2
-    optionalDependencies:
-      '@next/swc-android-arm-eabi': 12.2.4
-      '@next/swc-android-arm64': 12.2.4
-      '@next/swc-darwin-arm64': 12.2.4
-      '@next/swc-darwin-x64': 12.2.4
-      '@next/swc-freebsd-x64': 12.2.4
-      '@next/swc-linux-arm-gnueabihf': 12.2.4
-      '@next/swc-linux-arm64-gnu': 12.2.4
-      '@next/swc-linux-arm64-musl': 12.2.4
-      '@next/swc-linux-x64-gnu': 12.2.4
-      '@next/swc-linux-x64-musl': 12.2.4
-      '@next/swc-win32-arm64-msvc': 12.2.4
-      '@next/swc-win32-ia32-msvc': 12.2.4
-      '@next/swc-win32-x64-msvc': 12.2.4
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
-
-  /next/12.2.4_react-dom@18.2.0+react@18.2.0:
+  /next/12.2.4_biqbaboplfbrettd7655fr4n2y:
     resolution:
       {
         integrity: sha512-b1xlxEozmAWokAXzXsi5vlmU/IfJcFNIJA8dpU5UdkFbyDPio8wwb8mAQ/Y7rGtfTgG/t/u49BiyEA+xAgFvow==,
@@ -25990,7 +26031,54 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next/12.3.4_react-dom@17.0.2+react@17.0.2:
+  /next/12.2.4_sfoxds7t5ydpegc3knd667wn6m:
+    resolution:
+      {
+        integrity: sha512-b1xlxEozmAWokAXzXsi5vlmU/IfJcFNIJA8dpU5UdkFbyDPio8wwb8mAQ/Y7rGtfTgG/t/u49BiyEA+xAgFvow==,
+      }
+    engines: { node: '>=12.22.0' }
+    hasBin: true
+    peerDependencies:
+      fibers: '>= 3.1.0'
+      node-sass: ^6.0.0 || ^7.0.0
+      react: ^17.0.2 || ^18.0.0-0
+      react-dom: ^17.0.2 || ^18.0.0-0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 12.2.4
+      '@swc/helpers': 0.4.3
+      caniuse-lite: 1.0.30001359
+      postcss: 8.4.14
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      styled-jsx: 5.0.2_react@17.0.2
+      use-sync-external-store: 1.2.0_react@17.0.2
+    optionalDependencies:
+      '@next/swc-android-arm-eabi': 12.2.4
+      '@next/swc-android-arm64': 12.2.4
+      '@next/swc-darwin-arm64': 12.2.4
+      '@next/swc-darwin-x64': 12.2.4
+      '@next/swc-freebsd-x64': 12.2.4
+      '@next/swc-linux-arm-gnueabihf': 12.2.4
+      '@next/swc-linux-arm64-gnu': 12.2.4
+      '@next/swc-linux-arm64-musl': 12.2.4
+      '@next/swc-linux-x64-gnu': 12.2.4
+      '@next/swc-linux-x64-musl': 12.2.4
+      '@next/swc-win32-arm64-msvc': 12.2.4
+      '@next/swc-win32-ia32-msvc': 12.2.4
+      '@next/swc-win32-x64-msvc': 12.2.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  /next/12.3.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-VcyMJUtLZBGzLKo3oMxrEF0stxh8HwuW976pAzlHhI3t8qJ4SROjCrSh1T24bhrbjw55wfZXAbXPGwPt5FLRfQ==,
@@ -26069,7 +26157,6 @@ packages:
       }
     dependencies:
       lodash: 4.17.21
-    dev: true
 
   /node-fetch/2.6.7:
     resolution:
@@ -26146,7 +26233,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.3
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.1.2
       pstree.remy: 1.1.8
@@ -26349,7 +26436,6 @@ packages:
         integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==,
       }
     engines: { node: '>= 6' }
-    dev: true
 
   /object-hash/3.0.0:
     resolution:
@@ -27106,7 +27192,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.1
-    dev: true
 
   /postcss-import/14.1.0_postcss@8.4.16:
     resolution:
@@ -27136,7 +27221,6 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.1
-    dev: true
 
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution:
@@ -27151,6 +27235,7 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.1
+    dev: true
 
   /postcss-js/3.0.3:
     resolution:
@@ -27161,7 +27246,31 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.16
-    dev: true
+
+  /postcss-js/4.0.0_postcss@8.4.14:
+    resolution:
+      {
+        integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==,
+      }
+    engines: { node: ^12 || ^14 || >= 16 }
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.14
+    dev: false
+
+  /postcss-js/4.0.0_postcss@8.4.18:
+    resolution:
+      {
+        integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==,
+      }
+    engines: { node: ^12 || ^14 || >= 16 }
+    peerDependencies:
+      postcss: ^8.3.3
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.4.18
 
   /postcss-js/4.0.0_postcss@8.4.21:
     resolution:
@@ -27174,6 +27283,28 @@ packages:
     dependencies:
       camelcase-css: 2.0.1
       postcss: 8.4.21
+    dev: true
+
+  /postcss-load-config/3.1.4_aesdjsunmf4wiehhujt67my7tu:
+    resolution:
+      {
+        integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==,
+      }
+    engines: { node: '>= 10' }
+    peerDependencies:
+      postcss: '>=8.0.9'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      postcss:
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      lilconfig: 2.0.6
+      postcss: 8.4.21
+      ts-node: 10.9.1_3ts5pezbn3c3azuqsq74yqdemu
+      yaml: 1.10.2
+    dev: true
 
   /postcss-load-config/3.1.4_postcss@8.4.14:
     resolution:
@@ -27214,7 +27345,7 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /postcss-load-config/3.1.4_postcss@8.4.21:
+  /postcss-load-config/3.1.4_postcss@8.4.18:
     resolution:
       {
         integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==,
@@ -27230,29 +27361,8 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.0.6
-      postcss: 8.4.21
+      postcss: 8.4.18
       yaml: 1.10.2
-
-  /postcss-load-config/3.1.4_postcss@8.4.21+ts-node@10.9.1:
-    resolution:
-      {
-        integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==,
-      }
-    engines: { node: '>= 10' }
-    peerDependencies:
-      postcss: '>=8.0.9'
-      ts-node: '>=9.0.0'
-    peerDependenciesMeta:
-      postcss:
-        optional: true
-      ts-node:
-        optional: true
-    dependencies:
-      lilconfig: 2.0.6
-      postcss: 8.4.21
-      ts-node: 10.9.1_dce5d793216ec5b06690943fcc406465
-      yaml: 1.10.2
-    dev: true
 
   /postcss-nested/5.0.6_postcss@8.4.14:
     resolution:
@@ -27279,7 +27389,7 @@ packages:
       postcss-selector-parser: 6.0.10
     dev: true
 
-  /postcss-nested/5.0.6_postcss@8.4.21:
+  /postcss-nested/5.0.6_postcss@8.4.18:
     resolution:
       {
         integrity: sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==,
@@ -27288,8 +27398,21 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.21
+      postcss: 8.4.18
       postcss-selector-parser: 6.0.10
+
+  /postcss-nested/6.0.0_postcss@8.4.18:
+    resolution:
+      {
+        integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==,
+      }
+    engines: { node: '>=12.0' }
+    peerDependencies:
+      postcss: ^8.2.14
+    dependencies:
+      postcss: 8.4.18
+      postcss-selector-parser: 6.0.11
+    dev: false
 
   /postcss-nested/6.0.0_postcss@8.4.21:
     resolution:
@@ -27302,6 +27425,7 @@ packages:
     dependencies:
       postcss: 8.4.21
       postcss-selector-parser: 6.0.11
+    dev: true
 
   /postcss-nesting/10.1.9_postcss@8.4.14:
     resolution:
@@ -27312,7 +27436,7 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.0.1_e73911252e8c76a7ba13ab9c39479e7d
+      '@csstools/selector-specificity': 2.0.1_444rcjjorr3kpoqtvoodsr46pu
       postcss: 8.4.14
       postcss-selector-parser: 6.0.10
     dev: true
@@ -27326,7 +27450,7 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.0.1_7b6fee2724f05f3c8883c74281a3791a
+      '@csstools/selector-specificity': 2.0.1_pnx64jze6bptzcedy5bidi3zdi
       postcss: 8.4.16
       postcss-selector-parser: 6.0.10
     dev: true
@@ -27340,7 +27464,7 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.0.1_1d546e2941f6b4ca889831b9fbdc79d8
+      '@csstools/selector-specificity': 2.0.1_dvkg4kkb622mvceygg47xxdz3a
       postcss: 8.4.18
       postcss-selector-parser: 6.0.10
     dev: true
@@ -27370,7 +27494,6 @@ packages:
       {
         integrity: sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==,
       }
-    dev: true
 
   /postcss-value-parser/4.2.0:
     resolution:
@@ -27399,7 +27522,6 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
-    dev: true
 
   /postcss/8.4.18:
     resolution:
@@ -27422,6 +27544,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /preferred-pm/3.0.3:
     resolution:
@@ -27531,7 +27654,6 @@ packages:
         integrity: sha512-66hKPCr+72mlfiSjlEB1+45IjXSqvVAIy6mocupoww4tBFE9R9IhwwUGoI4G++Tc9Aq+2rxOt0RFU6gPcrte0A==,
       }
     engines: { node: '>= 0.8' }
-    dev: true
 
   /pretty-quick/3.1.3_prettier@2.8.4:
     resolution:
@@ -27880,7 +28002,6 @@ packages:
       glob: 7.2.3
       postcss: 8.4.16
       postcss-selector-parser: 6.0.10
-    dev: true
 
   /q/1.5.1:
     resolution:
@@ -27982,7 +28103,7 @@ packages:
       strip-json-comments: 2.0.1
     dev: false
 
-  /re-resizable/6.9.9_react-dom@17.0.2+react@17.0.2:
+  /re-resizable/6.9.9_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==,
@@ -28007,7 +28128,7 @@ packages:
       pure-color: 1.3.0
     dev: false
 
-  /react-beautiful-dnd/13.1.0_react-dom@17.0.2+react@17.0.2:
+  /react-beautiful-dnd/13.1.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-aGvblPZTJowOWUNiwd6tNfEpgkX5OxmpqxHKNW/4VmvZTNTbeiq7bA3bn5T+QSF2uibXB0D1DmJsb1aC/+3cUA==,
@@ -28022,7 +28143,7 @@ packages:
       raf-schd: 4.0.3
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-redux: 7.2.8_react-dom@17.0.2+react@17.0.2
+      react-redux: 7.2.8_sfoxds7t5ydpegc3knd667wn6m
       redux: 4.2.0
       use-memo-one: 1.1.2_react@17.0.2
     transitivePeerDependencies:
@@ -28043,11 +28164,11 @@ packages:
       material-colors: 1.2.6
       prop-types: 15.8.1
       react: 17.0.2
-      reactcss: 1.2.3
+      reactcss: 1.2.3_react@17.0.2
       tinycolor2: 1.4.2
     dev: false
 
-  /react-datetime/2.16.3_9b9afce5b760d4382de297dd21b1d59c:
+  /react-datetime/2.16.3_tonpzznxmdkdqlpcs7osdmovtq:
     resolution:
       {
         integrity: sha512-amWfb5iGEiyqjLmqCLlPpu2oN415jK8wX1qoTq7qn6EYiU7qQgbNHglww014PT4O/3G5eo/3kbJu/M/IxxTyGw==,
@@ -28063,7 +28184,7 @@ packages:
       prop-types: 15.7.2
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      react-onclickoutside: 6.12.2_react-dom@17.0.2+react@17.0.2
+      react-onclickoutside: 6.12.2_sfoxds7t5ydpegc3knd667wn6m
     dev: false
 
   /react-dom/17.0.2_react@17.0.2:
@@ -28119,7 +28240,7 @@ packages:
       react: 17.0.2
     dev: true
 
-  /react-final-form/6.5.9_final-form@4.20.7+react@17.0.2:
+  /react-final-form/6.5.9_s44h3cxpdxv6cks4bnqewerqda:
     resolution:
       {
         integrity: sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==,
@@ -28185,7 +28306,7 @@ packages:
       }
     dev: true
 
-  /react-json-view/1.21.3_react-dom@18.2.0+react@18.2.0:
+  /react-json-view/1.21.3_biqbaboplfbrettd7655fr4n2y:
     resolution:
       {
         integrity: sha512-13p8IREj9/x/Ye4WI/JpjhoIwuzEgUAtgJZNBJckfzJt1qyh24BdTm6UQNGnyTq9dapQdrqvquZTo3dz1X6Cjw==,
@@ -28212,7 +28333,7 @@ packages:
       }
     dev: false
 
-  /react-monaco-editor/0.51.0_44a4ff1120eec37d4c08627d30e9aebe:
+  /react-monaco-editor/0.51.0_issp6eja53bx2taimj6tb2noxy:
     resolution:
       {
         integrity: sha512-6jx1V8p6gHVKJHFaTvicOtmlhFjOJhekobeNd92ZAo7F5UvAin1cF7bxWLCKgtxClYZ7CB3Ar284Kpbhj22FpQ==,
@@ -28227,7 +28348,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /react-onclickoutside/6.12.2_react-dom@17.0.2+react@17.0.2:
+  /react-onclickoutside/6.12.2_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-NMXGa223OnsrGVp5dJHkuKxQ4czdLmXSp5jSV9OqiCky9LOpPATn3vLldc+q5fK3gKbEHvr7J1u0yhBh/xYkpA==,
@@ -28240,7 +28361,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /react-redux/7.2.8_react-dom@17.0.2+react@17.0.2:
+  /react-redux/7.2.8_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-6+uDjhs3PSIclqoCk0kd6iX74gzrGc3W5zcAjbrFgEdIjRSQObdIwfx80unTkVUYvbQ95Y8Av3OvFHq1w5EOUw==,
@@ -28272,7 +28393,7 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
-  /react-router-dom/6.3.0_react-dom@17.0.2+react@17.0.2:
+  /react-router-dom/6.3.0_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==,
@@ -28299,23 +28420,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-textarea-autosize/8.3.4_9506f604383c27787a7cb97c95a04323:
-    resolution:
-      {
-        integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==,
-      }
-    engines: { node: '>=10' }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@babel/runtime': 7.19.0
-      react: 17.0.2
-      use-composed-ref: 1.3.0_react@17.0.2
-      use-latest: 1.2.1_9506f604383c27787a7cb97c95a04323
-    transitivePeerDependencies:
-      - '@types/react'
-    dev: false
-
   /react-textarea-autosize/8.3.4_react@18.2.0:
     resolution:
       {
@@ -28333,7 +28437,24 @@ packages:
       - '@types/react'
     dev: false
 
-  /react-tracked/1.7.9_react-dom@17.0.2+react@17.0.2:
+  /react-textarea-autosize/8.3.4_sudpmbbyhqtxq6t4xf6jlicdem:
+    resolution:
+      {
+        integrity: sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@babel/runtime': 7.19.0
+      react: 17.0.2
+      use-composed-ref: 1.3.0_react@17.0.2
+      use-latest: 1.2.1_sudpmbbyhqtxq6t4xf6jlicdem
+    transitivePeerDependencies:
+      - '@types/react'
+    dev: false
+
+  /react-tracked/1.7.9_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-axBJegjdQbsHizZ0DtEpM4g3sDW1SF5mq9j9bk77mRbcFR+OeBR4vLAqO7E6/DOPeGdDDqLBBIFBy5tmjnOd+A==,
@@ -28352,7 +28473,7 @@ packages:
       proxy-compare: 2.1.0
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
-      use-context-selector: 1.3.10_react-dom@17.0.2+react@17.0.2
+      use-context-selector: 1.3.10_sfoxds7t5ydpegc3knd667wn6m
     dev: false
 
   /react/17.0.2:
@@ -28374,13 +28495,16 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
-  /reactcss/1.2.3:
+  /reactcss/1.2.3_react@17.0.2:
     resolution:
       {
         integrity: sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==,
       }
+    peerDependencies:
+      react: '*'
     dependencies:
       lodash: 4.17.21
+      react: 17.0.2
     dev: false
 
   /read-cache/1.0.0:
@@ -28579,7 +28703,6 @@ packages:
     dependencies:
       css-unit-converter: 1.1.2
       postcss-value-parser: 3.3.1
-    dev: true
 
   /redux/4.2.0:
     resolution:
@@ -29110,14 +29233,12 @@ packages:
       {
         integrity: sha512-gDK5mkALDFER2YLqH6imYvK6g02gpNGM4ILDZ472EwWfXZnC2ZEpoB2ECXTyOVUKuk/bPJZMzwQPBYICzP+D3w==,
       }
-    dev: true
 
   /rgba-regex/1.0.0:
     resolution:
       {
         integrity: sha512-zgn5OjNQXLUTdq8m17KdaicF6w89TZs8ZU8y0AYENIU6wG8GG6LLm0yLSiPY8DmaYmHdgRW8rnApjoT0fQRfMg==,
       }
-    dev: true
 
   /rimraf/2.6.3:
     resolution:
@@ -29207,7 +29328,7 @@ packages:
         integrity: sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==,
       }
     dependencies:
-      tslib: 2.4.0
+      tslib: 2.5.0
 
   /sade/1.8.1:
     resolution:
@@ -29272,6 +29393,8 @@ packages:
       micromatch: 3.1.10
       minimist: 1.2.6
       walker: 1.0.8
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /saslprep/1.0.3:
@@ -29394,6 +29517,8 @@ packages:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /sentence-case/3.0.4:
@@ -29418,6 +29543,8 @@ packages:
       escape-html: 1.0.3
       parseurl: 1.3.3
       send: 0.18.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /set-blocking/2.0.0:
@@ -29628,7 +29755,7 @@ packages:
       slate: 0.81.1
     dev: false
 
-  /slate-react/0.81.0_a934eed243d776c7f849b0091a69bb7e:
+  /slate-react/0.81.0_ve2o5usd253mp6cjwaeru2n3py:
     resolution:
       {
         integrity: sha512-bwryad4EvOmc7EFKb8aGg9DWNDh3KvToaggGieIgGTTbHJYHc9ADFC3A87Ittlpd5XUVopR0MpChQ3g3ODyvqw==,
@@ -29769,6 +29896,8 @@ packages:
       source-map: 0.5.7
       source-map-resolve: 0.5.3
       use: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /socks-proxy-agent/5.0.1:
@@ -30393,7 +30522,7 @@ packages:
     dev: false
     optional: true
 
-  /styled-components/5.3.5_281a4fa50a045c9112baf635f3bc27a7:
+  /styled-components/5.3.5_fane7jikarojcev26y27hpbhu4:
     resolution:
       {
         integrity: sha512-ndETJ9RKaaL6q41B69WudeqLzOpY1A/ET/glXkNZ2T7dPjPqpPCXXQjDFYZWwNnE5co0wX+gTCqx9mfxTmSIPg==,
@@ -30660,56 +30789,7 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/2.2.19_a191cbaa25c4a0a9f05cc78eac153be7:
-    resolution:
-      {
-        integrity: sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==,
-      }
-    engines: { node: '>=12.13.0' }
-    hasBin: true
-    peerDependencies:
-      autoprefixer: ^10.0.2
-      postcss: ^8.0.9
-    dependencies:
-      arg: 5.0.2
-      autoprefixer: 10.4.7_postcss@8.4.14
-      bytes: 3.1.2
-      chalk: 4.1.2
-      chokidar: 3.5.3
-      color: 4.2.3
-      cosmiconfig: 7.0.1
-      detective: 5.2.1
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.12
-      fs-extra: 10.1.0
-      glob-parent: 6.0.2
-      html-tags: 3.2.0
-      is-color-stop: 1.1.0
-      is-glob: 4.0.3
-      lodash: 4.17.21
-      lodash.topath: 4.5.2
-      modern-normalize: 1.1.0
-      node-emoji: 1.11.0
-      normalize-path: 3.0.0
-      object-hash: 2.2.0
-      postcss: 8.4.14
-      postcss-js: 3.0.3
-      postcss-load-config: 3.1.4_postcss@8.4.14
-      postcss-nested: 5.0.6_postcss@8.4.14
-      postcss-selector-parser: 6.0.10
-      postcss-value-parser: 4.2.0
-      pretty-hrtime: 1.0.3
-      purgecss: 4.1.3
-      quick-lru: 5.1.1
-      reduce-css-calc: 2.1.8
-      resolve: 1.22.1
-      tmp: 0.2.1
-    transitivePeerDependencies:
-      - ts-node
-    dev: true
-
-  /tailwindcss/2.2.19_dd5b83115bc64f84aeac6195b940d961:
+  /tailwindcss/2.2.19_3vnygek3yzhyjlvmmgk3sqgzme:
     resolution:
       {
         integrity: sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==,
@@ -30758,13 +30838,63 @@ packages:
       - ts-node
     dev: true
 
-  /tailwindcss/3.1.4:
+  /tailwindcss/2.2.19_ugi4xkrfysqkt4c4y6hkyfj344:
+    resolution:
+      {
+        integrity: sha512-6Ui7JSVtXadtTUo2NtkBBacobzWiQYVjYW0ZnKaP9S1ZCKQ0w7KVNz+YSDI/j7O7KCMHbOkz94ZMQhbT9pOqjw==,
+      }
+    engines: { node: '>=12.13.0' }
+    hasBin: true
+    peerDependencies:
+      autoprefixer: ^10.0.2
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      autoprefixer: 10.4.7_postcss@8.4.14
+      bytes: 3.1.2
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      color: 4.2.3
+      cosmiconfig: 7.0.1
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      fs-extra: 10.1.0
+      glob-parent: 6.0.2
+      html-tags: 3.2.0
+      is-color-stop: 1.1.0
+      is-glob: 4.0.3
+      lodash: 4.17.21
+      lodash.topath: 4.5.2
+      modern-normalize: 1.1.0
+      node-emoji: 1.11.0
+      normalize-path: 3.0.0
+      object-hash: 2.2.0
+      postcss: 8.4.14
+      postcss-js: 3.0.3
+      postcss-load-config: 3.1.4_postcss@8.4.14
+      postcss-nested: 5.0.6_postcss@8.4.14
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      pretty-hrtime: 1.0.3
+      purgecss: 4.1.3
+      quick-lru: 5.1.1
+      reduce-css-calc: 2.1.8
+      resolve: 1.22.1
+      tmp: 0.2.1
+    transitivePeerDependencies:
+      - ts-node
+
+  /tailwindcss/3.1.4_postcss@8.4.14:
     resolution:
       {
         integrity: sha512-NrxbFV4tYsga/hpWbRyUfIaBrNMXDxx5BsHgBS4v5tlyjf+sDsgBg5m9OxjrXIqAS/uR9kicxLKP+bEHI7BSeQ==,
       }
     engines: { node: '>=12.13.0' }
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -30779,11 +30909,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.21
-      postcss-import: 14.1.0_postcss@8.4.21
-      postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      postcss-nested: 5.0.6_postcss@8.4.21
+      postcss: 8.4.14
+      postcss-import: 14.1.0_postcss@8.4.14
+      postcss-js: 4.0.0_postcss@8.4.14
+      postcss-load-config: 3.1.4_postcss@8.4.14
+      postcss-nested: 5.0.6_postcss@8.4.14
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -30792,13 +30922,15 @@ packages:
       - ts-node
     dev: false
 
-  /tailwindcss/3.1.8:
+  /tailwindcss/3.1.8_postcss@8.4.14:
     resolution:
       {
         integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==,
       }
     engines: { node: '>=12.13.0' }
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -30813,45 +30945,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.21
-      postcss-import: 14.1.0_postcss@8.4.21
-      postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      postcss-nested: 5.0.6_postcss@8.4.21
-      postcss-selector-parser: 6.0.10
-      postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - ts-node
-
-  /tailwindcss/3.2.4:
-    resolution:
-      {
-        integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==,
-      }
-    engines: { node: '>=12.13.0' }
-    hasBin: true
-    dependencies:
-      arg: 5.0.2
-      chokidar: 3.5.3
-      color-name: 1.1.4
-      detective: 5.2.1
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.12
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      lilconfig: 2.0.6
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.21
-      postcss-import: 14.1.0_postcss@8.4.21
-      postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      postcss-nested: 6.0.0_postcss@8.4.21
+      postcss: 8.4.14
+      postcss-import: 14.1.0_postcss@8.4.14
+      postcss-js: 4.0.0_postcss@8.4.14
+      postcss-load-config: 3.1.4_postcss@8.4.14
+      postcss-nested: 5.0.6_postcss@8.4.14
       postcss-selector-parser: 6.0.10
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -30860,13 +30958,87 @@ packages:
       - ts-node
     dev: false
 
-  /tailwindcss/3.2.7_ts-node@10.9.1:
+  /tailwindcss/3.1.8_postcss@8.4.18:
+    resolution:
+      {
+        integrity: sha512-YSneUCZSFDYMwk+TGq8qYFdCA3yfBRdBlS7txSq0LUmzyeqRe3a8fBQzbz9M3WS/iFT4BNf/nmw9mEzrnSaC0g==,
+      }
+    engines: { node: '>=12.13.0' }
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.11
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.18
+      postcss-import: 14.1.0_postcss@8.4.18
+      postcss-js: 4.0.0_postcss@8.4.18
+      postcss-load-config: 3.1.4_postcss@8.4.18
+      postcss-nested: 5.0.6_postcss@8.4.18
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+
+  /tailwindcss/3.2.4_postcss@8.4.18:
+    resolution:
+      {
+        integrity: sha512-AhwtHCKMtR71JgeYDaswmZXhPcW9iuI9Sp2LvZPo9upDZ7231ZJ7eA9RaURbhpXGVlrjX4cFNlB4ieTetEb7hQ==,
+      }
+    engines: { node: '>=12.13.0' }
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
+    dependencies:
+      arg: 5.0.2
+      chokidar: 3.5.3
+      color-name: 1.1.4
+      detective: 5.2.1
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.2.12
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      lilconfig: 2.0.6
+      micromatch: 4.0.5
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.0.0
+      postcss: 8.4.18
+      postcss-import: 14.1.0_postcss@8.4.18
+      postcss-js: 4.0.0_postcss@8.4.18
+      postcss-load-config: 3.1.4_postcss@8.4.18
+      postcss-nested: 6.0.0_postcss@8.4.18
+      postcss-selector-parser: 6.0.10
+      postcss-value-parser: 4.2.0
+      quick-lru: 5.1.1
+      resolve: 1.22.1
+    transitivePeerDependencies:
+      - ts-node
+    dev: false
+
+  /tailwindcss/3.2.7_aesdjsunmf4wiehhujt67my7tu:
     resolution:
       {
         integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==,
       }
     engines: { node: '>=12.13.0' }
     hasBin: true
+    peerDependencies:
+      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -30885,7 +31057,7 @@ packages:
       postcss: 8.4.21
       postcss-import: 14.1.0_postcss@8.4.21
       postcss-js: 4.0.0_postcss@8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21+ts-node@10.9.1
+      postcss-load-config: 3.1.4_aesdjsunmf4wiehhujt67my7tu
       postcss-nested: 6.0.0_postcss@8.4.21
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
@@ -31110,7 +31282,6 @@ packages:
     engines: { node: '>=8.17.0' }
     dependencies:
       rimraf: 3.0.2
-    dev: true
 
   /tmpl/1.0.5:
     resolution:
@@ -31339,7 +31510,7 @@ packages:
       code-block-writer: 10.1.1
     dev: false
 
-  /ts-node/10.9.1_dce5d793216ec5b06690943fcc406465:
+  /ts-node/10.9.1_3ts5pezbn3c3azuqsq74yqdemu:
     resolution:
       {
         integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==,
@@ -31411,7 +31582,7 @@ packages:
         integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==,
       }
 
-  /tsup/4.14.0_postcss@8.4.14+typescript@4.7.4:
+  /tsup/4.14.0_m3gf5jmpd2aiwepqhoxxcqgnwi:
     resolution:
       {
         integrity: sha512-77rWdzhikTP9mQ34XMRzK83tw++LF6f4ox/HNERlgesB7g6g5VQ1iJlueG9O0P9HAZGVKavUwyoZv0+322p6rg==,
@@ -31443,6 +31614,18 @@ packages:
       - ts-node
     dev: false
 
+  /tsutils/3.21.0:
+    resolution:
+      {
+        integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==,
+      }
+    engines: { node: '>= 6' }
+    peerDependencies:
+      typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
+    dependencies:
+      tslib: 1.14.1
+    dev: true
+
   /tsutils/3.21.0_typescript@4.3.5:
     resolution:
       {
@@ -31454,6 +31637,7 @@ packages:
     dependencies:
       tslib: 1.14.1
       typescript: 4.3.5
+    dev: false
 
   /tsutils/3.21.0_typescript@4.8.4:
     resolution:
@@ -32241,7 +32425,7 @@ packages:
       react: 18.2.0
     dev: false
 
-  /use-context-selector/1.3.10_react-dom@17.0.2+react@17.0.2:
+  /use-context-selector/1.3.10_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
       {
         integrity: sha512-xprS9YQ0F56IPTOjev+Lm+TWZD7Pa20+slBeaClt4YtOOoHKFOF3A9Cfr7LDcX2QIZ9VTyxXCnA6/WhL4Cm47g==,
@@ -32273,22 +32457,6 @@ packages:
       react: 17.0.2
     dev: false
 
-  /use-isomorphic-layout-effect/1.1.2_9506f604383c27787a7cb97c95a04323:
-    resolution:
-      {
-        integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==,
-      }
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 17.0.47
-      react: 17.0.2
-    dev: false
-
   /use-isomorphic-layout-effect/1.1.2_react@18.2.0:
     resolution:
       {
@@ -32304,10 +32472,10 @@ packages:
       react: 18.2.0
     dev: false
 
-  /use-latest/1.2.1_9506f604383c27787a7cb97c95a04323:
+  /use-isomorphic-layout-effect/1.1.2_sudpmbbyhqtxq6t4xf6jlicdem:
     resolution:
       {
-        integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==,
+        integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==,
       }
     peerDependencies:
       '@types/react': '*'
@@ -32318,7 +32486,6 @@ packages:
     dependencies:
       '@types/react': 17.0.47
       react: 17.0.2
-      use-isomorphic-layout-effect: 1.1.2_9506f604383c27787a7cb97c95a04323
     dev: false
 
   /use-latest/1.2.1_react@18.2.0:
@@ -32335,6 +32502,23 @@ packages:
     dependencies:
       react: 18.2.0
       use-isomorphic-layout-effect: 1.1.2_react@18.2.0
+    dev: false
+
+  /use-latest/1.2.1_sudpmbbyhqtxq6t4xf6jlicdem:
+    resolution:
+      {
+        integrity: sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==,
+      }
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@types/react': 17.0.47
+      react: 17.0.2
+      use-isomorphic-layout-effect: 1.1.2_sudpmbbyhqtxq6t4xf6jlicdem
     dev: false
 
   /use-memo-one/1.1.2_react@17.0.2:


### PR DESCRIPTION
This bumps the esbuild versions used by @tinacms/graphql and @tinacms/scripts to match that used by @tinacms/cli.  The version currently used is affected by an installation bug on Ubuntu 20.04, resulting in @tinacms/cli being uninstallable.

Fixes #3668.

<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
