### PR TITLE
Better match for Forestry migrate

### DIFF
--- a/.changeset/shiny-rings-kneel.md
+++ b/.changeset/shiny-rings-kneel.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+better matching on forestry pages

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
@@ -110,151 +110,160 @@ const generateCollectionFromForestrySection = (
 ) => {
   if (section.read_only) return
 
-  {
-    // TODO: What should we do with read only sections?
-    if (section.read_only) return
+  // TODO: What should we do with read only sections?
+  if (section.read_only) return
 
-    const baseCollection: Omit<Collection, 'fields' | 'templates'> = {
-      label: section.label,
-      name: stringifyLabel(section.label),
-      path: section.path,
+  const baseCollection: Omit<Collection, 'fields' | 'templates'> = {
+    label: section.label,
+    name: stringifyLabel(section.label),
+    path: section.path || '/',
+  }
+  // Add include and exclude if they exist
+  if (section.match) {
+    baseCollection.match = {
+      ...(baseCollection?.match || {}),
+      include: transformForestryMatchToTinaMatch(section.match),
     }
-    // Add include and exclude if they exist
-    if (section.match) {
-      baseCollection.match = {
-        ...(baseCollection?.match || {}),
-        include: transformForestryMatchToTinaMatch(section.match),
-      }
+  }
+  if (section.exclude) {
+    baseCollection.match = {
+      ...(baseCollection?.match || {}),
+      exclude: transformForestryMatchToTinaMatch(section.exclude),
     }
-    if (section.exclude) {
-      baseCollection.match = {
-        ...(baseCollection?.match || {}),
-        exclude: transformForestryMatchToTinaMatch(section.exclude),
-      }
-    }
-    if (section.type === 'directory') {
-      const forestryTemplates = section?.templates || []
+  }
+  if (section.type === 'directory') {
+    const forestryTemplates = section?.templates || []
 
-      // If the section has no templates and has `create: all`
-      if (forestryTemplates.length === 0 && section.create === 'all') {
-        // For all template
-        for (let templateKey of templateMap.keys()) {
-          // get the shape of the template
-          const { templateObj } = templateMap.get(templateKey)
-          const pages: undefined | string[] = templateObj?.pages
-          // if has pages see if there is I page that matches the current section
-          if (pages) {
-            if (
-              pages.some((page) =>
-                minimatch(page, section.path + '/' + section.match)
-              )
-            ) {
-              forestryTemplates.push(templateKey)
-            }
+    // If the section has no templates and has `create: all`
+    if (forestryTemplates.length === 0 && section.create === 'all') {
+      // For all template
+      for (let templateKey of templateMap.keys()) {
+        // get the shape of the template
+        const { templateObj } = templateMap.get(templateKey)
+        const pages: undefined | string[] = templateObj?.pages
+        // if has pages see if there is I page that matches the current section
+        if (pages) {
+          // Glob used for matching
+          let glob = section.match
+
+          // We don't want to match the root if the path is empty or /
+          // This is because /*.md will not match on foo.md
+          const skipPath =
+            section.path === '' || section.path === '/' || !section.path
+          if (!skipPath) {
+            glob = section.path + '/' + section.match
+          }
+          // If we find any pages that match the glob add the forestry template to the section
+          if (
+            pages.some((page) => {
+              return minimatch(page, glob)
+            })
+          ) {
+            forestryTemplates.push(templateKey)
           }
         }
       }
+    }
 
-      const c: Collection =
-        (forestryTemplates?.length || 0) > 1
-          ? {
-              ...baseCollection,
-              templates: forestryTemplates.map((tem) => {
-                const { fields } = templateMap.get(tem)
-                return {
-                  fields: [BODY_FIELD, ...fields],
-                  label: tem,
-                  name: stringifyLabel(tem),
+    const c: Collection =
+      (forestryTemplates?.length || 0) > 1
+        ? {
+            ...baseCollection,
+            templates: forestryTemplates.map((tem) => {
+              const { fields } = templateMap.get(tem)
+              return {
+                fields: [BODY_FIELD, ...fields],
+                label: tem,
+                name: stringifyLabel(tem),
+              }
+            }),
+          }
+        : {
+            ...baseCollection,
+            fields: [
+              BODY_FIELD,
+              ...(forestryTemplates || []).flatMap((tem) => {
+                try {
+                  const { fields: additionalFields } = templateMap.get(tem)
+                  return additionalFields
+                } catch (e) {
+                  logger.log('Error parsing template ', tem)
+                  return []
                 }
               }),
-            }
-          : {
-              ...baseCollection,
-              fields: [
-                BODY_FIELD,
-                ...(forestryTemplates || []).flatMap((tem) => {
-                  try {
-                    const { fields: additionalFields } = templateMap.get(tem)
-                    return additionalFields
-                  } catch (e) {
-                    logger.log('Error parsing template ', tem)
-                    return []
-                  }
-                }),
-              ],
-            }
+            ],
+          }
 
-      if (section?.create === 'none') {
-        c.ui = {
-          ...c.ui,
-          allowedActions: {
-            create: false,
-          },
+    if (section?.create === 'none') {
+      c.ui = {
+        ...c.ui,
+        allowedActions: {
+          create: false,
+        },
+      }
+    }
+    return c
+  } else if (section.type === 'document') {
+    const filePath = section.path
+    const extname = path.extname(filePath)
+    const fileName = path.basename(filePath, extname)
+    const dir = path.dirname(filePath)
+    const ext = checkExt(extname)
+    if (ext) {
+      const fields: TinaField[] = []
+      if (ext === 'md' || ext === 'mdx') {
+        fields.push(BODY_FIELD)
+      }
+      // Go though all templates
+      for (let currentTemplateName of templateMap.keys()) {
+        const { templateObj, fields: additionalFields } =
+          templateMap.get(currentTemplateName)
+        const pages: string[] = templateObj?.pages || []
+
+        // find the template that has the current "path" in its pages
+        if (pages.includes(section.path)) {
+          fields.push(...additionalFields)
+          break
         }
       }
-      return c
-    } else if (section.type === 'document') {
-      const filePath = section.path
-      const extname = path.extname(filePath)
-      const fileName = path.basename(filePath, extname)
-      const dir = path.dirname(filePath)
-      const ext = checkExt(extname)
-      if (ext) {
-        const fields: TinaField[] = []
-        if (ext === 'md' || ext === 'mdx') {
-          fields.push(BODY_FIELD)
-        }
-        // Go though all templates
-        for (let currentTemplateName of templateMap.keys()) {
-          const { templateObj, fields: additionalFields } =
-            templateMap.get(currentTemplateName)
-          const pages: string[] = templateObj?.pages || []
 
-          // find the template that has the current "path" in its pages
-          if (pages.includes(section.path)) {
-            fields.push(...additionalFields)
-            break
-          }
-        }
-
-        // if we don't find any fields, add a dummy field
-        if (fields.length === 0) {
-          fields.push({
-            name: 'dummy',
-            label: 'Dummy field',
-            type: 'string',
-            description:
-              'This is a dummy field, please replace it with the fields you want to edit. See https://tina.io/docs/schema/ for more info',
-          })
-          logger.warn(
-            warnText(
-              `No fields found for ${section.path}. Please add the fields you want to edit to the ${section.label} collection in the config file.`
-            )
-          )
-        }
-
-        return {
-          ...baseCollection,
-          path: dir,
-          format: ext,
-          ui: {
-            allowedActions: {
-              create: false,
-              delete: false,
-            },
-          },
-          match: {
-            include: fileName,
-          },
-          fields,
-        }
-      } else {
-        logger.log(
+      // if we don't find any fields, add a dummy field
+      if (fields.length === 0) {
+        fields.push({
+          name: 'dummy',
+          label: 'Dummy field',
+          type: 'string',
+          description:
+            'This is a dummy field, please replace it with the fields you want to edit. See https://tina.io/docs/schema/ for more info',
+        })
+        logger.warn(
           warnText(
-            `Error: document section has an unsupported file extension: ${extname} in ${section.path}`
+            `No fields found for ${section.path}. Please add the fields you want to edit to the ${section.label} collection in the config file.`
           )
         )
       }
+
+      return {
+        ...baseCollection,
+        path: dir,
+        format: ext,
+        ui: {
+          allowedActions: {
+            create: false,
+            delete: false,
+          },
+        },
+        match: {
+          include: fileName,
+        },
+        fields,
+      }
+    } else {
+      logger.log(
+        warnText(
+          `Error: document section has an unsupported file extension: ${extname} in ${section.path}`
+        )
+      )
     }
   }
 }

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
@@ -108,8 +108,6 @@ const generateCollectionFromForestrySection = (
     }
   >
 ) => {
-  if (section.read_only) return
-
   // TODO: What should we do with read only sections?
   if (section.read_only) return
 
@@ -132,6 +130,25 @@ const generateCollectionFromForestrySection = (
     }
   }
   if (section.type === 'directory') {
+    if (
+      !section?.path ||
+      section.path === '/' ||
+      section.path === './' ||
+      section.path === '.'
+    ) {
+      console.log({ path: section.path })
+      console.log({ section })
+      logger.log(
+        warnText(
+          `Warning: Section ${
+            section.label
+          } is using a Root Path. Currently, Tina Does not support Root paths see ${linkText(
+            'https://github.com/tinacms/tinacms/issues/3768'
+          )} for more updates on this issue.`
+        )
+      )
+      return
+    }
     const forestryTemplates = section?.templates || []
 
     // If the section has no templates and has `create: all`

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -181,7 +181,7 @@ const chooseTypescript = async () => {
     type: 'confirm',
     initial: true,
     message:
-      'Would you like to use Typescript for your Tina Configuration (Recommend)?',
+      'Would you like to use Typescript for your Tina Configuration (Recommended)?',
   })
   return option['selection']
 }

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -1,6 +1,3 @@
-/**
-
-*/
 import path from 'path'
 import { format } from 'prettier'
 import {
@@ -183,7 +180,8 @@ const chooseTypescript = async () => {
     name: 'selection',
     type: 'confirm',
     initial: true,
-    message: 'Would you like to use Typescript?',
+    message:
+      'Would you like to use Typescript for your Tina Configuration (Recommend)?',
   })
   return option['selection']
 }


### PR DESCRIPTION
Fixes two issue brought up in office hours
- Migration was not probably matching when path is `""` or `"/"`
- Better message for Asking about typescript

