### PR TITLE
Don't log 'not found' errors to the console from the GraphQL server

### DIFF
--- a/.changeset/pink-mirrors-wave.md
+++ b/.changeset/pink-mirrors-wave.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Don't log "not found" errors to the console from the GraphQL server

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -54,6 +54,7 @@ import {
 } from './level'
 import { applyNameOverrides, replaceNameOverrides } from './alias-utils'
 import sha from 'js-sha1'
+import { NotFoundError } from '../error'
 
 type IndexStatusEvent = {
   status: 'inprogress' | 'complete' | 'failed'
@@ -204,7 +205,7 @@ export class Database {
         .get(normalizePath(filepath))
 
       if (!contentObject) {
-        throw new GraphQLError(`Unable to find record ${filepath}`)
+        throw new NotFoundError(`Unable to find record ${filepath}`)
       }
       return transformDocument(
         filepath,

--- a/packages/@tinacms/graphql/src/error.ts
+++ b/packages/@tinacms/graphql/src/error.ts
@@ -1,0 +1,16 @@
+import { ASTNode, GraphQLError, GraphQLErrorExtensions, Source } from 'graphql'
+
+export class NotFoundError extends GraphQLError {
+  constructor(
+    message: string,
+    nodes?: ASTNode | readonly ASTNode[],
+    source?: Source,
+    positions?: readonly number[],
+    path?: readonly (string | number)[],
+    originalError?: Error,
+    extensions?: GraphQLErrorExtensions
+  ) {
+    super(message, nodes, source, positions, path, originalError, extensions)
+    this.name = 'NotFoundError'
+  }
+}

--- a/packages/@tinacms/graphql/src/resolve.ts
+++ b/packages/@tinacms/graphql/src/resolve.ts
@@ -13,6 +13,7 @@ import type { GraphQLResolveInfo } from 'graphql'
 import type { Database } from './database'
 import { NAMER } from './ast-builder'
 import { handleFetchErrorError } from './resolver/error'
+import { NotFoundError } from './error'
 
 export const resolve = async ({
   config,
@@ -368,12 +369,16 @@ export const resolve = async ({
     if (res.errors) {
       if (!silenceErrors) {
         res.errors.map((e) => {
-          console.error(e.toString())
+          if (e instanceof NotFoundError) {
+            // do nothing
+          } else {
+            console.error(e.toString())
 
-          if (verboseValue) {
-            console.error('More error context below')
-            console.error(e.message)
-            console.error(e)
+            if (verboseValue) {
+              console.error('More error context below')
+              console.error(e.message)
+              console.error(e)
+            }
           }
         })
       }


### PR DESCRIPTION
When a document is not found I don't think that should be logged to the GraphQL console. It's not necessarily something the user cares about.

cc @logan-anderson 