### PR TITLE
UI Fixes

### DIFF
--- a/.changeset/pretty-cars-camp.md
+++ b/.changeset/pretty-cars-camp.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Embed dropdown UI, media list view styles

--- a/packages/@tinacms/toolkit/src/components/media/media-item.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-item.tsx
@@ -19,10 +19,10 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
   const thumbnail = (item.thumbnails || {})['75x75']
   return (
     <li
-      className={`relative flex shrink-0 gap-3 items-center py-2 pl-2 pr-3 transition duration-150 ease-out cursor-pointer border-b border-gray-150 ${
+      className={`group relative flex shrink-0 items-center transition duration-150 ease-out cursor-pointer border-b border-gray-150 ${
         active
           ? 'bg-gradient-to-r from-white to-gray-50/50 text-blue-500 hover:bg-gray-50'
-          : 'bg-white hover:bg-gray-50/50'
+          : 'bg-white hover:bg-gray-50/50 hover:text-blue-500'
       }`}
       onClick={() => {
         if (!active) {
@@ -37,18 +37,20 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
           NEW
         </span>
       )}
-      <div className="w-20 h-20 bg-gray-50 shadow border border-gray-100 rounded overflow-hidden flex justify-center flex-shrink-0">
+      <div className="w-16 h-16 bg-gray-50 border-r border-gray-150 overflow-hidden flex justify-center flex-shrink-0">
         {isImage(thumbnail) ? (
           <img
-            className="object-cover w-full h-full object-center"
+            className="object-cover w-full h-full object-center origin-center transition-all duration-150 ease-out group-hover:scale-110"
             src={thumbnail}
             alt={item.filename}
           />
         ) : (
-          <FileIcon className="w-3/5 h-full fill-gray-300" />
+          <FileIcon className="w-1/2 h-full fill-gray-300" />
         )}
       </div>
-      <span className={'text-base flex-grow w-full break-words truncate'}>
+      <span
+        className={'text-base flex-grow w-full break-words truncate px-3 py-2'}
+      >
         {item.filename}
       </span>
     </li>

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -478,7 +478,7 @@ export function MediaPicker({
             <Breadcrumb directory={directory} setDirectory={setDirectory} />
           </div>
 
-          <div className="flex items-center gap-4">
+          <div className="flex flex-wrap items-center gap-4">
             <Button
               busy={false}
               variant="white"

--- a/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/toolbar/toolbar-item.tsx
+++ b/packages/@tinacms/toolkit/src/packages/fields/plugins/MdxFieldPlugin/plate/plugins/ui/toolbar/toolbar-item.tsx
@@ -232,20 +232,26 @@ export const EmbedButton = ({
           >
             <Popover.Panel>
               {({ close }) => (
-                <div className="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none py-1 max-h-[10rem] overflow-y-auto">
-                  {templates.map((template) => (
-                    <span
-                      key={template.name}
-                      onMouseDown={(e) => {
-                        e.preventDefault()
-                        close()
-                        insertMDX(editor, template)
-                      }}
-                      className={`hover:bg-gray-50 hover:text-blue-500 cursor-pointer pointer-events-auto px-4 py-2 text-sm w-full flex items-center`}
-                    >
-                      {template.label || template.name}
-                    </span>
-                  ))}
+                <div className="origin-top-right absolute right-0 mt-2 w-56 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none max-h-[13rem] overflow-y-auto">
+                  <div className="sticky z-10 top-0 w-full h-8 -mb-8 opacity-10 bg-gradient-to-b from-blue-600 to-transparent"></div>
+                  <div className="relative py-1 z-20">
+                    {templates.map((template) => (
+                      <span
+                        key={template.name}
+                        onMouseDown={(e) => {
+                          e.preventDefault()
+                          close()
+                          insertMDX(editor, template)
+                        }}
+                        className={`relative z-30 hover:bg-gray-400/10 hover:text-blue-500 cursor-pointer pointer-events-auto px-4 py-2 text-sm w-full flex items-center`}
+                      >
+                        {template.label || template.name}
+                      </span>
+                    ))}
+                    <div className="absolute top-0 w-full h-8 bg-gradient-to-b from-white to-transparent"></div>
+                    <div className="absolute bottom-0 w-full h-8 bg-gradient-to-t from-white to-transparent"></div>
+                  </div>
+                  <div className="sticky z-10 bottom-0 w-full h-8 -mt-8 opacity-10 bg-gradient-to-t from-blue-600 to-transparent"></div>
                 </div>
               )}
             </Popover.Panel>


### PR DESCRIPTION
Two small UI fixes. 

1. Improve the media manager list mode by making the list items more compact. 
<img width="536" alt="Screenshot 2023-05-19 at 1 56 36 PM" src="https://github.com/tinacms/tinacms/assets/5075484/2ecdfafc-1128-4fe1-9d70-82d15ee3f70d">

2. Add scroll affordance to the rich text embed dropdown and increase max dropdown size.
<img width="307" alt="Screenshot 2023-05-19 at 1 57 18 PM" src="https://github.com/tinacms/tinacms/assets/5075484/18a70a43-13c0-43a8-a4ea-476c28f0dc77">
<img width="392" alt="Screenshot 2023-05-19 at 1 57 28 PM" src="https://github.com/tinacms/tinacms/assets/5075484/fab4d5e5-b3cc-43d4-8d6e-21309b957b13">
