### PR TITLE
Index the content before a build when self hosting

### DIFF
--- a/.changeset/healthy-ants-know.md
+++ b/.changeset/healthy-ants-know.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Index the content before a build when self hosting.

--- a/packages/@tinacms/cli/src/next/commands/baseCommands.ts
+++ b/packages/@tinacms/cli/src/next/commands/baseCommands.ts
@@ -92,11 +92,14 @@ export abstract class BaseCommand extends Command {
     database,
     graphQLSchema,
     tinaSchema,
+    text,
   }: {
     database: Database
     graphQLSchema: DocumentNode
     tinaSchema: TinaSchema
+    text?: string
   }) {
+    const textToUse = text || 'Indexing local files'
     const warnings: string[] = []
     await spin({
       waitFor: async () => {
@@ -106,7 +109,7 @@ export abstract class BaseCommand extends Command {
         })
         warnings.push(...res.warnings)
       },
-      text: 'Indexing local files',
+      text: textToUse,
     })
     if (warnings.length > 0) {
       logger.warn(`Indexing completed with ${warnings.length} warning(s)`)

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -97,7 +97,10 @@ export class BuildCommand extends BaseCommand {
       (configManager.hasSelfHostedConfig() || this.localOption) &&
       !this.skipIndexing
     ) {
+      // if we are building locally use the default spinner text
+      const text = this.localOption ? undefined : 'Indexing self-hosted content'
       await this.indexContentWithSpinner({
+        text,
         database,
         graphQLSchema,
         tinaSchema,

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -98,7 +98,9 @@ export class BuildCommand extends BaseCommand {
       !this.skipIndexing
     ) {
       // if we are building locally use the default spinner text
-      const text = this.localOption ? undefined : 'Indexing self-hosted content'
+      const text = this.localOption
+        ? undefined
+        : 'Indexing to self-hosted data layer'
       await this.indexContentWithSpinner({
         text,
         database,


### PR DESCRIPTION
When debugging some self hosting issues I noticed that we don't index the self hosted DB when building. We need to index on build so that they DB can get the newest markdown data. 

This may have been a regressing with our larger CLI PR a month or two ago.
