### PR TITLE
feat: router async

### DIFF
--- a/.changeset/blue-zoos-drive.md
+++ b/.changeset/blue-zoos-drive.md
@@ -1,0 +1,16 @@
+---
+'@tinacms/schema-tools': patch
+'tinacms': patch
+---
+
+Update the router function to work asynchronously. This means that a user can now fetch data or perform other async operations in the router function.
+
+Example:
+```ts
+ router: async ({ document }) => {
+  const res = await client.queries.post({
+    relativePath: document._sys.relativePath,
+  })
+  return `/posts/${res.data.slug}`
+},
+```

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -794,7 +794,7 @@ export interface UICollection<Form = any, CMS = any, TinaForm = any> {
   router?: (args: {
     document: Document
     collection: Collection<true>
-  }) => string | undefined
+  }) => Promise<string | undefined>
 
   /**
    * This function is called before a document is created or updated. It can be used to modify the values that are saved to the CMS. It can also be used to perform side effects such as sending a notification or triggering a build.

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -127,7 +127,7 @@ const TemplateMenu = ({
   )
 }
 
-export const handleNavigate = (
+export const handleNavigate = async (
   navigate: NavigateFunction,
   cms: TinaCMS,
   // FIXME: `Collection` is deceiving because it's just the value we get back from the API request
@@ -147,7 +147,7 @@ export const handleNavigate = (
    * Determine if the document has a route mapped
    */
   let routeOverride = collectionDefinition.ui?.router
-    ? collectionDefinition.ui?.router({
+    ? await collectionDefinition.ui?.router({
         document,
         collection: collectionDefinition,
       })


### PR DESCRIPTION
Update the router function to work asynchronously. This means that a user can now fetch data or perform other async operations in the router function.

Example:
```ts
 router: async ({ document }) => {
  const res = await client.queries.post({
    relativePath: document._sys.relativePath,
  })
  return `/posts/${res.data.slug}`
},
```