### PR TITLE
fix: search configuration for tina was throwing zod error for stopwordLanguages key

### DIFF
--- a/.changeset/slow-rockets-shake.md
+++ b/.changeset/slow-rockets-shake.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/schema-tools': patch
+---
+
+Fix optional config validation for search

--- a/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
+++ b/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
@@ -15,6 +15,7 @@ const tinaConfigKey = z
 const tinaSearchKey = z
   .object({
     indexerToken: z.string().optional(),
+    stopwordLanguages: z.array(z.string()).nonempty().optional(),
   })
   .strict()
   .optional()
@@ -30,6 +31,8 @@ export const tinaConfigZod = z.object({
     .object({
       tina: tinaSearchKey,
       searchClient: z.any().optional(),
+      indexBatchSize: z.number().gte(1).optional(),
+      maxSearchIndexFieldLength: z.number().gte(1).optional(),
     })
     .optional(),
 })


### PR DESCRIPTION
# what

When specifying the `search.tina.stopwordLanguages` in the tina config, zod throws `Unrecognized key(s) in object: 'stopwordLanguages'`. This is due to the strict constraint on the tina object and the lack of a stopwordLanguages key.