### PR TITLE
fix: #4201: correctly handle search indexing of list objects

### DIFF
--- a/.changeset/long-cows-happen.md
+++ b/.changeset/long-cows-happen.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/search': patch
+---
+
+Fix search indexing of list objects

--- a/packages/@tinacms/search/src/indexer/index.ts
+++ b/packages/@tinacms/search/src/indexer/index.ts
@@ -35,9 +35,7 @@ export class SearchIndexer {
 
   private makeIndexerCallback(itemCallback: (item: any) => Promise<void>) {
     return async (collection: Collection<true>, contentPaths: string[]) => {
-      const templateInfo = await this.schema.getTemplatesForCollectable(
-        collection
-      )
+      const templateInfo = this.schema.getTemplatesForCollectable(collection)
       await sequential(contentPaths as string[], async (path) => {
         const data = await transformDocumentIntoPayload(
           `${collection.path}/${path}`,

--- a/packages/@tinacms/search/src/indexer/utils.ts
+++ b/packages/@tinacms/search/src/indexer/utils.ts
@@ -90,7 +90,7 @@ export const processDocumentForIndexing = (
     data['_id'] = `${collection.name}:${relPath}`
     data['_relativePath'] = relPath
   }
-  for (const f of collection.fields || field?.fields || []) {
+  for (const f of field?.fields || collection.fields || []) {
     if (!f.searchable) {
       delete data[f.name]
       continue


### PR DESCRIPTION
# what

There was a small bug in the search indexing logic which only surfaced under the circumstances in #4201. The fields being the same name was a bit of a red herring, though. The problem was that it was using the collection field definitions on nested objects due to a logic error.