### PR TITLE
Fix matches

### DIFF
--- a/.changeset/silent-balloons-beg.md
+++ b/.changeset/silent-balloons-beg.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/schema-tools': patch
+---
+
+fix: Fix matches regression where matches on collections wouldn't match proper collection

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -113,7 +113,8 @@ export class TinaSchema {
       if (collection?.match?.include || collection?.match?.exclude) {
         // if the collection has a match or exclude, we need to check if the file matches
         const matches = this.getMatches({ collection })
-        const match = picomatch([filepath], matches).length > 0
+        const match = picomatch.isMatch(filepath, matches)
+
         if (!match) {
           return false
         }


### PR DESCRIPTION
Fix regression from https://github.com/tinacms/tinacms/commit/bcc0b25b32c6cb6d9f0d72c9e755dffc8cec91a3

Previously, isMatch always returned true, so we would fetch the wrong collections and fail in unexpected ways