### PR TITLE
fix: normalize windows paths in config-manager

### DIFF
--- a/.changeset/tricky-colts-live.md
+++ b/.changeset/tricky-colts-live.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix issue with windows paths not getting converted in config-manager

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -271,13 +271,15 @@ export class ConfigManager {
   }
   printRelativePath(filename: string) {
     if (filename) {
-      return filename.replace(`${this.rootPath}/`, '')
+      return filename.replace(/\\/g, '/').replace(`${this.rootPath}/`, '')
     }
     throw `No path provided to print`
   }
   printContentRelativePath(filename: string) {
     if (filename) {
-      return filename.replace(`${this.contentRootPath}/`, '')
+      return filename
+        .replace(/\\/g, '/')
+        .replace(`${this.contentRootPath}/`, '')
     }
     throw `No path provided to print`
   }


### PR DESCRIPTION
Discord user reported error on save: https://discord.com/channels/835168149439643678/1096106617184985240

Issue was due to config-manager not transforming the windows path separators