### PR TITLE
Filterable templates

### DIFF
--- a/.changeset/angry-chairs-kneel.md
+++ b/.changeset/angry-chairs-kneel.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Show filter/search inputs on collections with templates instead of fields

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -176,6 +176,22 @@ export const handleNavigate = (
   }
 }
 
+function getUniqueTemplateFields(collection: Collection<true>): TinaField[] {
+  const fieldSet: TinaField[] = []
+
+  collection.templates.forEach((template) => {
+    template.fields
+      .filter((f) => {
+        return fieldSet.find((x) => x.name === f.name) === undefined
+      })
+      .forEach((field) => {
+        fieldSet.push(field as TinaField)
+      })
+  })
+
+  return [...fieldSet]
+}
+
 const CollectionListPage = () => {
   const navigate = useNavigate()
   const { collectionName } = useParams()
@@ -285,28 +301,10 @@ const CollectionListPage = () => {
                 const admin: TinaAdminApi = cms.api.admin
                 const pageInfo = collection.documents.pageInfo
 
-                function getUniqueFields(collection): TinaField[] {
-                  const fieldSet: TinaField[] = []
-
-                  collection.templates.forEach((template) => {
-                    template.fields
-                      .filter((f) => {
-                        return (
-                          fieldSet.find((x) => x.name === f.name) === undefined
-                        )
-                      })
-                      .forEach((field) => {
-                        fieldSet.push(field as TinaField)
-                      })
-                  })
-
-                  return [...fieldSet]
-                }
-
                 // get unique fields from all templates
                 const fields = (
                   collectionExtra.templates?.length
-                    ? getUniqueFields(collectionExtra)
+                    ? getUniqueTemplateFields(collectionExtra)
                     : collectionExtra.fields
                 ).filter((x) =>
                   // only allow sortable fields

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -49,7 +49,7 @@ import GetCollection from '../components/GetCollection'
 import { RouteMappingPlugin } from '../plugins/route-mapping'
 import { PageBody, PageHeader, PageWrapper } from '../components/Page'
 import { TinaAdminApi } from '../api'
-import type { Collection } from '@tinacms/schema-tools'
+import type { Collection, TinaField } from '@tinacms/schema-tools'
 import { CollectionFolder, useCollectionFolder } from './utils'
 
 const LOCAL_STORAGE_KEY = 'tinacms.admin.collection.list.page'
@@ -284,10 +284,35 @@ const CollectionListPage = () => {
                 const documents = collection.documents.edges
                 const admin: TinaAdminApi = cms.api.admin
                 const pageInfo = collection.documents.pageInfo
-                const fields = collectionExtra.fields?.filter((x) =>
+
+                function getUniqueFields(collection): TinaField[] {
+                  const fieldSet: TinaField[] = []
+
+                  collection.templates.forEach((template) => {
+                    template.fields
+                      .filter((f) => {
+                        return (
+                          fieldSet.find((x) => x.name === f.name) === undefined
+                        )
+                      })
+                      .forEach((field) => {
+                        fieldSet.push(field as TinaField)
+                      })
+                  })
+
+                  return [...fieldSet]
+                }
+
+                // get unique fields from all templates
+                const fields = (
+                  collectionExtra.templates?.length
+                    ? getUniqueFields(collectionExtra)
+                    : collectionExtra.fields
+                ).filter((x) =>
                   // only allow sortable fields
                   ['string', 'number', 'datetime', 'boolean'].includes(x.type)
                 )
+
                 const sortField = fields?.find(
                   (field) => field.name === sortName
                 )


### PR DESCRIPTION
Previously, collections with templates instead of fields weren't getting the option to filter/search/sort
https://www.loom.com/share/9fa1adec08504274855a9216f0574f69?sid=524d5849-29ae-4e5b-9467-4fad42d17afe

fixes ENG-1103