### PR TITLE
Allow auth providers to display a custom login form in the Tina admin portal

### DIFF
--- a/.changeset/loud-panthers-check.md
+++ b/.changeset/loud-panthers-check.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/schema-tools': patch
+'tinacms': patch
+---
+
+This extends the existing `LoginStrategy` type to include a new `LoginScreen` option. A `getLoginScreen` function can be set on the AuthProvider to display a custom login screen, rather than showing the modal popups and forcing a redirect or displaying the default username and password form. This will hopefully simplify the process of creating custom auth providers and handling user authentication when self-hosting.

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -440,7 +440,11 @@ type TokenObject = {
   refresh_token?: string
 }
 
-export type LoginStrategy = 'UsernamePassword' | 'Redirect'
+export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
+
+type LoginScreenProps = {
+  handleAuthenticate: (props?: Record<string, string>) => Promise<void>
+}
 
 export interface AuthProvider {
   /**
@@ -480,6 +484,7 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
+  getLoginScreen: () => FC<LoginScreenProps> | null
   getSessionProvider: () => FC<{ basePath?: string }>
 }
 

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -37,7 +37,6 @@ export interface TinaCloudMediaStoreClass {
 export interface TinaCloudAuthWallProps {
   cms?: TinaCMS
   children: React.ReactNode
-  loginScreen?: React.ReactNode
   tinaioConfig?: TinaIOConfig
   getModalActions?: (args: {
     closeModal: () => void
@@ -50,7 +49,6 @@ export interface TinaCloudAuthWallProps {
 export const AuthWallInner = ({
   children,
   cms,
-  loginScreen,
   getModalActions,
 }: TinaCloudAuthWallProps) => {
   const client: Client = cms.api.tina
@@ -58,6 +56,7 @@ export const AuthWallInner = ({
   const isTinaCloud =
     !client.isLocalMode && !client.schema?.config?.config?.contentApiUrlOverride
   const loginStrategy = client.authProvider.getLoginStrategy()
+  const loginScreen = client.authProvider.getLoginScreen()
 
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
   const [errorMessage, setErrorMessage] = useState<
@@ -298,7 +297,11 @@ export const AuthWallInner = ({
           ]}
         />
       )}
-      {showChildren ? children : loginScreen ? loginScreen : null}
+      {showChildren
+        ? children
+        : loginScreen
+        ? loginScreen({ handleAuthenticate })
+        : null}
     </>
   )
 }

--- a/packages/tinacms/src/internalClient/authProvider.ts
+++ b/packages/tinacms/src/internalClient/authProvider.ts
@@ -44,6 +44,14 @@ export abstract class AbstractAuthProvider implements AuthProvider {
     return 'Redirect'
   }
 
+  /**
+   * A React component that renders the custom UI for the login screen.
+   * Set the LoginStrategy to LoginScreen when providing this function.
+   */
+  getLoginScreen() {
+    return null
+  }
+
   getSessionProvider() {
     return DefaultSessionProvider
   }


### PR DESCRIPTION
- This change allows each `AuthProvider` to display a custom login form within the Tina admin portal, rather than showing the modal popups and forcing a redirect or displaying the default username and password form. This will hopefully simplify the process of creating custom auth providers and handling user authentication when self-hosting
- On a technical level this PR:
    - extends the existing `LoginStrategy` type to include a new `LoginScreen` option
    - adds a `getLoginScreen` function to `AbstractAuthProvider`, which will return the login form
- This PR replaces the original version here: https://github.com/tinacms/tinacms/pull/4326
