### PR TITLE
Fix/media thumbnail

### DIFF
--- a/.changeset/khaki-geckos-reflect.md
+++ b/.changeset/khaki-geckos-reflect.md
@@ -1,0 +1,6 @@
+---
+"next-tinacms-cloudinary": patch
+"tinacms": patch
+---
+
+Fix/media thumbnail

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -206,14 +206,14 @@ function getCloudinaryToTinaFunc(opts: CloudinaryOptions) {
       directory,
       src: file[sel],
       thumbnails: {
-        '75x75': transformCloudinaryImage(file[sel], 'w_75,h_75,c_fill,q_auto'),
+        '75x75': transformCloudinaryImage(file[sel], 'w_75,h_75,c_fit,q_auto'),
         '400x400': transformCloudinaryImage(
           file[sel],
-          'w_400,h_400,c_fill,q_auto'
+          'w_400,h_400,c_fit,q_auto'
         ),
         '1000x1000': transformCloudinaryImage(
           file[sel],
-          'w_1000,h_1000,c_fill,q_auto'
+          'w_1000,h_1000,c_fit,q_auto'
         ),
       },
       type: 'file',

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -35,7 +35,7 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
       <div className="w-16 h-16 bg-gray-50 border-r border-gray-150 overflow-hidden flex justify-center flex-shrink-0">
         {isImage(thumbnail) ? (
           <img
-            className="object-cover w-full h-full object-center origin-center transition-all duration-150 ease-out group-hover:scale-110"
+            className="object-contain object-center w-full h-full origin-center transition-all duration-150 ease-out group-hover:scale-110"
             src={thumbnail}
             alt={item.filename}
           />
@@ -80,7 +80,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
       >
         {isImage(thumbnail) ? (
           <img
-            className="object-cover w-full h-full object-center"
+            className="object-contain object-center w-full h-full"
             src={thumbnail}
             alt={item.filename}
           />

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -507,7 +507,7 @@ const ActiveItemPreview = ({
           {isImage(thumbnail) ? (
             <div className="w-full max-h-[75%]">
               <img
-                className="block border border-gray-100 rounded-md overflow-hidden object-center object-contain w-full h-full shadow"
+                className="block border border-gray-100 rounded-md overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow"
                 src={thumbnail}
                 alt={activeItem.filename}
               />

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -507,7 +507,7 @@ const ActiveItemPreview = ({
           {isImage(thumbnail) ? (
             <div className="w-full max-h-[75%]">
               <img
-                className="block border border-gray-100 rounded-md overflow-hidden max-w-full max-h-full object-fit h-auto shadow"
+                className="block border border-gray-100 rounded-md overflow-hidden object-center object-contain w-full h-full shadow"
                 src={thumbnail}
                 alt={activeItem.filename}
               />


### PR DESCRIPTION
The image thumbnails in the media manager are often hard to understand due to object-fit: cover. (see right thumbnail below)
![Screenshot 2023-08-31 at 4 25 21 PM](https://github.com/tinacms/tinacms/assets/776019/be176cdf-21ef-4f11-94c0-52f87efb9490)

This PR changes this to contain the image like so:
![Screenshot 2023-08-31 at 4 25 15 PM](https://github.com/tinacms/tinacms/assets/776019/5d5be165-fe53-4b77-b80b-012d0f1192b8)

The cloudinary parameters needed to be changed as well. 

This was done for grid-view thumbnails, list-view thumbnails, and the large preview  
