### PR TITLE
Skip schema diff check when we have conflicting version of GraphQL

### DIFF
--- a/.changeset/stale-zebras-end.md
+++ b/.changeset/stale-zebras-end.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Skip schema diff check when we have conflicting version of GraphQL


### PR DESCRIPTION
Closes https://linear.app/tina/issue/ENG-938/graphqltina-conflict-on-gatsby-sites

^^ Kinda. This just skips that check in the CLI with a message:

```
Skipping schema check due to conflicting GraphQL versions
```

We could bundle the CLI's dependencies entirely, which would get around this but that might be a bit of a larger task.The diff check will still run from the admin, since we're already deduping `graphql` in the vite build.