### PR TITLE
use error policy in types

### DIFF
--- a/.changeset/strong-toes-compete.md
+++ b/.changeset/strong-toes-compete.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Use error policy in types.

--- a/packages/@tinacms/graphql/src/builder/index.ts
+++ b/packages/@tinacms/graphql/src/builder/index.ts
@@ -438,11 +438,17 @@ export class Builder {
       [NAMER.createName([collection.name])]: 'create',
       [NAMER.updateName([collection.name])]: 'update',
     })
+
+    // Is errorPolicy set to include?
+    const errorPolicyInclude =
+      this.config.tinaSchema.config?.config?.client?.errorPolicy === 'include'
     return astBuilder.FieldDefinition({
       type,
       name,
       args,
-      required: false,
+      // If the error policy is set to include, we need to make the field optional
+      // if it is set to throw it is required
+      required: !errorPolicyInclude,
     })
   }
 

--- a/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
+++ b/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
@@ -22,7 +22,12 @@ const tinaSearchKey = z
   .strict()
   .optional()
 export const tinaConfigZod = z.object({
-  client: z.object({ referenceDepth: z.number().optional() }).optional(),
+  client: z
+    .object({
+      referenceDepth: z.number().optional(),
+      errorPolicy: z.enum(['include', 'throw']).optional(),
+    })
+    .optional(),
   media: z
     .object({
       tina: tinaConfigKey,


### PR DESCRIPTION
Use the error policy to generate the graphql types.

Explanation: https://www.loom.com/share/4cb157b2699e4905bc24aea3ee1444ee?sid=539c1008-bfc7-4337-a65e-27fa43159c88