### PR TITLE
Filtering subitems to avoid duplicates

### DIFF
--- a/.changeset/funny-coins-help.md
+++ b/.changeset/funny-coins-help.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+filtering subitems to avoid duplicates

--- a/packages/tinacms/src/toolkit/react-sidebar/components/form-list.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/form-list.tsx
@@ -58,12 +58,25 @@ const FormListItem = ({
   depth: number
   setActiveFormId: (id: string) => void
 }) => {
+  const subItems = React.useMemo(
+    () =>
+      item.subItems.filter((subItem, index, self) => {
+        return (
+          subItem.type === 'document' &&
+          index ===
+            self.findIndex(
+              (s) => s.type === 'document' && s.formId === subItem.formId
+            )
+        )
+      }),
+    [item.subItems]
+  )
   return (
     <div className={`divide-y divide-gray-200`}>
       <Item setActiveFormId={setActiveFormId} item={item} depth={depth} />
       {item.subItems && (
         <ul className="divide-y divide-gray-200">
-          {item.subItems?.map((subItem) => {
+          {subItems.map((subItem) => {
             if (subItem.type === 'document') {
               return (
                 <li key={subItem.formId}>


### PR DESCRIPTION
Filtering all the nav items to avoid duplicate references, that caused errors in console.
The error: 
```
Warning: Encountered two children with the same key, `content/colors/foreground.json`. Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.

```