### PR TITLE
fix: fixes for search

### DIFF
--- a/.changeset/chatty-ravens-collect.md
+++ b/.changeset/chatty-ravens-collect.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/schema-tools': patch
+'@tinacms/search': patch
+'@tinacms/cli': patch
+---
+
+Fix search index tokenizer regex to not treat underscores as token separators

--- a/.changeset/cool-teachers-run.md
+++ b/.changeset/cool-teachers-run.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/search': patch
+---
+
+Switch to the official search-index library

--- a/.changeset/purple-students-deny.md
+++ b/.changeset/purple-students-deny.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Clear the search state when switching between collections

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -11,13 +11,7 @@ import { Codegen } from '../../codegen'
 import { createAndInitializeDatabase, createDBServer } from '../../database'
 import { BaseCommand } from '../baseCommands'
 import { spin } from '../../../utils/spinner'
-import { MemoryLevel } from 'memory-level'
-import {
-  SearchIndexer,
-  si,
-  LocalSearchIndexClient,
-  lookupStopwords,
-} from '@tinacms/search'
+import { SearchIndexer, LocalSearchIndexClient } from '@tinacms/search'
 
 export class DevCommand extends BaseCommand {
   static paths = [['dev'], ['server:start']]
@@ -28,6 +22,9 @@ export class DevCommand extends BaseCommand {
   })
   noWatch = Option.Boolean('--noWatch', false, {
     description: "Don't regenerate config on file changes",
+  })
+  outputSearchIndexPath = Option.String('--outputSearchIndexPath', {
+    description: 'Path to write the search index to',
   })
 
   static usage = Command.Usage({
@@ -145,20 +142,16 @@ export class DevCommand extends BaseCommand {
       configManager.outputGitignorePath,
       'index.html\nassets/'
     )
-
-    // @ts-ignore
-    const searchIndex = await si({
-      db: new MemoryLevel(),
-      stopwords: lookupStopwords(
-        configManager.config.search?.tina?.stopwordLanguages
-      ),
+    const searchIndexClient = new LocalSearchIndexClient({
+      stopwordLanguages: configManager.config.search?.tina?.stopwordLanguages,
+      tokenSplitRegex: configManager.config.search?.tina?.tokenSplitRegex,
     })
-    const searchIndexClient = new LocalSearchIndexClient(searchIndex)
+    await searchIndexClient.onStartIndexing()
 
     const server = await createDevServer(
       configManager,
       database,
-      searchIndex,
+      searchIndexClient.searchIndex,
       apiURL,
       this.noWatch
     )
@@ -192,6 +185,10 @@ export class DevCommand extends BaseCommand {
         },
         text: 'Building search index',
       })
+
+      if (this.outputSearchIndexPath) {
+        await searchIndexClient.export(this.outputSearchIndexPath)
+      }
     }
 
     if (!this.noWatch) {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/searchIndex.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/searchIndex.ts
@@ -13,6 +13,7 @@ export const createSearchIndexRouter = ({
   const put = async (req, res) => {
     const { docs } = req.body as { docs: Record<string, any>[] }
     const result = await searchIndex.PUT(docs)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ result }))
   }
 
@@ -29,6 +30,7 @@ export const createSearchIndexRouter = ({
         ...JSON.parse(optionsParam),
       }
     }
+    res.writeHead(200, { 'Content-Type': 'application/json' })
     if (query) {
       const result = await searchIndex.QUERY(JSON.parse(query), options)
       res.end(JSON.stringify(result))
@@ -45,6 +47,7 @@ export const createSearchIndexRouter = ({
       .slice(1)
       .join('/')
     const result = await searchIndex.DELETE(docId)
+    res.writeHead(200, { 'Content-Type': 'application/json' })
     res.end(JSON.stringify({ result }))
   }
 

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -607,6 +607,10 @@ export interface Config<
            * stopword languages to use (default: eng)
            */
           stopwordLanguages?: string[]
+          /**
+           * regex used for splitting tokens (default: /[\p{L}\d_]+/)
+           */
+          tokenSplitRegex?: string
         }
       }
   ) & {

--- a/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
+++ b/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
@@ -16,6 +16,7 @@ const tinaSearchKey = z
   .object({
     indexerToken: z.string().optional(),
     stopwordLanguages: z.array(z.string()).nonempty().optional(),
+    tokenSplitRegex: z.string().optional(),
   })
   .strict()
   .optional()

--- a/packages/@tinacms/search/package.json
+++ b/packages/@tinacms/search/package.json
@@ -43,7 +43,7 @@
     "memory-level": "^1.0.0",
     "module-error": "^1.0.2",
     "node-fetch": "2",
-    "search-index": "4.0.0-rc1",
+    "search-index": "4.0.0",
     "stopword": "^2.0.8",
     "sqlite-level": "^1.0.1"
   },

--- a/packages/@tinacms/search/package.json
+++ b/packages/@tinacms/search/package.json
@@ -43,7 +43,7 @@
     "memory-level": "^1.0.0",
     "module-error": "^1.0.2",
     "node-fetch": "2",
-    "@tinacms/search-index": "^3.5.2",
+    "search-index": "4.0.0-rc1",
     "stopword": "^2.0.8",
     "sqlite-level": "^1.0.1"
   },

--- a/packages/@tinacms/search/src/client/index.ts
+++ b/packages/@tinacms/search/src/client/index.ts
@@ -1,7 +1,7 @@
 import type { SearchClient } from '../types'
 import { SqliteLevel } from 'sqlite-level'
 import * as zlib from 'zlib'
-import si from '@tinacms/search-index'
+import si from 'search-index'
 import { MemoryLevel } from 'memory-level'
 import { lookupStopwords } from '../index'
 import fetch, { Headers } from 'node-fetch'

--- a/packages/@tinacms/search/src/client/index.ts
+++ b/packages/@tinacms/search/src/client/index.ts
@@ -33,6 +33,7 @@ export class LocalSearchIndexClient implements SearchClient {
   }
   async onStartIndexing() {
     this.searchIndex = await si({
+      // @ts-ignore
       db: this.memoryLevel,
       stopwords: this.stopwords,
       tokenSplitRegex: this.tokenSplitRegex,

--- a/packages/@tinacms/search/src/index.ts
+++ b/packages/@tinacms/search/src/index.ts
@@ -1,5 +1,5 @@
 import * as sw from 'stopword'
-import si from '@tinacms/search-index'
+import si from 'search-index'
 export { SearchIndexer } from './indexer'
 export { LocalSearchIndexClient, TinaCMSSearchIndexClient } from './client'
 export type { SearchClient } from './types'

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -222,6 +222,8 @@ const CollectionListPage = () => {
     // reset state when the route is changed
     setEndCursor('')
     setPrevCursors([])
+    setSearch('')
+    setSearchInput('')
   }, [loc])
 
   useEffect(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1066,7 +1066,7 @@ importers:
       memory-level: ^1.0.0
       module-error: ^1.0.2
       node-fetch: '2'
-      search-index: 4.0.0-rc1
+      search-index: 4.0.0
       sqlite-level: ^1.0.1
       stopword: ^2.0.8
       typescript: 4.3.5
@@ -1077,7 +1077,7 @@ importers:
       memory-level: 1.0.0
       module-error: 1.0.2
       node-fetch: 2.6.7
-      search-index: 4.0.0-rc1_abstract-level@1.0.3
+      search-index: 4.0.0_abstract-level@1.0.3
       sqlite-level: 1.0.1
       stopword: 2.0.8
     devDependencies:
@@ -19101,10 +19101,10 @@ packages:
     dependencies:
       pend: 1.2.0
 
-  /fergies-inverted-index/12.0.0-rc1_abstract-level@1.0.3:
+  /fergies-inverted-index/12.0.0_abstract-level@1.0.3:
     resolution:
       {
-        integrity: sha512-jpCKZIvSHYZhoi9+m+gxBzteHWLUNFkS0c+GNh1j8kbFJJmWTP52cdTaMm+0z+05Bs3vCis6f2ke/OE/LP6Nrw==,
+        integrity: sha512-lAkyiDSdQog0aqWhyO8/8gnwbh6k27bd18IWJw7IOl2EUWEh22O4C9ebnw8Li3E+HK3Plxgv6ql1Ty/C3gndvg==,
       }
     dependencies:
       browser-level: 1.0.1
@@ -23760,6 +23760,14 @@ packages:
     engines: { node: '>=8' }
     dev: false
 
+  /lru-cache/10.0.0:
+    resolution:
+      {
+        integrity: sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==,
+      }
+    engines: { node: 14 || >=16.14 }
+    dev: false
+
   /lru-cache/4.1.5:
     resolution:
       {
@@ -23786,14 +23794,6 @@ packages:
     engines: { node: '>=10' }
     dependencies:
       yallist: 4.0.0
-
-  /lru-cache/7.18.3:
-    resolution:
-      {
-        integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==,
-      }
-    engines: { node: '>=12' }
-    dev: false
 
   /lunr/2.3.9:
     resolution:
@@ -29341,18 +29341,18 @@ packages:
       compute-scroll-into-view: 1.0.17
     dev: false
 
-  /search-index/4.0.0-rc1_abstract-level@1.0.3:
+  /search-index/4.0.0_abstract-level@1.0.3:
     resolution:
       {
-        integrity: sha512-bRiBLuF7fV1drTWQZX1zgDKuzMrYKhujQQu2TLDCc3wgpDSNcIbE6c4/laiM189cGSPb9sK/SRn9oaIBJ63JbQ==,
+        integrity: sha512-D3MRIWXO5yF5c33B1DLh8yqWvJu4gaH9gaKUNeWIZMkwb/+j2y/wOe1OB1dyoFvBw3aUCxYZQJJDZK02HOGrDQ==,
       }
     engines: { node: '>=12' }
     dependencies:
       browser-level: 1.0.1
       charwise: 3.0.1
-      fergies-inverted-index: 12.0.0-rc1_abstract-level@1.0.3
+      fergies-inverted-index: 12.0.0_abstract-level@1.0.3
       level-read-stream: 1.1.0_abstract-level@1.0.3
-      lru-cache: 7.18.3
+      lru-cache: 10.0.0
       memory-level: 1.0.0
       ngraminator: 3.0.2
       p-queue: 7.3.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1055,7 +1055,6 @@ importers:
       '@tinacms/graphql': workspace:*
       '@tinacms/schema-tools': workspace:*
       '@tinacms/scripts': workspace:*
-      '@tinacms/search-index': ^3.5.2
       '@types/jest': ^26.0.4
       '@types/micromatch': ^4.0.2
       '@types/search-index': ^3.2.0
@@ -1067,17 +1066,18 @@ importers:
       memory-level: ^1.0.0
       module-error: ^1.0.2
       node-fetch: '2'
+      search-index: 4.0.0-rc1
       sqlite-level: ^1.0.1
       stopword: ^2.0.8
       typescript: 4.3.5
     dependencies:
       '@tinacms/graphql': link:../graphql
       '@tinacms/schema-tools': link:../schema-tools
-      '@tinacms/search-index': 3.5.2_abstract-level@1.0.3
       abstract-level: 1.0.3
       memory-level: 1.0.0
       module-error: 1.0.2
       node-fetch: 2.6.7
+      search-index: 4.0.0-rc1_abstract-level@1.0.3
       sqlite-level: 1.0.1
       stopword: 2.0.8
     devDependencies:
@@ -6008,48 +6008,6 @@ packages:
       tty-table: 4.1.6
     dev: false
 
-  /@changesets/cli/2.26.1:
-    resolution:
-      {
-        integrity: sha512-XnTa+b51vt057fyAudvDKGB0Sh72xutQZNAdXkCqPBKO2zvs2yYZx5hFZj1u9cbtpwM6Sxtcr02/FQJfZOzemQ==,
-      }
-    hasBin: true
-    dependencies:
-      '@babel/runtime': 7.21.0
-      '@changesets/apply-release-plan': 6.1.3
-      '@changesets/assemble-release-plan': 5.2.3
-      '@changesets/changelog-git': 0.1.14
-      '@changesets/config': 2.3.0
-      '@changesets/errors': 0.1.4
-      '@changesets/get-dependents-graph': 1.3.5
-      '@changesets/get-release-plan': 3.0.16
-      '@changesets/git': 2.0.0
-      '@changesets/logger': 0.0.5
-      '@changesets/pre': 1.0.14
-      '@changesets/read': 0.5.9
-      '@changesets/types': 5.2.1
-      '@changesets/write': 0.2.3
-      '@manypkg/get-packages': 1.1.3
-      '@types/is-ci': 3.0.0
-      '@types/semver': 6.2.3
-      ansi-colors: 4.1.3
-      chalk: 2.4.2
-      enquirer: 2.3.6
-      external-editor: 3.1.0
-      fs-extra: 7.0.1
-      human-id: 1.0.2
-      is-ci: 3.0.1
-      meow: 6.1.1
-      outdent: 0.5.0
-      p-limit: 2.3.0
-      preferred-pm: 3.0.3
-      resolve-from: 5.0.0
-      semver: 5.7.1
-      spawndamnit: 2.0.0
-      term-size: 2.2.1
-      tty-table: 4.1.6
-    dev: false
-
   /@changesets/config/2.3.0:
     resolution:
       {
@@ -9797,42 +9755,6 @@ packages:
       unified: 9.2.2
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@tinacms/fergies-inverted-index/11.0.2_abstract-level@1.0.3:
-    resolution:
-      {
-        integrity: sha512-a7w69q8h1OxmlltOFULEtVrPvio9k+NjvzcIDJxkPWG83mNL6LaqWNbdtR/RSrwKhgJzEIR0j8qPlQlqHup/GQ==,
-      }
-    dependencies:
-      browser-level: 1.0.1
-      charwise: 3.0.1
-      level-read-stream: 1.1.0_abstract-level@1.0.3
-      memory-level: 1.0.0
-      traverse: 0.6.7
-    transitivePeerDependencies:
-      - abstract-level
-    dev: false
-
-  /@tinacms/search-index/3.5.2_abstract-level@1.0.3:
-    resolution:
-      {
-        integrity: sha512-uC+ws99DDMDS6ihpE0rhj/aMfkOrZYHAUot+EkLxwhdM82sSSC7+OB985g2P5ZgGYhyQI3IeOlq02lFDKZ5fIA==,
-      }
-    engines: { node: '>=12' }
-    dependencies:
-      '@changesets/cli': 2.26.1
-      '@tinacms/fergies-inverted-index': 11.0.2_abstract-level@1.0.3
-      browser-level: 1.0.1
-      charwise: 3.0.1
-      level-read-stream: 1.1.0_abstract-level@1.0.3
-      lru-cache: 7.18.3
-      memory-level: 1.0.0
-      ngraminator: 3.0.2
-      p-queue: 7.3.4
-      term-vector: 1.0.0
-    transitivePeerDependencies:
-      - abstract-level
     dev: false
 
   /@tootallnate/once/1.1.2:
@@ -19178,6 +19100,21 @@ packages:
       }
     dependencies:
       pend: 1.2.0
+
+  /fergies-inverted-index/12.0.0-rc1_abstract-level@1.0.3:
+    resolution:
+      {
+        integrity: sha512-jpCKZIvSHYZhoi9+m+gxBzteHWLUNFkS0c+GNh1j8kbFJJmWTP52cdTaMm+0z+05Bs3vCis6f2ke/OE/LP6Nrw==,
+      }
+    dependencies:
+      browser-level: 1.0.1
+      charwise: 3.0.1
+      level-read-stream: 1.1.0_abstract-level@1.0.3
+      memory-level: 1.0.0
+      traverse: 0.6.7
+    transitivePeerDependencies:
+      - abstract-level
+    dev: false
 
   /fetch-ponyfill/7.1.0:
     resolution:
@@ -29402,6 +29339,26 @@ packages:
       }
     dependencies:
       compute-scroll-into-view: 1.0.17
+    dev: false
+
+  /search-index/4.0.0-rc1_abstract-level@1.0.3:
+    resolution:
+      {
+        integrity: sha512-bRiBLuF7fV1drTWQZX1zgDKuzMrYKhujQQu2TLDCc3wgpDSNcIbE6c4/laiM189cGSPb9sK/SRn9oaIBJ63JbQ==,
+      }
+    engines: { node: '>=12' }
+    dependencies:
+      browser-level: 1.0.1
+      charwise: 3.0.1
+      fergies-inverted-index: 12.0.0-rc1_abstract-level@1.0.3
+      level-read-stream: 1.1.0_abstract-level@1.0.3
+      lru-cache: 7.18.3
+      memory-level: 1.0.0
+      ngraminator: 3.0.2
+      p-queue: 7.3.4
+      term-vector: 1.0.0
+    transitivePeerDependencies:
+      - abstract-level
     dev: false
 
   /section-matter/1.0.0:


### PR DESCRIPTION
# what

- fix bug where collections that had names with underscores were not searchable
- allow the tokenizer regexp to be customizable (to accommodate other characters)
- refactor search indexing clients a bit and add a debug output cli flag for dev mode
- fix UI issue where search state was not reset after changing selected collection
- switch to the official `search-index` library