### PR TITLE
Ensure urls are sanitized in a tags for rich-text

### DIFF
--- a/.changeset/metal-rats-tap.md
+++ b/.changeset/metal-rats-tap.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+Ensure urls are sanitized in a tags for rich-text

--- a/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
+++ b/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
@@ -526,5 +526,22 @@ const sanitizeUrl = (url: string | undefined) => {
     return ''
   }
 
-  return parsedUrl.href
+  /**
+   * Trailing slash is added from new URL(...) for urls with no pathname,
+   * if the passed in url had one, keep it there, else just use the origin
+   * eg:
+   *
+   * http://example.com/ -> http://example.com/
+   * http://example.com -> http://example.com
+   * http://example.com/a/b -> http://example.com/a/b
+   * http://example.com/a/b/ -> http://example.com/a/b/
+   */
+  if (parsedUrl.pathname === '/') {
+    if (url.endsWith('/')) {
+      return parsedUrl.href
+    }
+    return parsedUrl.origin
+  } else {
+    return parsedUrl.href
+  }
 }

--- a/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
+++ b/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
@@ -270,7 +270,7 @@ export const remarkToSlate = (
   const link = (content: Md.Link): Plate.LinkElement => {
     return {
       type: 'a',
-      url: content.url,
+      url: sanitizeUrl(content.url),
       title: content.title,
       children: flatten(
         content.children.map((child) => staticPhrasingContent(child))
@@ -397,7 +397,12 @@ export const remarkToSlate = (
         const children = flatten(
           node.children.map((child) => phrashingMark(child, marks))
         )
-        accum.push({ type: 'a', url: node.url, title: node.title, children })
+        accum.push({
+          type: 'a',
+          url: sanitizeUrl(node.url),
+          title: node.title,
+          children,
+        })
         break
       }
       case 'text':
@@ -500,4 +505,26 @@ export class RichTextParseError extends Error {
     // Custom debugging information
     this.position = position
   }
+}
+
+// Prevent javascript scheme (eg. `javascript:alert(document.domain)`)
+const sanitizeUrl = (url: string | undefined) => {
+  const allowedSchemes = ['http', 'https', 'mailto', 'tel']
+  if (!url) return ''
+
+  let parsedUrl: URL | null = null
+
+  try {
+    parsedUrl = new URL(url)
+  } catch (error) {
+    return url
+  }
+
+  const scheme = parsedUrl.protocol.slice(0, -1)
+  if (allowedSchemes && !allowedSchemes.includes(scheme)) {
+    console.warn(`Invalid URL scheme detected ${scheme}`)
+    return ''
+  }
+
+  return parsedUrl.href
 }


### PR DESCRIPTION
Partially closes https://github.com/tinacms/tinacms/issues/4011.

The plate vulnerability is addressed [here](https://github.com/tinacms/tinacms/pull/4029). Though I don't think it affects us directly since we're not using their built-in link logic