### PR TITLE
fix: Fix the initialization of sort order in collection list when previous desc sort order in local storage

### DIFF
--- a/.changeset/few-ears-decide.md
+++ b/.changeset/few-ears-decide.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix the initialization of sort order in collection list when previous desc sort order in local storage

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -171,7 +171,8 @@ const CollectionListPage = () => {
             name: '',
           })
   )
-  const [sortOrder, setSortOrder] = useState('asc' as 'asc' | 'desc')
+  const { order = 'asc' } = JSON.parse(sortKey || '{}')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(order)
   const loc = useLocation()
   useEffect(() => {
     // set sort key to cached value on route change


### PR DESCRIPTION
# what

If sort key and order is stored in local storage (from a previous page load) and order is desc, the sort order will be different than the value in the react state which will cause the next button to be disabled.
