### PR TITLE
Fix media store types

### DIFF
--- a/.changeset/calm-lions-smell.md
+++ b/.changeset/calm-lions-smell.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixes [this type issue](https://github.com/tinacms/tinacms/issues/3799)

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -76,12 +76,16 @@ export const defineLegacyConfig = (
   return config
 }
 
+interface MediaStoreClass {
+  new (...args: any[]): MediaStore
+}
+
 export const defineStaticConfig = (
   config: Config<
     (cms: TinaCMS) => TinaCMS,
     formifyCallback,
     DocumentCreatorCallback,
-    MediaStore
+    MediaStoreClass
   >
 ) => {
   if (!config.schema) {


### PR DESCRIPTION
Fixes #3799 

Fixes ENG-920


## How to test

Add one a media store [as described in the docs](https://tina.io/docs/reference/media/external/cloudinary/) and confirm that no type errors appear.

(The tina-cloud-starter-iframe example already has this setup but commented out)