### PR TITLE
Dont trigger hover events for ListFieldMeta when wrapping objects

### DIFF
--- a/.changeset/eight-stingrays-shout.md
+++ b/.changeset/eight-stingrays-shout.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Dont trigger hover events for ListFieldMeta when wrapping objects

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/BlocksFieldPlugin/index.tsx
@@ -103,6 +103,7 @@ const Blocks = ({
       label={field.label}
       description={field.description}
       error={meta.error}
+      triggerHoverEvents={false}
       index={index}
       tinaForm={tinaForm}
       actions={

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/GroupListFieldPlugin.tsx
@@ -86,6 +86,7 @@ const Group = ({ tinaForm, form, field, input, meta, index }: GroupProps) => {
       description={field.description}
       error={meta.error}
       index={index}
+      triggerHoverEvents={false}
       tinaForm={tinaForm}
       actions={
         (!fixedLength || (fixedLength && !isMax)) && (

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldMeta.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/ListFieldMeta.tsx
@@ -19,6 +19,7 @@ interface FieldMetaProps extends React.HTMLAttributes<HTMLElement> {
   error?: string
   margin?: boolean
   index?: number
+  triggerHoverEvents?: boolean
   tinaForm: Form
 }
 
@@ -32,15 +33,22 @@ export const ListFieldMeta = ({
   actions,
   index,
   tinaForm,
+  triggerHoverEvents,
   ...props
 }: FieldMetaProps) => {
   const { dispatch: setHoveredField } = useEvent<FieldHoverEvent>('field:hover')
   const { dispatch: setFocusedField } = useEvent<FieldFocusEvent>('field:focus')
+  const hoverEvents = {}
+  if (triggerHoverEvents) {
+    hoverEvents['onMouseOver'] = () =>
+      setHoveredField({ id: tinaForm.id, fieldName: name })
+    hoverEvents['onMouseOut'] = () =>
+      setHoveredField({ id: null, fieldName: null })
+  }
   return (
     <FieldWrapper
       margin={margin}
-      onMouseOver={() => setHoveredField({ id: tinaForm.id, fieldName: name })}
-      onMouseOut={() => setHoveredField({ id: null, fieldName: null })}
+      {...hoverEvents}
       onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
       style={{ zIndex: index ? 1000 - index : undefined }}
       {...props}


### PR DESCRIPTION
This fixes an issue where the active field indicator isn't working for fields inside objects. This is happening because of how our form builder stacks forms instead of replaces them. We wrap a group list in `ListFieldMeta` , which has a hover listener so we can show the active field on that list. But when you click into the list item, you're still inside that `ListFieldMeta` wrapper, so hovering on a text field in your block correctly triggers a hover event for `blocks.1.title`, but it also still triggers a hover event for blocks, and that happens after the title one, so the active field gets set as blocks, when it should be `blocks.1.title`. This is also why active field works on the blog post page, because there's no block to step into.

The fix, for now, is to disable the hover event in ListFieldMeta when hovering over list items that are objects. Things still work fine because those objects also have listeners for hover. The proper fix is to pull the [form navigation PR](https://github.com/tinacms/tinacms/pull/3452) up to date