### PR TITLE
Provide browser-specific version of @tinacms/mdx

### DIFF
--- a/.changeset/two-insects-deny.md
+++ b/.changeset/two-insects-deny.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/scripts': patch
+'@tinacms/mdx': patch
+---
+
+Provide browser-specific version of @tinacms/mdx

--- a/packages/@tinacms/mdx/package.json
+++ b/packages/@tinacms/mdx/package.json
@@ -3,15 +3,12 @@
   "version": "1.3.4",
   "typings": "dist/index.d.ts",
   "main": "dist/index.js",
+  "browser": "dist/index.browser.es.js",
   "module": "dist/index.es.js",
   "files": [
     "package.json",
     "dist"
   ],
-  "exports": {
-    "import": "./dist/index.es.js",
-    "require": "./dist/index.js"
-  },
   "license": "Apache-2.0",
   "buildConfig": {
     "entryPoints": [

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -517,6 +517,18 @@ export const buildIt = async (entryPoint, packageJSON) => {
         outfile: path.join(process.cwd(), 'dist', 'index.js'),
         external: Object.keys({ ...peerDeps }),
       })
+      await esbuild({
+        entryPoints: [path.join(process.cwd(), entry)],
+        bundle: true,
+        platform: 'node',
+        target: 'es2020',
+        format: 'esm',
+        outfile: path.join(process.cwd(), 'dist', 'index.es.js'),
+        // Bundle dependencies, the remark ecosystem only publishes ES modules
+        // and includes "development" export maps which actually throw errors during
+        // development, which we don't want to expose our users to.
+        external: Object.keys({ ...peerDeps }),
+      })
       // The ES version is targeting the browser, this is used by the rich-text's raw mode
       await esbuild({
         entryPoints: [path.join(process.cwd(), entry)],
@@ -524,7 +536,7 @@ export const buildIt = async (entryPoint, packageJSON) => {
         platform: 'browser',
         target: 'es2020',
         format: 'esm',
-        outfile: path.join(process.cwd(), 'dist', 'index.es.js'),
+        outfile: path.join(process.cwd(), 'dist', 'index.browser.es.js'),
         // Bundle dependencies, the remark ecosystem only publishes ES modules
         // and includes "development" export maps which actually throw errors during
         // development, which we don't want to expose our users to.


### PR DESCRIPTION
`@tinacms/mdx` now exports 3 things:

```
"main": "dist/index.js",
"browser": "dist/index.browser.es.js",
"module": "dist/index.es.js",
```
The CLI is using `dist/index.js`, the rich-text "raw" view is using `dist/index.browser.es.js` and Tina Cloud is using `dist/index.es.js`. 