### PR TITLE
fix: update internal client to only set Authorization header when token is available

### DIFF
--- a/.changeset/thick-dancers-rush.md
+++ b/.changeset/thick-dancers-rush.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix: do not set Authorization header if token not present

--- a/packages/tinacms/src/internalClient/index.test.ts
+++ b/packages/tinacms/src/internalClient/index.test.ts
@@ -25,6 +25,7 @@ describe('Tina Client', () => {
         branch: 'main',
         tokenStorage: 'LOCAL_STORAGE',
         customContentApiUrl: 'http://tina.io/fakeURL',
+        tinaGraphQLVersion: '1.1',
       })
     })
     it('sets isLocalMode to false', () => {

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -385,12 +385,16 @@ mutation addPendingDocumentMutation(
     query: ((gqlTag: typeof gql) => DocumentNode) | string,
     { variables }: { variables: object }
   ): Promise<ReturnType> {
+    const token = await this.getToken()
+    const headers = {
+      'Content-Type': 'application/json',
+    }
+    if (token?.id_token) {
+      headers['Authorization'] = 'Bearer ' + token.id_token
+    }
     const res = await fetch(this.contentApiUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + (await this.getToken()).id_token,
-      },
+      headers,
       body: JSON.stringify({
         query: typeof query === 'function' ? print(query(gql)) : query,
         variables,
@@ -565,10 +569,13 @@ mutation addPendingDocumentMutation(
     init?: RequestInit
   ): Promise<Response> {
     const headers = init?.headers || {}
+    const token = await this.getToken()
+    if (token?.id_token) {
+      headers['Authorization'] = 'Bearer ' + token.id_token
+    }
     return await fetch(input, {
       ...init,
       headers: new Headers({
-        Authorization: 'Bearer ' + (await this.getToken()).id_token,
         ...headers,
       }),
     })

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -570,15 +570,12 @@ mutation addPendingDocumentMutation(
   ): Promise<Response> {
     const headers = init?.headers || {}
     const token = await this.getToken()
-    if (!token?.id_token) {
-      throw new Error('Authentication required')
+    if (token?.id_token) {
+      headers['Authorization'] = 'Bearer ' + token?.id_token
     }
     return await fetch(input, {
       ...init,
-      headers: new Headers({
-        Authorization: 'Bearer ' + token?.id_token,
-        ...headers,
-      }),
+      headers: new Headers(headers),
     })
   }
 

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -226,6 +226,7 @@ export class Client {
       }
     )
     this.clientId = options.clientId
+
     switch (tokenStorage) {
       case 'LOCAL_STORAGE':
         this.getToken = async function () {
@@ -385,17 +386,15 @@ mutation addPendingDocumentMutation(
     { variables }: { variables: object }
   ): Promise<ReturnType> {
     const token = await this.getToken()
-    const headers = {
-      'Content-Type': 'application/json',
-    }
-    if (token?.id_token) {
-      headers['Authorization'] = 'Bearer ' + token.id_token
-    } else {
+    if (!token?.id_token) {
       throw new Error('Authentication required')
     }
     const res = await fetch(this.contentApiUrl, {
       method: 'POST',
-      headers,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + token?.id_token,
+      },
       body: JSON.stringify({
         query: typeof query === 'function' ? print(query(gql)) : query,
         variables,
@@ -571,14 +570,13 @@ mutation addPendingDocumentMutation(
   ): Promise<Response> {
     const headers = init?.headers || {}
     const token = await this.getToken()
-    if (token?.id_token) {
-      headers['Authorization'] = 'Bearer ' + token.id_token
-    } else {
+    if (!token?.id_token) {
       throw new Error('Authentication required')
     }
     return await fetch(input, {
       ...init,
       headers: new Headers({
+        Authorization: 'Bearer ' + token?.id_token,
         ...headers,
       }),
     })

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -386,15 +386,15 @@ mutation addPendingDocumentMutation(
     { variables }: { variables: object }
   ): Promise<ReturnType> {
     const token = await this.getToken()
-    if (!token?.id_token) {
-      throw new Error('Authentication required')
+    const headers = {
+      'Content-Type': 'application/json',
+    }
+    if (token?.id_token) {
+      headers['Authorization'] = 'Bearer ' + token?.id_token
     }
     const res = await fetch(this.contentApiUrl, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: 'Bearer ' + token?.id_token,
-      },
+      headers,
       body: JSON.stringify({
         query: typeof query === 'function' ? print(query(gql)) : query,
         variables,

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -226,7 +226,7 @@ export class Client {
       }
     )
     this.clientId = options.clientId
-
+    console.log({ tokenStorage })
     switch (tokenStorage) {
       case 'LOCAL_STORAGE':
         this.getToken = async function () {
@@ -385,7 +385,9 @@ mutation addPendingDocumentMutation(
     query: ((gqlTag: typeof gql) => DocumentNode) | string,
     { variables }: { variables: object }
   ): Promise<ReturnType> {
+    console.log('request')
     const token = await this.getToken()
+    console.log({ token })
     const headers = {
       'Content-Type': 'application/json',
     }
@@ -570,6 +572,8 @@ mutation addPendingDocumentMutation(
   ): Promise<Response> {
     const headers = init?.headers || {}
     const token = await this.getToken()
+    console.log('fetchWithToken')
+    console.log({ token })
     if (token?.id_token) {
       headers['Authorization'] = 'Bearer ' + token.id_token
     }

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -226,7 +226,6 @@ export class Client {
       }
     )
     this.clientId = options.clientId
-    console.log({ tokenStorage })
     switch (tokenStorage) {
       case 'LOCAL_STORAGE':
         this.getToken = async function () {
@@ -385,9 +384,7 @@ mutation addPendingDocumentMutation(
     query: ((gqlTag: typeof gql) => DocumentNode) | string,
     { variables }: { variables: object }
   ): Promise<ReturnType> {
-    console.log('request')
     const token = await this.getToken()
-    console.log({ token })
     const headers = {
       'Content-Type': 'application/json',
     }
@@ -572,8 +569,6 @@ mutation addPendingDocumentMutation(
   ): Promise<Response> {
     const headers = init?.headers || {}
     const token = await this.getToken()
-    console.log('fetchWithToken')
-    console.log({ token })
     if (token?.id_token) {
       headers['Authorization'] = 'Bearer ' + token.id_token
     }

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -390,6 +390,8 @@ mutation addPendingDocumentMutation(
     }
     if (token?.id_token) {
       headers['Authorization'] = 'Bearer ' + token.id_token
+    } else {
+      throw new Error('Authentication required')
     }
     const res = await fetch(this.contentApiUrl, {
       method: 'POST',
@@ -571,6 +573,8 @@ mutation addPendingDocumentMutation(
     const token = await this.getToken()
     if (token?.id_token) {
       headers['Authorization'] = 'Bearer ' + token.id_token
+    } else {
+      throw new Error('Authentication required')
     }
     return await fetch(input, {
       ...init,


### PR DESCRIPTION
# what

Previously, if token was not set, Authorization header was being set with value of `Bearer null` which will generate an incorrect 403 status. The correct status should be 401.
