### PR TITLE
Various bug fixes

### DIFF
--- a/.changeset/clean-roses-think.md
+++ b/.changeset/clean-roses-think.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Ensure schema changes are picked up by the Vite dev server so we don't get schema mismatch errors during local dev

--- a/.changeset/cyan-moons-peel.md
+++ b/.changeset/cyan-moons-peel.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Ensure tinaField links to references land on the select field instead of the referenced form

--- a/.changeset/empty-birds-press.md
+++ b/.changeset/empty-birds-press.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Improve type signature for tinaField so potentially null fields don't show a Typescript error

--- a/packages/@tinacms/app/src/lib/util.ts
+++ b/packages/@tinacms/app/src/lib/util.ts
@@ -93,7 +93,12 @@ export const getDeepestMetadata = (state: Object, complexKey: string): any => {
     }
     const value = current[key]
     if (value?._tina_metadata) {
-      metadata = value._tina_metadata
+      // We're at a reference field, we don't want to select the
+      // reference form, just the reference select field
+      if (complexKey === value._tina_metadata?.prefix && metadata) {
+      } else {
+        metadata = value._tina_metadata
+      }
     }
     current = value
   }

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -120,10 +120,9 @@ export const createConfig = async ({
             ignored: ['**/*'],
           }
         : {
-            // Since we prebuild the file, the prebuild is the only file the Vite server should
-            // know/care about
+            // Ignore everything except for the alias fields we specified above
             ignored: [
-              `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx)`,
+              `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx|_graphql.json)`,
             ],
           },
       fs: {

--- a/packages/tinacms/src/react.tsx
+++ b/packages/tinacms/src/react.tsx
@@ -180,10 +180,13 @@ export const tinaField = <
     }
   }
 >(
-  object: T,
+  object: T | undefined | null,
   property?: keyof Omit<T, '__typename' | '_sys'>,
   index?: number
 ) => {
+  if (!object) {
+    return ''
+  }
   if (object._content_source) {
     if (!property) {
       return [


### PR DESCRIPTION
- Noticed that when the schema is changed the Vite app was showing a schema mismatch error
- For nullable fields (eg `tinaField(post.author, 'name')`) the `tinaField` function was showing a Typescript error
- Using `tinaField` on a reference was resulting in the referenced form being selected instead of the parent form's reference select field.