### PR TITLE
Prebuild Tina config file

### DIFF
--- a/.changeset/nine-eagles-fail.md
+++ b/.changeset/nine-eagles-fail.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Change the way the Tina config file is built, so dependencies with Tailwind classes are picked up automatically

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -47,11 +47,13 @@ export class ConfigManager {
   outputHTMLFilePath: string
   outputGitignorePath: string
   selfHostedDatabaseFilePath?: string
+  prebuildFilePath?: string
   spaRootPath: string
   spaMainPath: string
   spaHTMLPath: string
   tinaGraphQLVersionFromCLI?: string
   legacyNoSDK?: boolean
+  watchList?: string[]
 
   constructor({
     rootPath = process.cwd(),
@@ -186,10 +188,13 @@ export class ConfigManager {
     }
 
     // Load the config file with ES build
-    this.config = await this.loadConfigFile(
+    const { config, prebuildPath, watchList } = await this.loadConfigFile(
       this.generatedFolderPath,
       this.tinaConfigFilePath
     )
+    this.watchList = watchList
+    this.config = config
+    this.prebuildFilePath = prebuildPath
 
     this.publicFolderPath = path.join(
       this.rootPath,
@@ -294,6 +299,11 @@ export class ConfigManager {
     }
     throw `No path provided to print`
   }
+  printPrebuildFilePath() {
+    return this.prebuildFilePath
+      .replace(/\\/g, '/')
+      .replace(`${this.rootPath}/${this.tinaFolderPath}/`, '')
+  }
   printContentRelativePath(filename: string) {
     if (filename) {
       return filename
@@ -348,14 +358,38 @@ export class ConfigManager {
     // good way of invalidating them when this file changes
     // https://github.com/nodejs/modules/issues/307
     const tmpdir = path.join(os.tmpdir(), Date.now().toString())
+    const prebuild = path.join(this.generatedFolderPath, 'config.prebuild.jsx')
     const outfile = path.join(tmpdir, 'config.build.jsx')
     const outfile2 = path.join(tmpdir, 'config.build.js')
     const tempTSConfigFile = path.join(tmpdir, 'tsconfig.json')
+    const external = ['react', 'react-dom', 'next']
     await fs.outputFileSync(tempTSConfigFile, '{}')
+    const result2 = await esbuild.build({
+      entryPoints: [configFilePath],
+      bundle: true,
+      target: ['es2020'],
+      platform: 'browser',
+      format: 'esm',
+      logLevel: 'silent',
+      external: ['tinacms', ...external],
+      ignoreAnnotations: true,
+      outfile: prebuild,
+      loader: loaders,
+      metafile: true,
+    })
+    const flattenedList = []
+    Object.keys(result2.metafile.inputs).forEach((key) => {
+      if (key.includes('node_modules') || key.includes('__generated__')) {
+        return
+      }
+      flattenedList.push(key)
+    })
     await esbuild.build({
       entryPoints: [configFilePath],
       bundle: true,
       target: ['es2020'],
+      external,
+      logLevel: 'silent',
       platform: 'node',
       outfile,
       loader: loaders,
@@ -363,14 +397,21 @@ export class ConfigManager {
     await esbuild.build({
       entryPoints: [outfile],
       bundle: true,
+      // Suppress warning about comparison with -0 from client module
+      logLevel: 'silent',
       platform: 'node',
+      external,
       outfile: outfile2,
       loader: loaders,
     })
     const result = require(outfile2)
     await fs.removeSync(outfile)
     await fs.removeSync(outfile2)
-    return result.default
+    return {
+      config: result.default,
+      prebuildPath: prebuild,
+      watchList: flattenedList,
+    }
   }
 }
 

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -54,7 +54,7 @@ export const createConfig = async ({
   })
 
   const alias = {
-    TINA_IMPORT: configManager.tinaConfigFilePath,
+    TINA_IMPORT: configManager.prebuildFilePath,
     SCHEMA_IMPORT: configManager.generatedGraphQLJSONPath,
   }
   if (configManager.shouldSkipSDK()) {
@@ -119,7 +119,13 @@ export const createConfig = async ({
         ? {
             ignored: ['**/*'],
           }
-        : undefined,
+        : {
+            // Since we prebuild the file, the prebuild is the only file the Vite server should
+            // know/care about
+            ignored: [
+              `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx)`,
+            ],
+          },
       fs: {
         strict: false,
       },
@@ -135,9 +141,14 @@ export const createConfig = async ({
        * `splitVendorChunkPlugin` is needed because `tinacms` and `@tinacms/toolkit` are quite large,
        * Vite's chunking strategy chokes on memory issues for smaller machines (ie. on CI).
        */
-      react(),
+      react({
+        babel: {
+          // Supresses the warning [NOTE] babel The code generator has deoptimised the styling of
+          compact: true,
+        },
+      }),
       splitVendorChunkPlugin(),
-      tinaTailwind(configManager.spaRootPath, configManager.tinaConfigFilePath),
+      tinaTailwind(configManager.spaRootPath, configManager.prebuildFilePath),
       ...plugins,
     ],
   }

--- a/packages/@tinacms/cli/src/next/vite/tailwind.ts
+++ b/packages/@tinacms/cli/src/next/vite/tailwind.ts
@@ -8,7 +8,10 @@ import lineClamp from '@tailwindcss/line-clamp'
 import aspectRatio from '@tailwindcss/aspect-ratio'
 import path from 'path'
 
-export const tinaTailwind = (spaPath: string, configFilePath): Plugin => {
+export const tinaTailwind = (
+  spaPath: string,
+  prebuildFilePath: string
+): Plugin => {
   return {
     name: 'vite-plugin-tina',
     // @ts-ignore
@@ -16,7 +19,7 @@ export const tinaTailwind = (spaPath: string, configFilePath): Plugin => {
       const plugins: Plugin[] = []
       const content = [
         path.join(spaPath, 'src/**/*.{vue,js,ts,jsx,tsx,svelte}'),
-        path.join(configFilePath, '../**/*.{vue,js,ts,jsx,tsx,svelte}'),
+        prebuildFilePath,
       ]
 
       const tw = tailwind({

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -51,18 +51,6 @@ export class TinaSchema {
         if (collection.format === 'mdx') {
           field.parser = { type: 'mdx' }
         } else {
-          field.templates?.forEach((template) => {
-            if (!template.match) {
-              console.warn(
-                `WARNING: Found rich-text template at ${
-                  collection.name
-                }.${path.join(
-                  '.'
-                )} with no matches property.\nVisit https://tina.io/docs/reference/types/rich-text/#custom-shortcode-syntax to learn more
-                `
-              )
-            }
-          })
           field.parser = { type: 'markdown' }
         }
       }


### PR DESCRIPTION
Change the way the Tina config file is built, so dependencies with Tailwind classes are picked up automatically

- The `tina/config` file and all of it's imports, including external deps are bundled into the prebuild (at `tina/__generated__/config.prebuild.jsx`)
- Tailwind is given this path as one of it's `content` values so that it scans this directory

This PR also does some clean up
- No longer relying on Vite to handle reloads on config. There was already some buggy behavior here since the SPA didn't wait for the new config to re-index the database, now it does. Reloads should still happen when working on modules like `tinacms` or `@tinacms/toolkit`
- Removes duplicated `indexContent` calls
- Improves logging for errors from the dev server.
- Suppresses some warnings from the CLI that weren't helpful to the end user

