### PR TITLE
fix: issue where collection lookup fails with folder having match property

### DIFF
--- a/.changeset/strong-cheetahs-brake.md
+++ b/.changeset/strong-cheetahs-brake.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix issue where collection lookup fails with folder having match property

--- a/packages/@tinacms/graphql/src/database/datalayer.ts
+++ b/packages/@tinacms/graphql/src/database/datalayer.ts
@@ -649,6 +649,7 @@ export const makeFolderOpsForCollection = <T extends object>(
         type: 'put',
         key: `${collection.path}/${parentFolderKey}.${collection.format}`,
         value: {
+          __collection: collection.name,
           __folderBasename: path.basename(folderName),
           __folderPath: folderName,
         },

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -206,10 +206,12 @@ export class Database {
           : undefined
       const { collection, template } = hasOwnProperty(
         contentObject,
-        '__folderBasename'
+        '__collection'
       )
         ? {
-            collection: await this.collectionForPath(filepath),
+            collection: tinaSchema.getCollection(
+              contentObject['__collection'] as string
+            ),
             template: undefined,
           } // folders have no templates
         : tinaSchema.getCollectionAndTemplateByFullPath(filepath, templateName)
@@ -873,6 +875,7 @@ export class Database {
             cursor: btoa(edge.cursor),
           }
         } catch (error) {
+          console.log(error)
           if (
             error instanceof Error &&
             (!edge.path.includes('.tina/__generated__/_graphql.json') ||


### PR DESCRIPTION
If a collection has a match property, collection lookup for folders using getCollectionbyFullPath fails, because the filepath is '<collectionRoot>/sha.<filetype>' and not the actual full path. 

Fix is to attach the collection to the folder virtual entry and skip collection lookup by path.