### PR TITLE
Search placeholder

### DIFF
--- a/packages/@tinacms/toolkit/src/packages/styles/Message.tsx
+++ b/packages/@tinacms/toolkit/src/packages/styles/Message.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { BiInfoCircle, BiCheckCircle, BiError } from 'react-icons/bi'
+import { BsArrowRightShort } from 'react-icons/bs'
+
+const MessageIcon = ({
+  type = 'success',
+  className = '',
+}: {
+  type?: 'success' | 'warning' | 'error' | 'info'
+  className?: string
+}) => {
+  const icons = {
+    success: BiCheckCircle,
+    warning: BiError,
+    error: BiError,
+    info: BiInfoCircle,
+  }
+
+  const Icon = icons[type]
+
+  return <Icon className={className} />
+}
+
+export const Message = ({
+  children,
+  type = 'success',
+  size = 'medium',
+  className = '',
+  link,
+  linkLabel = 'Learn More',
+}: {
+  children?: React.ReactNode | React.ReactNode[]
+  type?: 'success' | 'warning' | 'error' | 'info'
+  size?: 'small' | 'medium'
+  className?: string
+  link?: string
+  linkLabel?: string
+}) => {
+  const containerClasses = {
+    success: 'bg-gradient-to-r from-green-50 to-green-100 border-green-200',
+    warning: 'bg-gradient-to-r from-yellow-50 to-yellow-100 border-yellow-200',
+    error: 'bg-gradient-to-r from-red-50 to-red-100 border-red-200',
+    info: 'bg-gradient-to-r from-blue-50 to-blue-100 border-blue-100',
+  }
+
+  const textClasses = {
+    success: 'text-green-700',
+    warning: 'text-yellow-700',
+    error: 'text-red-700',
+    info: 'text-blue-700',
+  }
+
+  const iconClasses = {
+    success: 'text-green-400',
+    warning: 'text-yellow-400',
+    error: 'text-red-400',
+    info: 'text-blue-400',
+  }
+
+  const sizeClasses = {
+    small: 'px-3 py-1.5 text-xs',
+    medium: 'px-4 py-2.5 text-sm',
+  }
+
+  return (
+    <div
+      className={`rounded-lg border shadow-sm ${sizeClasses[size]} ${containerClasses[type]} ${className}`}
+    >
+      <div className="flex items-center gap-2">
+        <MessageIcon
+          type={type}
+          className={`${
+            size === 'small' ? 'w-5' : 'w-6'
+          } h-auto flex-shrink-0 ${iconClasses[type]}`}
+        />
+        <div className={`flex-1 ${textClasses[type]}`}>{children}</div>
+        {link && (
+          <a
+            href={link}
+            target="_blank"
+            className="flex-shrink-0 flex items-center gap-1 text-blue-600 underline decoration-blue-200 hover:text-blue-500 hover:decoration-blue-500 transition-all ease-out duration-150"
+          >
+            {linkLabel} <BsArrowRightShort className="w-4 h-auto" />
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/@tinacms/toolkit/src/packages/styles/index.ts
+++ b/packages/@tinacms/toolkit/src/packages/styles/index.ts
@@ -7,3 +7,4 @@
 export * from './Button'
 export * from './FontLoader'
 export * from './OverflowMenu'
+export * from './Message'

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -50,7 +50,6 @@ import { PageBody, PageHeader, PageWrapper } from '../components/Page'
 import { TinaAdminApi } from '../api'
 import type { Collection } from '@tinacms/schema-tools'
 import { CollectionFolder, useCollectionFolder } from './utils'
-import { MdOutlineInfo } from 'react-icons/md'
 
 const LOCAL_STORAGE_KEY = 'tinacms.admin.collection.list.page'
 const isSSR = typeof window === 'undefined'

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -25,6 +25,7 @@ import {
   Button,
   CursorPaginator,
   Input,
+  Message,
   Modal,
   ModalActions,
   ModalBody,
@@ -447,14 +448,14 @@ const CollectionListPage = () => {
                                       <label className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal">
                                         Search
                                       </label>
-                                      <a
-                                        target="_blank"
-                                        href="https://tina.io/docs/reference/search/overview"
-                                        className="inline-flex text-xs"
+                                      <Message
+                                        link="https://tina.io/docs/reference/search/overview"
+                                        linkLabel="Read The Docs"
+                                        type="info"
+                                        size="small"
                                       >
-                                        <p>Search not configured.</p>
-                                        <MdOutlineInfo className="w-4 h-auto ml-1.5 opacity-80" />
-                                      </a>
+                                        Search not configured.
+                                      </Message>
                                     </>
                                   )}
                                 </div>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -444,10 +444,7 @@ const CollectionListPage = () => {
                                     />
                                   ) : (
                                     <>
-                                      <label
-                                        htmlFor="search"
-                                        className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal"
-                                      >
+                                      <label className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal">
                                         Search
                                       </label>
                                       <a

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -49,6 +49,7 @@ import { PageBody, PageHeader, PageWrapper } from '../components/Page'
 import { TinaAdminApi } from '../api'
 import type { Collection } from '@tinacms/schema-tools'
 import { CollectionFolder, useCollectionFolder } from './utils'
+import { MdOutlineInfo } from 'react-icons/md'
 
 const LOCAL_STORAGE_KEY = 'tinacms.admin.collection.list.page'
 const isSSR = typeof window === 'undefined'
@@ -432,15 +433,34 @@ const CollectionListPage = () => {
                                     />
                                   </div>
                                 )}
-                                {searchEnabled && (
-                                  <SearchInput
-                                    loading={_loading}
-                                    search={search}
-                                    setSearch={setSearch}
-                                    searchInput={searchInput}
-                                    setSearchInput={setSearchInput}
-                                  />
-                                )}
+                                <div className="flex flex-1 flex-col gap-2 items-start w-full">
+                                  {searchEnabled ? (
+                                    <SearchInput
+                                      loading={_loading}
+                                      search={search}
+                                      setSearch={setSearch}
+                                      searchInput={searchInput}
+                                      setSearchInput={setSearchInput}
+                                    />
+                                  ) : (
+                                    <>
+                                      <label
+                                        htmlFor="search"
+                                        className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal"
+                                      >
+                                        Search
+                                      </label>
+                                      <a
+                                        target="_blank"
+                                        href="https://tina.io/docs/reference/search/overview"
+                                        className="inline-flex text-xs"
+                                      >
+                                        <p>Search not configured.</p>
+                                        <MdOutlineInfo className="w-4 h-auto ml-1.5 opacity-80" />
+                                      </a>
+                                    </>
+                                  )}
+                                </div>
                               </>
                             )}
                           </div>


### PR DESCRIPTION
Add placeholder UI for when search isn't configured, linking to docs.
closes ENG-1029

<img width="773" alt="Screenshot 2023-06-09 at 10 51 17 AM" src="https://github.com/tinacms/tinacms/assets/5075484/0efc222f-289e-4f15-b29a-ec29b1b28a74">
