### PR TITLE
Clean media grid

### DIFF
--- a/.changeset/fuzzy-mangos-perform.md
+++ b/.changeset/fuzzy-mangos-perform.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/toolkit': patch
+---
+
+fix: Use clean page-sizes on media manager (to make pagination more obvious)

--- a/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
+++ b/packages/@tinacms/toolkit/src/components/media/media-manager.tsx
@@ -420,7 +420,7 @@ export function MediaPicker({
                 } ${
                   list.items.length > 0 &&
                   viewMode === 'grid' &&
-                  'w-full p-4 gap-4 grid grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3 @2xl:grid-cols-4 @4xl:grid-cols-6 @6xl:grid-cols-8 auto-rows-auto content-start justify-start'
+                  'w-full p-4 gap-4 grid grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3 @2xl:grid-cols-4 @4xl:grid-cols-6 @6xl:grid-cols-9 auto-rows-auto content-start justify-start'
                 } ${isDragActive ? `border-2 border-blue-500 rounded-lg` : ``}`}
               >
                 <input {...getInputProps()} />

--- a/packages/@tinacms/toolkit/src/packages/core/media.ts
+++ b/packages/@tinacms/toolkit/src/packages/core/media.ts
@@ -113,7 +113,7 @@ export interface MediaList {
  * ```
  */
 export class MediaManager implements MediaStore {
-  private _pageSize: number = 20
+  private _pageSize: number = 36
 
   constructor(public store: MediaStore, private events: EventBus) {}
 


### PR DESCRIPTION
<img width="1468" alt="Screenshot 2023-07-26 at 3 28 46 PM" src="https://github.com/tinacms/tinacms/assets/3323181/027bbfec-9b0b-42bb-952a-9dd06940879c">

Use clean page sizes, so it's more obvious media is paginated

closes ENG-1083