### PR TITLE
Show search even with no filterable fields

### DIFF
--- a/.changeset/five-shirts-remember.md
+++ b/.changeset/five-shirts-remember.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Show search input even when collection contains only non-filterable fields

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -487,33 +487,33 @@ const CollectionListPage = () => {
                                     />
                                   </div>
                                 )}
-                                <div className="flex flex-1 flex-col gap-2 items-start w-full">
-                                  {searchEnabled ? (
-                                    <SearchInput
-                                      loading={_loading}
-                                      search={search}
-                                      setSearch={setSearch}
-                                      searchInput={searchInput}
-                                      setSearchInput={setSearchInput}
-                                    />
-                                  ) : (
-                                    <>
-                                      <label className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal">
-                                        Search
-                                      </label>
-                                      <Message
-                                        link="https://tina.io/docs/reference/search/overview"
-                                        linkLabel="Read The Docs"
-                                        type="info"
-                                        size="small"
-                                      >
-                                        Search not configured.
-                                      </Message>
-                                    </>
-                                  )}
-                                </div>
                               </>
                             )}
+                            <div className="flex flex-1 flex-col gap-2 items-start w-full">
+                              {searchEnabled ? (
+                                <SearchInput
+                                  loading={_loading}
+                                  search={search}
+                                  setSearch={setSearch}
+                                  searchInput={searchInput}
+                                  setSearchInput={setSearchInput}
+                                />
+                              ) : (
+                                <>
+                                  <label className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal">
+                                    Search
+                                  </label>
+                                  <Message
+                                    link="https://tina.io/docs/reference/search/overview"
+                                    linkLabel="Read The Docs"
+                                    type="info"
+                                    size="small"
+                                  >
+                                    Search not configured.
+                                  </Message>
+                                </>
+                              )}
+                            </div>
                           </div>
                         </div>
                         <div className="flex self-end	justify-self-end">


### PR DESCRIPTION
For collections with only no text fields, we previously omitted the search input, and the filters

<img width="1349" alt="Screenshot 2023-08-10 at 2 55 50 PM" src="https://github.com/tinacms/tinacms/assets/3323181/bda7c222-da0b-40e7-b6cd-89e9d18f8942">

Now we only omit the filters:
<img width="991" alt="Screenshot 2023-08-10 at 3 08 47 PM" src="https://github.com/tinacms/tinacms/assets/3323181/eebd4e01-912a-4802-9e5a-f9f860380c6d">

