### PR TITLE
fix: media manager to pass back error when generating upload_url fails due to existing file

### DIFF
--- a/.changeset/eighty-weeks-rule.md
+++ b/.changeset/eighty-weeks-rule.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix media manager to pass back error when upload_url fails due to existing file

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -118,6 +118,12 @@ export class TinaMediaStore implements MediaStore {
           { method: 'GET' }
         )
 
+        if (res.status === 412) {
+          const { message = 'Unexpected error generating upload url' } =
+            await res.json()
+          throw new Error(message)
+        }
+
         const { signedUrl } = await res.json()
         if (!signedUrl) {
           throw new Error('Unexpected error generating upload url')

--- a/packages/tinacms/src/toolkit/tina-cms.ts
+++ b/packages/tinacms/src/toolkit/tina-cms.ts
@@ -101,7 +101,7 @@ export class TinaCMS extends CMS {
           level: 'error',
           message: `Failed to upload file(s) ${event?.uploaded
             .map((x) => x.file.name)
-            .join(', ')}. See error message: \n\n ${event?.error.toString()}`,
+            .join(', ')}. \n\n ${event?.error.toString()}`,
         }
       },
       'media:delete:failure': () => ({


### PR DESCRIPTION
Handle 412 response from assets api by displaying the error to the user. Will now indicate when the issue is due to an existing file.

Demo: https://www.loom.com/share/0b1af46f5c9546de9ee88dc63ffd9f57?sid=db8ba5f9-b80a-4982-806e-1b7ca89df593