### PR TITLE
Upgrade prism

### DIFF
--- a/.changeset/forty-readers-begin.md
+++ b/.changeset/forty-readers-begin.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Upgrade prism react renderer, allow for theming

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -78,7 +78,7 @@
     "graphql": "15.8.0",
     "graphql-tag": "^2.11.0",
     "lodash.set": "^4.3.2",
-    "prism-react-renderer": "^1.3.5",
+    "prism-react-renderer": "^2.0.6",
     "react-icons": "^4.3.1",
     "react-router-dom": "6.3.0",
     "yup": "^0.32.0",

--- a/packages/tinacms/src/rich-text/prism.tsx
+++ b/packages/tinacms/src/rich-text/prism.tsx
@@ -14,7 +14,7 @@ export const Prism = (props: {
     <Highlight
       theme={themes[props.theme || 'github']}
       code={props.value}
-      language={props.lang}
+      language={props.lang || ''}
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre className={className} style={style}>

--- a/packages/tinacms/src/rich-text/prism.tsx
+++ b/packages/tinacms/src/rich-text/prism.tsx
@@ -3,16 +3,17 @@
 */
 
 import React from 'react'
-import Highlight, { defaultProps } from 'prism-react-renderer'
-import theme from 'prism-react-renderer/themes/github'
+import { Highlight, themes } from 'prism-react-renderer'
 
-export const Prism = (props: { value: string; lang?: string }) => {
+export const Prism = (props: {
+  value: string
+  lang?: string
+  theme?: keyof typeof themes
+}) => {
   return (
     <Highlight
-      {...defaultProps}
-      theme={theme}
+      theme={themes[props.theme || 'github']}
       code={props.value}
-      // @ts-ignore prism will ignore syntax for languages it doesn't have
       language={props.lang}
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1281,7 +1281,7 @@ importers:
       jest-file-snapshot: ^0.5.0
       lodash.set: ^4.3.2
       next: 12.2.4
-      prism-react-renderer: ^1.3.5
+      prism-react-renderer: ^2.0.6
       react: 17.0.2
       react-dom: 17.0.2
       react-icons: ^4.3.1
@@ -1306,7 +1306,7 @@ importers:
       graphql: 15.8.0
       graphql-tag: 2.12.6_graphql@15.8.0
       lodash.set: 4.3.2
-      prism-react-renderer: 1.3.5_react@17.0.2
+      prism-react-renderer: 2.0.6_react@17.0.2
       react-icons: 4.4.0_react@17.0.2
       react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
       yup: 0.32.11
@@ -13335,6 +13335,13 @@ packages:
       {
         integrity: sha512-ymZk3LEC/fsut+/Q5qejp6R9O1rMxz3XaRHDV6kX8MrGAhOSPqVARbDi+EZvInBpw+BnCX3TD240byVkOfQsHg==,
       }
+
+  /@types/prismjs/1.26.0:
+    resolution:
+      {
+        integrity: sha512-ZTaqn/qSqUuAq1YwvOFQfVW1AR/oQJlLSZVustdjwI+GZ8kr0MSHBj0tsXPW1EqHubx50gtBEjbPGsdZwQwCjQ==,
+      }
+    dev: false
 
   /@types/progress/2.0.5:
     resolution:
@@ -27508,6 +27515,19 @@ packages:
     peerDependencies:
       react: '>=0.14.9'
     dependencies:
+      react: 17.0.2
+    dev: false
+
+  /prism-react-renderer/2.0.6_react@17.0.2:
+    resolution:
+      {
+        integrity: sha512-ERzmAI5UvrcTw5ivfEG20/dYClAsC84eSED5p9X3oKpm0xPV4A5clFK1mp7lPIdKmbLnQYsPTGiOI7WS6gWigw==,
+      }
+    peerDependencies:
+      react: '>=16.0.0'
+    dependencies:
+      '@types/prismjs': 1.26.0
+      clsx: 1.2.1
       react: 17.0.2
     dev: false
 


### PR DESCRIPTION
Fixes Next build error:
```
Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: [missing argument].[missing argument]
```
I got mixed results here, have no idea why but I was able to break this on previous tina versions as well as the latest beta. Ultimately upgrading to a more modern build of the prism library seems to have fixed things. I suspect our `cjs` builds aren't playing well with default exports in some cases but can't pin it down with this

Bonus is that we can now provide a `theme` prop:

```jsx
  code_block: (props) => <Prism {...props} theme="palenight" />,
```