### PR TITLE
export "client" from generated db file

### DIFF
--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -327,6 +327,8 @@ function createDatabaseClient<GenQueries = Record<string, unknown>>({
 
 export const databaseClient = createDatabaseClient({ queries });
 
+export const client = databaseClient;
+
 export default databaseClient;
 `
   }


### PR DESCRIPTION
to make it easier to migrate we should export 'client' from the database client file. 

Why?

it is very popular to have `import { client} from '../tina/__generated__/client'` and when updating it would be nice if users only had to change the import path.  