### PR TITLE
Always ask for pacakge manager

### DIFF
--- a/packages/@tinacms/cli/src/cmds/init/apply.ts
+++ b/packages/@tinacms/cli/src/cmds/init/apply.ts
@@ -338,7 +338,11 @@ const addDependencies = async (
 ) => {
   const tagVersion = params.tinaVersion ? `@${params.tinaVersion}` : ''
   const { dataLayerAdapter, nextAuth, packageManager } = config
-  let deps = [`tinacms`, '@tinacms/cli']
+  let deps = []
+  if (!env.tinaConfigExists) {
+    deps.push('tinacms')
+    deps.push('@tinacms/cli')
+  }
   let devDeps = []
   if (nextAuth) {
     deps.push('tinacms-next-auth', 'next-auth')
@@ -371,7 +375,7 @@ const addDependencies = async (
     yarn: `yarn add ${deps.join(' ')}`,
   }
 
-  if (packageManagers[packageManager]) {
+  if (packageManagers[packageManager] && deps.length > 0) {
     logger.info(logText('Adding dependencies, this might take a moment...'))
     logger.info(indentedCmd(`${logText(packageManagers[packageManager])}`))
     await execShellCommand(packageManagers[packageManager])
@@ -493,7 +497,13 @@ const addDatabaseFile = async ({
   })
 }
 
-const addGqlApiHandler = async ({ config, generatedFile }) => {
+const addGqlApiHandler = async ({
+  config,
+  generatedFile,
+}: {
+  config: Record<any, any>
+  generatedFile: GeneratedFile
+}) => {
   let vars: GQLTemplateVariables = {
     isLocalEnvVarName: config.isLocalEnvVarName,
     typescript: config.typescript,

--- a/packages/@tinacms/cli/src/cmds/init/configure.ts
+++ b/packages/@tinacms/cli/src/cmds/init/configure.ts
@@ -93,16 +93,6 @@ async function configure(
   // This is always run durring tinacms init
   const tinaSetupPrompts: prompts.PromptObject[] = [
     {
-      name: 'packageManager',
-      type: 'select',
-      message: 'Choose your package manager',
-      choices: [
-        { title: 'PNPM', value: 'pnpm' },
-        { title: 'Yarn', value: 'yarn' },
-        { title: 'NPM', value: 'npm' },
-      ],
-    },
-    {
       name: 'typescript',
       type: 'confirm',
       initial: true,
@@ -170,24 +160,8 @@ async function configure(
   ]
   // These questions are adding when running `tinacms init backend`
   // askForPackageManager is true when they skipped the normal init setup
-  const backendSetupCommands = (
-    askForPackageManager: boolean
-  ): prompts.PromptObject[] => {
-    const maybeCommands: prompts.PromptObject[] = []
-    if (askForPackageManager) {
-      maybeCommands.push({
-        name: 'packageManager',
-        type: 'select',
-        message: 'Choose your package manager',
-        choices: [
-          { title: 'PNPM', value: 'pnpm' },
-          { title: 'Yarn', value: 'yarn' },
-          { title: 'NPM', value: 'npm' },
-        ],
-      })
-    }
+  const backendSetupCommands = (): prompts.PromptObject[] => {
     return [
-      ...maybeCommands,
       {
         name: 'hosting',
         type: 'select',
@@ -351,11 +325,21 @@ async function configure(
           },
         ] as { title: string; value: Framework }[],
       },
+      {
+        name: 'packageManager',
+        type: 'select',
+        message: 'Choose your package manager',
+        choices: [
+          { title: 'PNPM', value: 'pnpm' },
+          { title: 'Yarn', value: 'yarn' },
+          { title: 'NPM', value: 'npm' },
+        ],
+      },
 
       // only setup TinaCMS if they don't have a tina config
       ...(skipTinaSetupCommands ? [] : tinaSetupPrompts),
       // Only add the backend init quesitons if they are running the backend init command
-      ...(opts.isBacked ? backendSetupCommands(skipTinaSetupCommands) : []),
+      ...(opts.isBacked ? backendSetupCommands() : []),
       // tina/config.ts
       ...generatedFileOverwritePrompt({
         condition: (_) => !env.tinaConfigExists,


### PR DESCRIPTION
I was noticing that when doing a backend init on a site that already has tina setup it was not doing an install (Adding new self hosting deps). 

This PR updates the questions so that it always asks for the package manager so that it has that info to use to run the install command.