### PR TITLE
Fix nested mdx templates

### DIFF
--- a/.changeset/swift-pants-return.md
+++ b/.changeset/swift-pants-return.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix issue where deeply nested mdx fields were not picking up the correct template"

--- a/.changeset/wicked-beers-perform.md
+++ b/.changeset/wicked-beers-perform.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Hide cloud sidebar panel when self-hosted

--- a/packages/tinacms/src/toolkit/forms/form.ts
+++ b/packages/tinacms/src/toolkit/forms/form.ts
@@ -452,7 +452,11 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
           }
         } else {
           const childrenIndex = namePathIndex + 1
-          const propsIndex = namePath.findIndex((value) => value === 'props')
+          // Find the props for the next item, ignoring parent 'props'
+          const propsIndex =
+            namePath
+              .slice(childrenIndex)
+              .findIndex((value) => value === 'props') + childrenIndex
           const itemName = namePath.slice(childrenIndex, propsIndex).join('.')
           const item = getIn(value, itemName)
           const props = item.props

--- a/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
@@ -193,7 +193,7 @@ export const Nav = ({
             </ul>
           </>
         )}
-        {!!cloudConfigs?.length && (
+        {!cms.isSelfHosted && !!cloudConfigs?.length && (
           <>
             <h4 className="uppercase font-sans font-bold text-sm mb-3 mt-8 text-gray-700">
               Cloud

--- a/packages/tinacms/src/toolkit/tina-cms.ts
+++ b/packages/tinacms/src/toolkit/tina-cms.ts
@@ -81,6 +81,7 @@ export class TinaCMS extends CMS {
   dispatch: React.Dispatch<TinaAction>
   // We always attach the tina client to the cms instance
   api: { [key: string]: any; tina?: Client } = {}
+  isSelfHosted?: boolean
 
   constructor({
     sidebar,
@@ -91,6 +92,8 @@ export class TinaCMS extends CMS {
     ...config
   }: TinaCMSConfig = {}) {
     super(config)
+
+    this.isSelfHosted = isSelfHosted
 
     this.alerts.setMap({
       'media:upload:failure': (


### PR DESCRIPTION
When an MDX component is nested 2 levels deep, we were picking up the index of the first item while trying to resolve the second. Closes https://github.com/tinacms/tinacms/issues/4187