### PR TITLE
fix: #4240: fix issue where background color of search button was being overridden

### DIFF
--- a/.changeset/blue-cherries-hug.md
+++ b/.changeset/blue-cherries-hug.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix button styling issue when using Firefox

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -897,7 +897,6 @@ const SearchInput = ({
               setSearchLoaded(false)
             }}
             variant="primary"
-            type="submit"
           >
             Search <BiSearch className="w-5 h-full ml-1.5 opacity-70" />
           </Button>

--- a/packages/tinacms/src/toolkit/styles/button.tsx
+++ b/packages/tinacms/src/toolkit/styles/button.tsx
@@ -22,7 +22,7 @@ export const Button = ({
   disabled,
   rounded = 'full',
   children,
-  className,
+  className = '',
   ...props
 }: ButtonProps) => {
   const baseClasses =


### PR DESCRIPTION
# what

Fix #4240 by removing type='submit' from the search button which was causing the body style from overriding the background color. Also fix the button component to not add `undefined` to the class when no className is specified (although it didn't seem to cause any issues)