### PR TITLE
fix: verify sha exists before partial reindexing

### DIFF
--- a/.changeset/silent-shoes-smash.md
+++ b/.changeset/silent-shoes-smash.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/graphql': patch
+'@tinacms/cli': patch
+---
+
+Fixes issue when an existing database contains sha metadata for partial reindexing and the sha is missing from the repository

--- a/packages/@tinacms/cli/src/next/commands/baseCommands.ts
+++ b/packages/@tinacms/cli/src/next/commands/baseCommands.ts
@@ -11,7 +11,7 @@ import { startSubprocess2 } from '../../utils/start-subprocess'
 import { logger } from '../../logger'
 import { spin } from '../../utils/spinner'
 import { warnText } from '../../utils/theme'
-import { getChangedFiles, getSha } from '@tinacms/graphql'
+import { getChangedFiles, getSha, shaExists } from '@tinacms/graphql'
 import fs from 'fs-extra'
 import { ConfigManager } from '../config-manager'
 
@@ -126,8 +126,10 @@ export abstract class BaseCommand extends Command {
           }
         }
         const lastSha = await database.getMetadata('lastSha')
+        const exists =
+          lastSha && (await shaExists({ fs, dir: rootPath, sha: lastSha }))
         let res
-        if (partialReindex && lastSha && sha) {
+        if (partialReindex && lastSha && exists && sha) {
           const pathFilter: Record<string, { matches?: string[] }> = {}
           if (configManager.isUsingLegacyFolder) {
             pathFilter['.tina/__generated__/_schema.json'] = {}

--- a/packages/@tinacms/graphql/src/git/index.ts
+++ b/packages/@tinacms/graphql/src/git/index.ts
@@ -94,3 +94,17 @@ export const getChangedFiles = async ({
   })
   return results
 }
+
+export const shaExists = async ({
+  fs,
+  dir,
+  sha,
+}: {
+  fs: CallbackFsClient | PromiseFsClient
+  dir: string
+  sha: string
+}): Promise<boolean> =>
+  git
+    .readCommit({ fs, dir, oid: sha })
+    .then(() => true)
+    .catch(() => false)

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -21,7 +21,7 @@ export type {
 } from './database'
 import type { Database } from './database'
 import type { Config } from '@tinacms/schema-tools'
-export { getChangedFiles, getSha } from './git'
+export { getChangedFiles, getSha, shaExists } from './git'
 
 export { sequential, assertShape } from './util'
 export {


### PR DESCRIPTION
# what

Detect whether the stored last commit sha used for partial reindexing exists before attempting to find changed files. Handles case where the stored sha gets removed or lost somehow.
