### PR TITLE
feat: invoke index status callback once new version is ready

### DIFF
--- a/.changeset/nine-rings-double.md
+++ b/.changeset/nine-rings-double.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Improve full reindexing to update status to complete as soon as the new version of the index is ready


### PR DESCRIPTION
When using versioned indexes, the current index status logic will wait until after the old version is cleaned up before firing the status complete event. This may significantly delay reindexing. This update modifies the logic to fire the status complete as soon as the new version is ready and before the delete of the old index occurs.