### PR TITLE
Move branch check to its own check

### DIFF
--- a/.changeset/sour-chicken-watch.md
+++ b/.changeset/sour-chicken-watch.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Move branch check to a seperate check.

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -14,8 +14,10 @@ import {
   getIntrospectionQuery,
 } from 'graphql'
 import { diff } from '@graphql-inspector/core'
-import { waitForDB } from './waitForDB'
+import { IndexStatusResponse, waitForDB } from './waitForDB'
 import { createAndInitializeDatabase, createDBServer } from '../../database'
+import { sleepAndCallFunc } from '../../../utils/sleep'
+import { dangerText, linkText } from '../../../utils/theme'
 
 export class BuildCommand extends Command {
   static paths = [['build']]
@@ -147,16 +149,21 @@ export class BuildCommand extends Command {
     const token = config.token
     const { clientId, branch, host } = parseURL(apiURL)
     const url = `https://${host}/db/${clientId}/status/${branch}`
-    const bar = new Progress('Checking clientId, token and branch. :prog', 1)
+    const bar = new Progress('Checking clientId and token. :prog', 1)
 
+    // Check the client information
+    let branchKnown = false
     try {
-      await request({
+      const res = await request({
         token,
         url,
       })
       bar.tick({
         prog: '✅',
       })
+      if (!(res.status === 'unknown')) {
+        branchKnown = true
+      }
     } catch (e) {
       summary({
         heading: 'Error when checking client information',
@@ -165,10 +172,6 @@ export class BuildCommand extends Command {
             emoji: '❌',
             heading: 'You provided',
             subItems: [
-              {
-                key: 'branch',
-                value: config.branch,
-              },
               {
                 key: 'clientId',
                 value: config.clientId,
@@ -183,6 +186,75 @@ export class BuildCommand extends Command {
       })
       throw e
     }
+
+    const branchBar = new Progress('Checking branch is on Tina Cloud. :prog', 1)
+
+    // We know the branch is known (could be status: 'failed', 'inprogress' or 'success')
+    if (branchKnown) {
+      branchBar.tick({
+        prog: '✅',
+      })
+      return
+    }
+
+    // We know the branch is status: 'unknown'
+
+    // Check for a max of 6 times
+    for (let i = 0; i <= 5; i++) {
+      await sleepAndCallFunc({
+        fn: async () => {
+          const res = await request({
+            token,
+            url,
+          })
+          if (this.verbose) {
+            logger.info(
+              `Branch status: ${res.status}. Attempt: ${
+                i + 1
+              }. Trying again in 5 seconds.`
+            )
+          }
+          if (!(res.status === 'unknown')) {
+            branchBar.tick({
+              prog: '✅',
+            })
+            return
+          }
+        },
+        ms: 5000,
+      })
+    }
+
+    branchBar.tick({
+      prog: '❌',
+    })
+
+    // I wanted to use the summary function here but I was getting the following error:
+    // RangeError: Invalid count value
+    // at String.repeat (<anonymous>)
+    // summary({
+    //   heading: `ERROR: Branch '${branch}' is not on Tina Cloud. Please make sure that branch '${branch}' exists in your repository and that you have pushed your all changes to the remote. View all all branches and there current status here: https://app.tina.io/projects/${clientId}/configuration`,
+    //   items: [
+    //     {
+    //       emoji: '❌',
+    //       heading: 'You provided',
+    //       subItems: [
+    //         {
+    //           key: 'branch',
+    //           value: config.branch,
+    //         },
+    //       ],
+    //     },
+    //   ],
+    // })
+    logger.error(
+      `${dangerText(
+        `ERROR: Branch '${branch}' is not on Tina Cloud.`
+      )} Please make sure that branch '${branch}' exists in your repository and that you have pushed your all changes to the remote. View all all branches and there current status here: ${linkText(
+        `https://app.tina.io/projects/${clientId}/configuration`
+      )}`
+    )
+    throw new Error('Branch is not on Tina Cloud')
   }
 
   async checkGraphqlSchema(
@@ -272,7 +344,7 @@ async function request(args: {
   return {
     status: json?.status,
     timestamp: json?.timestamp,
-  }
+  } as { status: IndexStatusResponse['status']; timestamp: number }
 }
 
 export const fetchRemoteGraphqlSchema = async ({

--- a/packages/@tinacms/cli/src/utils/sleep.ts
+++ b/packages/@tinacms/cli/src/utils/sleep.ts
@@ -1,0 +1,14 @@
+function timeout(ms): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+export async function sleepAndCallFunc<T>({
+  fn,
+  ms,
+}: {
+  fn: () => Promise<T>
+  ms: number
+}) {
+  await timeout(ms)
+  const res = await fn()
+  return res
+}


### PR DESCRIPTION
Moves the checking of if a branch is valid or not to a separate check. 

We now do the following
1. Check clientId and token are correct
2. Check that Tina Cloud known about a branch
3. Check that Indexing succeeds.


If branch comes back as `status: "unknown"` (after waiting for 30 seconds)  this error will occur 

<img width="806" alt="Screenshot 2023-03-20 at 11 10 55 AM" src="https://user-images.githubusercontent.com/43075109/226386631-6e238695-72c6-48e9-ab55-83dd7dcd4a09.png">



Contains logic from https://github.com/tinacms/tinacms/pull/3713 and https://github.com/tinacms/tinacms/pull/3705