### PR TITLE
Avoid "development" module imports on dev server

### DIFF
--- a/.changeset/warm-candles-count.md
+++ b/.changeset/warm-candles-count.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/scripts': patch
+'@tinacms/app': patch
+'@tinacms/cli': patch
+---
+
+Bundle the MDX package with its dependencies so we can avoid awkward import issues related to the remark ecosystem modules

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -517,39 +517,19 @@ export const buildIt = async (entryPoint, packageJSON) => {
         outfile: path.join(process.cwd(), 'dist', 'index.js'),
         external: Object.keys({ ...peerDeps }),
       })
+      // The ES version is targeting the browser, this is used by the rich-text's raw mode
       await esbuild({
         entryPoints: [path.join(process.cwd(), entry)],
         bundle: true,
-        platform: 'node',
+        platform: 'browser',
         target: 'es2020',
         format: 'esm',
         outfile: path.join(process.cwd(), 'dist', 'index.es.js'),
-        external,
+        // Bundle dependencies, the remark ecosystem only publishes ES modules
+        // and includes "development" export maps which actually throw errors during
+        // development, which we don't want to expose our users to.
+        external: Object.keys({ ...peerDeps }),
       })
-      /**
-       * For MDX, we need to use it in the frontend with rich-text's raw mode. And we use
-       * a package.json to install most modules at dev time for the user. But in order
-       * to do that with the latest version of @tinacms/mdx, it's easiest to inline the dependency
-       * directly. Especially because this package bundles its dependencies
-       */
-      // const appMDXPath = path.join(
-      //   process.cwd(),
-      //   '..',
-      //   'app',
-      //   'appFiles',
-      //   'src',
-      //   'fields',
-      //   'rich-text',
-      //   'monaco',
-      //   'mdx.js'
-      // )
-      // await esbuild({
-      //   entryPoints: [path.join(process.cwd(), entry)],
-      //   bundle: true,
-      //   format: 'esm',
-      //   outfile: appMDXPath,
-      //   external: Object.keys({ ...peerDeps }),
-      // })
     } else {
       await esbuild({
         entryPoints: [path.join(process.cwd(), entry)],


### PR DESCRIPTION
Packages like [micromark](https://github.com/micromark/micromark/blob/main/packages/micromark/package.json#L57) specify development imports, which Vite will use when the dev server is running. This is fine, except that these modules actually throw errors when their production counterparts do not, so bundling MDX pulls in its dependencies as production modules to avoid this.