### PR TITLE
Fix issue with visual editing choosing right form

### DIFF
--- a/.changeset/dull-knives-wonder.md
+++ b/.changeset/dull-knives-wonder.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+Fix issue where navigating in and out of visual editing mode would not pick up the correct active form

--- a/packages/@tinacms/toolkit/src/tina-state.tsx
+++ b/packages/@tinacms/toolkit/src/tina-state.tsx
@@ -129,6 +129,7 @@ export function tinaReducer(state: TinaState, action: TinaAction): TinaState {
       return {
         ...state,
         quickEditSupported: false,
+        activeFormId: null,
         formLists: [],
         forms: [],
       }
@@ -150,12 +151,14 @@ export function tinaReducer(state: TinaState, action: TinaAction): TinaState {
       let activeFormId = state.activeFormId
       if (!activeFormId && state.formLists.length === 0) {
         action.value.items.forEach((item) => {
-          if (item.type === 'document') {
-            const form = state.forms.find(
-              ({ tinaForm }) => item.formId === tinaForm.id
-            )
-            if (!form.tinaForm.global) {
-              activeFormId = item.formId
+          if (!activeFormId) {
+            if (item.type === 'document') {
+              const form = state.forms.find(
+                ({ tinaForm }) => item.formId === tinaForm.id
+              )
+              if (!form.tinaForm.global) {
+                activeFormId = item.formId
+              }
             }
           }
         })


### PR DESCRIPTION
Fixes 2 issues:

The cleanup process during unmount didn't clear the active form.
Also, when choosing an active form we were choosing the last form item instead of the first.