### PR TITLE
Only preserve legacy values if no field is defined for them

### DIFF
--- a/.changeset/late-vans-wash.md
+++ b/.changeset/late-vans-wash.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Update mutation logic so that existing markdown values aren't overwritten by the Tina form, only if the schema has not defined that field

--- a/.prettierignore
+++ b/.prettierignore
@@ -24,3 +24,4 @@ terraform/**/.terraform
 **/.next/**
 examples/hugo-quickstart
 **/out.md
+_response.md

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -509,7 +509,7 @@ export class Resolver {
   }) => {
     const doc = await this.getDocument(realPath)
 
-    const oldDoc = doc?._rawData || {}
+    const oldDoc = this.resolveLegacyValues(doc?._rawData || {}, collection)
     /**
      * TODO: Remove when `addPendingDocument` is no longer needed.
      */
@@ -563,6 +563,42 @@ export class Resolver {
     //@ts-ignore
     await this.database.put(realPath, { ...oldDoc, ...params }, collection.name)
     return this.getDocument(realPath)
+  }
+
+  /**
+   * Returns top-level fields which are not defined in the collection, so their
+   * values are not eliminated from Tina when new values are saved
+   */
+  public resolveLegacyValues = (oldDoc, collection: Collection<true>) => {
+    const legacyValues = {}
+    Object.entries(oldDoc).forEach(([key, value]) => {
+      const reservedKeys = [
+        '$_body',
+        '_collection',
+        '_keepTemplateKey',
+        '_template',
+        '_relativePath',
+        '_id',
+      ]
+      if (reservedKeys.includes(key)) {
+        return
+      }
+      if (oldDoc._template) {
+        const template = collection.templates?.find(
+          ({ name }) => name === oldDoc._template
+        )
+        if (template) {
+          if (!template.fields.find(({ name }) => name === key)) {
+            legacyValues[key] = value
+          }
+        }
+      } else {
+        if (!collection.fields.find(({ name }) => name === key)) {
+          legacyValues[key] = value
+        }
+      }
+    })
+    return legacyValues
   }
 
   public resolveDocument = async ({

--- a/packages/@tinacms/graphql/src/spec/forestry-sample/mutations/updateDocument/_response.md
+++ b/packages/@tinacms/graphql/src/spec/forestry-sample/mutations/updateDocument/_response.md
@@ -1,8 +1,4 @@
 ---
 title: Ok
-author: content/authors/homer.md
 _template: post
 ---
-
-
-How's that?

--- a/packages/@tinacms/graphql/src/spec/forestry-sample/mutations/updateDocument/_response.md
+++ b/packages/@tinacms/graphql/src/spec/forestry-sample/mutations/updateDocument/_response.md
@@ -2,3 +2,4 @@
 title: Ok
 _template: post
 ---
+

--- a/packages/@tinacms/graphql/src/spec/movies/mutations/updateDocument/_response.md
+++ b/packages/@tinacms/graphql/src/spec/movies/mutations/updateDocument/_response.md
@@ -1,8 +1,8 @@
 ---
 title: A New Hope
-director: content/directors/george.md
-genre: scifi
 rating: 10
+genre: scifi
+director: content/directors/george.md
 ---
 
 Here is some `inline code`.

--- a/packages/@tinacms/graphql/src/spec/movies/mutations/updateDocument/_variables.json
+++ b/packages/@tinacms/graphql/src/spec/movies/mutations/updateDocument/_variables.json
@@ -1,6 +1,9 @@
 {
   "params": {
     "title": "A New Hope",
+    "director": "content/directors/george.md",
+    "genre": "scifi",
+    "rating": 10,
     "body": {
       "children": [
         {


### PR DESCRIPTION
Update mutation logic so that existing markdown values aren't overwritten by the Tina form, only if the schema has not defined that field. 

Eg:

```
title: Hello
tags:
  - a
  - b
```
And a schema:
```
{
  //...
  fields: [
    {type: 'string', name: 'title'},
  ]
}
```
`tags` won't be changed, but if there is a field defined for `tags`, whatever value is sent in from the Tina form will be used, even `null`:
```
title: Hello
tags: null
```
