### PR TITLE
Remove start script

### DIFF
--- a/packages/@tinacms/cli/src/utils/script-helpers.test.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.test.ts
@@ -21,14 +21,12 @@ describe('extendNextScripts', () => {
         foo: 'bar',
         dev: 'next dev -p 3000',
         build: 'next build -p 3000',
-        start: 'next start -p 3000',
       })
 
       expect(newScripts).toEqual({
         foo: 'bar',
         dev: 'tinacms dev -c "next dev -p 3000"',
         build: 'tinacms build && next build -p 3000',
-        start: 'tinacms build && next start -p 3000',
       })
     })
   })
@@ -43,7 +41,6 @@ describe('extendNextScripts', () => {
         foo: 'bar',
         dev: 'tinacms dev -c "next dev"',
         build: 'tinacms build && next build',
-        start: 'tinacms build && next start',
       })
     })
   })

--- a/packages/@tinacms/cli/src/utils/script-helpers.ts
+++ b/packages/@tinacms/cli/src/utils/script-helpers.ts
@@ -29,10 +29,6 @@ export function extendNextScripts(
       !scripts?.build || !scripts?.build?.startsWith('tinacms build &&')
         ? `tinacms build && ${scripts?.build || 'next build'}`
         : scripts?.build,
-    start:
-      !scripts?.start || !scripts?.start?.startsWith('tinacms build &&')
-        ? `tinacms build && ${scripts?.start || 'next start'}`
-        : scripts?.start,
   }
 
   if (opts?.addSetupUsers && !scripts['setup:users']) {


### PR DESCRIPTION
When we generate new scripts in the users package.json for next.js sites we don't need to wrap the start script in tinacms build since it is assumed that the build script has all ready been run.
