### PR TITLE
Fix has tina config function

### DIFF
--- a/.changeset/flat-files-mate.md
+++ b/.changeset/flat-files-mate.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+fix hasTinaMediaConfig function

--- a/packages/@tinacms/graphql/src/resolver/media-utils.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.ts
@@ -100,12 +100,14 @@ const cleanUpSlashes = (path: string): string => {
 }
 
 const hasTinaMediaConfig = (schema: Schema<true>): boolean => {
-  if (
-    schema.config?.media?.tina?.publicFolder &&
-    schema.config?.media?.tina?.mediaRoot
-  ) {
-    return true
-  }
+  if (!schema.config?.media?.tina) return false
 
-  return false
+  // If they don't have both publicFolder and mediaRoot, they don't have a Tina Media config
+  if (
+    typeof schema.config?.media?.tina?.publicFolder !== 'string' &&
+    typeof schema.config?.media?.tina?.mediaRoot !== 'string'
+  )
+    return false
+
+  return true
 }


### PR DESCRIPTION
Fixes ENG-958

## Why this fix? 

this issue was caused because {publicFolder: ""} was set. The old function would check `publicFolder` and not `type of publicFolder === 'string'`. 

## How to test

This needs to be tested on TinaCloud
- pull down code
- update @tinacms/graphql-1.4 deps to the snapshot release 0.0.0-20230503154010

(I was able to test and the issue was fixed)