### PR TITLE
fix: indexing error handling

### DIFF
--- a/.changeset/orange-snails-notice.md
+++ b/.changeset/orange-snails-notice.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix to not index content where we are unable to load it due to template issues

--- a/.changeset/ten-countries-sort.md
+++ b/.changeset/ten-countries-sort.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix to log errors in spinner

--- a/packages/@tinacms/cli/src/utils/spinner.ts
+++ b/packages/@tinacms/cli/src/utils/spinner.ts
@@ -24,7 +24,12 @@ async function localSpin<T>({
 
   // spinner start
   spinner.start()
-  const res = await waitFor()
+  let res
+  try {
+    res = await waitFor()
+  } catch (e) {
+    console.error(e)
+  }
   // spinner stop
   spinner.stop()
   console.log('')

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1229,6 +1229,12 @@ const _indexContent = async (
         collection,
         templateInfo
       )
+
+      // if we aren't able to load the data, we can't index it
+      if (!aliasedData) {
+        return
+      }
+
       const normalizedPath = normalizePath(filepath)
       const folderKey = folderTreeBuilder.update(
         normalizedPath,


### PR DESCRIPTION
Fixes:
- errors were getting swallowed inside the spinner
- when we aren't able to load content due to the ambiguous template error it was still indexing