### PR TITLE
fix: errors can not be undefined

### DIFF
--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -317,7 +317,7 @@ function createDatabaseClient<GenQueries = Record<string, unknown>>({
 }) {
   const request = async ({ query, variables, user }) => {
     const data = await databaseRequest({ query, variables, user });
-    return { data: data.data as any, query, variables, errors: data.errors };
+    return { data: data.data as any, query, variables, errors: data.errors || null };
   };
   const q = queries({
     request,


### PR DESCRIPTION
fix this error:

```
Error occurred prerendering page "/posts". Read more: https://nextjs.org/docs/messages/prerender-error
Error: Error serializing `.errors` returned from `getStaticProps` in "/posts".
Reason: `undefined` cannot be serialized as JSON. Please use `null` or omit this value.
    at isSerializable (/Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/lib/is-serializable-props.js:52:19)
    at /Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/lib/is-serializable-props.js:59:66
    at Array.every (<anonymous>)
    at isSerializable (/Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/lib/is-serializable-props.js:56:39)
    at isSerializableProps (/Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/lib/is-serializable-props.js:79:12)
    at renderToHTML (/Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/server/render.js:497:118)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async /Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/export/worker.js:459:36
    at async Span.traceAsyncFn (/Users/kldavis/projects/tina-self-hosted-demo/node_modules/next/dist/trace/trace.js:103:20)
```