### PR TITLE
fix: ENG-1035: local search index updates on changes

### DIFF
--- a/.changeset/odd-fireants-share.md
+++ b/.changeset/odd-fireants-share.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix scanContentByPaths to not invoke callback when there are no nonCollectionPaths

--- a/.changeset/tender-pots-sit.md
+++ b/.changeset/tender-pots-sit.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix local search indexing to properly update the index on filesystem changes

--- a/packages/@tinacms/graphql/src/database/util.ts
+++ b/packages/@tinacms/graphql/src/database/util.ts
@@ -202,7 +202,9 @@ export const scanContentByPaths = async (
   for (const collection of Object.keys(pathsByCollection)) {
     await callback(collections[collection], pathsByCollection[collection])
   }
-  await callback(undefined, nonCollectionPaths)
+  if (nonCollectionPaths.length) {
+    await callback(undefined, nonCollectionPaths)
+  }
 }
 
 export const partitionPathsByCollection = async (


### PR DESCRIPTION
- Fix issue where the any changes to content in local dev were not being reflected in the local search
- Fix bug in the scanContentByPaths where callback was being invoked when there were no non-collection paths (found while fixing the previous issue)