### PR TITLE
fix: bogus warning

### DIFF
--- a/packages/tinacms-authjs/src/index.ts
+++ b/packages/tinacms-authjs/src/index.ts
@@ -2,6 +2,7 @@ import NextAuth, { AuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import { getServerSession } from 'next-auth/next'
 import type { BackendAuthentication } from '@tinacms/datalayer'
+import { TINA_CREDENTIALS_PROVIDER_NAME } from './tinacms'
 
 const authenticate = async (
   databaseClient: any,
@@ -69,17 +70,14 @@ const TinaAuthJSOptions = ({
   ...overrides,
 })
 
-const TINA_CREDENTIALS_PROVIDER_NAME = 'TinaCredentials'
-
 const TinaCredentialsProvider = ({
   databaseClient,
   name = TINA_CREDENTIALS_PROVIDER_NAME,
 }: {
   databaseClient: any // TODO can we type this?
   name?: string
-}) =>
-  CredentialsProvider({
-    name,
+}) => {
+  const p = CredentialsProvider({
     credentials: {
       username: { label: 'Username', type: 'text' },
       password: { label: 'Password', type: 'password' },
@@ -87,6 +85,9 @@ const TinaCredentialsProvider = ({
     authorize: async (credentials) =>
       authenticate(databaseClient, credentials.username, credentials.password),
   })
+  p.name = name
+  return p
+}
 
 const AuthJsBackendAuthentication = ({
   authOptions,

--- a/packages/tinacms-authjs/src/tinacms.ts
+++ b/packages/tinacms-authjs/src/tinacms.ts
@@ -8,12 +8,14 @@ import {
 } from 'next-auth/react'
 import { AbstractAuthProvider } from 'tinacms'
 
+export const TINA_CREDENTIALS_PROVIDER_NAME = 'TinaCredentials'
+
 export class DefaultAuthJSProvider extends AbstractAuthProvider {
   readonly callbackUrl: string
   readonly name: string
   constructor(props?: { name?: string; callbackUrl?: string }) {
     super()
-    this.name = props?.name || 'Credentials'
+    this.name = props?.name || TINA_CREDENTIALS_PROVIDER_NAME
     this.callbackUrl = props?.callbackUrl || '/admin/index.html'
   }
   async authenticate(props?: {}): Promise<any> {


### PR DESCRIPTION
Credentials provider name wasn't getting set so the following warning was being shown:

```
WARNING: Catch-all api route ['/api/tina/*'] with specified Auth.js provider ['Credentials'] not supported. See https://tina.io/docs/self-hosted/overview/#customprovider for more information.
```