### PR TITLE
refactor: pull out the lookup map creation so the database / bridge don't need to be concerned with it

### DIFF
--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -19,6 +19,7 @@ export class Codegen {
     definitions: TypeDefinitionNode[]
   }
   tinaSchema: TinaSchema
+  lookup: any
 
   constructor({
     configManager,
@@ -27,6 +28,7 @@ export class Codegen {
     fragDoc,
     graphqlSchemaDoc,
     tinaSchema,
+    lookup,
   }: {
     configManager: ConfigManager
     port?: number
@@ -37,6 +39,7 @@ export class Codegen {
       definitions: TypeDefinitionNode[]
     }
     tinaSchema: TinaSchema
+    lookup: any
   }) {
     this.graphqlSchemaDoc = graphqlSchemaDoc
     this.configManager = configManager
@@ -45,6 +48,7 @@ export class Codegen {
     this.tinaSchema = tinaSchema
     this.queryDoc = queryDoc
     this.fragDoc = fragDoc
+    this.lookup = lookup
   }
 
   async writeConfigFile(fileName: string, data: string) {
@@ -92,6 +96,8 @@ export class Codegen {
       '_schema.json',
       JSON.stringify(this.tinaSchema.schema)
     )
+    // update _lookup.json
+    await this.writeConfigFile('_lookup.json', JSON.stringify(this.lookup))
 
     const apiURL = this.getApiURL()
     if (this.configManager.shouldSkipSDK()) {

--- a/packages/@tinacms/cli/src/next/commands/audit-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/audit-command/index.ts
@@ -63,8 +63,7 @@ export class AuditCommand extends Command {
       Number(this.datalayerPort),
       this.clean ? undefined : new AuditFileSystemBridge(configManager.rootPath)
     )
-    const { tinaSchema, graphQLSchema } = await buildSchema(
-      database,
+    const { tinaSchema, graphQLSchema, lookup } = await buildSchema(
       configManager.config
     )
 
@@ -74,6 +73,7 @@ export class AuditCommand extends Command {
         const res = await database.indexContent({
           graphQLSchema,
           tinaSchema,
+          lookup,
         })
         warnings.push(...res.warnings)
       },

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -102,10 +102,8 @@ export class BuildCommand extends Command {
       configManager,
       Number(this.datalayerPort)
     )
-    const { queryDoc, fragDoc, graphQLSchema, tinaSchema } = await buildSchema(
-      database,
-      configManager.config
-    )
+    const { queryDoc, fragDoc, graphQLSchema, tinaSchema, lookup } =
+      await buildSchema(configManager.config)
 
     const codegen = new Codegen({
       configManager: configManager,
@@ -113,6 +111,7 @@ export class BuildCommand extends Command {
       fragDoc,
       graphqlSchemaDoc: graphQLSchema,
       tinaSchema,
+      lookup,
     })
     const apiURL = await codegen.execute()
 

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -126,8 +126,8 @@ export class DevCommand extends Command {
         database.clearCache()
       }
 
-      const { tinaSchema, graphQLSchema, queryDoc, fragDoc } =
-        await buildSchema(database, configManager.config)
+      const { tinaSchema, graphQLSchema, lookup, queryDoc, fragDoc } =
+        await buildSchema(configManager.config)
 
       const codegen = new Codegen({
         configManager: configManager,
@@ -136,6 +136,7 @@ export class DevCommand extends Command {
         fragDoc,
         graphqlSchemaDoc: graphQLSchema,
         tinaSchema,
+        lookup,
       })
       const apiURL = await codegen.execute()
 
@@ -167,6 +168,7 @@ export class DevCommand extends Command {
           const res = await database.indexContent({
             graphQLSchema,
             tinaSchema,
+            lookup,
           })
           warnings.push(...res.warnings)
         },

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -29,13 +29,8 @@ export { buildDotTinaFiles }
 export type DummyType = unknown
 
 // TODO: Can we just remove this or rename buildDotFiles. Having a wrapper function is confusing.
-export const buildSchema = async (
-  database: Database,
-  config: Config,
-  flags?: string[]
-) => {
+export const buildSchema = async (config: Config, flags?: string[]) => {
   return buildDotTinaFiles({
-    database,
     config,
     flags,
   })


### PR DESCRIPTION
Builder keeps an in memory lookup map. buildDotTinaFiles returns the lookup,  along with the schema files. codegen handles writing the config file (_lookup.json) (instead of having that handled separately in bridge / database)