### PR TITLE
fix: reuse schema on full reindex

### DIFF
--- a/.changeset/great-starfishes-drop.md
+++ b/.changeset/great-starfishes-drop.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Update indexAllContent to use the passed in schema instead of fetching it from level after writing

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -99,7 +99,7 @@ export class ConfigManager {
     )
     if (!this.tinaConfigFilePath) {
       throw new Error(
-        `Unable to find confg file in ${this.tinaFolderPath}. Looking for a file named "config.{ts,tsx,js,jsx}"`
+        `Unable to find config file in ${this.tinaFolderPath}. Looking for a file named "config.{ts,tsx,js,jsx}"`
       )
     }
     this.selfHostedDatabaseFilePath = await this.getPathWithExtension(

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -571,12 +571,20 @@ export class Database {
       .get(schemaPath)) as unknown as Schema
   }
 
-  public getSchema = async (level?: Level) => {
+  public getSchema = async (level?: Level, existingSchema?: Schema) => {
     if (this.tinaSchema) {
       return this.tinaSchema
     }
     await this.initLevel()
-    const schema = await this.getTinaSchema(level || this.level)
+    const schema =
+      existingSchema || (await this.getTinaSchema(level || this.level))
+    if (!schema) {
+      throw new Error(
+        `Unable to get schema from level db: ${normalizePath(
+          path.join(this.getGeneratedFolder(), `_schema.json`)
+        )}`
+      )
+    }
     this.tinaSchema = await createSchema({ schema })
     return this.tinaSchema
   }
@@ -904,7 +912,10 @@ export class Database {
           normalizePath(path.join(this.getGeneratedFolder(), '_lookup.json')),
           lookup
         )
-        const result = await this._indexAllContent(nextLevel)
+        const result = await this._indexAllContent(
+          nextLevel,
+          tinaSchema.schema as any
+        )
         if (this.config.version) {
           await this.updateDatabaseVersion(nextVersion)
         }
@@ -1023,9 +1034,9 @@ export class Database {
     await this.onDelete(normalizePath(filepath))
   }
 
-  public _indexAllContent = async (level: Level) => {
+  public _indexAllContent = async (level: Level, schema?: Schema) => {
     const warnings: string[] = []
-    const tinaSchema = await this.getSchema(level)
+    const tinaSchema = await this.getSchema(level, schema)
     const operations: PutOp[] = []
     const enqueueOps = async (ops: PutOp[]): Promise<void> => {
       operations.push(...ops)


### PR DESCRIPTION
# what

IndexAllContent takes the tina schema as a parameter and writes it to the level database and then immediately fetches it from the level database at the start of indexing. If the level implementation uses an eventually consistent model, the schema may not yet be available for reading. This can lead to an error like:

```
ERROR	TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at addNamespaceToSchema (/var/task/js/content-api/src/event-queue/index.cjs:533497:23)
    at validateSchema (/var/task/js/content-api/src/event-queue/index.cjs:533719:19)
    at createSchema (/var/task/js/content-api/src/event-queue/index.cjs:533974:29)
    at Object.getSchema (/var/task/js/content-api/src/event-queue/index.cjs:534880:31)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object._indexAllContent (/var/task/js/content-api/src/event-queue/index.cjs:535215:26)
    at async /var/task/js/content-api/src/event-queue/index.cjs:535106:26
    at async Object.indexStatusCallbackWrapper (/var/task/js/content-api/src/event-queue/index.cjs:535361:22)
    at async Object.indexContent (/var/task/js/content-api/src/event-queue/index.cjs:535075:14)
```

This happens because createSchema is getting a null schema object. To fix this, instead of reading from the level db, we can just re-use the passed in schema during the indexing process, to ensure that  we always have a schema.

This pr makes that change and adds a null check to provide a better error in the case of the schema still not being present.

There is also an unrelated typo fix.