### PR TITLE
fix issue with build.host in defineConfig

### DIFF
--- a/.changeset/witty-timers-attack.md
+++ b/.changeset/witty-timers-attack.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix regression where `build.host` was not passed correctly

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -106,6 +106,7 @@ export const createConfig = async ({
       include: ['react/jsx-runtime', 'react/jsx-dev-runtime'],
     },
     server: {
+      host: configManager.config?.build?.host ?? false,
       watch: noWatch
         ? {
             ignored: ['**/*'],


### PR DESCRIPTION
Fixes  #3871

Fixes regression where the host from config was not getting passed to vite. 


cc @wommy @steffkes 