### PR TITLE
Assume we are only getting indexed branches from Github

### DIFF
--- a/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
+++ b/packages/@tinacms/toolkit/src/plugins/branch-switcher/BranchSwitcher.tsx
@@ -100,7 +100,17 @@ export const BranchSwitcher = ({
     }).then(async (createdBranchName) => {
       // @ts-ignore
       cms.alerts.success('Branch created.')
-      await refreshBranchList()
+      // add the newly created branch to the list
+      setBranchList((oldBranchList) => {
+        return [
+          ...oldBranchList,
+          {
+            indexStatus: { status: 'unknown' },
+            name: createdBranchName,
+          },
+        ]
+      })
+      setListState('ready')
     })
   }, [])
 

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -43,8 +43,6 @@ const parseRefForBranchName = (ref: string) => {
 const ListBranchResponse = z
   .object({
     name: z.string(),
-    protected: z.boolean(),
-    commit: z.object({ sha: z.string(), url: z.string() }),
   })
   .array()
 
@@ -188,7 +186,7 @@ export class Client {
   events = new EventBus() // automatically hooked into global event bus when attached via cms.registerApi
 
   constructor({ tokenStorage = 'MEMORY', ...options }: ServerOptions) {
-    this.tinaGraphQLVersion = options.tinaGraphQLVersion
+    this.tinaGraphQLVersion = 'beta' || options.tinaGraphQLVersion
     this.onLogin = options.schema?.config?.admin?.auth?.onLogin
     this.onLogout = options.schema?.config?.admin?.auth?.onLogout
     if (options.schema?.config?.admin?.auth?.logout) {


### PR DESCRIPTION
Fixes ENG-853

Previously, we where getting the branches from Github, [when we update Tina Cloud](https://github.com/tinacms/tina-cloud/pull/1793) to get the branches from the app meta data it will not return the branch initially since it takes a little bit to get the update from Github. 

This PR updates the refresh data to add the new branch to the list instead of re-refetching the entire list.


