### PR TITLE
Fix onLogout

### DIFF
--- a/.changeset/perfect-feet-help.md
+++ b/.changeset/perfect-feet-help.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fixes https://github.com/tinacms/tinacms/issues/4356

--- a/packages/tinacms/src/admin/pages/LogoutPage.tsx
+++ b/packages/tinacms/src/admin/pages/LogoutPage.tsx
@@ -21,6 +21,7 @@ export const LogoutRedirect = () => {
       // TODO: what to do with onLogout?
       if (cms?.api?.tina?.onLogout) {
         await cms?.api?.tina?.onLogout()
+        await new Promise((resolve) => setTimeout(resolve, 500))
       }
     }
     setEdit(false)

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -282,6 +282,7 @@ export const AuthWallInner = ({
                   await authProvider.logout()
                   if (typeof client?.onLogout === 'function') {
                     await client.onLogout()
+                    await new Promise((resolve) => setTimeout(resolve, 500))
                   }
                   window.location.href = new URL(window.location.href).pathname
                 } catch (e) {

--- a/packages/tinacms/src/toolkit/components/account/update-password.tsx
+++ b/packages/tinacms/src/toolkit/components/account/update-password.tsx
@@ -56,6 +56,7 @@ export function UpdatePassword(props: {}) {
         .then(async () => {
           if (typeof client?.onLogout === 'function') {
             await client.onLogout()
+            await new Promise((resolve) => setTimeout(resolve, 500))
           }
           window.location.href = new URL(window.location.href).pathname
         })

--- a/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
@@ -159,6 +159,9 @@ export const Nav = ({
                               await cms.api.tina?.authProvider.logout()
                               if (cms?.api?.tina?.onLogout) {
                                 await cms?.api?.tina?.onLogout()
+                                await new Promise((resolve) =>
+                                  setTimeout(resolve, 500)
+                                )
                               }
                               window.location.href = new URL(
                                 window.location.href


### PR DESCRIPTION
Fixes https://github.com/tinacms/tinacms/issues/4356 by adding a timeout that waits for browser events to finish before refreshing the page.
