### PR TITLE
feat: trim whitespace from readonly token to prevent accidental cut and paste issues

### DIFF
--- a/.changeset/tasty-walls-serve.md
+++ b/.changeset/tasty-walls-serve.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Trim whitespace from readonly token to ignore any accidental whitespace from cut and paste

--- a/packages/tinacms/src/unifiedClient/index.ts
+++ b/packages/tinacms/src/unifiedClient/index.ts
@@ -32,7 +32,7 @@ export class TinaClient<GenQueries> {
   public queries: GenQueries
   constructor({ token, url, queries }: TinaClientArgs<GenQueries>) {
     this.apiUrl = url
-    this.readonlyToken = token
+    this.readonlyToken = token?.trim()
     this.queries = queries(this)
   }
 


### PR DESCRIPTION
User accidentally pasted read only token with newline and it caused auth errors during build: https://discord.com/channels/835168149439643678/1101233609521758331

This PR trims the string (if it is defined)