### PR TITLE
Add placeholder screen to admin

### DIFF
--- a/.changeset/curly-cycles-run.md
+++ b/.changeset/curly-cycles-run.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/app': patch
+'@tinacms/cli': patch
+---
+
+Placeholder view for when assets fail to load

--- a/packages/@tinacms/app/index.html
+++ b/packages/@tinacms/app/index.html
@@ -8,6 +8,57 @@
   </head>
   <body class="tina-tailwind">
     <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <script>
+      function handleLoadError() {
+        // Assets have failed to load
+        document.getElementById('root').innerHTML =
+          '<style type="text/css">\
+        #no-assets-placeholder body {\
+          font-family: sans-serif;\
+          font-size: 16px;\
+          line-height: 1.4;\
+          color: #333;\
+          background-color: #f5f5f5;\
+        }\
+        #no-assets-placeholder {\
+          max-width: 600px;\
+          margin: 0 auto;\
+          padding: 40px;\
+          text-align: center;\
+          background-color: #fff;\
+          box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);\
+        }\
+        #no-assets-placeholder h1 {\
+          font-size: 24px;\
+          margin-bottom: 20px;\
+        }\
+        #no-assets-placeholder p {\
+          margin-bottom: 10px;\
+        }\
+        #no-assets-placeholder a {\
+          color: #0077cc;\
+          text-decoration: none;\
+        }\
+        #no-assets-placeholder a:hover {\
+          text-decoration: underline;\
+        }\
+        </style>\
+        <div id=\'no-assets-placeholder\'>\
+          <h1>Oops!</h1>\
+          <p>\
+            Your TinaCMS configuration may be misconfigured, and we could not load\
+            the assets for this page.\
+          </p>\
+          <p>\
+            Please visit <a href="https://tina.io">https://tina.io</a> for help.\
+          </p>\
+        </div>'
+      }
+    </script>
+    <script
+      type="module"
+      src="/src/main.tsx"
+      onerror="handleLoadError()"
+    ></script>
   </body>
 </html>

--- a/packages/@tinacms/app/index.html
+++ b/packages/@tinacms/app/index.html
@@ -45,13 +45,13 @@
         }\
         </style>\
         <div id=\'no-assets-placeholder\'>\
-          <h1>Oops!</h1>\
+          <h1>Failed loading TinaCMS assets</h1>\
           <p>\
             Your TinaCMS configuration may be misconfigured, and we could not load\
             the assets for this page.\
           </p>\
           <p>\
-            Please visit <a href="https://tina.io">https://tina.io</a> for help.\
+            Please visit <a href="https://tina.io/docs/tina-cloud/faq/#how-do-i-resolve-failed-loading-tinacms-assets-error">this doc</a> for help.\
           </p>\
         </div>'
       }

--- a/packages/@tinacms/app/index.html
+++ b/packages/@tinacms/app/index.html
@@ -10,6 +10,7 @@
     <div id="root"></div>
     <script>
       function handleLoadError() {
+        console.error('Failed to load assets')
         // Assets have failed to load
         document.getElementById('root').innerHTML =
           '<style type="text/css">\
@@ -54,11 +55,15 @@
           </p>\
         </div>'
       }
+
+      // Check if #root has childen after 2 seconds
+      // If not, we assume that the assets have failed to load
+      setTimeout(() => {
+        if (!document.getElementById('root').children.length) {
+          handleLoadError()
+        }
+      }, 2000)
     </script>
-    <script
-      type="module"
-      src="/src/main.tsx"
-      onerror="handleLoadError()"
-    ></script>
+    <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/packages/@tinacms/cli/src/next/commands/dev-command/html.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/html.ts
@@ -30,13 +30,13 @@ const errorHTML = `<style type="text/css">
 }
 </style>
 <div id="no-assets-placeholder">
-<h1>Oops!</h1>
+<h1>Failed loading TinaCMS assets</h1>
 <p>
   Your TinaCMS configuration may be misconfigured, and we could not load
   the assets for this page.
 </p>
 <p>
-  Please visit <a href="https://tina.io">https://tina.io</a> for help.
+  Please visit <a href="https://tina.io/docs/tina-cloud/faq/#how-do-i-resolve-failed-loading-tinacms-assets-error">this doc</a> for help.
 </p>
 </div>
 </div>`

--- a/packages/@tinacms/cli/src/next/commands/dev-command/html.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/html.ts
@@ -1,3 +1,48 @@
+const errorHTML = `<style type="text/css">
+#no-assets-placeholder body {
+  font-family: sans-serif;
+  font-size: 16px;
+  line-height: 1.4;
+  color: #333;
+  background-color: #f5f5f5;
+}
+#no-assets-placeholder {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 40px;
+  text-align: center;
+  background-color: #fff;
+  box-shadow: 0px 0px 20px rgba(0, 0, 0, 0.1);
+}
+#no-assets-placeholder h1 {
+  font-size: 24px;
+  margin-bottom: 20px;
+}
+#no-assets-placeholder p {
+  margin-bottom: 10px;
+}
+#no-assets-placeholder a {
+  color: #0077cc;
+  text-decoration: none;
+}
+#no-assets-placeholder a:hover {
+  text-decoration: underline;
+}
+</style>
+<div id="no-assets-placeholder">
+<h1>Oops!</h1>
+<p>
+  Your TinaCMS configuration may be misconfigured, and we could not load
+  the assets for this page.
+</p>
+<p>
+  Please visit <a href="https://tina.io">https://tina.io</a> for help.
+</p>
+</div>
+</div>`
+  .trim()
+  .replace(/[\r\n\s]+/g, ' ')
+
 export const devHTML = (port: string) => `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -15,9 +60,16 @@ export const devHTML = (port: string) => `<!DOCTYPE html>
     window.__vite_plugin_react_preamble_installed__ = true
   </script>
   <script type="module" src="http://localhost:${port}/@vite/client"></script>
+  <script>
+  function handleLoadError() {
+    // Assets have failed to load
+    document.getElementById('root').innerHTML = '${errorHTML}';
+  }
+  </script>
   <script
     type="module"
     src="http://localhost:${port}/src/main.tsx"
+    onerror="handleLoadError()"
   ></script>
   <body class="tina-tailwind">
     <div id="root"></div>


### PR DESCRIPTION
Add admin placeholder screen if assets fail to load.

<img width="973" alt="Screen Shot 2023-05-09 at 2 37 52 PM" src="https://github.com/tinacms/tinacms/assets/3323181/d493719a-a476-4839-89bc-24faa0c64812">

closes #ENG-972