### PR TITLE
Recreate GithubBridge to support separate content repos in self-hosted projects

### DIFF
--- a/.changeset/lovely-forks-talk.md
+++ b/.changeset/lovely-forks-talk.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/datalayer': patch
+'@tinacms/graphql': patch
+'@tinacms/cli': patch
+---
+
+This adds a GithubBridge in order to better support separate content repositories for self-hosted projects. This will also help provide a path to better support reindexing for self-hosted projects (i.e. keeping the data layer updated when changes are pushed directly via git, rather than made through the Tina UI). See further notes in this discussion: https://github.com/tinacms/tinacms/discussions/3589#discussioncomment-4960323 and this issue: https://github.com/tinacms/tinacms/issues/3609

--- a/packages/@tinacms/cli/src/next/database.ts
+++ b/packages/@tinacms/cli/src/next/database.ts
@@ -54,7 +54,10 @@ export async function createAndInitializeDatabase(
     configManager.config.contentApiUrlOverride
   ) {
     database = (await configManager.loadDatabaseFile()) as Database
-    database.bridge = bridge
+    // Use the bridge specified in the database file if one exists
+    if (!database.bridge) {
+      database.bridge = bridge
+    }
   } else {
     if (
       configManager.hasSelfHostedConfig() &&

--- a/packages/@tinacms/github-bridge/README.md
+++ b/packages/@tinacms/github-bridge/README.md
@@ -1,0 +1,15 @@
+# TinaCMS GitHub Bridge
+
+This package provides a `GithubBridge` for [TinaCMS](https://tina.io/) in order to better support separate content repositories for self-hosted projects.
+
+This will also help provide a path to better support reindexing for self-hosted projects (i.e. keeping the data layer updated when changes are pushed directly via git, rather than made through the Tina UI)
+
+**See the example usage in the `tina/database.ts` file within the `[examples/tina-self-hosted-demo](https://github.com/tinacms/tinacms/blob/main/examples/tina-self-hosted-demo/tina/database.ts)`**
+
+## Background
+
+See the background notes in this discussion thread: https://github.com/tinacms/tinacms/discussions/3589#discussioncomment-4960323 and the further details in this issue: https://github.com/tinacms/tinacms/issues/3609, including this video overview of the key components to consider: https://www.loom.com/share/c7d1c4f5bda04ec3a1dacff2a03efac1
+
+This package draws heavily from the original `GithubBridge` that previously existed within the `@tinacms/datalayer` package - i.e. [this historical file](https://github.com/tinacms/tinacms/blob/930260c839cbd1908e9e6902734c94f6d64d3282/packages/%40tinacms/datalayer/src/database/bridge/github.ts) that was removed in [this commit](https://github.com/tinacms/tinacms/commit/fb74f4a129164e3b40ff7cd38928682dadab945c)
+
+Introduced in this PR: https://github.com/tinacms/tinacms/pull/3936

--- a/packages/@tinacms/github-bridge/package.json
+++ b/packages/@tinacms/github-bridge/package.json
@@ -1,0 +1,53 @@
+{
+  "name": "@tinacms/github-bridge",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "module": "./dist/index.es.js",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.es.js",
+      "require": "./dist/index.js"
+    }
+  },
+  "typings": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "license": "Apache-2.0",
+  "buildConfig": {
+    "entryPoints": [
+      {
+        "name": "src/index.ts"
+      }
+    ]
+  },
+  "devDependencies": {
+    "@tinacms/scripts": "workspace:*",
+    "@types/jest": "^27.0.1",
+    "@types/lodash-es": "4.17.7",
+    "jest": "^27.0.6",
+    "typescript": "4.3.5"
+  },
+  "peerDependencies": {},
+  "scripts": {
+    "build": "tinacms-scripts build",
+    "test": "jest --passWithNoTests",
+    "types": "pnpm tsc",
+    "test-watch": "jest  --passWithNoTests --watch",
+    "generate:schema": "yarn node scripts/generateSchema.js"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org"
+  },
+  "repository": {
+    "url": "https://github.com/tinacms/tinacms.git",
+    "directory": "packages/@tinacms/github-bridge"
+  },
+  "dependencies": {
+    "@octokit/rest": "^19.0.11",
+    "@tinacms/graphql": "workspace:*",
+    "graphql": "15.8.0",
+    "lodash-es": "4.17.21"
+  }
+}

--- a/packages/@tinacms/github-bridge/src/database/bridge/github.ts
+++ b/packages/@tinacms/github-bridge/src/database/bridge/github.ts
@@ -1,0 +1,168 @@
+import path from 'path'
+import { flatten } from 'lodash-es'
+import { Octokit } from '@octokit/rest'
+import { GraphQLError } from 'graphql'
+import type { Bridge } from '@tinacms/graphql'
+
+type RepoConfig = {
+  owner: string
+  repo: string
+  ref: string
+}
+
+export class GithubBridge implements Bridge {
+  public rootPath: string
+  private repoConfig: RepoConfig
+  private appOctoKit: Octokit
+
+  constructor(rootPath: string, accessToken: string, repoConfig: RepoConfig) {
+    this.rootPath = rootPath || ''
+    this.repoConfig = repoConfig
+    this.appOctoKit = new Octokit({ auth: accessToken })
+  }
+
+  // Is it useful to run an `endsWith(extension)` filter here?
+  public async glob(pattern: string, extension: string) {
+    const results = await this.readDir(pattern)
+    return results.map((item) => {
+      const filepath = item.replace(this.rootPath, '')
+      return this.removeSurroundingSlashes(filepath)
+    })
+  }
+
+  public async delete(filepath: string) {
+    const fullPath = this.buildFullPath(filepath)
+    let fileSha: string | undefined = undefined
+    try {
+      fileSha = await this.getExistingFile(fullPath)
+    } catch (e) {}
+
+    if (!fileSha) {
+      throw new Error(`Could not find file to delete at path: ${fullPath}`)
+    }
+
+    await this.appOctoKit.repos.deleteFile({
+      ...this.repoConfig,
+      branch: this.repoConfig.ref,
+      path: fullPath,
+      message: 'Update from GraphQL client',
+      sha: fileSha,
+    })
+  }
+
+  public async get(filepath: string) {
+    const fullPath = this.buildFullPath(filepath)
+    return this.appOctoKit.repos
+      .getContent({
+        ...this.repoConfig,
+        path: fullPath,
+      })
+      .then((response) => {
+        if (!Array.isArray(response.data) && response.data.type === 'file') {
+          return Buffer.from(response.data.content, 'base64').toString()
+        } else {
+          throw new Error(
+            `Could not find file at path: ${fullPath} in Github Repository: '${this.repoConfig.owner}/${this.repoConfig.repo}'`
+          )
+        }
+      })
+      .catch((e) => {
+        if (e.status === 401) {
+          throw new GraphQLError(
+            `Unauthorized request to Github Repository: '${this.repoConfig.owner}/${this.repoConfig.repo}', please ensure your access token is valid.`,
+            null,
+            null,
+            null,
+            null,
+            e,
+            { status: e.status }
+          )
+        }
+        throw new GraphQLError(
+          `Unable to find record '${fullPath}' in Github Repository: '${this.repoConfig.owner}/${this.repoConfig.repo}', Ref: '${this.repoConfig.ref}'`,
+          null,
+          null,
+          null,
+          null,
+          e,
+          { status: e.status }
+        )
+      })
+  }
+
+  public async put(filepath: string, data: string) {
+    const fullPath = this.buildFullPath(filepath)
+    let fileSha: string | undefined = undefined
+    try {
+      fileSha = await this.getExistingFile(fullPath)
+    } catch (e) {
+      console.log('No file exists, creating new one')
+    }
+
+    await this.appOctoKit.repos.createOrUpdateFileContents({
+      ...this.repoConfig,
+      branch: this.repoConfig.ref,
+      path: fullPath,
+      message: 'Update from GraphQL client',
+      content: new Buffer(data).toString('base64'),
+      sha: fileSha,
+    })
+  }
+
+  // Leading and trailing slashes cause errors in `@octokit/rest`
+  private removeSurroundingSlashes(filepath: string): string {
+    return filepath.replace(/^\/|\/$/g, '')
+  }
+
+  private buildFullPath(filepath: string): string {
+    return this.removeSurroundingSlashes(path.join(this.rootPath, filepath))
+  }
+
+  private async readDir(filepath: string): Promise<string[]> {
+    const fullPath = this.buildFullPath(filepath)
+    const repos = await this.appOctoKit.repos
+      .getContent({
+        ...this.repoConfig,
+        path: fullPath,
+      })
+      .then(async (response) => {
+        if (Array.isArray(response.data)) {
+          return await Promise.all(
+            await response.data.map(async (d) => {
+              if (d.type === 'dir') {
+                const nestedItems = await this.readDir(d.path)
+                if (Array.isArray(nestedItems)) {
+                  return nestedItems.map((nestedItem) => {
+                    return path.join(d.path, nestedItem)
+                  })
+                } else {
+                  throw new Error(
+                    `Expected items to be an array of strings for readDir at ${d.path}`
+                  )
+                }
+              }
+              return d.path
+            })
+          )
+        }
+
+        throw new Error(
+          `Expected to return an array from Github directory ${path}`
+        )
+      })
+    return flatten(repos)
+  }
+
+  private async getExistingFile(filepath: string): Promise<string | undefined> {
+    return this.appOctoKit.repos
+      .getContent({
+        ...this.repoConfig,
+        path: filepath,
+      })
+      .then((response) => {
+        if (!Array.isArray(response.data)) {
+          return response.data.sha
+        }
+      })
+  }
+}

--- a/packages/@tinacms/github-bridge/src/index.ts
+++ b/packages/@tinacms/github-bridge/src/index.ts
@@ -1,0 +1,1 @@
+export { GithubBridge } from './database/bridge/github'

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import fs from 'fs-extra'
 import type { DocumentNode } from 'graphql'
 import { GraphQLError } from 'graphql'
 import micromatch from 'micromatch'

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -18,7 +18,6 @@ export type {
   OnPutCallback,
   CreateDatabase,
 } from './database'
-import type { Database } from './database'
 import type { Config } from '@tinacms/schema-tools'
 
 export { sequential, assertShape } from './util'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,6 +610,29 @@ importers:
       jest-matcher-utils: 27.0.6
       typescript: 4.3.5
 
+  packages/@tinacms/github-bridge:
+    specifiers:
+      '@octokit/rest': ^19.0.11
+      '@tinacms/graphql': workspace:*
+      '@tinacms/scripts': workspace:*
+      '@types/jest': ^27.0.1
+      '@types/lodash-es': 4.17.7
+      graphql: 15.8.0
+      jest: ^27.0.6
+      lodash-es: 4.17.21
+      typescript: 4.3.5
+    dependencies:
+      '@octokit/rest': 19.0.11
+      '@tinacms/graphql': link:../graphql
+      graphql: 15.8.0
+      lodash-es: 4.17.21
+    devDependencies:
+      '@tinacms/scripts': link:../scripts
+      '@types/jest': 27.5.2
+      '@types/lodash-es': 4.17.7
+      jest: 27.5.1
+      typescript: 4.3.5
+
   packages/@tinacms/graphql:
     specifiers:
       '@graphql-tools/relay-operation-optimizer': ^6.4.1
@@ -8790,13 +8813,31 @@ packages:
       }
     engines: { node: '>= 14' }
     dependencies:
-      '@octokit/types': 9.0.0
+      '@octokit/types': 9.2.3
     dev: false
 
   /@octokit/core/4.2.0:
     resolution:
       {
         integrity: sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==,
+      }
+    engines: { node: '>= 14' }
+    dependencies:
+      '@octokit/auth-token': 3.0.3
+      '@octokit/graphql': 5.0.5
+      '@octokit/request': 6.2.3
+      '@octokit/request-error': 3.0.3
+      '@octokit/types': 9.0.0
+      before-after-hook: 2.2.2
+      universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@octokit/core/4.2.1:
+    resolution:
+      {
+        integrity: sha512-tEDxFx8E38zF3gT7sSMDrT1tGumDgsw5yPG6BBh/X+5ClIQfMH/Yqocxz1PnHx6CHyF6pxmovUTOfZAUvQ0Lvw==,
       }
     engines: { node: '>= 14' }
     dependencies:
@@ -8818,7 +8859,7 @@ packages:
       }
     engines: { node: '>= 14' }
     dependencies:
-      '@octokit/types': 9.0.0
+      '@octokit/types': 9.2.3
       is-plain-object: 5.0.0
       universal-user-agent: 6.0.0
     dev: false
@@ -8831,7 +8872,7 @@ packages:
     engines: { node: '>= 14' }
     dependencies:
       '@octokit/request': 6.2.3
-      '@octokit/types': 9.0.0
+      '@octokit/types': 9.2.3
       universal-user-agent: 6.0.0
     transitivePeerDependencies:
       - encoding
@@ -8841,6 +8882,13 @@ packages:
     resolution:
       {
         integrity: sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==,
+      }
+    dev: false
+
+  /@octokit/openapi-types/17.2.0:
+    resolution:
+      {
+        integrity: sha512-MazrFNx4plbLsGl+LFesMo96eIXkFgEtaKbnNpdh4aQ0VM10aoylFsTYP1AEjkeoRNZiiPe3T6Gl2Hr8dJWdlQ==,
       }
     dev: false
 
@@ -8857,6 +8905,20 @@ packages:
       '@octokit/types': 9.0.0
     dev: false
 
+  /@octokit/plugin-paginate-rest/6.1.2_@octokit+core@4.2.1:
+    resolution:
+      {
+        integrity: sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==,
+      }
+    engines: { node: '>= 14' }
+    peerDependencies:
+      '@octokit/core': '>=4'
+    dependencies:
+      '@octokit/core': 4.2.1
+      '@octokit/tsconfig': 1.0.2
+      '@octokit/types': 9.2.3
+    dev: false
+
   /@octokit/plugin-request-log/1.0.4_@octokit+core@4.2.0:
     resolution:
       {
@@ -8866,6 +8928,17 @@ packages:
       '@octokit/core': '>=3'
     dependencies:
       '@octokit/core': 4.2.0
+    dev: false
+
+  /@octokit/plugin-request-log/1.0.4_@octokit+core@4.2.1:
+    resolution:
+      {
+        integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==,
+      }
+    peerDependencies:
+      '@octokit/core': '>=3'
+    dependencies:
+      '@octokit/core': 4.2.1
     dev: false
 
   /@octokit/plugin-rest-endpoint-methods/7.0.1_@octokit+core@4.2.0:
@@ -8882,6 +8955,20 @@ packages:
       deprecation: 2.3.1
     dev: false
 
+  /@octokit/plugin-rest-endpoint-methods/7.1.2_@octokit+core@4.2.1:
+    resolution:
+      {
+        integrity: sha512-R0oJ7j6f/AdqPLtB9qRXLO+wjI9pctUn8Ka8UGfGaFCcCv3Otx14CshQ89K4E88pmyYZS8p0rNTiprML/81jig==,
+      }
+    engines: { node: '>= 14' }
+    peerDependencies:
+      '@octokit/core': '>=3'
+    dependencies:
+      '@octokit/core': 4.2.1
+      '@octokit/types': 9.2.3
+      deprecation: 2.3.1
+    dev: false
+
   /@octokit/request-error/3.0.3:
     resolution:
       {
@@ -8889,7 +8976,7 @@ packages:
       }
     engines: { node: '>= 14' }
     dependencies:
-      '@octokit/types': 9.0.0
+      '@octokit/types': 9.2.3
       deprecation: 2.3.1
       once: 1.4.0
     dev: false
@@ -8903,10 +8990,25 @@ packages:
     dependencies:
       '@octokit/endpoint': 7.0.5
       '@octokit/request-error': 3.0.3
-      '@octokit/types': 9.0.0
+      '@octokit/types': 9.2.3
       is-plain-object: 5.0.0
       node-fetch: 2.6.7
       universal-user-agent: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
+  /@octokit/rest/19.0.11:
+    resolution:
+      {
+        integrity: sha512-m2a9VhaP5/tUw8FwfnW2ICXlXpLPIqxtg3XcAiGMLj/Xhw3RSBfZ8le/466ktO1Gcjr8oXudGnHhxV1TXJgFxw==,
+      }
+    engines: { node: '>= 14' }
+    dependencies:
+      '@octokit/core': 4.2.1
+      '@octokit/plugin-paginate-rest': 6.1.2_@octokit+core@4.2.1
+      '@octokit/plugin-request-log': 1.0.4_@octokit+core@4.2.1
+      '@octokit/plugin-rest-endpoint-methods': 7.1.2_@octokit+core@4.2.1
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -8926,6 +9028,13 @@ packages:
       - encoding
     dev: false
 
+  /@octokit/tsconfig/1.0.2:
+    resolution:
+      {
+        integrity: sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA==,
+      }
+    dev: false
+
   /@octokit/types/9.0.0:
     resolution:
       {
@@ -8933,6 +9042,15 @@ packages:
       }
     dependencies:
       '@octokit/openapi-types': 16.0.0
+    dev: false
+
+  /@octokit/types/9.2.3:
+    resolution:
+      {
+        integrity: sha512-MMeLdHyFIALioycq+LFcA71v0S2xpQUX2cw6pPbHQjaibcHYwLnmK/kMZaWuGfGfjBJZ3wRUq+dOaWsvrPJVvA==,
+      }
+    dependencies:
+      '@octokit/openapi-types': 17.2.0
     dev: false
 
   /@pkgr/utils/2.3.1:
@@ -10850,6 +10968,15 @@ packages:
     resolution:
       {
         integrity: sha512-R+zTeVUKDdfoRxpAryaQNRKk3105Rrgx2CFRClIgRGaqDTdjsm8h6IYA8ir584W3ePzkZfst5xIgDwYrlh9HLg==,
+      }
+    dependencies:
+      '@types/lodash': 4.14.182
+    dev: true
+
+  /@types/lodash-es/4.17.7:
+    resolution:
+      {
+        integrity: sha512-z0ptr6UI10VlU6l5MYhGwS4mC8DZyYer2mCoyysZtSF7p26zOX8UpbrV0YpNYLGS8K4PUFIyEr62IMFFjveSiQ==,
       }
     dependencies:
       '@types/lodash': 4.14.182


### PR DESCRIPTION
## Summary

- This adds a `GithubBridge` in order to better support separate content repositories for self-hosted projects
- This will also help provide a path to better support reindexing for self-hosted projects (i.e. keeping the data layer updated when changes are pushed directly via git, rather than made through the Tina UI)

This PR draws heavily from the original `GithubBridge` that previously existed - i.e. [this historical file](https://github.com/tinacms/tinacms/blob/930260c839cbd1908e9e6902734c94f6d64d3282/packages/%40tinacms/datalayer/src/database/bridge/github.ts) that was removed in [this commit](https://github.com/tinacms/tinacms/commit/fb74f4a129164e3b40ff7cd38928682dadab945c), so full credit to whoever wrote the original implementation!

## Background

- See the excellent information @logan-anderson provided in this discussion thread: https://github.com/tinacms/tinacms/discussions/3589#discussioncomment-4960323
- And the further details in this issue: https://github.com/tinacms/tinacms/issues/3609, including this video overview of the key components to consider: https://www.loom.com/share/c7d1c4f5bda04ec3a1dacff2a03efac1
- Follows on from the updates in this PR: #3830 
