### PR TITLE
Increase stalebot timer

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 120
+daysUntilStale: 180
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 14
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned


### PR DESCRIPTION
Closes #4282

Not going as far as to remove Stalebot, but increase the timer to 6ish months for something to be stale, and 14 days for it to be autoclosed afterwards