### PR TITLE
Fix/forestry migration bug

### DIFF
--- a/.changeset/pink-comics-doubt.md
+++ b/.changeset/pink-comics-doubt.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+fix issue where migration would error if a user selected no to migrating templates

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -117,7 +117,7 @@ export async function initStaticTina({
     }
   }
 
-  // await addDependencies(packageManager)
+  await addDependencies(packageManager)
 
   if (isForestryMigration) {
     await addTemplateFile({ baseDir: '', usingTypescript, templateCode })

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -75,17 +75,16 @@ export async function initStaticTina({
     // CollectionsString is the string that will be added to the tina config
     // importStatements are the import statements that will be added to the tina config
     // templateCodeString is the string that will be added to the template.{ts,js} file
-    const { collectionString, importStatements, templateCodeString } =
-      await forestryMigrate({
-        usingTypescript,
-        pathToForestryConfig,
-        rootPath,
-        framework,
-      })
-    if (collectionString) {
-      templateCode = templateCodeString
-      collections = collectionString
-      extraText = importStatements
+    const res = await forestryMigrate({
+      usingTypescript,
+      pathToForestryConfig,
+      rootPath,
+      framework,
+    })
+    if (res) {
+      templateCode = res.templateCodeString
+      collections = res.collectionString
+      extraText = res.importStatements
       isForestryMigration = true
     }
   }
@@ -118,9 +117,9 @@ export async function initStaticTina({
     }
   }
 
-  await addDependencies(packageManager)
+  // await addDependencies(packageManager)
 
-  if (hasForestryConfig) {
+  if (isForestryMigration) {
     await addTemplateFile({ baseDir: '', usingTypescript, templateCode })
   }
 


### PR DESCRIPTION
Fixes a bug where if a user selected no to migrating forestry templates they would get an error in init. 

Fixes #3847

## How to test
- Run init
-  Select no to forestry migration
- Verify init worked 