### PR TITLE
feat: warn nextauth custom provider

### DIFF
--- a/packages/@tinacms/datalayer/src/backend/index.ts
+++ b/packages/@tinacms/datalayer/src/backend/index.ts
@@ -8,6 +8,7 @@ type NodeApiHandler = (
 type DatabaseClient = any
 
 export interface BackendAuthentication {
+  initialize?: () => Promise<void>
   isAuthorized: (
     req: IncomingMessage,
     res: ServerResponse
@@ -42,7 +43,10 @@ export function TinaNodeBackend({
   authentication,
   databaseClient,
 }: TinaBackendOptions) {
-  const { isAuthorized, extraRoutes } = authentication
+  const { initialize, isAuthorized, extraRoutes } = authentication
+  initialize?.().catch((e) => {
+    console.error(e)
+  })
   const handler = MakeNodeApiHandler({
     isAuthorized,
     extraRoutes,

--- a/packages/tinacms-authjs/src/index.ts
+++ b/packages/tinacms-authjs/src/index.ts
@@ -69,9 +69,11 @@ const TinaAuthJSOptions = ({
   ...overrides,
 })
 
+const TINA_CREDENTIALS_PROVIDER_NAME = 'TinaCredentials'
+
 const TinaCredentialsProvider = ({
   databaseClient,
-  name = 'Credentials',
+  name = TINA_CREDENTIALS_PROVIDER_NAME,
 }: {
   databaseClient: any // TODO can we type this?
   name?: string
@@ -92,6 +94,21 @@ const AuthJsBackendAuthentication = ({
   authOptions: AuthOptions
 }) => {
   const backendAuthentication: BackendAuthentication = {
+    initialize: async () => {
+      if (!authOptions.providers?.length) {
+        throw new Error('No authentication providers specified')
+      }
+      const [provider, ...rest] = authOptions.providers
+      if (
+        rest.length > 0 ||
+        provider.type !== 'credentials' ||
+        provider.name !== TINA_CREDENTIALS_PROVIDER_NAME
+      ) {
+        console.warn(
+          `Catch-all api route ['/api/tina/*'] with specified Auth.js provider ['${provider.name}'] not supported. See https://tina.io/docs/self-hosted/overview/#customprovider for more information.`
+        )
+      }
+    },
     isAuthorized: async (req, res) => {
       // @ts-ignore
       const session = await getServerSession(req, res, authOptions)

--- a/packages/tinacms-authjs/src/index.ts
+++ b/packages/tinacms-authjs/src/index.ts
@@ -105,7 +105,7 @@ const AuthJsBackendAuthentication = ({
         provider.name !== TINA_CREDENTIALS_PROVIDER_NAME
       ) {
         console.warn(
-          `Catch-all api route ['/api/tina/*'] with specified Auth.js provider ['${provider.name}'] not supported. See https://tina.io/docs/self-hosted/overview/#customprovider for more information.`
+          `WARNING: Catch-all api route ['/api/tina/*'] with specified Auth.js provider ['${provider.name}'] not supported. See https://tina.io/docs/self-hosted/overview/#customprovider for more information.`
         )
       }
     },


### PR DESCRIPTION
Add a warning on backend api initialization when using a custom provider with the /api/tina/* catch-all

Demo: https://www.loom.com/share/af508f26eb6543e5a5012923e8724c6d?sid=cf83351e-99e6-4673-800f-de93443ce9e2

Note that this doesn't know whether a separate next-auth api handler has been configured, so the warning will show whenever the tina backend is initialized.