### PR TITLE
Add Before Submit function

### DIFF
--- a/.changeset/soft-glasses-watch.md
+++ b/.changeset/soft-glasses-watch.md
@@ -1,0 +1,40 @@
+---
+'@tinacms/schema-tools': patch
+'tinacms': patch
+---
+
+Add a `beforeSubmit` hook function on a collection.ui. This give users the ability to run a function before the form is submitted. 
+
+If the function returns values those values will be used will be submitted instead of the form values.
+
+If the function returns a falsy value the original form values will be submitted.
+
+### Example
+
+
+
+```js
+// tina/config.{ts.js}
+
+export default defineConfig({
+  schema: {
+    collections: [
+      {
+        ui: {
+          // Example of beforeSubmit
+          beforeSubmit: async ({ values }) => {
+            return {
+              ...values,
+              lastUpdated: new Date().toISOString(),
+            };
+          },
+          //...
+        },
+        //...
+      },
+      //...
+    ],
+  },
+  //...
+});
+```

--- a/examples/basic-iframe/content/page/home.mdx
+++ b/examples/basic-iframe/content/page/home.mdx
@@ -1,8 +1,7 @@
 +++
 Title = "Title"
+lastUpdated = 2023-08-04T14:50:41.204Z
 +++
-
-
 
 this is a test!
 

--- a/examples/basic-iframe/tina/config.js
+++ b/examples/basic-iframe/tina/config.js
@@ -91,6 +91,15 @@ export default defineConfig({
         format: 'mdx',
         frontmatterFormat: 'toml',
         frontmatterDelimiters: ['+++', '+++'],
+        ui: {
+          // Example of beforeSubmit
+          beforeSubmit: async ({ values }) => {
+            return {
+              ...values,
+              lastUpdated: new Date().toISOString(),
+            }
+          },
+        },
         fields: [
           {
             label: 'Title',
@@ -114,6 +123,13 @@ export default defineConfig({
               //     return 'Too Long!!!'
               //   }
               // },
+            },
+          },
+          {
+            name: 'lastUpdated',
+            type: 'datetime',
+            ui: {
+              component: 'hidden',
             },
           },
           {

--- a/examples/basic-iframe/tina/config.js
+++ b/examples/basic-iframe/tina/config.js
@@ -93,7 +93,6 @@ export default defineConfig({
         frontmatterDelimiters: ['+++', '+++'],
         ui: {
           // Example of beforeSubmit
-          /** @type {(args: {cms: TinaCMS, values: Record<string, any>, form: any, tinaForm: any})=>Promise<Record<any,any>>} */
           beforeSubmit: async ({ values, cms, form, tinaForm }) => {
             return {
               ...values,

--- a/examples/basic-iframe/tina/config.js
+++ b/examples/basic-iframe/tina/config.js
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tinacms'
+import { TinaCMS, defineConfig } from 'tinacms'
 
 export default defineConfig({
   // Example of how you can override the frontend url
@@ -93,7 +93,8 @@ export default defineConfig({
         frontmatterDelimiters: ['+++', '+++'],
         ui: {
           // Example of beforeSubmit
-          beforeSubmit: async ({ values }) => {
+          /** @type {(args: {cms: TinaCMS, values: Record<string, any>, form: any, tinaForm: any})=>Promise<Record<any,any>>} */
+          beforeSubmit: async ({ values, cms, form, tinaForm }) => {
             return {
               ...values,
               lastUpdated: new Date().toISOString(),

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -797,7 +797,21 @@ export interface UICollection<Form = any, CMS = any, TinaForm = any> {
   }) => string | undefined
 
   /**
-   * The
+   * This function is called before a document is created or updated. It can be used to modify the values that are saved to the CMS. It can also be used to perform side effects such as sending a notification or triggering a build.
+   *
+   * @example
+   *
+   *
+   *```js
+   * beforeSubmit: async ({ values }) => {
+   *   return {
+   *     ...values,
+   *     lastUpdated: new Date().toISOString(),
+   *   };
+   * },
+   *```
+   *
+   *
    *
    */
   beforeSubmit?: (arg: {

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -749,7 +749,7 @@ type Document = {
     extension: string
   }
 }
-export interface UICollection {
+export interface UICollection<Form = any, CMS = any, TinaForm = any> {
   /**
    * Customize the way filenames are generated during content creation
    */
@@ -795,6 +795,17 @@ export interface UICollection {
     document: Document
     collection: Collection<true>
   }) => string | undefined
+
+  /**
+   * The
+   *
+   */
+  beforeSubmit?: (arg: {
+    values: Record<string, unknown>
+    cms: CMS
+    form: Form
+    tinaForm: TinaForm
+  }) => Promise<void | Record<string, unknown>>
 }
 
 export type DefaultItem<ReturnType> = ReturnType | (() => ReturnType)

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -22,6 +22,7 @@ import {
 import { BiGitBranch } from 'react-icons/bi'
 import { MdOutlineSaveAlt } from 'react-icons/md'
 import { formatBranchName } from '@toolkit/plugin-branch-switcher'
+import { TinaSchema } from '@tinacms/schema-tools'
 
 export interface FormBuilderProps {
   form: { tinaForm: Form; activeFieldName?: string }
@@ -159,7 +160,14 @@ export const FormBuilder: FC<FormBuilderProps> = ({
     <FinalForm
       key={tinaForm.id}
       form={tinaForm.finalForm}
-      onSubmit={tinaForm.onSubmit}
+      onSubmit={async (values, form, cb) => {
+        const schema: TinaSchema = cms.api.tina.schema
+        const collection = schema.getCollectionByFullPath(tinaForm.relativePath)
+        const valOverride = collection?.ui?.beforeSubmit
+          ? await collection?.ui?.beforeSubmit({ cms, form, values, tinaForm })
+          : false
+        return tinaForm.onSubmit(valOverride || values, form, cb)
+      }}
     >
       {({
         handleSubmit,


### PR DESCRIPTION
Fixes ENG-1081

Add a `beforeSubmit` hook function on a collection.ui. This give users the ability to run a function before the form is submitted. 

If the function returns values those values will be used will be submitted instead of the form values.

If the function returns a falsy value the original form values will be submitted.

### Example



```js
// tina/config.{ts.js}

export default defineConfig({
  schema: {
    collections: [
      {
        ui: {
          // Example of beforeSubmit
          beforeSubmit: async ({ values }) => {
            return {
              ...values,
              lastUpdated: new Date().toISOString(),
            };
          },
          //...
        },
        //...
      },
      //...
    ],
  },
  //...
});
```