### PR TITLE
better wait for indexing logic

### DIFF
--- a/.changeset/wild-scissors-cheer.md
+++ b/.changeset/wild-scissors-cheer.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Recheck when indexing status is unknown


### PR DESCRIPTION
In some cases if a brach had not started to index it would get status: 'unknown' and fail. This PR updates the logic to recheck of a max of 6 times when the status is "unknown".

New error message

```
IndexFailedError: Attempting to index but responded with status 'unknown'. This means that Tina Cloud does not know about branch 'fooy'. Please make sure that branch 'fooy' exists in your repository and that you have pushed your changes to the remote. View all all branches and there current status here: https://app.tina.io/projects/<ClientID>configuration  

Additional Info: {
  "branch": "fooy",
  "clientId": "****",
  "token": "***"
}
```