### PR TITLE
fix: invalid or incomplete introspection error

### DIFF
--- a/.changeset/light-ties-fail.md
+++ b/.changeset/light-ties-fail.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Catch condition where remote schema does not exist to avoid "Invalid or incomplete introspection error" being thrown during build checks

--- a/.changeset/light-ties-fail.md
+++ b/.changeset/light-ties-fail.md
@@ -1,5 +1,6 @@
 ---
 '@tinacms/cli': patch
+'@tinacms/graphql': patch
 ---
 
 Catch condition where remote schema does not exist to avoid "Invalid or incomplete introspection error" being thrown during build checks

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -405,7 +405,6 @@ export const fetchRemoteGraphqlSchema = async ({
     headers.append('X-API-KEY', token)
   }
   const body = JSON.stringify({ query: getIntrospectionQuery(), variables: {} })
-  console.log({ body })
 
   headers.append('Content-Type', 'application/json')
 

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -405,6 +405,7 @@ export const fetchRemoteGraphqlSchema = async ({
     headers.append('X-API-KEY', token)
   }
   const body = JSON.stringify({ query: getIntrospectionQuery(), variables: {} })
+  console.log({ body })
 
   headers.append('Content-Type', 'application/json')
 

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -294,6 +294,17 @@ export class BuildCommand extends BaseCommand {
       token,
     })
 
+    if (!remoteSchema) {
+      bar.tick({
+        prog: '❌',
+      })
+      let errorMessage = `The remote GraphQL schema does not exist. Check indexing for this branch.`
+      if (config?.branch) {
+        errorMessage += `\n\nAdditional info: Branch: ${config.branch}, Client ID: ${config.clientId} `
+      }
+      throw new Error(errorMessage)
+    }
+
     const remoteGqlSchema = buildClientSchema(remoteSchema)
 
     // This will always be the filesystem bridge.

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -176,7 +176,9 @@ export class Database {
       let version = await this.getDatabaseVersion()
       if (!version) {
         version = ''
-        await this.updateDatabaseVersion(version)
+        try {
+          await this.updateDatabaseVersion(version)
+        } catch (e) {} // this might fail on queries that don't have a version
       }
       this.level = this.rootLevel.sublevel(version, SUBLEVEL_OPTIONS)
     }
@@ -609,10 +611,12 @@ export class Database {
     return this._lookup[returnType]
   }
   public getGraphQLSchema = async (): Promise<DocumentNode> => {
+    console.log('Database.getGraphQLSchema')
     await this.initLevel()
     const graphqlPath = normalizePath(
       path.join(this.getGeneratedFolder(), `_graphql.json`)
     )
+    console.log('graphqlPath', graphqlPath)
     return (await this.level
       .sublevel<string, Record<string, any>>(
         CONTENT_ROOT_PREFIX,

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -950,6 +950,7 @@ export class Database {
     tinaSchema: TinaSchema
     lookup?: object
   }) => {
+    console.log('indexContent called')
     if (!this.bridge) {
       throw new Error('No bridge configured')
     }

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -114,6 +114,7 @@ export class Database {
   private _lookup: { [returnType: string]: LookupMapType } | undefined
 
   constructor(public config: CreateDatabase) {
+    console.log('db.ctor')
     this.tinaDirectory = config.tinaDirectory || 'tina'
     this.bridge = config.bridge
     this.rootLevel =
@@ -351,6 +352,7 @@ export class Database {
     data: { [key: string]: unknown },
     collectionName?: string
   ) => {
+    console.log('db.put', filepath)
     await this.initLevel()
 
     try {

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -114,7 +114,6 @@ export class Database {
   private _lookup: { [returnType: string]: LookupMapType } | undefined
 
   constructor(public config: CreateDatabase) {
-    console.log('db.ctor')
     this.tinaDirectory = config.tinaDirectory || 'tina'
     this.bridge = config.bridge
     this.rootLevel =
@@ -354,7 +353,6 @@ export class Database {
     data: { [key: string]: unknown },
     collectionName?: string
   ) => {
-    console.log('db.put', filepath)
     await this.initLevel()
 
     try {
@@ -611,12 +609,10 @@ export class Database {
     return this._lookup[returnType]
   }
   public getGraphQLSchema = async (): Promise<DocumentNode> => {
-    console.log('Database.getGraphQLSchema')
     await this.initLevel()
     const graphqlPath = normalizePath(
       path.join(this.getGeneratedFolder(), `_graphql.json`)
     )
-    console.log('graphqlPath', graphqlPath)
     return (await this.level
       .sublevel<string, Record<string, any>>(
         CONTENT_ROOT_PREFIX,
@@ -956,7 +952,6 @@ export class Database {
     tinaSchema: TinaSchema
     lookup?: object
   }) => {
-    console.log('indexContent called')
     if (!this.bridge) {
       throw new Error('No bridge configured')
     }

--- a/packages/@tinacms/graphql/src/resolve.ts
+++ b/packages/@tinacms/graphql/src/resolve.ts
@@ -40,11 +40,15 @@ export const resolve = async ({
   isAudit?: boolean
 }) => {
   try {
+    console.log('resolve1')
     const verboseValue = verbose ?? true
     const graphQLSchemaAst = await database.getGraphQLSchema()
+    console.log('resolve2')
     const graphQLSchema = buildASTSchema(graphQLSchemaAst)
+    console.log('resolve3')
 
     const tinaConfig = await database.getTinaSchema()
+    console.log('resolve4')
     const tinaSchema = (await createSchema({
       // TODO: please update all the types to import from @tinacms/schema-tools
       // @ts-ignore
@@ -52,12 +56,14 @@ export const resolve = async ({
       // @ts-ignore
       flags: tinaConfig?.meta?.flags,
     })) as unknown as TinaSchema
+    console.log('resolve5')
     const resolver = await createResolver({
       config,
       database,
       tinaSchema,
       isAudit: isAudit || false,
     })
+    console.log('resolve6')
 
     const res = await graphql({
       schema: graphQLSchema,

--- a/packages/@tinacms/graphql/src/resolve.ts
+++ b/packages/@tinacms/graphql/src/resolve.ts
@@ -43,6 +43,9 @@ export const resolve = async ({
     console.log('resolve1')
     const verboseValue = verbose ?? true
     const graphQLSchemaAst = await database.getGraphQLSchema()
+    if (!graphQLSchemaAst) {
+      throw new GraphQLError(`GraphQL schema not found`)
+    }
     console.log('resolve2')
     const graphQLSchema = buildASTSchema(graphQLSchemaAst)
     console.log('resolve3')

--- a/packages/@tinacms/graphql/src/resolve.ts
+++ b/packages/@tinacms/graphql/src/resolve.ts
@@ -40,18 +40,14 @@ export const resolve = async ({
   isAudit?: boolean
 }) => {
   try {
-    console.log('resolve1')
     const verboseValue = verbose ?? true
     const graphQLSchemaAst = await database.getGraphQLSchema()
     if (!graphQLSchemaAst) {
       throw new GraphQLError(`GraphQL schema not found`)
     }
-    console.log('resolve2')
     const graphQLSchema = buildASTSchema(graphQLSchemaAst)
-    console.log('resolve3')
 
     const tinaConfig = await database.getTinaSchema()
-    console.log('resolve4')
     const tinaSchema = (await createSchema({
       // TODO: please update all the types to import from @tinacms/schema-tools
       // @ts-ignore
@@ -59,14 +55,12 @@ export const resolve = async ({
       // @ts-ignore
       flags: tinaConfig?.meta?.flags,
     })) as unknown as TinaSchema
-    console.log('resolve5')
     const resolver = await createResolver({
       config,
       database,
       tinaSchema,
       isAudit: isAudit || false,
     })
-    console.log('resolve6')
 
     const res = await graphql({
       schema: graphQLSchema,


### PR DESCRIPTION
- Update build-command to prevent ugly `Invalid or incomplete introspection result` when there isn't a graphql schema in tina cloud. Display a more user friendly error instead.
- Update initLevel to not throw an error if unable to write _metadata when it doesn't currently exist. This condition should only occur when calling a get function on the database when the branch has not been indexed. By adding this, the api won't throw an unexpected exception and return a 500 error.
- Add a check to the resolver to verify that the graphql schema returned from the database is not undefined. We can catch this and throw a user friendly error (and return a 200 status code).