### PR TITLE
Allow each `AuthProvider` to render a custom login screen, not just redirect to a login page

### DIFF
--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type React from 'react'
 
 type Meta = {
@@ -442,6 +441,12 @@ type TokenObject = {
 
 export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
 
+type LoginScreenProps = {
+  handleAuthenticate: () => Promise<void>
+  authProps: Record<string, string>
+  setAuthProps: React.Dispatch<React.SetStateAction<Record<string, string>>>
+}
+
 export interface AuthProvider {
   /**
    *  Used for getting the token from the custom auth provider
@@ -480,8 +485,8 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
-  getLoginScreen: () => FC | null
-  getSessionProvider: () => FC<{ basePath?: string }>
+  getLoginScreen: () => React.FC<LoginScreenProps> | null
+  getSessionProvider: () => React.FC<{ basePath?: string }>
 }
 
 interface AuthHooks {
@@ -876,7 +881,7 @@ export type Option =
   | string
   | {
       label?: string
-      icon?: FC
+      icon?: React.FC
       value: string
     }
 

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -440,7 +440,7 @@ type TokenObject = {
   refresh_token?: string
 }
 
-export type LoginStrategy = 'UsernamePassword' | 'Redirect'
+export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
 
 export interface AuthProvider {
   /**
@@ -480,6 +480,7 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
+  getLoginScreen: () => FC | null
   getSessionProvider: () => FC<{ basePath?: string }>
 }
 

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -37,7 +37,6 @@ export interface TinaCloudMediaStoreClass {
 export interface TinaCloudAuthWallProps {
   cms?: TinaCMS
   children: React.ReactNode
-  loginScreen?: React.ReactNode
   tinaioConfig?: TinaIOConfig
   getModalActions?: (args: {
     closeModal: () => void
@@ -50,7 +49,6 @@ export interface TinaCloudAuthWallProps {
 export const AuthWallInner = ({
   children,
   cms,
-  loginScreen,
   getModalActions,
 }: TinaCloudAuthWallProps) => {
   const client: Client = cms.api.tina
@@ -58,6 +56,7 @@ export const AuthWallInner = ({
   const isTinaCloud =
     !client.isLocalMode && !client.schema?.config?.config?.contentApiUrlOverride
   const loginStrategy = client.authProvider.getLoginStrategy()
+  const loginScreen = client.authProvider.getLoginScreen()
 
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
   const [errorMessage, setErrorMessage] = useState<
@@ -298,7 +297,7 @@ export const AuthWallInner = ({
           ]}
         />
       )}
-      {showChildren ? children : loginScreen ? loginScreen : null}
+      {showChildren ? children : loginScreen ? loginScreen({}) : null}
     </>
   )
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -297,7 +297,11 @@ export const AuthWallInner = ({
           ]}
         />
       )}
-      {showChildren ? children : loginScreen ? loginScreen({}) : null}
+      {showChildren
+        ? children
+        : loginScreen
+        ? loginScreen({ handleAuthenticate, authProps, setAuthProps })
+        : null}
     </>
   )
 }

--- a/packages/tinacms/src/internalClient/authProvider.ts
+++ b/packages/tinacms/src/internalClient/authProvider.ts
@@ -44,6 +44,14 @@ export abstract class AbstractAuthProvider implements AuthProvider {
     return 'Redirect'
   }
 
+  /**
+   * A React component that renders the custom UI for the login screen.
+   * Set the LoginStrategy to LoginScreen when providing this function.
+   */
+  getLoginScreen() {
+    return null
+  }
+
   getSessionProvider() {
     return DefaultSessionProvider
   }


### PR DESCRIPTION
## Notes

- This is an extension to the latest in-progress work on the `self-host` branch
    - It includes small tweaks to the `tinacms` and `@tinacms/schema-tools` packages
- Given it's not a PR to the `main` branch, I haven't run `pnpm changeset` to generate a changeset file
    - If you're happy to merge these changes into the `self-host` branch then I assume they can be included as part of the changeset that PR will generate? Please let me know if that's incorrect and I can add a changeset - I just didn't think it made sense to attempt any version bumps when pushing into a feature branch other than `main`

## Feature description

**Add `getLoginScreen` to `AbstractAuthProvider`**

- This extends the existing `LoginStrategy` type to include a new `LoginScreen` option
- When the `LoginStrategy` is set to `LoginScreen` and a `getLoginScreen` function is provided to return a `React.ReactNode` the main `AuthWallInner` will display the custom login screen provided, rather than showing the modal popups and forcing a redirect or displaying the username and password form

## Next steps

If you're happy with this idea, I could help refactor the `UsernamePassword` login strategy to use the LoginScreen, which would make also make it more flexible to be extended in future (or for users to bring their own authentication form components)

**UPDATE:** I've opened a follow-up PR that demonstrates what it would look like to update the existing `UsernamePasswordAuthJSProvider` to use the login screen: #4328. I'd love to see the `getLoginScreen` function (or something similar) added to TinaCMS and really only created the second PR as a demo in case it's helpful - there's definitely no reason we couldn't add the `getLoginScreen` function but leave the `UsernamePasswordAuthJSProvider` form untouched