### PR TITLE
Add media root to s3

### DIFF
--- a/.changeset/soft-ladybugs-joke.md
+++ b/.changeset/soft-ladybugs-joke.md
@@ -1,0 +1,5 @@
+---
+'next-tinacms-s3': patch
+---
+
+Add the `mediaRoot` option to the s3 media store

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -23,6 +23,7 @@ import { promisify } from 'util'
 export interface S3Config {
   config: S3ClientConfig
   bucket: string
+  mediaRoot?: string
   authorized: (_req: NextApiRequest, _res: NextApiResponse) => Promise<boolean>
 }
 
@@ -40,6 +41,15 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
   const client = new S3Client(config.config)
   const bucket = config.bucket
   const region = config.config.region || 'us-east-1'
+  let mediaRoot = config.mediaRoot || ''
+  if (mediaRoot) {
+    if (!mediaRoot.endsWith('/')) {
+      mediaRoot = mediaRoot + '/'
+    }
+    if (mediaRoot.startsWith('/')) {
+      mediaRoot = mediaRoot.substr(1)
+    }
+  }
   const endpoint =
     config.config.endpoint || `https://s3.${region}.amazonaws.com`
   let cdnUrl =
@@ -56,9 +66,9 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
     }
     switch (req.method) {
       case 'GET':
-        return listMedia(req, res, client, bucket, cdnUrl)
+        return listMedia(req, res, client, bucket, mediaRoot, cdnUrl)
       case 'POST':
-        return uploadMedia(req, res, client, bucket, cdnUrl)
+        return uploadMedia(req, res, client, bucket, mediaRoot, cdnUrl)
       case 'DELETE':
         return deleteAsset(req, res, client, bucket)
       default:
@@ -72,6 +82,7 @@ async function uploadMedia(
   res: NextApiResponse,
   client: S3Client,
   bucket: string,
+  mediaRoot: string,
   cdnUrl: string
 ) {
   try {
@@ -104,7 +115,9 @@ async function uploadMedia(
     const filename = path.basename(filePath)
     const params: PutObjectCommandInput = {
       Bucket: bucket,
-      Key: prefix + filename,
+      Key: mediaRoot
+        ? path.join(mediaRoot, prefix + filename)
+        : prefix + filename,
       Body: blob,
       ACL: 'public-read',
     }
@@ -122,7 +135,11 @@ async function uploadMedia(
           '400x400': src,
           '1000x1000': src,
         },
-        src,
+        src:
+          cdnUrl +
+          (mediaRoot
+            ? path.join(mediaRoot, prefix + filename)
+            : prefix + filename),
       })
     } catch (e) {
       res.status(500).send(findErrorMessage(e))
@@ -134,11 +151,30 @@ async function uploadMedia(
   }
 }
 
+function stripMediaRoot(mediaRoot: string, key: string) {
+  if (!mediaRoot) {
+    return key
+  }
+  const mediaRootParts = mediaRoot.split('/').filter((part) => part)
+  if (!mediaRootParts || !mediaRootParts[0]) {
+    return key
+  }
+  const keyParts = key.split('/').filter((part) => part)
+  // remove each part of the key that matches the mediaRoot parts
+  for (let i = 0; i < mediaRootParts.length; i++) {
+    if (keyParts[0] === mediaRootParts[i]) {
+      keyParts.shift()
+    }
+  }
+  return keyParts.join('/')
+}
+
 async function listMedia(
   req: NextApiRequest,
   res: NextApiResponse,
   client: S3Client,
   bucket: string,
+  mediaRoot: string,
   cdnUrl: string
 ) {
   try {
@@ -154,7 +190,7 @@ async function listMedia(
     const params: ListObjectsCommandInput = {
       Bucket: bucket,
       Delimiter: '/',
-      Prefix: prefix,
+      Prefix: mediaRoot ? path.join(mediaRoot, prefix) : prefix,
       Marker: offset?.toString(),
       MaxKeys: directory && !offset ? +limit + 1 : +limit,
     }
@@ -165,19 +201,26 @@ async function listMedia(
 
     const items = []
 
-    response.CommonPrefixes?.forEach(({ Prefix }) =>
+    response.CommonPrefixes?.forEach(({ Prefix }) => {
+      const strippedPrefix = stripMediaRoot(mediaRoot, Prefix)
+      if (!strippedPrefix) {
+        return
+      }
       items.push({
         id: Prefix,
         type: 'dir',
-        filename: path.basename(Prefix),
-        directory: path.dirname(Prefix),
+        filename: path.basename(strippedPrefix),
+        directory: path.dirname(strippedPrefix),
       })
-    )
+    })
 
     items.push(
       ...(response.Contents || [])
-        .filter((file) => file.Key !== prefix)
-        .map(getS3ToTinaFunc(cdnUrl))
+        .filter((file) => {
+          const strippedKey = stripMediaRoot(mediaRoot, file.Key)
+          return strippedKey !== prefix
+        })
+        .map(getS3ToTinaFunc(cdnUrl, mediaRoot))
     )
 
     res.json({
@@ -228,10 +271,11 @@ async function deleteAsset(
   }
 }
 
-function getS3ToTinaFunc(cdnUrl) {
+function getS3ToTinaFunc(cdnUrl, mediaRoot?: string) {
   return function s3ToTina(file: _Object): Media {
-    const filename = path.basename(file.Key)
-    const directory = path.dirname(file.Key) + '/'
+    const strippedKey = stripMediaRoot(mediaRoot, file.Key)
+    const filename = path.basename(strippedKey)
+    const directory = path.dirname(strippedKey) + '/'
 
     const src = cdnUrl + file.Key
     return {


### PR DESCRIPTION
Adds the `mediaRoot` option to the s3 media store. 


EX
```ts
// pages/api/s3/[...media].ts

import {
  mediaHandlerConfig,
  createMediaHandler,
} from 'next-tinacms-s3/dist/handlers'

import { isAuthorized } from '@tinacms/auth'

export const config = mediaHandlerConfig

export default createMediaHandler({
  config: {
    credentials: {
      accessKeyId: process.env.NEXT_PUBLIC_S3_ACCESS_KEY || '',
      secretAccessKey: process.env.S3_SECRET_KEY || '',
    },
    region: process.env.NEXT_PUBLIC_S3_REGION,
  },
  mediaRoot: 'tina',
  bucket: process.env.NEXT_PUBLIC_S3_BUCKET || '',
  authorized: async (req, _res) => {
    if (process.env.NODE_ENV === 'development') {
      return true
    }
    try {
      const user = await isAuthorized(req)

      return user && user.verified
    } catch (e) {
      console.error(e)
      return false
    }
  },
})
```