### PR TITLE
fix: use stopwords to filter the search query

### DIFF
--- a/packages/@tinacms/search/src/client/index.ts
+++ b/packages/@tinacms/search/src/client/index.ts
@@ -3,7 +3,7 @@ import { SqliteLevel } from 'sqlite-level'
 import * as zlib from 'zlib'
 import si from 'search-index'
 import { MemoryLevel } from 'memory-level'
-import { lookupStopwords } from '../index'
+import { lookupStopwords } from '../indexer/utils'
 import fetch, { Headers } from 'node-fetch'
 
 const DEFAULT_TOKEN_SPLIT_REGEX = /[\p{L}\d_]+/gu

--- a/packages/@tinacms/search/src/index-client.ts
+++ b/packages/@tinacms/search/src/index-client.ts
@@ -1,14 +1,25 @@
 export type { SearchClient } from './types'
 export { processDocumentForIndexing } from './indexer/utils'
+import { lookupStopwords } from './indexer/utils'
 
-export const queryToSearchIndexQuery = (query: string) => {
+export const queryToSearchIndexQuery = (
+  query: string,
+  stopwordLanguages?: string[]
+) => {
   let q
   const parts = query.split(' ')
+  const stopwords = lookupStopwords(stopwordLanguages)
   if (parts.length === 1) {
     q = { AND: [parts[0]] }
   } else {
     // TODO only allow AND for now - need parser
-    q = { AND: parts.filter((part) => part.toLowerCase() !== 'and') }
+    q = {
+      AND: parts.filter(
+        (part) =>
+          part.toLowerCase() !== 'and' &&
+          stopwords.indexOf(part.toLowerCase()) === -1
+      ),
+    }
   }
   return q
 }

--- a/packages/@tinacms/search/src/index.ts
+++ b/packages/@tinacms/search/src/index.ts
@@ -1,21 +1,5 @@
-import * as sw from 'stopword'
 import si from 'search-index'
 export { SearchIndexer } from './indexer'
 export { LocalSearchIndexClient, TinaCMSSearchIndexClient } from './client'
 export type { SearchClient } from './types'
-export { default as sw } from 'stopword'
 export { si }
-
-export const lookupStopwords = (
-  keys?: string[],
-  defaultStopWords: string[] = sw.eng
-) => {
-  let stopwords = defaultStopWords
-  if (keys) {
-    stopwords = []
-    for (const key of keys) {
-      stopwords.push(...sw[key])
-    }
-  }
-  return stopwords
-}

--- a/packages/@tinacms/search/src/indexer/utils.ts
+++ b/packages/@tinacms/search/src/indexer/utils.ts
@@ -1,4 +1,5 @@
 import { Collection, ObjectField } from '@tinacms/schema-tools'
+import * as sw from 'stopword'
 
 class StringBuilder {
   private readonly buffer: string[]
@@ -147,4 +148,23 @@ export const processDocumentForIndexing = (
     }
   }
   return data
+}
+
+const memo: Record<string, string[]> = {}
+export const lookupStopwords = (
+  keys?: string[],
+  defaultStopWords: string[] = sw.eng
+) => {
+  let stopwords = defaultStopWords
+  if (keys) {
+    if (memo[keys.join(',')]) {
+      return memo[keys.join(',')]
+    }
+    stopwords = []
+    for (const key of keys) {
+      stopwords.push(...sw[key])
+    }
+    memo[keys.join(',')] = stopwords
+  }
+  return stopwords
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -185,7 +185,10 @@ export const TinaCloudProvider = (
     } else {
       const hasTinaSearch = Boolean(props.schema.config?.search?.tina)
       if (hasTinaSearch) {
-        searchClient = new TinaCMSSearchClient(cms.api.tina)
+        searchClient = new TinaCMSSearchClient(
+          cms.api.tina,
+          props.schema.config?.search?.tina
+        )
       } else {
         searchClient = props.schema.config?.search?.searchClient
       }

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -853,7 +853,10 @@ export class LocalClient extends Client {
 }
 
 export class TinaCMSSearchClient implements SearchClient {
-  constructor(private client: Client) {}
+  constructor(
+    private client: Client,
+    private tinaSearchConfig?: { stopwordLanguages?: string[] }
+  ) {}
   async query(
     query: string,
     options?: {
@@ -866,7 +869,10 @@ export class TinaCMSSearchClient implements SearchClient {
     total: number
     prevCursor: string | null
   }> {
-    const q = queryToSearchIndexQuery(query)
+    const q = queryToSearchIndexQuery(
+      query,
+      this.tinaSearchConfig?.stopwordLanguages
+    )
     const opt = optionsToSearchIndexOptions(options)
     const optionsParam = opt['PAGE'] ? `&options=${JSON.stringify(opt)}` : ''
     const res = await this.client.fetchWithToken(


### PR DESCRIPTION
# what

Fixes issue where copying the full text of a title into a search query would result in no results because of the stopwords used in the query not existing in the search index