### PR TITLE
Fix template collection branch create

### DIFF
--- a/.changeset/eighty-socks-search.md
+++ b/.changeset/eighty-socks-search.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix issue where \_template value was provided when creating a document from the editorial workflow

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -187,14 +187,17 @@ export const RenderForm = ({
     // @ts-ignore internal types aren't up to date
     template.ui?.defaultItem ||
     // @ts-ignore
-    template?.defaultItem
+    template?.defaultItem ||
+    {}
 
   const form = useMemo(() => {
     const folderName = folder.fullyQualifiedName ? folder.name : ''
     return new Form({
       crudType: 'create',
       initialValues:
-        typeof defaultItem === 'function' ? defaultItem() : defaultItem,
+        typeof defaultItem === 'function'
+          ? { ...defaultItem(), _template: templateName }
+          : { ...defaultItem, _template: templateName },
       extraSubscribeValues: { active: true, submitting: true, touched: true },
       onChange: (values) => {
         if (!values?.submitting) {

--- a/packages/tinacms/src/unifiedClient/index.ts
+++ b/packages/tinacms/src/unifiedClient/index.ts
@@ -90,7 +90,7 @@ export class TinaClient<GenQueries> {
     }
     return {
       data: json?.data as DataType,
-      errors: json?.errors as GraphQLError[] | undefined,
+      errors: (json?.errors || null) as GraphQLError[] | null,
       query: args.query,
     }
   }


### PR DESCRIPTION
When we transform the form values we append the `_template` value to the payload, but since the editorial workflow throws the form values into local storage, when it pulls them out the `_template` value doesn't get passed in. This PR just appends the `_template` value to the "create" form's initial values so they're always there

cc @logan-anderson 