### PR TITLE
Skip tokenizing html when parser is configured for skipping it

### DIFF
--- a/.changeset/curly-rules-flow.md
+++ b/.changeset/curly-rules-flow.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+Skip html tokenization when skipEscaping is enabled.

--- a/examples/kitchen-sink/.tina/config.tsx
+++ b/examples/kitchen-sink/.tina/config.tsx
@@ -750,6 +750,26 @@ export default defineConfig({
                 ],
               },
               {
+                name: 'center',
+                label: 'Centered HTML',
+                match: {
+                  start: '{{<',
+                  name: 'center',
+                  end: '>}}',
+                },
+                fields: [
+                  {
+                    name: 'children',
+                    label: 'Children',
+                    type: 'rich-text',
+                    parser: {
+                      type: 'markdown',
+                      skipEscaping: 'html',
+                    },
+                  },
+                ],
+              },
+              {
                 name: 'pullQuote',
                 label: 'Pull Quote',
                 match: {

--- a/packages/@tinacms/mdx/src/next/parse/markdown.ts
+++ b/packages/@tinacms/mdx/src/next/parse/markdown.ts
@@ -9,8 +9,16 @@ import type { Options } from '../shortcodes'
 export const fromMarkdown = (value: string, field: RichTextField) => {
   const patterns = getFieldPatterns(field)
   const acornDefault = acorn as unknown as Options['acorn']
+  let skipHTML = false
+  if (field.parser?.type === 'markdown') {
+    if (['all', 'html'].includes(field.parser?.skipEscaping || '')) {
+      skipHTML = true
+    }
+  }
   const tree = mdastFromMarkdown(value, {
-    extensions: [mdxJsx({ acorn: acornDefault, patterns, addResult: true })],
+    extensions: [
+      mdxJsx({ acorn: acornDefault, patterns, addResult: true, skipHTML }),
+    ],
     mdastExtensions: [mdxJsxFromMarkdown({ patterns })],
   })
 

--- a/packages/@tinacms/mdx/src/next/shortcodes/lib/factory-tag.ts
+++ b/packages/@tinacms/mdx/src/next/shortcodes/lib/factory-tag.ts
@@ -15,7 +15,7 @@ import { codes } from 'micromark-util-symbol/codes.js'
 import { constants } from 'micromark-util-symbol/constants.js'
 import { types } from 'micromark-util-symbol/types.js'
 import { VFileMessage } from 'vfile-message'
-import { findCode, printCode } from './util'
+import { findCode } from './util'
 import type {
   Tokenizer,
   TokenizeContext,

--- a/packages/@tinacms/mdx/src/next/shortcodes/lib/jsx-flow.ts
+++ b/packages/@tinacms/mdx/src/next/shortcodes/lib/jsx-flow.ts
@@ -1,10 +1,11 @@
 import { factorySpace } from 'micromark-factory-space'
-import { markdownLineEnding } from 'micromark-util-character'
+import { markdownLineEndingOrSpace } from 'micromark-util-character'
 import { codes } from 'micromark-util-symbol/codes.js'
 import { types } from 'micromark-util-symbol/types.js'
 import { factoryTag } from './factory-tag'
 import type { Construct, Tokenizer, State } from 'micromark-util-types'
 import type { Acorn, AcornOptions } from 'micromark-factory-mdx-expression'
+import { findCode } from './util'
 
 export const jsxFlow: (
   acorn: Acorn | undefined,
@@ -56,14 +57,23 @@ export const jsxFlow: (
     }
 
     const after: State = function (code) {
-      return code === codes.lessThan
-        ? start(code)
-        : code === codes.eof || markdownLineEnding(code)
-        ? ok(code)
-        : nok(code)
+      const character = findCode(pattern.start[0])
+      if (code === character) {
+        return start(code)
+      }
+      if (code === codes.eof) {
+        return ok(code)
+      }
+      if (markdownLineEndingOrSpace(code)) {
+        return ok(code)
+      }
+      return nok(code)
     }
 
     return start
   }
-  return { tokenize: tokenizeJsxFlow, concrete: true }
+  return {
+    tokenize: tokenizeJsxFlow,
+    concrete: true,
+  }
 }

--- a/packages/@tinacms/mdx/src/next/shortcodes/lib/syntax.ts
+++ b/packages/@tinacms/mdx/src/next/shortcodes/lib/syntax.ts
@@ -18,6 +18,7 @@ export type Options = {
   acornOptions?: AcornOptions
   patterns?: Pattern[]
   addResult?: boolean
+  skipHTML?: boolean
 }
 
 export function mdxJsx(options: Options = {}): Extension {
@@ -70,8 +71,13 @@ export function mdxJsx(options: Options = {}): Extension {
     }
   })
 
+  let disabledTokens: string[] = []
+  if (options.skipHTML) {
+    disabledTokens = ['htmlFlow', 'htmlText']
+  }
   return {
     flow: flowRules,
     text: textRules,
+    disable: { null: disabledTokens },
   }
 }

--- a/packages/@tinacms/mdx/src/next/shortcodes/lib/util.ts
+++ b/packages/@tinacms/mdx/src/next/shortcodes/lib/util.ts
@@ -35,5 +35,9 @@ export const printCode = (num: number) => {
   console.log(lookupValue)
 }
 export const logSelf = (item: any) => {
-  console.log(item.events.map((e: any) => `${e[0]} - ${e[1].type}`))
+  console.log(
+    item.events.map((e: any) => {
+      return `${e[0]} - ${e[1].type} | ${item.sliceSerialize(e[1])}`
+    })
+  )
 }

--- a/packages/@tinacms/mdx/src/next/shortcodes/mdast/index.ts
+++ b/packages/@tinacms/mdx/src/next/shortcodes/mdast/index.ts
@@ -623,9 +623,9 @@ export const mdxJsxToMarkdown = function (
     }
 
     if (!selfClosing) {
-      value += tracker.move(
+      const closingTag =
         pattern.start + ' /' + (patternName || ' ') + ' ' + pattern.end
-      )
+      value += tracker.move(closingTag)
     }
 
     exit()

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/field.ts
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/field.ts
@@ -1,0 +1,25 @@
+import { RichTextField } from '@tinacms/schema-tools'
+
+export const field: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+  parser: { type: 'markdown', skipEscaping: 'html' },
+  templates: [
+    {
+      name: 'center',
+      label: 'Centered HTML',
+      match: {
+        start: '{{<',
+        name: 'center',
+        end: '>}}',
+      },
+      fields: [
+        {
+          name: 'children',
+          label: 'Children',
+          type: 'rich-text',
+        },
+      ],
+    },
+  ],
+}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/in.md
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/in.md
@@ -1,0 +1,5 @@
+A regular line of text
+
+{{< center >}}
+<h2>Some text</h2>
+{{< /center >}}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/index.test.ts
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/index.test.ts
@@ -1,0 +1,13 @@
+import { it, expect } from 'vitest'
+import { parseMDX } from '../../parse'
+import { stringifyMDX } from '../../stringify'
+import { field } from './field'
+import input from './in.md?raw'
+import * as util from '../util'
+
+it('matches input', () => {
+  const tree = parseMDX(input, field, (v) => v)
+  const string = stringifyMDX(tree, field, (v) => v)
+  expect(util.print(tree)).toMatchFile(util.nodePath(__dirname))
+  expect(string).toMatchFile(util.mdPath(__dirname))
+})

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/node.json
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/node.json
@@ -1,0 +1,40 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "p",
+      "children": [
+        {
+          "type": "text",
+          "text": "A regular line of text"
+        }
+      ]
+    },
+    {
+      "type": "mdxJsxFlowElement",
+      "name": "center",
+      "children": [
+        {
+          "type": "text",
+          "text": ""
+        }
+      ],
+      "props": {
+        "children": {
+          "type": "root",
+          "children": [
+            {
+              "type": "p",
+              "children": [
+                {
+                  "type": "text",
+                  "text": "<h2>Some text</h2>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/out.md
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-1/out.md
@@ -1,0 +1,5 @@
+A regular line of text
+
+{{< center >}}
+<h2>Some text</h2>
+{{< /center >}}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/field.ts
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/field.ts
@@ -1,0 +1,25 @@
+import { RichTextField } from '@tinacms/schema-tools'
+
+export const field: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+  parser: { type: 'markdown', skipEscaping: 'all' },
+  templates: [
+    {
+      name: 'center',
+      label: 'Centered HTML',
+      match: {
+        start: '{{<',
+        name: 'center',
+        end: '>}}',
+      },
+      fields: [
+        {
+          name: 'children',
+          label: 'Children',
+          type: 'rich-text',
+        },
+      ],
+    },
+  ],
+}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/in.md
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/in.md
@@ -1,0 +1,5 @@
+A regular line of text
+
+{{< center >}}
+<Some>
+{{< /center >}}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/index.test.ts
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/index.test.ts
@@ -1,0 +1,13 @@
+import { it, expect } from 'vitest'
+import { parseMDX } from '../../parse'
+import { stringifyMDX } from '../../stringify'
+import { field } from './field'
+import input from './in.md?raw'
+import * as util from '../util'
+
+it('matches input', () => {
+  const tree = parseMDX(input, field, (v) => v)
+  const string = stringifyMDX(tree, field, (v) => v)
+  expect(util.print(tree)).toMatchFile(util.nodePath(__dirname))
+  expect(string).toMatchFile(util.mdPath(__dirname))
+})

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/node.json
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/node.json
@@ -1,0 +1,40 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "p",
+      "children": [
+        {
+          "type": "text",
+          "text": "A regular line of text"
+        }
+      ]
+    },
+    {
+      "type": "mdxJsxFlowElement",
+      "name": "center",
+      "children": [
+        {
+          "type": "text",
+          "text": ""
+        }
+      ],
+      "props": {
+        "children": {
+          "type": "root",
+          "children": [
+            {
+              "type": "p",
+              "children": [
+                {
+                  "type": "text",
+                  "text": "<Some>"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/out.md
+++ b/packages/@tinacms/mdx/src/next/tests/block-with-html-children-2/out.md
@@ -1,0 +1,5 @@
+A regular line of text
+
+{{< center >}}
+<Some>
+{{< /center >}}


### PR DESCRIPTION
HTML is tokenized in a way that treats the next line as part of the html block. So the following code:

```
<div>
Item
```
Is parsed as 
```
{
  "type": "root",
  "children": [
    {
      "type": "html",
      "value": "<div>\nItem"
    }
  ],
}
```
This creates an issue when child elements of shortcodes are html, since the next line is the closing shortcode:
```
{{ myshortcode }}
<div>
{{ /myshortcode }}
```
The shortcode tokenizing logic doesn't even get a chance to run on the line `{{ /myshortcode }}`, it's consumed as HTML. The result is `<div>\n{{ /myshortcode }}` is shown in the rich-text editor for that node, and we print an extra closing tag during stringify:
```
{{ myshortcode }}
<div>
{{ /myshortcode }}
{{ /myshortcode }}
```


For now I think it makes sense to turn off the html tokenizer entirely when `skipEscaping` is turned on (which is what this PR does). And it might make sense for us to just turn off html tokenizing altogether, or replace it with our own more forgiving solution.