### PR TITLE
Update handling of top-level images during stringify

### DIFF
--- a/.changeset/quiet-points-hammer.md
+++ b/.changeset/quiet-points-hammer.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+Update handling of top-level images during stringify

--- a/packages/@tinacms/mdx/src/next/stringify/pre-processing.ts
+++ b/packages/@tinacms/mdx/src/next/stringify/pre-processing.ts
@@ -113,11 +113,18 @@ export const blockElement = (
       }
     }
     case 'img':
+      // Slate editor treats `img` as a block-level element, wrap
+      // it in an empty paragraph
       return {
-        type: 'image',
-        url: imageCallback(content.url),
-        alt: content.alt,
-        title: content.caption,
+        type: 'paragraph',
+        children: [
+          {
+            type: 'image',
+            url: imageCallback(content.url),
+            alt: content.alt,
+            title: content.caption,
+          },
+        ],
       }
     default:
       throw new Error(`BlockElement: ${content.type} is not yet supported`)

--- a/packages/@tinacms/mdx/src/next/tests/image-at-block-level/field.ts
+++ b/packages/@tinacms/mdx/src/next/tests/image-at-block-level/field.ts
@@ -1,0 +1,6 @@
+import { RichTextField } from '@tinacms/schema-tools'
+
+export const field: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+}

--- a/packages/@tinacms/mdx/src/next/tests/image-at-block-level/index.test.ts
+++ b/packages/@tinacms/mdx/src/next/tests/image-at-block-level/index.test.ts
@@ -1,0 +1,12 @@
+import { it, expect } from 'vitest'
+import { stringifyMDX } from '../../stringify'
+import { field } from './field'
+import * as util from '../util'
+import node from './node.json'
+
+it('matches input', () => {
+  const stringifyImageCallback = (v: string) => v.replace('http://some-url', '')
+  // @ts-ignore
+  const string = stringifyMDX(node, field, stringifyImageCallback)
+  expect(string).toMatchFile(util.mdPath(__dirname))
+})

--- a/packages/@tinacms/mdx/src/next/tests/image-at-block-level/node.json
+++ b/packages/@tinacms/mdx/src/next/tests/image-at-block-level/node.json
@@ -1,0 +1,34 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "p",
+      "children": [
+        {
+          "type": "text",
+          "text": "Image callback should persist"
+        }
+      ]
+    },
+    {
+      "type": "img",
+      "url": "http://some-url/my-pic.jpg",
+      "caption": null,
+      "children": [
+        {
+          "type": "text",
+          "text": ""
+        }
+      ]
+    },
+    {
+      "type": "p",
+      "children": [
+            {
+              "type": "text",
+              "text": ""
+            }
+      ]
+    }
+  ]
+}

--- a/packages/@tinacms/mdx/src/next/tests/image-at-block-level/out.md
+++ b/packages/@tinacms/mdx/src/next/tests/image-at-block-level/out.md
@@ -1,0 +1,3 @@
+Image callback should persist
+
+![](/my-pic.jpg)

--- a/packages/@tinacms/mdx/src/stringify/index.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.ts
@@ -268,10 +268,17 @@ export const blockElement = (
     }
     case 'img':
       return {
-        type: 'image',
-        url: imageCallback(content.url),
-        alt: content.alt,
-        title: content.caption,
+        // Slate editor treats `img` as a block-level element, wrap
+        // it in an empty paragraph
+        type: 'paragraph',
+        children: [
+          {
+            type: 'image',
+            url: imageCallback(content.url),
+            alt: content.alt,
+            title: content.caption,
+          },
+        ],
       }
     default:
       throw new Error(`BlockElement: ${content.type} is not yet supported`)


### PR DESCRIPTION
We recently updated a bunch of our mdast dependencies which is the only thing I can think of at the moment which might have broken this. Previously we allowed an `image` block to pass through as flow content, even though it's not. Still trying to track down what changed but I _think_ it was from an external dependency bump. Tests didn't catch this because the backend tests assume a valid ast going in and out, and our rich-text editor sometimes needs to fudge things a bit for compatibility. Still looking into it but this should fix the immediate need.