### PR TITLE
Svg Width

### DIFF
--- a/.changeset/two-rabbits-move.md
+++ b/.changeset/two-rabbits-move.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Sets minimum width for SVG images

--- a/packages/@tinacms/toolkit/src/packages/fields/components/ImageUpload/ImageUpload.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/components/ImageUpload/ImageUpload.tsx
@@ -24,12 +24,18 @@ interface ImageUploadProps {
   loading?: boolean
 }
 
-const StyledImage = ({ src }) => (
-  <img
-    src={src}
-    className="block max-w-full rounded shadow overflow-hidden max-h-48 h-auto object-contain transition-opacity duration-100 ease-out m-0 bg-gray-200 bg-auto bg-center bg-no-repeat"
-  />
-)
+const StyledImage = ({ src }) => {
+  const isSvg = /\.svg$/.test(src)
+
+  return (
+    <img
+      src={src}
+      className={`"block max-w-full rounded shadow overflow-hidden max-h-48 h-auto object-contain transition-opacity duration-100 ease-out m-0 bg-gray-200 bg-auto bg-center bg-no-repeat ${
+        isSvg ? 'min-w-[12rem]' : ''
+      }`}
+    />
+  )
+}
 
 const StyledFile = ({ src }) => {
   return (


### PR DESCRIPTION
This sets a minimum width for SVG images given they don't always have a defined width.

Fixes #3835 