### PR TITLE
feat: custom next-auth api endpoint path

### DIFF
--- a/examples/tina-self-hosted-demo/pages/api/tina/auth/[...nextauth].ts
+++ b/examples/tina-self-hosted-demo/pages/api/tina/auth/[...nextauth].ts
@@ -1,5 +1,5 @@
 import NextAuth from 'next-auth'
-import { AuthJsOptions } from '../../../tina/auth'
+import { AuthJsOptions } from '../../../../tina/auth'
 
 export default async function handler(...params: any[]) {
   await NextAuth(AuthJsOptions)(...params)

--- a/examples/tina-self-hosted-demo/pages/api/tina/gql.ts
+++ b/examples/tina-self-hosted-demo/pages/api/tina/gql.ts
@@ -1,5 +1,5 @@
-import withTinaAuth from '../../tina/auth'
-import databaseClient from '../../tina/__generated__/databaseClient'
+import withTinaAuth from '../../../tina/auth'
+import databaseClient from '../../../tina/__generated__/databaseClient'
 
 async function handler(req, res) {
   const { query, variables } = req.body

--- a/examples/tina-self-hosted-demo/tina/config.tsx
+++ b/examples/tina-self-hosted-demo/tina/config.tsx
@@ -12,9 +12,11 @@ import {
 } from 'tinacms-authjs/dist/tinacms'
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
+// process.env.NEXTAUTH_URL = process.env.NEXT_PUBLIC_NEXTAUTH_URL
+// console.log(process.env.NEXTAUTH_URL)
 
 const config = defineStaticConfig({
-  contentApiUrlOverride: '/api/gql',
+  contentApiUrlOverride: '/api/tina/gql',
   clientId: process.env.NEXT_PUBLIC_TINA_CLIENT_ID!,
   authProvider: isLocal
     ? new LocalAuthProvider()

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -480,6 +480,7 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
+  getSessionProvider: () => React.ReactElement
 }
 
 interface AuthHooks {

--- a/packages/tinacms-authjs/src/tinacms.ts
+++ b/packages/tinacms-authjs/src/tinacms.ts
@@ -1,5 +1,11 @@
 import { Collection, LoginStrategy } from '@tinacms/schema-tools'
-import { getCsrfToken, getSession, signIn, signOut } from 'next-auth/react'
+import {
+  getCsrfToken,
+  getSession,
+  signIn,
+  signOut,
+  SessionProvider,
+} from 'next-auth/react'
 import { AbstractAuthProvider } from 'tinacms'
 
 export class DefaultAuthJSProvider extends AbstractAuthProvider {
@@ -25,6 +31,10 @@ export class DefaultAuthJSProvider extends AbstractAuthProvider {
   async authorize(context?: any): Promise<any> {
     const user: any = (await getSession(context))?.user || {}
     return user.role === 'user'
+  }
+
+  getSessionProvider() {
+    return SessionProvider
   }
 }
 
@@ -63,7 +73,7 @@ export class UsernamePasswordAuthJSProvider extends DefaultAuthJSProvider {
   async authenticate(props: { username: string; password: string }) {
     const csrfToken = await getCsrfToken()
     // TODO make api baseUrl configurable
-    return fetch('/api/auth/callback/credentials', {
+    return fetch('/api/tina/auth/callback/credentials', {
       redirect: 'error', //redirect should throw an error
       method: 'POST',
       headers: {

--- a/packages/tinacms-clerk/package.json
+++ b/packages/tinacms-clerk/package.json
@@ -32,7 +32,6 @@
     },
     "repository": {
       "url": "https://github.com/tinacms/tinacms.git",
-      "directory": "packages/next-auth"
+      "directory": "packages/tinacms-clerk"
     }
   }
-  

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -409,6 +409,7 @@ export const TinaCloudProvider = (
   // Weather or not we are using Tina Cloud for auth
   const isTinaCloud =
     !client.isLocalMode && !client.schema?.config?.config?.contentApiUrlOverride
+  const SessionProvider = client.authProvider.getSessionProvider()
 
   const handleListBranches = async (): Promise<Branch[]> => {
     const branches = await cms.api.tina.listBranches({
@@ -486,16 +487,18 @@ export const TinaCloudProvider = (
   }, [isTinaCloud, cms])
 
   return (
-    <BranchDataProvider
-      currentBranch={currentBranch}
-      setCurrentBranch={(b) => {
-        setCurrentBranch(b)
-      }}
-    >
-      <TinaProvider cms={cms}>
-        <AuthWallInner {...props} cms={cms} />
-      </TinaProvider>
-    </BranchDataProvider>
+    <SessionProvider basePath="/api/tina/auth">
+      <BranchDataProvider
+        currentBranch={currentBranch}
+        setCurrentBranch={(b) => {
+          setCurrentBranch(b)
+        }}
+      >
+        <TinaProvider cms={cms}>
+          <AuthWallInner {...props} cms={cms} />
+        </TinaProvider>
+      </BranchDataProvider>
+    </SessionProvider>
   )
 }
 

--- a/packages/tinacms/src/auth/defaultSessionProvider.tsx
+++ b/packages/tinacms/src/auth/defaultSessionProvider.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const DefaultSessionProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => <>{children}</>
+
+export default DefaultSessionProvider

--- a/packages/tinacms/src/internalClient/authProvider.ts
+++ b/packages/tinacms/src/internalClient/authProvider.ts
@@ -1,5 +1,6 @@
 import { AuthProvider, LoginStrategy } from '@tinacms/schema-tools'
 import { authenticate, AUTH_TOKEN_KEY, TokenObject } from '../auth/authenticate'
+import DefaultSessionProvider from '../auth/defaultSessionProvider'
 
 export abstract class AbstractAuthProvider implements AuthProvider {
   /**
@@ -40,6 +41,10 @@ export abstract class AbstractAuthProvider implements AuthProvider {
 
   getLoginStrategy(): LoginStrategy {
     return 'Redirect'
+  }
+
+  getSessionProvider() {
+    return DefaultSessionProvider
   }
 
   abstract getToken()


### PR DESCRIPTION
support custom next-auth path (`/api/tina/auth/*`) to support consolidated api without rewrite