### PR TITLE
Export date format

### DIFF
--- a/.changeset/two-schools-fry.md
+++ b/.changeset/two-schools-fry.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Export dates as date format in md/mdx

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -908,10 +908,7 @@ const resolveDateInput = (value: string) => {
     throw 'Invalid Date'
   }
 
-  /**
-   * toISOString() converts to UTC
-   */
-  return date //date.toISOString()
+  return date
 }
 
 type FieldParams = {

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -911,7 +911,7 @@ const resolveDateInput = (value: string) => {
   /**
    * toISOString() converts to UTC
    */
-  return date.toISOString()
+  return date //date.toISOString()
 }
 
 type FieldParams = {


### PR DESCRIPTION
Exporting dates as dates, instead of ISO strings

gray-matter / js-yml automatically parses the date appropriately given the format type

Mdx/mdx with yaml formats them like so:

<img width="300" alt="Screen Shot 2023-04-13 at 1 51 23 PM" src="https://user-images.githubusercontent.com/3323181/231830167-43568025-cc72-4a56-a66b-0d6d1f2d95da.png">

json like so:

<img width="354" alt="Screen Shot 2023-04-13 at 1 51 15 PM" src="https://user-images.githubusercontent.com/3323181/231830208-6d37dd72-2c68-4837-b674-7973bbb5f8f5.png">

Our GraphQL API still returns fields as string:
<img width="361" alt="Screen Shot 2023-04-13 at 1 55 34 PM" src="https://user-images.githubusercontent.com/3323181/231830998-f469cccf-63a1-4894-a1a7-51543548fa54.png">

