### PR TITLE
fix: #3608: max value character using for queries did not encompass cyrillic characters

### DIFF
--- a/.changeset/honest-baboons-wonder.md
+++ b/.changeset/honest-baboons-wonder.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix cyrillic characters in indexes were being incorrectly filtered out

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -730,7 +730,9 @@ export class Database {
     }
 
     if (!query.lt && !query.lte) {
-      query.lte = filterSuffixes?.right ? `${filterSuffixes.right}\xFF` : '\xFF'
+      query.lte = filterSuffixes?.right
+        ? `${filterSuffixes.right}\uFFFF`
+        : '\uFFFF'
     }
 
     let edges: { cursor: string; path: string }[] = []


### PR DESCRIPTION
# what

The character used for the upper range in data layer filtering didn't encompass cyrillic characters, so index values constructed using these characters were getting filtered out incorrectly

Fix #3608 