### PR TITLE
fix: #3952: use uri decoder on folder name from url

### DIFF
--- a/.changeset/red-peaches-move.md
+++ b/.changeset/red-peaches-move.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix to decode the folder name from the url

--- a/packages/tinacms/src/admin/pages/utils.tsx
+++ b/packages/tinacms/src/admin/pages/utils.tsx
@@ -32,9 +32,10 @@ export const useCollectionFolder = () => {
   useEffect(() => {
     // set folder using the pathname
     const match = loc.pathname.match(folderRegex)
+    const folderName = match ? decodeURIComponent(match[1]) : ''
     const update = {
-      name: match ? match[1] : '',
-      fullyQualifiedName: match ? (match[1] ? `~/${match[1]}` : '~') : '',
+      name: folderName,
+      fullyQualifiedName: match ? (folderName ? `~/${folderName}` : '~') : '',
       loading: false,
       parentName: '',
     }


### PR DESCRIPTION
Fix #3952 

Special characters in the folder name from the url were url encoded, causing queries to use incorrect folder name