### PR TITLE
fix: folder root collection issues

### DIFF
--- a/.changeset/large-kids-sin.md
+++ b/.changeset/large-kids-sin.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix root level collection issues including a folder related bug

--- a/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
@@ -22,6 +22,7 @@ export class FilesystemBridge implements Bridge {
       path.join(basePath, '**', `/*${extension}`).replace(/\\/g, '/'),
       {
         dot: true,
+        ignore: ['**/node_modules/**'],
       }
     )
     const posixRootPath = normalize(this.outputPath)

--- a/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
@@ -19,7 +19,7 @@ export class FilesystemBridge implements Bridge {
   public async glob(pattern: string, extension: string) {
     const basePath = path.join(this.outputPath, ...pattern.split('/'))
     const items = await fg(
-      path.join(basePath, '**', `/*${extension}`).replace(/\\/g, '/'),
+      path.join(basePath, '**', `/*\.${extension}`).replace(/\\/g, '/'),
       {
         dot: true,
         ignore: ['**/node_modules/**'],

--- a/packages/@tinacms/graphql/src/database/datalayer.ts
+++ b/packages/@tinacms/graphql/src/database/datalayer.ts
@@ -560,6 +560,9 @@ export class FolderTreeBuilder {
 
   update(documentPath: string, collectionPath: string) {
     let folderPath = path.dirname(documentPath)
+    if (folderPath === '.') {
+      folderPath = ''
+    }
     if (collectionPath) {
       folderPath = stripCollectionFromPath(collectionPath, folderPath)
     }

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1149,7 +1149,7 @@ export class Database {
       const normalPath = normalizePath(collection.path)
       const format = collection.format || 'md'
       // Get all possible paths for this collection
-      const documentPaths = await this.bridge.glob(normalPath, format)
+      const documentPaths = await this.bridge.glob(normalPath, `\.${format}`)
 
       // filter paths based on match and exclude
       const matches = this.tinaSchema.getMatches({ collection })

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1149,7 +1149,7 @@ export class Database {
       const normalPath = normalizePath(collection.path)
       const format = collection.format || 'md'
       // Get all possible paths for this collection
-      const documentPaths = await this.bridge.glob(normalPath, `\.${format}`)
+      const documentPaths = await this.bridge.glob(normalPath, format)
 
       // filter paths based on match and exclude
       const matches = this.tinaSchema.getMatches({ collection })


### PR DESCRIPTION
- glob was matching "-[ext]". A script named `node_modules/.bin/concat-md` was matching when a collection was configured at the root which was not a valid markdown. Updated to match literally ".[ext]".
- When configured with a root level collection, tina was scanning node_modules in dev mode and was causing a `ENAMETOOLONG` error. This change excludes node_modules folders entirely.
- the folder construction logic doesn't properly handle root level paths causing a '.' folder to be created instead of '' (root)