### PR TITLE
Empty field group fix

### DIFF
--- a/.changeset/neat-meals-walk.md
+++ b/.changeset/neat-meals-walk.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+fix: Fix active form on nested group when value is empty

--- a/packages/tinacms/src/toolkit/forms/form.ts
+++ b/packages/tinacms/src/toolkit/forms/form.ts
@@ -314,7 +314,7 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
   }
   private getFieldGroup({
     formOrObjectField,
-    values,
+    values = {},
     namePathIndex,
     namePath,
   }: {


### PR DESCRIPTION
fixes #4165

Fixes an issue where CMS blows up when navigating in a nested group, if the nested group has no value in front matter