### PR TITLE
Separate repo lockfile

### DIFF
--- a/.changeset/odd-hounds-draw.md
+++ b/.changeset/odd-hounds-draw.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+fix: add tina-lock file to external content directories when localContentPath is set

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -100,14 +100,26 @@ export class DevCommand extends BaseCommand {
           const schemaObject = require(configManager.generatedSchemaJSONPath)
           const lookupObject = require(configManager.generatedLookupJSONPath)
           const graphqlSchemaObject = require(configManager.generatedGraphQLJSONPath)
+
+          const tinaLockFilename = 'tina-lock.json'
+          const tinaLockContent = JSON.stringify({
+            schema: schemaObject,
+            lookup: lookupObject,
+            graphql: graphqlSchemaObject,
+          })
           await fs.writeFileSync(
-            path.join(configManager.tinaFolderPath, 'tina-lock.json'),
-            JSON.stringify({
-              schema: schemaObject,
-              lookup: lookupObject,
-              graphql: graphqlSchemaObject,
-            })
+            path.join(configManager.tinaFolderPath, tinaLockFilename),
+            tinaLockContent
           )
+
+          if (configManager.hasSeparateContentRoot()) {
+            const rootPath = await configManager.getTinaFolderPath(
+              configManager.contentRootPath
+            )
+            const filePath = path.join(rootPath, tinaLockFilename)
+            await fs.ensureFile(filePath)
+            await fs.outputFile(filePath, tinaLockContent)
+          }
         }
 
         if (!this.noWatch) {


### PR DESCRIPTION
Update the "Content in a separate repo" workflow to export tina-lock in the external local repo.
(I don't think this has been working since we switched from pushing up a `__generated__` directory to a pushing a `tina-lock.json`)