### PR TITLE
Fix main export field for @tinacms/app

### DIFF
--- a/.changeset/plenty-dots-give.md
+++ b/.changeset/plenty-dots-give.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/app": patch
+"@tinacms/cli": patch
+---
+
+Fix main export field for @tinacms/app

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -1,8 +1,7 @@
 {
   "name": "@tinacms/app",
   "version": "1.2.0",
-  "type": "module",
-  "main": "index.html",
+  "main": "src/main.tsx",
   "license": "Apache-2.0",
   "devDependencies": {
     "@types/react": "17.0.2",

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -168,12 +168,8 @@ export class ConfigManager {
     this.outputHTMLFilePath = path.join(this.outputFolderPath, 'index.html')
     this.outputGitignorePath = path.join(this.outputFolderPath, '.gitignore')
 
-    // This package lists `index.html` as it's main field export
-    this.spaHTMLPath = url.pathToFileURL(
-      require.resolve('@tinacms/app')
-    ).pathname
-    this.spaRootPath = this.spaHTMLPath.replace('/index.html', '')
-    this.spaMainPath = path.join(this.spaRootPath, 'src', 'main.tsx')
+    this.spaMainPath = require.resolve('@tinacms/app')
+    this.spaRootPath = path.join(this.spaMainPath, '..', '..')
   }
 
   async getTinaFolderPath(rootPath) {

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -117,7 +117,7 @@ export const createConfig = async ({
       },
     },
     build: {
-      sourcemap: true,
+      sourcemap: false,
       outDir: configManager.outputFolderPath,
       emptyOutDir: true,
       rollupOptions: rollupOptions,


### PR DESCRIPTION
Found this late yesterday but didn't have time to fix until now. Windows wasn't resolving the `main` field since it was html. This just exports `src/main.tsx` as the main field, which I guess it likes. 

Closes https://github.com/tinacms/tinacms/issues/3741