### PR TITLE
Fix/dev server restart error

### DIFF
--- a/.changeset/purple-ghosts-march.md
+++ b/.changeset/purple-ghosts-march.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Clear collectionIndexDefinitions on server restart

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -721,6 +721,7 @@ export class Database {
   public clearCache() {
     this.tinaSchema = null
     this._lookup = null
+    this.collectionIndexDefinitions = null
   }
 
   public flush = async (filepath: string) => {


### PR DESCRIPTION
Fixes an issue that would occur when adding a new collecting. 

## Error

When adding a new collection  the dev server would restart but the collectionIndexDefinitions would not. This would cause an error on the backend when trying to re-index the content. 

## Fix

set `collectionIndexDefinitions = null` when the dev server restarts


reported in discord: https://discord.com/channels/835168149439643678/1177628428573347880