### PR TITLE
Add support for build.basePath to be an environment variable

### DIFF
--- a/.changeset/ninety-rings-peel.md
+++ b/.changeset/ninety-rings-peel.md
@@ -1,0 +1,7 @@
+---
+'@tinacms/app': patch
+'@tinacms/cli': patch
+'tinacms': patch
+---
+
+Add support for build.basePath to be an environment variable

--- a/packages/@tinacms/app/src/App.tsx
+++ b/packages/@tinacms/app/src/App.tsx
@@ -38,10 +38,8 @@ const SetPreview = () => {
       ...MdxFieldPluginExtendible,
       Component: Editor,
     })
-    let basePath
-    if (config.build.basePath) {
-      basePath = config.build.basePath.replace(/^\/|\/$/g, '')
-    }
+    const basePath = __BASE_PATH__.replace(/^\/|\/$/g, '')
+    cms.flags.set('tina-basepath', basePath)
     cms.flags.set(
       'tina-preview',
       `${basePath ? `${basePath}/` : ''}${config.build.outputFolder.replace(

--- a/packages/@tinacms/app/src/Playground.tsx
+++ b/packages/@tinacms/app/src/Playground.tsx
@@ -8,11 +8,6 @@ import { queries } from 'CLIENT_IMPORT'
 
 import 'graphiql/graphiql.min.css'
 
-const fetcher = createGraphiQLFetcher({
-  url: __API_URL__,
-  headers: { 'X-API-KEY': __TOKEN__ },
-})
-
 const Playground = () => {
   const cms = useCMS()
   const [query, setQuery] = React.useState('')
@@ -60,6 +55,10 @@ const Playground = () => {
   }, [])
 
   const ref = React.useRef()
+
+  const getToken = () => {
+    return JSON.parse(localStorage.getItem('tinacms-auth') || '{}')?.id_token
+  }
 
   if (!autoQueries) {
     return null
@@ -130,11 +129,16 @@ const Playground = () => {
       </div>
     )
   }
-
   return (
     <div style={{ height: '100vh' }}>
       <GraphiQL
-        fetcher={fetcher}
+        fetcher={async (params, options) => {
+          const fetcher = createGraphiQLFetcher({
+            url: __API_URL__,
+            headers: { Authorization: `Bearer ${getToken()}` },
+          })
+          return fetcher(params, options)
+        }}
         query={query}
         defaultEditorToolsVisibility="variables"
         isHeadersEditorEnabled={false}

--- a/packages/@tinacms/app/src/vite-env.d.ts
+++ b/packages/@tinacms/app/src/vite-env.d.ts
@@ -4,4 +4,5 @@
 
 /// <reference types="vite/client" />
 declare const __API_URL__: string
+declare const __BASE_PATH__: string
 declare const __TINA_GRAPHQL_VERSION__: string

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -206,7 +206,7 @@ export const createConfig = async ({
       // Used by picomatch https://github.com/micromatch/picomatch/blob/master/lib/utils.js#L4
       'process.platform': `"${process.platform}"`,
       __API_URL__: `"${apiURL}"`,
-      __TOKEN__: `"${configManager.config.token}"`,
+      __BASE_PATH__: `"${configManager.config?.build?.basePath || ''}"`,
       __TINA_GRAPHQL_VERSION__: `"${configManager.getTinaGraphQLVersion()}"`,
     },
     logLevel: 'error', // Vite import warnings are noisy

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -52,10 +52,12 @@ const MaybeRedirectToPreview = ({
   redirect: boolean
   children: JSX.Element
 }) => {
+  const cms = useCMS()
   const navigate = useNavigate()
   React.useEffect(() => {
+    const basePath = cms.flags.get('tina-basepath')
     if (redirect) {
-      navigate('/~')
+      navigate(`/~${basePath ? `/${basePath}` : ''}`)
     }
   }, [redirect])
 


### PR DESCRIPTION
Previously you needed to provide either a `TINA_` prefixed env var or a hardcoded one for the Tina SPA to recognize it, now the value is always available regardless of env variable name.


Also removes token being passed to graphiql ui