### PR TITLE
fix: Skip media status check on external media

### DIFF
--- a/.changeset/real-lies-study.md
+++ b/.changeset/real-lies-study.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+fix: Skip media status check on external media

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -613,7 +613,7 @@ const SyncStatusContainer = ({ children }) => {
   const [syncStatus, setSyncStatus] = useState<
     'loading' | 'synced' | 'needs-sync'
   >(checkForSyncStatus ? 'loading' : 'synced')
-
+  //
   useEffect(() => {
     const checkSyncStatus = async () => {
       const project = await cms.api.tina.getProject()

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -607,7 +607,7 @@ const SyncStatusContainer = ({ children }) => {
   const isLocal = cms.api.tina.isLocalMode
 
   const tinaMedia = cms.api.tina.schema.schema?.config?.media?.tina || {}
-  const hasTinaMedia = tinaMedia.mediaRoot || tinaMedia.publicFolder
+  const hasTinaMedia = !!(tinaMedia.mediaRoot || tinaMedia.publicFolder)
 
   const checkForSyncStatus = hasTinaMedia && !isLocal
   const [syncStatus, setSyncStatus] = useState<

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -609,21 +609,22 @@ const SyncStatusContainer = ({ children }) => {
   const tinaMedia = cms.api.tina.schema.schema?.config?.media?.tina || {}
   const hasTinaMedia = !!(tinaMedia.mediaRoot || tinaMedia.publicFolder)
 
-  const checkForSyncStatus = hasTinaMedia && !isLocal
+  const doCheckSyncStatus = hasTinaMedia && !isLocal
   const [syncStatus, setSyncStatus] = useState<
     'loading' | 'synced' | 'needs-sync'
-  >(checkForSyncStatus ? 'loading' : 'synced')
+  >(doCheckSyncStatus ? 'loading' : 'synced')
+  //
 
   useEffect(() => {
     const checkSyncStatus = async () => {
-      const project = await cms.api.tina.getProject()
+      if (doCheckSyncStatus) {
+        const project = await cms.api.tina.getProject()
 
-      setSyncStatus(project.mediaBranch ? 'synced' : 'needs-sync')
+        setSyncStatus(project.mediaBranch ? 'synced' : 'needs-sync')
+      }
     }
 
-    if (checkForSyncStatus) {
-      checkSyncStatus()
-    }
+    checkSyncStatus()
   }, [])
 
   return syncStatus == 'needs-sync' ? (

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -613,7 +613,7 @@ const SyncStatusContainer = ({ children }) => {
   const [syncStatus, setSyncStatus] = useState<
     'loading' | 'synced' | 'needs-sync'
   >(checkForSyncStatus ? 'loading' : 'synced')
-  //
+
   useEffect(() => {
     const checkSyncStatus = async () => {
       const project = await cms.api.tina.getProject()

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -606,13 +606,8 @@ const SyncStatusContainer = ({ children }) => {
   const cms = useCMS()
   const isLocal = cms.api.tina.isLocalMode
 
-  const hasTinaMedia =
-    Object.keys(cms.api.tina.schema.schema?.config?.media?.tina || {}).includes(
-      'mediaRoot'
-    ) &&
-    Object.keys(cms.api.tina.schema.schema?.config?.media?.tina || {}).includes(
-      'publicFolder'
-    )
+  const tinaMedia = cms.api.tina.schema.schema?.config?.media?.tina || {}
+  const hasTinaMedia = tinaMedia.mediaRoot || tinaMedia.publicFolder
 
   const checkForSyncStatus = hasTinaMedia && !isLocal
   const [syncStatus, setSyncStatus] = useState<

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -614,9 +614,10 @@ const SyncStatusContainer = ({ children }) => {
       'publicFolder'
     )
 
+  const checkForSyncStatus = hasTinaMedia && !isLocal
   const [syncStatus, setSyncStatus] = useState<
     'loading' | 'synced' | 'needs-sync'
-  >(hasTinaMedia && !isLocal ? 'loading' : 'synced')
+  >(checkForSyncStatus ? 'loading' : 'synced')
 
   useEffect(() => {
     const checkSyncStatus = async () => {
@@ -625,7 +626,7 @@ const SyncStatusContainer = ({ children }) => {
       setSyncStatus(project.mediaBranch ? 'synced' : 'needs-sync')
     }
 
-    if (!isLocal) {
+    if (checkForSyncStatus) {
       checkSyncStatus()
     }
   }, [])


### PR DESCRIPTION
Fix regression where we check for Tina media status (and disable media manager) for external media setups.
We should only do this when tina media is configured