### PR TITLE
add error link

### DIFF
--- a/.changeset/seven-grapes-retire.md
+++ b/.changeset/seven-grapes-retire.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+add error link

--- a/packages/@tinacms/graphql/src/database/util.ts
+++ b/packages/@tinacms/graphql/src/database/util.ts
@@ -341,7 +341,7 @@ export const loadAndParseWithAliases = async (
   const template = getTemplateForFile(templateInfo, data as any)
   if (!template) {
     console.warn(
-      `Document: ${filepath} has an ambiguous template, skipping from indexing`
+      `Document: ${filepath} has an ambiguous template, skipping from indexing. See https://tina.io/docs/errors/ambiguous-template/ for more info.`
     )
     return
   }


### PR DESCRIPTION
Add's error link for ambiguous templates.

Docs PR: https://github.com/tinacms/tina.io/pull/1672