### PR TITLE
Fix Database.get on folders within collections that have templates

### DIFF
--- a/.changeset/serious-schools-punch.md
+++ b/.changeset/serious-schools-punch.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix Database.get on folders within collections that have templates

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -204,10 +204,17 @@ export class Database {
         typeof contentObject._template === 'string'
           ? contentObject._template
           : undefined
-      const { collection, template } =
-        tinaSchema.getCollectionAndTemplateByFullPath(filepath, templateName)
+      const { collection, template } = hasOwnProperty(
+        contentObject,
+        '__folderBasename'
+      )
+        ? {
+            collection: await this.collectionForPath(filepath),
+            template: undefined,
+          } // folders have no templates
+        : tinaSchema.getCollectionAndTemplateByFullPath(filepath, templateName)
 
-      const field = template.fields.find((field) => {
+      const field = template?.fields.find((field) => {
         if (field.type === 'string' || field.type === 'rich-text') {
           if (field.isBody) {
             return true
@@ -228,7 +235,9 @@ export class Database {
         ...data,
         _collection: collection.name,
         _keepTemplateKey: !!collection.templates,
-        _template: lastItem(template.namespace),
+        _template: template?.namespace
+          ? lastItem(template?.namespace)
+          : undefined,
         _relativePath: filepath
           .replace(collection.path, '')
           .replace(/^\/|\/$/g, ''),


### PR DESCRIPTION
The hydrator in the database was failing on folders when calling getCollectionAndTemplateByFullPath() when templates are defined on a collection. This was being surfaced as a TinaQueryError but the folder object was present, just missing the _templates key.