### PR TITLE
fix: Bitwise OR operator to Logical OR operator in media store limit

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
+++ b/packages/@tinacms/toolkit/src/packages/core/media-store.default.ts
@@ -227,7 +227,7 @@ export class TinaMediaStore implements MediaStore {
       if (await this.isAuthenticated()) {
         res = await this.api.fetchWithToken(
           `${this.url}/list/${options.directory || ''}?limit=${
-            options.limit | 20
+            options.limit || 20
           }${options.offset ? `&cursor=${options.offset}` : ''}`
         )
 
@@ -244,7 +244,7 @@ export class TinaMediaStore implements MediaStore {
     } else {
       res = await this.fetchFunction(
         `${this.url}/list/${options.directory || ''}?limit=${
-          options.limit | 20
+          options.limit || 20
         }${options.offset ? `&cursor=${options.offset}` : ''}`
       )
 


### PR DESCRIPTION
Because of the use of a Bitwise OR operator instead of a Logical OR operator, unexpected behavior occurred when changing the pageSize of the media manager. This PR fixes this operator so it works as expected.

Before:
![Screenshot from 2023-05-09 16-25-00](https://github.com/tinacms/tinacms/assets/117638641/5598df11-946e-4ccf-8d10-ab2b951676be)

After:
![Screenshot from 2023-05-09 16-27-26](https://github.com/tinacms/tinacms/assets/117638641/4fd4fb82-f94d-4b30-911c-f8b43b40d862)
