### PR TITLE
Handle ambiguous templates from indexing

### DIFF
--- a/.changeset/late-peaches-change.md
+++ b/.changeset/late-peaches-change.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+Handle ambiguous templates from indexing

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1122,13 +1122,18 @@ const _indexContent = async (
           frontmatterFormat: collection?.frontmatterFormat,
         }
       )
+      const template = getTemplateForFile(templateInfo, data as any)
+      if (!template) {
+        console.warn(
+          `Document: ${filepath} has an ambiguous template, skipping from indexing`
+        )
+        return
+      }
+
       const normalizedPath = normalizePath(filepath)
 
       const aliasedData = templateInfo
-        ? replaceNameOverrides(
-            getTemplateForFile(templateInfo, data as any),
-            data
-          )
+        ? replaceNameOverrides(template, data)
         : data
 
       await enqueueOps([
@@ -1212,9 +1217,7 @@ const getTemplateForFile = (
         (t) => lastItem(t.namespace) === data._template
       )
     } else {
-      throw new Error(
-        `Expected _template to be provided for document in an ambiguous collection`
-      )
+      return undefined
     }
   }
   throw new Error(`Unable to determine template`)


### PR DESCRIPTION
Skip ambiguous from indexing, so we log a warning instead of failing.
This led to some friction when importing Forestry sites with missing templates

closes https://linear.app/tina/issue/ENG-874/spike-can-we-handle-ambiguous-templates-a-bit-better-when-importing