### PR TITLE
Improve error message when a _template property isn't one of the templates in the collection

### DIFF
--- a/.changeset/witty-turkeys-dress.md
+++ b/.changeset/witty-turkeys-dress.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Improve error message when a \_template property isn't one of the templates in the collection

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1264,9 +1264,19 @@ const getTemplateForFile = (
   }
   if (templateInfo.type === 'union') {
     if (hasOwnProperty(data, '_template')) {
-      return templateInfo.templates.find(
+      const template = templateInfo.templates.find(
         (t) => lastItem(t.namespace) === data._template
       )
+      if (!template) {
+        throw new Error(
+          `Unable to find template "${
+            data._template
+          }". Possible templates are: ${templateInfo.templates
+            .map((template) => `"${template.name}"`)
+            .join(', ')}.`
+        )
+      }
+      return template
     } else {
       throw new Error(
         `Expected _template to be provided for document in an ambiguous collection`


### PR DESCRIPTION
Message will now say:
```
Error: Unable to find template "blockPag". Possible templates are: "showcase", "blockPage".
```

Closes ENG-865