### PR TITLE
Fix read only token name

### DIFF
--- a/.changeset/moody-rockets-admire.md
+++ b/.changeset/moody-rockets-admire.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix the name of the read only token in the init process

--- a/packages/@tinacms/cli/src/cmds/init/prompts/askTinaCloudSetup.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/askTinaCloudSetup.ts
@@ -32,7 +32,7 @@ export const askTinaCloudSetup = async ({ config }: { config: Config }) => {
       value: clientId,
     },
     {
-      key: 'NEXT_PUBLIC_TINA_CLIENT_SECRET',
+      key: 'TINA_TOKEN',
       value: token,
     }
   )


### PR DESCRIPTION
The key for the read only token did did not match the env var used in the config. This causes an issue when a user runs `tinacms init backend` and uses Tina Cloud