### PR TITLE
Fix generated config file

### DIFF
--- a/packages/@tinacms/cli/src/cmds/init/apply.ts
+++ b/packages/@tinacms/cli/src/cmds/init/apply.ts
@@ -190,6 +190,8 @@ async function apply({
   }
 
   if (
+    // if the config was just generated we do not need to update the config file because it will be generated correctly
+    env.tinaConfigExists &&
     // Are we running tinacms init backend
     params.isBackendInit &&
     // Do the user choose the 'self-host' option

--- a/packages/@tinacms/cli/src/cmds/init/templates/config.ts
+++ b/packages/@tinacms/cli/src/cmds/init/templates/config.ts
@@ -49,8 +49,8 @@ const generateCollectionString = (args: ConfigTemplateArgs) => {
     },
   ]`
   const nextExampleCollection = `[
+    ${extraTinaCollections || ''}
     {
-      ${extraTinaCollections || ''}
       name: 'post',
       label: 'Posts',
       path: 'content/posts',


### PR DESCRIPTION
If a user ran `tinacms init backend` without having a tina config already it would be generated incorrectly. (it would get two user collections and extra imports).

This PR updates the code so that the code transformations only get applied if the config was not just generated.