### PR TITLE
Fix issue where deeply nested mdx fields were not picking up the correct template

### DIFF
--- a/.changeset/swift-pants-return.md
+++ b/.changeset/swift-pants-return.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix issue where deeply nested mdx fields were not picking up the correct template"

--- a/packages/tinacms/src/toolkit/forms/form.ts
+++ b/packages/tinacms/src/toolkit/forms/form.ts
@@ -452,7 +452,11 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
           }
         } else {
           const childrenIndex = namePathIndex + 1
-          const propsIndex = namePath.findIndex((value) => value === 'props')
+          // Find the props for the next item, ignoring parent 'props'
+          const propsIndex =
+            namePath
+              .slice(childrenIndex)
+              .findIndex((value) => value === 'props') + childrenIndex
           const itemName = namePath.slice(childrenIndex, propsIndex).join('.')
           const item = getIn(value, itemName)
           const props = item.props


### PR DESCRIPTION


When an MDX component is nested 2 levels deep, we were picking up the index of the first item while trying to resolve the second. Closes https://github.com/tinacms/tinacms/issues/4187