### PR TITLE
fix: ENG-1014: prevent unhandled promise rejection when unable to determine collection for file

### DIFF
--- a/.changeset/sharp-masks-double.md
+++ b/.changeset/sharp-masks-double.md
@@ -3,4 +3,4 @@
 '@tinacms/app': patch
 ---
 
-Prevent unhandled promise when not able to determine collection for file
+Prevent unhandled promise rejection when not able to determine collection for file

--- a/.changeset/sharp-masks-double.md
+++ b/.changeset/sharp-masks-double.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/graphql': patch
+'@tinacms/app': patch
+---
+
+Prevent unhandled promise when not able to determine collection for file

--- a/packages/@tinacms/app/src/lib/graphql-reducer.ts
+++ b/packages/@tinacms/app/src/lib/graphql-reducer.ts
@@ -870,7 +870,11 @@ const getTemplateForDocument = (
   tinaSchema: TinaSchema
 ) => {
   const id = resolvedDocument._internalSys.path
-  const collection = tinaSchema.getCollectionByFullPath(id)
+  let collection: Collection<true> | undefined
+  try {
+    collection = tinaSchema.getCollectionByFullPath(id)
+  } catch (e) {}
+
   if (!collection) {
     throw new Error(`Unable to determine collection for path ${id}`)
   }

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -265,17 +265,20 @@ export class DevCommand extends BaseCommand {
           return
         }
         const pathFromRoot = configManager.printContentRelativePath(addedFile)
-        database.indexContentByPaths([pathFromRoot])
+        console.log('added', pathFromRoot)
+        database.indexContentByPaths([pathFromRoot]).catch(logger.error)
       })
       .on('change', async (changedFile) => {
         const pathFromRoot = configManager.printContentRelativePath(changedFile)
         // Optionally we can reload the page when this happens
         // server.ws.send({ type: 'full-reload', path: '*' })
-        database.indexContentByPaths([pathFromRoot])
+        console.log('changed', pathFromRoot)
+        database.indexContentByPaths([pathFromRoot]).catch(logger.error)
       })
       .on('unlink', async (removedFile) => {
         const pathFromRoot = configManager.printContentRelativePath(removedFile)
-        database.deleteContentByPaths([pathFromRoot])
+        console.log('removed', pathFromRoot)
+        database.deleteContentByPaths([pathFromRoot]).catch(logger.error)
       })
   }
   watchQueries(configManager: ConfigManager, callback: () => Promise<string>) {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -265,20 +265,17 @@ export class DevCommand extends BaseCommand {
           return
         }
         const pathFromRoot = configManager.printContentRelativePath(addedFile)
-        console.log('added', pathFromRoot)
-        database.indexContentByPaths([pathFromRoot]).catch(logger.error)
+        database.indexContentByPaths([pathFromRoot]).catch(console.error)
       })
       .on('change', async (changedFile) => {
         const pathFromRoot = configManager.printContentRelativePath(changedFile)
         // Optionally we can reload the page when this happens
         // server.ws.send({ type: 'full-reload', path: '*' })
-        console.log('changed', pathFromRoot)
-        database.indexContentByPaths([pathFromRoot]).catch(logger.error)
+        database.indexContentByPaths([pathFromRoot]).catch(console.error)
       })
       .on('unlink', async (removedFile) => {
         const pathFromRoot = configManager.printContentRelativePath(removedFile)
-        console.log('removed', pathFromRoot)
-        database.deleteContentByPaths([pathFromRoot]).catch(logger.error)
+        database.deleteContentByPaths([pathFromRoot]).catch(console.error)
       })
   }
   watchQueries(configManager: ConfigManager, callback: () => Promise<string>) {

--- a/packages/@tinacms/graphql/src/database/datalayer.ts
+++ b/packages/@tinacms/graphql/src/database/datalayer.ts
@@ -767,7 +767,7 @@ export const makeFolderOpsForCollection = <T extends object>(
 export const makeIndexOpsForDocument = <T extends object>(
   filepath: string,
   collection: string | undefined,
-  indexDefinitions: IndexDefinition[],
+  indexDefinitions: Record<string, IndexDefinition>,
   data: T,
   opType: 'put' | 'del',
   level: Level,

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1454,10 +1454,10 @@ const getTemplateForFile = (
   templateInfo: CollectionTemplateable,
   data: { [key: string]: unknown }
 ) => {
-  if (templateInfo.type === 'object') {
+  if (templateInfo?.type === 'object') {
     return templateInfo.template
   }
-  if (templateInfo.type === 'union') {
+  if (templateInfo?.type === 'union') {
     if (hasOwnProperty(data, '_template')) {
       const template = templateInfo.templates.find(
         (t) => lastItem(t.namespace) === data._template

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1351,7 +1351,7 @@ const _indexContent = async (
       throw new TinaFetchError(`Unable to seed ${filepath}`, {
         originalError: error,
         file: filepath,
-        collection: collection.name,
+        collection: collection?.name,
         stack: error.stack,
       })
     }

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -128,7 +128,9 @@ export class Database {
     filepath: string
   ): Promise<Collection<true> | undefined> => {
     const tinaSchema = await this.getSchema(this.level)
-    return tinaSchema.getCollectionByFullPath(filepath)
+    try {
+      return tinaSchema.getCollectionByFullPath(filepath)
+    } catch (e) {}
   }
 
   private getGeneratedFolder = () =>
@@ -481,7 +483,7 @@ export class Database {
   }
 
   public async getTemplateDetailsForFile(
-    collection: TinaCloudCollection<true>,
+    collection: Collection<true>,
     data: { [key: string]: unknown }
   ) {
     const tinaSchema = await this.getSchema()
@@ -516,8 +518,10 @@ export class Database {
     filepath: string,
     data: { [key: string]: unknown }
   ) => {
-    const tinaSchema = await this.getSchema(this.level)
-    const collection = tinaSchema.getCollectionByFullPath(filepath)
+    const collection = await this.collectionForPath(filepath)
+    if (!collection) {
+      throw new Error(`Unable to find collection for path ${filepath}`)
+    }
 
     const { template } = await this.getTemplateDetailsForFile(collection, data)
     const bodyField = template.fields.find((field) => {


### PR DESCRIPTION
# what

Fixes ENG-1014. dev command now works on the reproduction repo and output is now:

```
Error: Unable to determine template
    at getTemplateForFile (/Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5995:9)
    at /Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5848:24 {
  name: 'TinaFetchError',
  collection: undefined,
  file: 'content/foundation/_index.md',
  originalError: Error: Unable to determine template
      at getTemplateForFile (/Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5995:9)
      at /Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5848:24
}
Error: Unable to determine template
    at getTemplateForFile (/Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5995:9)
    at /Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5848:24 {
  name: 'TinaFetchError',
  collection: undefined,
  file: 'content/fds/_index.md',
  originalError: Error: Unable to determine template
      at getTemplateForFile (/Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5995:9)
      at /Users/kldavis/projects/support/ethswarm-blog-hugo/node_modules/@tinacms/graphql/dist/index.js:5848:24
}
```

The unhandled promise rejection was because the chokidar handlers didn't have error handlers attached and this repo for some reason had files that were being added but weren't in collections.