### PR TITLE
fix: exit and log when parse errors occur during indexing

### DIFF
--- a/.changeset/empty-countries-drive.md
+++ b/.changeset/empty-countries-drive.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Update dev & build commands to log and exit on indexing errors

--- a/.changeset/sharp-dragons-ring.md
+++ b/.changeset/sharp-dragons-ring.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Change content parsing logic to unconditionally log parse errors

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -78,8 +78,10 @@ export class BuildCommand extends BaseCommand {
     try {
       await configManager.processConfig()
     } catch (e) {
-      logger.error(e.message)
-      logger.error('Unable to build, please fix your Tina config and try again')
+      logger.error(`\n${dangerText(e.message)}`)
+      logger.error(
+        dangerText('Unable to build, please fix your Tina config and try again')
+      )
       process.exit(1)
     }
     let server: ViteDevServer | undefined
@@ -114,14 +116,22 @@ export class BuildCommand extends BaseCommand {
       const text = this.localOption
         ? undefined
         : 'Indexing to self-hosted data layer'
-      await this.indexContentWithSpinner({
-        text,
-        database,
-        graphQLSchema,
-        tinaSchema,
-        configManager,
-        partialReindex: this.partialReindex,
-      })
+      try {
+        await this.indexContentWithSpinner({
+          text,
+          database,
+          graphQLSchema,
+          tinaSchema,
+          configManager,
+          partialReindex: this.partialReindex,
+        })
+      } catch (e) {
+        logger.error(`\n\n${dangerText(e.message)}\n`)
+        if (this.verbose) {
+          console.error(e)
+        }
+        process.exit(1)
+      }
     }
 
     if (this.localOption) {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -107,7 +107,7 @@ export class DevCommand extends BaseCommand {
             lookup: lookupObject,
             graphql: graphqlSchemaObject,
           })
-          await fs.writeFileSync(
+          fs.writeFileSync(
             path.join(configManager.tinaFolderPath, tinaLockFilename),
             tinaLockContent
           )
@@ -137,14 +137,14 @@ export class DevCommand extends BaseCommand {
         }
         return { apiURL, database, graphQLSchema, tinaSchema }
       } catch (e) {
-        logger.error(dangerText(e.message))
+        logger.error(`\n\n${dangerText(e.message)}\n`)
         if (this.verbose) {
           console.error(e)
         }
         if (firstTime) {
           logger.error(
             warnText(
-              'Unable to start dev server, please fix your Tina config and try again'
+              'Unable to start dev server, please fix your Tina config / resolve any errors above and try again'
             )
           )
           process.exit(1)

--- a/packages/@tinacms/cli/src/utils/spinner.ts
+++ b/packages/@tinacms/cli/src/utils/spinner.ts
@@ -24,12 +24,9 @@ async function localSpin<T>({
 
   // spinner start
   spinner.start()
-  let res
-  try {
-    res = await waitFor()
-  } catch (e) {
-    console.error(e)
-  }
+
+  const res = await waitFor()
+
   // spinner stop
   spinner.stop()
   console.log('')

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1257,7 +1257,7 @@ const _indexContent = async (
   const tinaSchema = await database.getSchema()
   let templateInfo: CollectionTemplateable | null = null
   if (collection) {
-    templateInfo = await tinaSchema.getTemplatesForCollectable(collection)
+    templateInfo = tinaSchema.getTemplatesForCollectable(collection)
   }
 
   const folderTreeBuilder = new FolderTreeBuilder()

--- a/packages/@tinacms/graphql/src/database/util.ts
+++ b/packages/@tinacms/graphql/src/database/util.ts
@@ -94,40 +94,45 @@ export const parseFile = <T extends object>(
     frontmatterDelimiters?: [string, string] | string
   }
 ): T => {
-  switch (format) {
-    case '.markdown':
-    case '.mdx':
-    case '.md':
-      const contentJSON = matter(content || '', {
-        language: markdownParseConfig?.frontmatterFormat ?? 'yaml',
-        delimiters: markdownParseConfig?.frontmatterDelimiters ?? '---',
-        engines: matterEngines,
-      })
-      const markdownData = {
-        ...contentJSON.data,
-        $_body: contentJSON.content,
-      }
-      assertShape<T>(markdownData, yupSchema)
-      return markdownData
-    case '.json':
-      if (!content) {
-        return {} as T
-      }
-      return JSON.parse(content)
-    case '.toml':
-      if (!content) {
-        return {} as T
-      }
-      return toml.parse(content) as T
-    case '.yaml':
-    case '.yml':
-      if (!content) {
-        return {} as T
-      }
-      return yaml.safeLoad(content) as T
-    default:
-      throw new Error(`Must specify a valid format, got ${format}`)
+  try {
+    switch (format) {
+      case '.markdown':
+      case '.mdx':
+      case '.md':
+        const contentJSON = matter(content || '', {
+          language: markdownParseConfig?.frontmatterFormat ?? 'yaml',
+          delimiters: markdownParseConfig?.frontmatterDelimiters ?? '---',
+          engines: matterEngines,
+        })
+        const markdownData = {
+          ...contentJSON.data,
+          $_body: contentJSON.content,
+        }
+        assertShape<T>(markdownData, yupSchema)
+        return markdownData
+      case '.json':
+        if (!content) {
+          return {} as T
+        }
+        return JSON.parse(content)
+      case '.toml':
+        if (!content) {
+          return {} as T
+        }
+        return toml.parse(content) as T
+      case '.yaml':
+      case '.yml':
+        if (!content) {
+          return {} as T
+        }
+        return yaml.safeLoad(content) as T
+    }
+  } catch (e) {
+    // ensure that parser errors are always logged out
+    console.error(e)
+    throw e
   }
+  throw new Error(`Must specify a valid format, got ${format}`)
 }
 
 export type FormatType = 'json' | 'md' | 'mdx' | 'markdown'


### PR DESCRIPTION
Address issues with parse errors no getting logged at index time

demo: https://www.loom.com/share/e7de458ca8c240baa515249c0028a9d4?sid=56a8d346-1fe3-44d6-be86-b6a40f11dce8

Also confirmed that any parse errors while editing in dev mode are handled the same - error is logged and when the file is corrected the dev server restarts itself