### PR TITLE
Use LoginScreen for UsernamePasswordAuthJSProvider, not modal (follows #4326)

### DIFF
--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -1,4 +1,3 @@
-import type { FC } from 'react'
 import type React from 'react'
 
 type Meta = {
@@ -442,6 +441,12 @@ type TokenObject = {
 
 export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
 
+type LoginScreenProps = {
+  handleAuthenticate: () => Promise<void>
+  authProps: Record<string, string>
+  setAuthProps: React.Dispatch<React.SetStateAction<Record<string, string>>>
+}
+
 export interface AuthProvider {
   /**
    *  Used for getting the token from the custom auth provider
@@ -480,8 +485,8 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
-  getLoginScreen: () => FC | null
-  getSessionProvider: () => FC<{ basePath?: string }>
+  getLoginScreen: () => React.FC<LoginScreenProps> | null
+  getSessionProvider: () => React.FC<{ basePath?: string }>
 }
 
 interface AuthHooks {
@@ -876,7 +881,7 @@ export type Option =
   | string
   | {
       label?: string
-      icon?: FC
+      icon?: React.FC
       value: string
     }
 

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -439,12 +439,9 @@ type TokenObject = {
   refresh_token?: string
 }
 
-export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
-
-type LoginScreenProps = {
-  handleAuthenticate: () => Promise<void>
-  authProps: Record<string, string>
-  setAuthProps: React.Dispatch<React.SetStateAction<Record<string, string>>>
+export type LoginStrategy = 'Redirect' | 'LoginScreen' | 'UsernamePassword'
+export type LoginScreenProps = {
+  handleAuthenticate: (authProps?: Record<string, string>) => Promise<void>
 }
 
 export interface AuthProvider {

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -440,7 +440,7 @@ type TokenObject = {
   refresh_token?: string
 }
 
-export type LoginStrategy = 'UsernamePassword' | 'Redirect'
+export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
 
 export interface AuthProvider {
   /**
@@ -480,6 +480,7 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
+  getLoginScreen: () => FC | null
   getSessionProvider: () => FC<{ basePath?: string }>
 }
 

--- a/packages/tinacms-authjs/src/UsernamePasswordLoginScreen.tsx
+++ b/packages/tinacms-authjs/src/UsernamePasswordLoginScreen.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react'
+import type { LoginScreenProps } from '@tinacms/schema-tools'
+import { AsyncButton } from 'tinacms'
+
+const inputClasses =
+  'shadow-inner focus:shadow-outline focus:border-blue-500 focus:outline-none block text-base placeholder:text-gray-300 px-3 py-2 text-gray-600 w-full bg-white border border-gray-200 transition-all ease-out duration-150 focus:text-gray-900 rounded-md'
+
+export const UsernamePasswordLoginScreen = ({
+  handleAuthenticate,
+}: LoginScreenProps) => {
+  const [authProps, setAuthProps] = useState<{
+    username: string
+    password: string
+  }>({ username: '', password: '' })
+
+  return (
+    <div className="flex items-center justify-center bg-gray-50 p-6 sm:p-8 lg:p-10">
+      <div className="max-w-md w-full">
+        <h1 className="text-xl pb-4">Sign in to Tina</h1>
+        <div className="pb-2">
+          <label className="block pb-1">
+            <span className="text-gray-700">Username</span>
+          </label>
+          <input
+            id="username"
+            name="username"
+            type="text"
+            className={inputClasses}
+            autoComplete="username"
+            required
+            placeholder="Username"
+            value={authProps.username}
+            onChange={(e) =>
+              setAuthProps((prevState) => ({
+                ...prevState,
+                username: e.target.value,
+              }))
+            }
+          />
+        </div>
+        <div className="pb-2">
+          <label className="block pb-1">
+            <span className="text-gray-700">Password</span>
+          </label>
+          <input
+            id="password"
+            name="password"
+            type="password"
+            className={inputClasses}
+            autoComplete="current-password"
+            required
+            placeholder="Password"
+            value={authProps.password}
+            onChange={(e) =>
+              setAuthProps((prevState) => ({
+                ...prevState,
+                password: e.target.value,
+              }))
+            }
+          />
+        </div>
+        <div className="pt-2">
+          <AsyncButton
+            name="Login"
+            action={handleAuthenticate}
+            primary={true}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/tinacms-authjs/src/tinacms.ts
+++ b/packages/tinacms-authjs/src/tinacms.ts
@@ -6,6 +6,7 @@ import {
   signOut,
   SessionProvider,
 } from 'next-auth/react'
+import { UsernamePasswordLoginScreen } from './UsernamePasswordLoginScreen'
 import { AbstractAuthProvider } from 'tinacms'
 import type { FC } from 'react'
 
@@ -123,7 +124,12 @@ export class UsernamePasswordAuthJSProvider extends DefaultAuthJSProvider {
   }
 
   getLoginStrategy(): LoginStrategy {
+    // Would it make sense to change this to 'LoginScreen'?
     return 'UsernamePassword'
+  }
+
+  getLoginScreen() {
+    return UsernamePasswordLoginScreen as FC
   }
 }
 

--- a/packages/tinacms/src/auth/AuthModal.tsx
+++ b/packages/tinacms/src/auth/AuthModal.tsx
@@ -45,7 +45,7 @@ export const ErrorLabel = ({ style = {}, ...props }) => (
   <p style={{ ...style, color: 'var(--tina-color-error)' }} {...props} />
 )
 
-interface ButtonProps {
+export interface ButtonProps {
   name: string
   action(): Promise<void>
   primary: boolean

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -37,7 +37,6 @@ export interface TinaCloudMediaStoreClass {
 export interface TinaCloudAuthWallProps {
   cms?: TinaCMS
   children: React.ReactNode
-  loginScreen?: React.ReactNode
   tinaioConfig?: TinaIOConfig
   getModalActions?: (args: {
     closeModal: () => void
@@ -50,7 +49,6 @@ export interface TinaCloudAuthWallProps {
 export const AuthWallInner = ({
   children,
   cms,
-  loginScreen,
   getModalActions,
 }: TinaCloudAuthWallProps) => {
   const client: Client = cms.api.tina
@@ -58,6 +56,7 @@ export const AuthWallInner = ({
   const isTinaCloud =
     !client.isLocalMode && !client.schema?.config?.config?.contentApiUrlOverride
   const loginStrategy = client.authProvider.getLoginStrategy()
+  const loginScreen = client.authProvider.getLoginScreen()
 
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
   const [errorMessage, setErrorMessage] = useState<
@@ -298,7 +297,7 @@ export const AuthWallInner = ({
           ]}
         />
       )}
-      {showChildren ? children : loginScreen ? loginScreen : null}
+      {showChildren ? children : loginScreen ? loginScreen({}) : null}
     </>
   )
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -85,6 +85,10 @@ export const AuthWallInner = ({
                 }
                 setShowChildren(true)
                 cms.enable()
+                cms.dispatch({
+                  type: 'sidebar:set-display-state',
+                  value: 'open',
+                })
               } else {
                 setErrorMessage({
                   title: 'Access Denied:',
@@ -254,7 +258,7 @@ export const TinaCloudProvider = (
     () =>
       props.cms ||
       new TinaCMS({
-        enabled: true,
+        enabled: false,
         sidebar: true,
         isLocalClient: props.isLocalClient,
         isSelfHosted: props.isSelfHosted,

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -297,7 +297,11 @@ export const AuthWallInner = ({
           ]}
         />
       )}
-      {showChildren ? children : loginScreen ? loginScreen({}) : null}
+      {showChildren
+        ? children
+        : loginScreen
+        ? loginScreen({ handleAuthenticate, authProps, setAuthProps })
+        : null}
     </>
   )
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -1,7 +1,6 @@
-import { ModalBuilder } from './AuthModal'
+import { ModalBuilder, AsyncButton as ModalButton } from './AuthModal'
 import React, { useEffect, useState } from 'react'
 import {
-  BaseTextField,
   TinaCMS,
   TinaProvider,
   MediaStore,
@@ -24,6 +23,9 @@ import { useTinaAuthRedirect } from './useTinaAuthRedirect'
 import { CreateClientProps, createClient } from '../utils'
 import { setEditing } from '@tinacms/sharedctx'
 import { TinaAdminApi } from '../admin/api'
+
+// Export for use in the UsernamePasswordLoginScreen
+export const AsyncButton = ModalButton
 
 type ModalNames = null | 'authenticate' | 'error'
 
@@ -63,10 +65,6 @@ export const AuthWallInner = ({
     { title: string; message: string } | undefined
   >()
   const [showChildren, setShowChildren] = useState<boolean>(false)
-  const [authProps, setAuthProps] = useState<{
-    username: string
-    password: string
-  }>({ username: '', password: '' })
   const [authenticated, setAuthenticated] = useState<boolean>(false)
 
   React.useEffect(() => {
@@ -133,7 +131,7 @@ export const AuthWallInner = ({
       })
     : []
 
-  const handleAuthenticate = async () => {
+  const handleAuthenticate = async (authProps?: Record<string, string>) => {
     try {
       setAuthenticated(false)
       const token = await client.authProvider.authenticate(authProps)
@@ -152,23 +150,8 @@ export const AuthWallInner = ({
   }
 
   let modalTitle = 'Tina Cloud Authorization'
-  if (
-    activeModal === 'authenticate' &&
-    loginStrategy === 'Redirect' &&
-    !isTinaCloud
-  ) {
+  if (loginStrategy === 'Redirect' && !isTinaCloud) {
     modalTitle = 'Enter into edit mode'
-  } else if (
-    activeModal === 'authenticate' &&
-    loginStrategy === 'UsernamePassword'
-  ) {
-    modalTitle = 'Sign in to Tina'
-  } else if (activeModal === 'error') {
-    if (loginStrategy === 'Redirect' && !isTinaCloud) {
-      modalTitle = 'Enter into edit mode'
-    } else if (loginStrategy === 'UsernamePassword') {
-      modalTitle = 'Sign in to Tina'
-    }
   }
 
   return (
@@ -206,63 +189,6 @@ export const AuthWallInner = ({
           ]}
         ></ModalBuilder>
       )}
-      {activeModal === 'authenticate' &&
-        loginStrategy === 'UsernamePassword' && (
-          <ModalBuilder
-            title={modalTitle}
-            message={''}
-            close={close}
-            actions={[
-              ...otherModalActions,
-              {
-                name: 'Login',
-                action: handleAuthenticate,
-                primary: true,
-              },
-            ]}
-          >
-            <div className="flex items-center justify-center bg-gray-50 px-4 sm:px-6 lg:px-8">
-              <div className="max-w-md w-full space-y-6">
-                <label className="block">
-                  <span className="text-gray-700">Username</span>
-                  <BaseTextField
-                    id="username"
-                    name="username"
-                    type="text"
-                    autoComplete="username"
-                    required
-                    placeholder="Username"
-                    value={authProps.username}
-                    onChange={(e) =>
-                      setAuthProps((prevState) => ({
-                        ...prevState,
-                        username: e.target.value,
-                      }))
-                    }
-                  />
-                </label>
-                <label className="block">
-                  <span className="text-gray-700">Password</span>
-                  <BaseTextField
-                    id="password"
-                    name="password"
-                    type="password"
-                    autoComplete="current-password"
-                    required
-                    placeholder="Password"
-                    value={authProps.password}
-                    onChange={(e) =>
-                      setAuthProps((prevState) => ({
-                        ...prevState,
-                        password: e.target.value,
-                      }))
-                    }
-                  />
-                </label>
-              </div>
-            </div>
-          </ModalBuilder>
-        )}
       {activeModal === 'error' && errorMessage && (
         <ModalBuilder
           title={modalTitle}
@@ -300,7 +226,7 @@ export const AuthWallInner = ({
       {showChildren
         ? children
         : loginScreen
-        ? loginScreen({ handleAuthenticate, authProps, setAuthProps })
+        ? loginScreen({ handleAuthenticate })
         : null}
     </>
   )

--- a/packages/tinacms/src/internalClient/authProvider.ts
+++ b/packages/tinacms/src/internalClient/authProvider.ts
@@ -44,6 +44,14 @@ export abstract class AbstractAuthProvider implements AuthProvider {
     return 'Redirect'
   }
 
+  /**
+   * A React component that renders the custom UI for the login screen.
+   * Set the LoginStrategy to LoginScreen when providing this function.
+   */
+  getLoginScreen() {
+    return null
+  }
+
   getSessionProvider() {
     return DefaultSessionProvider
   }


### PR DESCRIPTION
## Notes

- Follows on from #4326 
- This relates to the `self-host` branch that @logan-anderson and @kldavis4 have been developing
- Let me know if you'd like me to add a changeset - I assumed it wasn't necessary given it's a PR suggestion into the unreleased `self-host` feature branch but if that's incorrect I can easily add a changeset
- I'd love to see the `getLoginScreen` function from PR 4326 (or something similar) added to TinaCMS and really only created this second PR as a demo in case it's helpful
    - Definitely no worries at all if you'd prefer to close this PR and leave the `UsernamePasswordAuthJSProvider` form untouched, but hopefully you'll consider the `getLoginScreen` function from PR 4326 regardless 🤞  

## Feature description

- This refactors the form code for the `UsernamePasswordAuthJSProvider` so it now appears on a login screen, rather than appearing in a modal
- It also includes a suggestion to hide the TinaCMS sidebar until the user has signed into the admin portal, though this second commit could easily be reverted if you'd prefer to always show the TinaCMS sidebar alongside the login screen

<img width="1429" alt="image" src="https://github.com/tinacms/tinacms/assets/7799612/9b19c6f9-7df5-4148-bb51-cce42da58928">
