### PR TITLE
Add get login screen to auth provider

### DIFF
--- a/.changeset/loud-panthers-check.md
+++ b/.changeset/loud-panthers-check.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/schema-tools': patch
+'tinacms': patch
+---
+
+This extends the existing `LoginStrategy` type to include a new `LoginScreen` option. A `getLoginScreen` function can be set on the AuthProvider to display a custom login screen, rather than showing the modal popups and forcing a redirect or displaying the default username and password form. This will hopefully simplify the process of creating custom auth providers and handling user authentication when self-hosting.

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -440,7 +440,11 @@ type TokenObject = {
   refresh_token?: string
 }
 
-export type LoginStrategy = 'UsernamePassword' | 'Redirect'
+export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
+
+type LoginScreenProps = {
+  handleAuthenticate: (props?: Record<string, string>) => Promise<void>
+}
 
 export interface AuthProvider {
   /**
@@ -480,6 +484,7 @@ export interface AuthProvider {
   isAuthorized: (context?: any) => Promise<boolean>
   isAuthenticated: () => Promise<boolean>
   getLoginStrategy: () => LoginStrategy
+  getLoginScreen: () => FC<LoginScreenProps> | null
   getSessionProvider: () => FC<{ basePath?: string }>
 }
 

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -442,7 +442,7 @@ type TokenObject = {
 
 export type LoginStrategy = 'UsernamePassword' | 'Redirect' | 'LoginScreen'
 
-type LoginScreenProps = {
+export type LoginScreenProps = {
   handleAuthenticate: (props?: Record<string, string>) => Promise<void>
 }
 

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -37,7 +37,6 @@ export interface TinaCloudMediaStoreClass {
 export interface TinaCloudAuthWallProps {
   cms?: TinaCMS
   children: React.ReactNode
-  loginScreen?: React.ReactNode
   tinaioConfig?: TinaIOConfig
   getModalActions?: (args: {
     closeModal: () => void
@@ -50,7 +49,6 @@ export interface TinaCloudAuthWallProps {
 export const AuthWallInner = ({
   children,
   cms,
-  loginScreen,
   getModalActions,
 }: TinaCloudAuthWallProps) => {
   const client: Client = cms.api.tina
@@ -58,6 +56,7 @@ export const AuthWallInner = ({
   const isTinaCloud =
     !client.isLocalMode && !client.schema?.config?.config?.contentApiUrlOverride
   const loginStrategy = client.authProvider.getLoginStrategy()
+  const loginScreen = client.authProvider.getLoginScreen()
 
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
   const [errorMessage, setErrorMessage] = useState<
@@ -298,7 +297,11 @@ export const AuthWallInner = ({
           ]}
         />
       )}
-      {showChildren ? children : loginScreen ? loginScreen : null}
+      {showChildren
+        ? children
+        : loginScreen
+        ? loginScreen({ handleAuthenticate })
+        : null}
     </>
   )
 }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -133,10 +133,14 @@ export const AuthWallInner = ({
       })
     : []
 
-  const handleAuthenticate = async () => {
+  const handleAuthenticate = async (
+    loginScreenProps?: Record<string, string>
+  ) => {
     try {
       setAuthenticated(false)
-      const token = await client.authProvider.authenticate(authProps)
+      const token = await client.authProvider.authenticate(
+        loginScreenProps || authProps
+      )
       if (typeof client?.onLogin === 'function') {
         await client?.onLogin({ token })
       }
@@ -300,7 +304,10 @@ export const AuthWallInner = ({
       {showChildren
         ? children
         : loginScreen
-        ? loginScreen({ handleAuthenticate })
+        ? loginScreen({
+            handleAuthenticate: async (props: Record<string, string>) =>
+              handleAuthenticate(props),
+          })
         : null}
     </>
   )

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -57,6 +57,11 @@ export const AuthWallInner = ({
     !client.isLocalMode && !client.schema?.config?.config?.contentApiUrlOverride
   const loginStrategy = client.authProvider.getLoginStrategy()
   const loginScreen = client.authProvider.getLoginScreen()
+  if (loginStrategy === 'LoginScreen' && !loginScreen) {
+    throw new Error(
+      'LoginScreen is set as the login strategy but no login screen component was provided'
+    )
+  }
 
   const [activeModal, setActiveModal] = useState<ModalNames>(null)
   const [errorMessage, setErrorMessage] = useState<
@@ -303,7 +308,8 @@ export const AuthWallInner = ({
       )}
       {showChildren
         ? children
-        : loginScreen
+        : client.authProvider?.getLoginStrategy() === 'LoginScreen' &&
+          loginScreen
         ? loginScreen({
             handleAuthenticate: async (props: Record<string, string>) =>
               handleAuthenticate(props),

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -25,6 +25,7 @@ import { formifyCallback } from './hooks/use-graphql-forms'
 
 import { RichTextTemplate, validateSchema } from '@tinacms/schema-tools'
 export { NAMER, resolveField } from '@tinacms/schema-tools'
+export type { LoginScreenProps, LoginStrategy } from '@tinacms/schema-tools'
 
 import {
   TinaSchema,

--- a/packages/tinacms/src/internalClient/authProvider.ts
+++ b/packages/tinacms/src/internalClient/authProvider.ts
@@ -44,6 +44,14 @@ export abstract class AbstractAuthProvider implements AuthProvider {
     return 'Redirect'
   }
 
+  /**
+   * A React component that renders the custom UI for the login screen.
+   * Set the LoginStrategy to LoginScreen when providing this function.
+   */
+  getLoginScreen() {
+    return null
+  }
+
   getSessionProvider() {
     return DefaultSessionProvider
   }


### PR DESCRIPTION
Based on #4349 with some fixes

PoC:

Add the following to `examples/tina-self-hosted-demo`:

```
import * as React from 'react'
import { LoginStrategy, LoginScreenProps } from 'tinacms'

class MyAuthProvider extends UsernamePasswordAuthJSProvider {
  getLoginScreen(): React.FC<LoginScreenProps> {
    return (props: LoginScreenProps) =>
      <div>Custom Login Screen: <button onClick={
        () => props.handleAuthenticate({ username: 'tinauser', password: 'tinarocks' })}>Login</button> </div>
  }
  getLoginStrategy(): LoginStrategy {
    return 'LoginScreen'
  }
}
```

and replace the UsernamePasswordAuthJSProvider with MyAuthProvider.

To test, setup .env in the self hosted example and run `pnpm run dev:prod`. Clear cookies and login.

Demo: https://www.loom.com/share/f56a2d1fc9ca4bbb8a01e38a7049f877