### PR TITLE
Re-add GitHubBridge to support self-hosting with separate content repos

### DIFF
--- a/.changeset/nine-baboons-exercise.md
+++ b/.changeset/nine-baboons-exercise.md
@@ -1,0 +1,7 @@
+---
+'tinacms-gitprovider-github': minor
+'@tinacms/graphql': minor
+'@tinacms/cli': minor
+---
+
+This re-adds the original GithubBridge in order to better support separate content repositories for self-hosted projects. This will also help provide a path to better support reindexing for self-hosted projects (i.e. keeping the data layer updated when changes are pushed directly via git, rather than made through the Tina UI). See further notes in this discussion: https://github.com/tinacms/tinacms/discussions/3589#discussioncomment-4960323 and this issue: https://github.com/tinacms/tinacms/issues/3609

--- a/packages/@tinacms/cli/src/next/database.ts
+++ b/packages/@tinacms/cli/src/next/database.ts
@@ -54,7 +54,10 @@ export async function createAndInitializeDatabase(
     configManager.config.contentApiUrlOverride
   ) {
     database = (await configManager.loadDatabaseFile()) as Database
-    database.bridge = bridge
+    // Use the bridge specified in the database file if one exists
+    if (!database.bridge) {
+      database.bridge = bridge
+    }
   } else {
     if (
       configManager.hasSelfHostedConfig() &&

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -17,6 +17,7 @@ export type {
   DatabaseArgs,
   GitProvider,
   CreateDatabase,
+  LookupMapType,
 } from './database'
 export {
   Database,

--- a/packages/@tinacms/graphql/src/index.ts
+++ b/packages/@tinacms/graphql/src/index.ts
@@ -17,7 +17,6 @@ export type {
   DatabaseArgs,
   GitProvider,
   CreateDatabase,
-  LookupMapType,
 } from './database'
 export {
   Database,

--- a/packages/tinacms-gitprovider-github/README.md
+++ b/packages/tinacms-gitprovider-github/README.md
@@ -36,3 +36,132 @@ export default isLocal ? createLocalDatabase() ? createDatabase({
 | `commitMessage`  | The commit message to use when saving content. Defaults to `Edited with TinaCMS`.                                           |
 | `rootPath`       | This path will be prefixed to all paths (good for monorepos)                                                                |
 | `octokitOptions` | Options passed to the [Octokit constructor ](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) |
+
+## Using the GitHubBridge
+
+- Designed for use in your `.tina/database.ts` or `tina/database.ts` file.
+- **Allows you to use Tina self-hosting in conjunction with separate content repositories**
+- One important caveat is that this approach could lead to GitHub rate limiting errors on certain projects, particularly larger sites with lots of pages/files
+- The ability to pass `systemFiles` to the `GithubBridge` is intended to allow multi-tenant projects where the content repos do not need to contain any Tina folders or files at all. The code repository can pass the necessary Tina system files to the GitHub bridge at built time, and no Tina files need to be committed or tracked in the content repositories. This is particularly useful when multiple content repositories/sites are built from a central code repository
+
+```ts
+import { createDatabase, createLocalDatabase } from '@tinacms/datalayer'
+import { RedisLevel } from 'upstash-redis-level'
+import {
+  GitHubProvider,
+  GitHubBridge,
+  type SystemFiles,
+} from 'tinacms-gitprovider-github'
+import { createAppAuth } from '@octokit/auth-app'
+// These example imports would be related to your database.ts file
+import graphql from './__generated__/_graphql.json'
+import lookup from './__generated__/_lookup.json'
+
+const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
+
+const systemFiles: SystemFiles = {
+  _graphql: graphql as SystemFiles['_graphql'],
+  _lookup: lookup as SystemFiles['_lookup'],
+}
+
+const github = {
+  owner: 'your-org-or-username',
+  repo: 'your-repo-name',
+  branch: 'main',
+}
+
+const database = isLocal
+  ? createLocalDatabase()
+  : createDatabase({
+      // You can pass system files to the GitHubBridge on init.
+      // It then fetches all other files from the content repo.
+      bridge: isLocal
+        ? undefined
+        : new GithubBridge({
+            owner: github.owner,
+            repo: github.repo,
+            branch: github.branch,
+            // The rootPath value is particularly useful for mono repos
+            // rootPath: 'packages/some-site',
+            systemFiles,
+            // Either provide a token or a separate auth strategy like the example below
+            // token: 'github-personal-access-token',
+            octokitOptions: {
+              authStrategy: createAppAuth,
+              auth: {
+                appId: process.env.GITHUB_APP_ID,
+                privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+                installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+                // repositoryIds: [], // number[]
+                // repositoryNames: [], // string[]
+                // permissions: {}, // Permissions
+                // refresh: true, // boolean
+              },
+            },
+          }),
+      // The contentNamespace for files in your site's Redis DB
+      // When left blank it defaults to a value of 'tinacms'
+      namespace: 'your-namespace',
+      // The tinaDirectory defaults to the 'tina' folder name
+      // tinaDirectory: '.tina',
+      // databaseAdapter: new RedisLevel<string, Record<string, any>>({
+      //   // This sets the name of the Redis hash for your site
+      //   namespace: 'my-site',
+      //   redis: {
+      //     url: process.env.KV_REST_API_URL ?? 'http://localhost:8079',
+      //     token: process.env.KV_REST_API_TOKEN ?? '',
+      //   },
+      //   debug: process.env.DEBUG === 'true' || false,
+      // }) as any,
+      databaseAdapter: new MongodbLevel<string, Record<string, any>>({
+        dbName: 'your-site',
+        collectionName: 'branch-name',
+        mongoUri: process.env.MONGODB_URI as string,
+      }),
+      // https://tina.io/docs/reference/self-hosted/git-provider/github/
+      gitProvider: new GitHubProvider({
+        owner: github.owner,
+        repo: github.repo,
+        branch: github.branch,
+        commitMessage: 'Content update from TinaCMS',
+        // The rootPath value is particularly useful for mono repos
+        // rootPath: 'packages/some-site',
+        // Either provide a token or a separate auth strategy like the example below
+        // token: 'github-personal-access-token',
+        // https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options
+        octokitOptions: {
+          authStrategy: createAppAuth,
+          auth: {
+            appId: process.env.GITHUB_APP_ID,
+            privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+            installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+            // repositoryIds: [], // number[]
+            // repositoryNames: [], // string[]
+            // permissions: {}, // Permissions
+            // refresh: true, // boolean
+          },
+        },
+      }),
+    })
+
+export default database
+```
+
+## GitHubBridge options
+
+**Summary:** Supports all Git Provider Options listed above except for `commitMessage`, and also allows for `systemFiles` to be provided (containing a copy of the local `_graphql.json` and `_lookup.json`)
+
+| Option   | Description                                                                               |
+| -------- | ----------------------------------------------------------------------------------------- |
+| `branch` | The branch to save content to.                                                            |
+| `owner`  | The owner of the repo.                                                                    |
+| `repo`   | The repo to save content to.                                                              |
+| `token`  | A [Github Personal Access Token](https://github.com/settings/personal-access-tokens/new). |
+
+### Optional Options
+
+| Option           | Description                                                                                                                 |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `rootPath`       | This path will be prefixed to all paths (good for monorepos)                                                                |
+| `systemFiles`    | Pass the local `_graphql.json` and `_lookup.json` (useful to avoid committing Tina files to content repositories)           |
+| `octokitOptions` | Options passed to the [Octokit constructor ](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) |

--- a/packages/tinacms-gitprovider-github/README.md
+++ b/packages/tinacms-gitprovider-github/README.md
@@ -160,10 +160,6 @@ You must either supply a `token` or an alternative authentication strategy via t
 | `octokitOptions`  | Options passed to the [Octokit constructor ](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) |
 | `tinaFilesConfig` | Can be used to find Tina files in the code repository (useful to avoid committing Tina files to content repositories)       |
 
-### Notes on `tinaFilesConfig`
-
-**IMPORTANT:** If you're using the `tina` folder (rather than the `.tina` folder), then you will need to update your `.gitignore` to explicitly track the `_schema.json`, `_graphql.json` and `_lookup.json` files. Those files don't generally need to be tracked when using the newer `tina` folder naming convention, but you will need them if planning to retrieve those files from the code repository (rather than the content repository) when loading TinaCMS.
-
 The `tinaFilesConfig` option is an object with 2 keys:
 
 - the `useFilesystemBridge` is a boolean you can set to `true` if you would like to find Tina files in the local filesystem of the code repository, rather than retrieving those files from the content repository

--- a/packages/tinacms-gitprovider-github/README.md
+++ b/packages/tinacms-gitprovider-github/README.md
@@ -22,47 +22,37 @@ export default isLocal ? createLocalDatabase() ? createDatabase({
 
 ### Required Options
 
-| Option   | Description                                                                               |
-| -------- | ----------------------------------------------------------------------------------------- |
-| `branch` | The branch to save content to.                                                            |
-| `owner`  | The owner of the repo.                                                                    |
-| `repo`   | The repo to save content to.                                                              |
-| `token`  | A [Github Personal Access Token](https://github.com/settings/personal-access-tokens/new). |
+| Option   | Description                    |
+| -------- | ------------------------------ |
+| `branch` | The branch to save content to. |
+| `owner`  | The owner of the repo.         |
+| `repo`   | The repo to save content to.   |
 
 ### Optional Options
+
+You must either supply a `token` or an alternative authentication strategy via the `octokitOptions`
 
 | Option           | Description                                                                                                                 |
 | ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | `commitMessage`  | The commit message to use when saving content. Defaults to `Edited with TinaCMS`.                                           |
 | `rootPath`       | This path will be prefixed to all paths (good for monorepos)                                                                |
+| `token`          | A [Github Personal Access Token](https://github.com/settings/personal-access-tokens/new).                                   |
 | `octokitOptions` | Options passed to the [Octokit constructor ](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) |
 
 ## Using the GitHubBridge
 
 - Designed for use in your `.tina/database.ts` or `tina/database.ts` file.
 - **Allows you to use Tina self-hosting in conjunction with separate content repositories**
-- One important caveat is that this approach could lead to GitHub rate limiting errors on certain projects, particularly larger sites with lots of pages/files
-- The ability to pass `systemFiles` to the `GithubBridge` is intended to allow multi-tenant projects where the content repos do not need to contain any Tina folders or files at all. The code repository can pass the necessary Tina system files to the GitHub bridge at built time, and no Tina files need to be committed or tracked in the content repositories. This is particularly useful when multiple content repositories/sites are built from a central code repository
+- One important caveat is that this approach could lead to GitHub rate limiting errors on certain projects, particularly larger sites with lots of pages/files. This could occur given the GitHubBridge makes requests directly to the GitHub API.
+- The ability to pass `tinaFilesConfig` is intended to support multi-tenant projects where the Tina folder lives in the code repository so the content repositories do not need to contain any Tina folders or files at all. In this case the GitHub bridge will defer to the FilesystemBridge to retrieve the auto-generated Tina files, so those files do not need to be committed or tracked in the content repositories. This is particularly useful when multiple content repositories/sites are built from a central code repository.
 
 ```ts
 import { createDatabase, createLocalDatabase } from '@tinacms/datalayer'
 import { RedisLevel } from 'upstash-redis-level'
-import {
-  GitHubProvider,
-  GitHubBridge,
-  type SystemFiles,
-} from 'tinacms-gitprovider-github'
+import { GitHubProvider, GitHubBridge } from 'tinacms-gitprovider-github'
 import { createAppAuth } from '@octokit/auth-app'
-// These example imports would be related to your database.ts file
-import graphql from './__generated__/_graphql.json'
-import lookup from './__generated__/_lookup.json'
 
 const isLocal = process.env.TINA_PUBLIC_IS_LOCAL === 'true'
-
-const systemFiles: SystemFiles = {
-  _graphql: graphql as SystemFiles['_graphql'],
-  _lookup: lookup as SystemFiles['_lookup'],
-}
 
 const github = {
   owner: 'your-org-or-username',
@@ -73,8 +63,6 @@ const github = {
 const database = isLocal
   ? createLocalDatabase()
   : createDatabase({
-      // You can pass system files to the GitHubBridge on init.
-      // It then fetches all other files from the content repo.
       bridge: isLocal
         ? undefined
         : new GithubBridge({
@@ -83,7 +71,6 @@ const database = isLocal
             branch: github.branch,
             // The rootPath value is particularly useful for mono repos
             // rootPath: 'packages/some-site',
-            systemFiles,
             // Either provide a token or a separate auth strategy like the example below
             // token: 'github-personal-access-token',
             octokitOptions: {
@@ -97,6 +84,11 @@ const database = isLocal
                 // permissions: {}, // Permissions
                 // refresh: true, // boolean
               },
+            },
+            // Optionally find Tina files in the code repo instead of the content repo
+            tinaFilesConfig: {
+              useFilesystemBridge: true,
+              tinaFolderPath: '',
             },
           }),
       // The contentNamespace for files in your site's Redis DB
@@ -149,19 +141,30 @@ export default database
 
 ## GitHubBridge options
 
-**Summary:** Supports all Git Provider Options listed above except for `commitMessage`, and also allows for `systemFiles` to be provided (containing a copy of the local `_graphql.json` and `_lookup.json`)
+**Summary:** Supports all Git Provider Options listed above except for `commitMessage`, and also allows for a `tinaFilesConfig` option to be provided (in order to configure the GitHubBridge to find the Tina files in the local filesystem of the content repository, rather than looking for those in the code repository)
 
-| Option   | Description                                                                               |
-| -------- | ----------------------------------------------------------------------------------------- |
-| `branch` | The branch to save content to.                                                            |
-| `owner`  | The owner of the repo.                                                                    |
-| `repo`   | The repo to save content to.                                                              |
-| `token`  | A [Github Personal Access Token](https://github.com/settings/personal-access-tokens/new). |
+| Option   | Description                    |
+| -------- | ------------------------------ |
+| `branch` | The branch to save content to. |
+| `owner`  | The owner of the repo.         |
+| `repo`   | The repo to save content to.   |
 
 ### Optional Options
 
-| Option           | Description                                                                                                                 |
-| ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `rootPath`       | This path will be prefixed to all paths (good for monorepos)                                                                |
-| `systemFiles`    | Pass the local `_graphql.json` and `_lookup.json` (useful to avoid committing Tina files to content repositories)           |
-| `octokitOptions` | Options passed to the [Octokit constructor ](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) |
+You must either supply a `token` or an alternative authentication strategy via the `octokitOptions`
+
+| Option            | Description                                                                                                                 |
+| ----------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `rootPath`        | This path will be prefixed to all paths (good for monorepos)                                                                |
+| `token`           | A [Github Personal Access Token](https://github.com/settings/personal-access-tokens/new).                                   |
+| `octokitOptions`  | Options passed to the [Octokit constructor ](https://github.com/octokit/octokit.js/blob/main/README.md#constructor-options) |
+| `tinaFilesConfig` | Can be used to find Tina files in the code repository (useful to avoid committing Tina files to content repositories)       |
+
+### Notes on `tinaFilesConfig`
+
+**IMPORTANT:** If you're using the `tina` folder (rather than the `.tina` folder), then you will need to update your `.gitignore` to explicitly track the `_schema.json`, `_graphql.json` and `_lookup.json` files. Those files don't generally need to be tracked when using the newer `tina` folder naming convention, but you will need them if planning to retrieve those files from the code repository (rather than the content repository) when loading TinaCMS.
+
+The `tinaFilesConfig` option is an object with 2 keys:
+
+- the `useFilesystemBridge` is a boolean you can set to `true` if you would like to find Tina files in the local filesystem of the code repository, rather than retrieving those files from the content repository
+- the `tinaFolderPath` is the path to where the Tina folder resides in the local filesystem of the code repository

--- a/packages/tinacms-gitprovider-github/package.json
+++ b/packages/tinacms-gitprovider-github/package.json
@@ -21,7 +21,6 @@
     "build": "tinacms-scripts build"
   },
   "dependencies": {
-    "@octokit/auth-app": "^6.0.1",
     "@octokit/rest": "^19.0.7",
     "graphql": "^16.8.1",
     "js-base64": "^3.7.4",

--- a/packages/tinacms-gitprovider-github/package.json
+++ b/packages/tinacms-gitprovider-github/package.json
@@ -21,11 +21,15 @@
     "build": "tinacms-scripts build"
   },
   "dependencies": {
+    "@octokit/auth-app": "^6.0.1",
     "@octokit/rest": "^19.0.7",
-    "js-base64": "^3.7.4"
+    "graphql": "^16.8.1",
+    "js-base64": "^3.7.4",
+    "lodash-es": "4.17.21"
   },
   "devDependencies": {
     "@tinacms/datalayer": "workspace:*",
+    "@tinacms/graphql": "workspace:*",
     "@tinacms/scripts": "workspace:*",
     "@types/node": "^13.13.1"
   },

--- a/packages/tinacms-gitprovider-github/src/GitHubBridge.ts
+++ b/packages/tinacms-gitprovider-github/src/GitHubBridge.ts
@@ -1,0 +1,207 @@
+import path from 'path'
+import { flatten } from 'lodash-es'
+import { Octokit } from '@octokit/rest'
+import { GraphQLError } from 'graphql'
+import type { DocumentNode } from 'graphql'
+import type { Bridge, LookupMapType } from '@tinacms/graphql'
+import type { GitHubProviderOptions } from './index'
+
+/**
+ * NOTE: you can use a GitHub app rather than a personal token
+ * using a version of the example code belowe
+ */
+// import { createAppAuth } from '@octokit/auth-app'
+// const octokitOptions = {
+//   authStrategy: createAppAuth,
+//   auth: {
+//     appId: process.env.GITHUB_APP_ID,
+//     privateKey: process.env.GITHUB_APP_PRIVATE_KEY,
+//     installationId: process.env.GITHUB_APP_INSTALLATION_ID,
+//     // repositoryIds: [], // number[]
+//     // repositoryNames: [], // string[]
+//     // permissions: {}, // Permissions
+//     // refresh: true, // boolean
+//   },
+// }
+
+export type SystemFiles = {
+  // _schema: string
+  _graphql: DocumentNode
+  _lookup: { [returnType: string]: LookupMapType }
+}
+
+type GitHubBridgeConfig = GitHubProviderOptions & {
+  systemFiles?: SystemFiles
+}
+
+export class GitHubBridge implements Bridge {
+  public rootPath: string
+  private owner: string
+  private repo: string
+  private branch: string
+  private octokit: Octokit
+  // private _schema: string | undefined
+  private _graphql: SystemFiles['_graphql'] | undefined
+  private _lookup: SystemFiles['_lookup'] | undefined
+
+  constructor({
+    owner,
+    repo,
+    branch,
+    rootPath,
+    systemFiles,
+    ...args
+  }: GitHubBridgeConfig) {
+    this.rootPath = rootPath ?? ''
+    this.owner = owner
+    this.repo = repo
+    this.branch = branch ?? 'main'
+    // this._schema = systemFiles?._schema
+    this._graphql = systemFiles?._graphql
+    this._lookup = systemFiles?._lookup
+    this.octokit = new Octokit({
+      auth: args.token,
+      ...(args.octokitOptions || {}),
+    })
+  }
+
+  public async delete(filepath: string) {
+    console.log(
+      `File deleted in data layer file (sync handled by GitProvider): ${filepath}`
+    )
+  }
+
+  public async put(filepath: string, data: string) {
+    console.log(
+      `File created/updated in data layer (sync handled by GitProvider): ${filepath}`
+    )
+  }
+
+  // Is it useful to run an `endsWith(extension)` filter here?
+  public async glob(pattern: string, extension: string) {
+    const results = await this.readDir(pattern)
+    return results.map((item) => {
+      const filepath = item.replace(this.rootPath, '')
+      return this.removeSurroundingSlashes(filepath)
+    })
+  }
+
+  public async get(filepath: string) {
+    if (this.isSystemFile(filepath)) {
+      const systemFile = this.getSystemFile(filepath)
+      if (systemFile) return systemFile
+    }
+
+    const fullPath = this.buildFullPath(filepath)
+    return this.octokit.repos
+      .getContent({
+        owner: this.owner,
+        repo: this.repo,
+        ref: this.branch,
+        path: fullPath,
+      })
+      .then((response) => {
+        if (!Array.isArray(response.data) && response.data.type === 'file') {
+          return Buffer.from(response.data.content, 'base64').toString()
+        } else {
+          throw new Error(
+            `Could not find file at path: ${fullPath} in GitHub Repository: '${this.owner}/${this.repo}'`
+          )
+        }
+      })
+      .catch((e) => {
+        if (e.status === 401) {
+          throw new GraphQLError(
+            `Unauthorized request to GitHub Repository: '${this.owner}/${this.repo}', please ensure your access token is valid.`,
+            null,
+            null,
+            null,
+            null,
+            e,
+            { status: e.status }
+          )
+        }
+        throw new GraphQLError(
+          `Unable to find record '${fullPath}' in GitHub Repository: '${this.owner}/${this.repo}', Branch: '${this.branch}'`,
+          null,
+          null,
+          null,
+          null,
+          e,
+          { status: e.status }
+        )
+      })
+  }
+
+  // Leading and trailing slashes cause errors in `@octokit/rest`
+  private removeSurroundingSlashes(filepath: string): string {
+    return filepath.replace(/^\/|\/$/g, '')
+  }
+
+  private systemFilenameMatches: Record<keyof SystemFiles, string> = {
+    // // _schema: '/_schema.json',
+    _lookup: '/_lookup.json',
+    _graphql: '/_graphql.json',
+  }
+
+  private isSystemFile(filepath: string): boolean {
+    return Object.values(this.systemFilenameMatches).some((filename) =>
+      filepath.endsWith(filename)
+    )
+  }
+
+  private getSystemFile(filepath: string): string | undefined {
+    const filenameMatches = this.systemFilenameMatches
+    switch (true) {
+      // case filepath.endsWith(filenameMatches._schema):
+      //   return JSON.stringify(this._schema)
+      case filepath.endsWith(filenameMatches._lookup):
+        return JSON.stringify(this._lookup)
+      case filepath.endsWith(filenameMatches._graphql):
+        return JSON.stringify(this._graphql)
+      default:
+        return undefined
+    }
+  }
+
+  private buildFullPath(filepath: string): string {
+    return this.removeSurroundingSlashes(path.join(this.rootPath, filepath))
+  }
+
+  private async readDir(filepath: string): Promise<string[]> {
+    const fullPath = this.buildFullPath(filepath)
+    const repos = await this.octokit.repos
+      .getContent({
+        owner: this.owner,
+        repo: this.repo,
+        ref: this.branch,
+        path: fullPath,
+      })
+      .then(async (response) => {
+        if (Array.isArray(response.data)) {
+          return await Promise.all(
+            await response.data.map(async (d) => {
+              if (d.type === 'dir') {
+                const nestedItems = await this.readDir(d.path)
+                if (Array.isArray(nestedItems)) {
+                  return nestedItems.map((nestedItem) => {
+                    return path.join(d.path, nestedItem)
+                  })
+                } else {
+                  throw new Error(
+                    `Expected items to be an array of strings for readDir at ${d.path}`
+                  )
+                }
+              }
+              return d.path
+            })
+          )
+        }
+
+        throw new Error(
+          `Expected to return an array from GitHub directory ${path}`
+        )
+      })
+    return flatten(repos)
+  }
+}

--- a/packages/tinacms-gitprovider-github/src/index.ts
+++ b/packages/tinacms-gitprovider-github/src/index.ts
@@ -2,6 +2,9 @@ import { Octokit } from '@octokit/rest'
 import { Base64 } from 'js-base64'
 import type { GitProvider } from '@tinacms/datalayer'
 
+export { GitHubBridge } from './GitHubBridge'
+export type { SystemFiles } from './GitHubBridge'
+
 type OctokitOptions = ConstructorParameters<typeof Octokit>[0]
 export interface GitHubProviderOptions {
   owner: string

--- a/packages/tinacms-gitprovider-github/src/index.ts
+++ b/packages/tinacms-gitprovider-github/src/index.ts
@@ -3,13 +3,12 @@ import { Base64 } from 'js-base64'
 import type { GitProvider } from '@tinacms/datalayer'
 
 export { GitHubBridge } from './GitHubBridge'
-export type { SystemFiles } from './GitHubBridge'
 
 type OctokitOptions = ConstructorParameters<typeof Octokit>[0]
 export interface GitHubProviderOptions {
   owner: string
   repo: string
-  token: string
+  token?: string // Token is optional if using a different auth strategy in the octokitOptions
   branch: string
   commitMessage?: string
   rootPath?: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,7 +149,7 @@ importers:
       eslint-config-next: 13.4.7_ypn2ylkkyfa5i233caldtndbqa
       postcss: 8.4.18
       puppeteer: 18.2.1
-      tailwindcss: 3.2.7_postcss@8.4.18
+      tailwindcss: 3.2.7
       typescript: 4.8.4
       vite: 4.3.9
       vitest: 0.32.2
@@ -210,7 +210,7 @@ importers:
       postcss: 8.4.18
       postcss-import: 14.1.0_postcss@8.4.18
       postcss-nesting: 10.1.9_postcss@8.4.18
-      tailwindcss: 3.2.7_postcss@8.4.18
+      tailwindcss: 3.2.7
       typescript: 4.8.4
 
   experimental-examples/kitchen-sink:
@@ -334,7 +334,7 @@ importers:
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       react-router-dom: 6.3.0_sfoxds7t5ydpegc3knd667wn6m
-      tailwindcss: 3.2.7_postcss@8.4.14
+      tailwindcss: 3.2.7
       tinacms: link:../../tinacms
       typescript: 4.7.4
       zod: 3.17.3
@@ -509,7 +509,7 @@ importers:
       chalk: 2.4.2
       chokidar: 3.5.3
       cli-spinner: 0.2.10
-      clipanion: 3.2.0_typanion@3.13.0
+      clipanion: 3.2.0
       cors: 2.8.5
       crypto-js: 4.1.1
       dotenv: 16.0.1
@@ -1322,16 +1322,24 @@ importers:
 
   packages/tinacms-gitprovider-github:
     specifiers:
+      '@octokit/auth-app': ^6.0.1
       '@octokit/rest': ^19.0.7
       '@tinacms/datalayer': workspace:*
+      '@tinacms/graphql': workspace:*
       '@tinacms/scripts': workspace:*
       '@types/node': ^13.13.1
+      graphql: ^16.8.1
       js-base64: ^3.7.4
+      lodash-es: 4.17.21
     dependencies:
+      '@octokit/auth-app': 6.0.1
       '@octokit/rest': 19.0.7
+      graphql: 16.8.1
       js-base64: 3.7.5
+      lodash-es: 4.17.21
     devDependencies:
       '@tinacms/datalayer': link:../@tinacms/datalayer
+      '@tinacms/graphql': link:../@tinacms/graphql
       '@tinacms/scripts': link:../@tinacms/scripts
       '@types/node': 13.13.52
 
@@ -9481,6 +9489,68 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
+  /@octokit/auth-app/6.0.1:
+    resolution:
+      {
+        integrity: sha512-tjCD4nzQNZgmLH62+PSnTF6eGerisFgV4v6euhqJik6yWV96e1ZiiGj+NXIqbgnpjLmtnBqVUrNyGKu3DoGEGA==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/auth-oauth-app': 7.0.1
+      '@octokit/auth-oauth-user': 4.0.1
+      '@octokit/request': 8.1.6
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.3.0
+      deprecation: 2.3.1
+      lru-cache: 10.0.0
+      universal-github-app-jwt: 1.1.1
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-oauth-app/7.0.1:
+    resolution:
+      {
+        integrity: sha512-RE0KK0DCjCHXHlQBoubwlLijXEKfhMhKm9gO56xYvFmP1QTMb+vvwRPmQLLx0V+5AvV9N9I3lr1WyTzwL3rMDg==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/auth-oauth-device': 6.0.1
+      '@octokit/auth-oauth-user': 4.0.1
+      '@octokit/request': 8.1.6
+      '@octokit/types': 12.3.0
+      '@types/btoa-lite': 1.0.2
+      btoa-lite: 1.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-oauth-device/6.0.1:
+    resolution:
+      {
+        integrity: sha512-yxU0rkL65QkjbqQedgVx3gmW7YM5fF+r5uaSj9tM/cQGVqloXcqP2xK90eTyYvl29arFVCW8Vz4H/t47mL0ELw==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/oauth-methods': 4.0.1
+      '@octokit/request': 8.1.6
+      '@octokit/types': 12.3.0
+      universal-user-agent: 6.0.0
+    dev: false
+
+  /@octokit/auth-oauth-user/4.0.1:
+    resolution:
+      {
+        integrity: sha512-N94wWW09d0hleCnrO5wt5MxekatqEJ4zf+1vSe8MKMrhZ7gAXKFOKrDEZW2INltvBWJCyDUELgGRv8gfErH1Iw==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/auth-oauth-device': 6.0.1
+      '@octokit/oauth-methods': 4.0.1
+      '@octokit/request': 8.1.6
+      '@octokit/types': 12.3.0
+      btoa-lite: 1.0.0
+      universal-user-agent: 6.0.0
+    dev: false
+
   /@octokit/auth-token/3.0.3:
     resolution:
       {
@@ -9521,6 +9591,17 @@ packages:
       universal-user-agent: 6.0.0
     dev: false
 
+  /@octokit/endpoint/9.0.4:
+    resolution:
+      {
+        integrity: sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/types': 12.3.0
+      universal-user-agent: 6.0.0
+    dev: false
+
   /@octokit/graphql/5.0.5:
     resolution:
       {
@@ -9535,10 +9616,39 @@ packages:
       - encoding
     dev: false
 
+  /@octokit/oauth-authorization-url/6.0.2:
+    resolution:
+      {
+        integrity: sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==,
+      }
+    engines: { node: '>= 18' }
+    dev: false
+
+  /@octokit/oauth-methods/4.0.1:
+    resolution:
+      {
+        integrity: sha512-1NdTGCoBHyD6J0n2WGXg9+yDLZrRNZ0moTEex/LSPr49m530WNKcCfXDghofYptr3st3eTii+EHoG5k/o+vbtw==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/oauth-authorization-url': 6.0.2
+      '@octokit/request': 8.1.6
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.3.0
+      btoa-lite: 1.0.0
+    dev: false
+
   /@octokit/openapi-types/16.0.0:
     resolution:
       {
         integrity: sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==,
+      }
+    dev: false
+
+  /@octokit/openapi-types/19.1.0:
+    resolution:
+      {
+        integrity: sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==,
       }
     dev: false
 
@@ -9592,6 +9702,18 @@ packages:
       once: 1.4.0
     dev: false
 
+  /@octokit/request-error/5.0.1:
+    resolution:
+      {
+        integrity: sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/types': 12.3.0
+      deprecation: 2.3.1
+      once: 1.4.0
+    dev: false
+
   /@octokit/request/6.2.3:
     resolution:
       {
@@ -9609,6 +9731,19 @@ packages:
       - encoding
     dev: false
 
+  /@octokit/request/8.1.6:
+    resolution:
+      {
+        integrity: sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==,
+      }
+    engines: { node: '>= 18' }
+    dependencies:
+      '@octokit/endpoint': 9.0.4
+      '@octokit/request-error': 5.0.1
+      '@octokit/types': 12.3.0
+      universal-user-agent: 6.0.0
+    dev: false
+
   /@octokit/rest/19.0.7:
     resolution:
       {
@@ -9622,6 +9757,15 @@ packages:
       '@octokit/plugin-rest-endpoint-methods': 7.0.1_@octokit+core@4.2.0
     transitivePeerDependencies:
       - encoding
+    dev: false
+
+  /@octokit/types/12.3.0:
+    resolution:
+      {
+        integrity: sha512-nJ8X2HRr234q3w/FcovDlA+ttUU4m1eJAourvfUUtwAWeqL8AsyRqfnLvVnYn3NFbUnsmzQCzLNdFerPwdmcDQ==,
+      }
+    dependencies:
+      '@octokit/openapi-types': 19.1.0
     dev: false
 
   /@octokit/types/9.0.0:
@@ -11379,7 +11523,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.7_postcss@8.4.18
+      tailwindcss: 3.2.7
     dev: false
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.2.7:
@@ -11394,7 +11538,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
-      tailwindcss: 3.2.7_postcss@8.4.18
+      tailwindcss: 3.2.7
     dev: false
 
   /@tailwindcss/typography/0.5.9_tailwindcss@3.3.2:
@@ -11664,6 +11808,13 @@ packages:
         integrity: sha512-+euflG6ygo4bn0JHtn4pYqcXwRtLvElQ7/nnjDu7iYG56H0+OhCd7d6Ug0IE3WcFpZozBKW2+80FUbv5QGk5AQ==,
       }
     dev: true
+
+  /@types/btoa-lite/1.0.2:
+    resolution:
+      {
+        integrity: sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==,
+      }
+    dev: false
 
   /@types/cacheable-request/6.0.3:
     resolution:
@@ -12039,6 +12190,15 @@ packages:
       }
     dev: true
 
+  /@types/jsonwebtoken/9.0.5:
+    resolution:
+      {
+        integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==,
+      }
+    dependencies:
+      '@types/node': 17.0.45
+    dev: false
+
   /@types/keyv/3.1.4:
     resolution:
       {
@@ -12278,7 +12438,6 @@ packages:
       {
         integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
       }
-    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution:
@@ -15924,12 +16083,26 @@ packages:
       buffer: 5.7.1
     dev: false
 
+  /btoa-lite/1.0.0:
+    resolution:
+      {
+        integrity: sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==,
+      }
+    dev: false
+
   /buffer-crc32/0.2.13:
     resolution:
       {
         integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
       }
     dev: true
+
+  /buffer-equal-constant-time/1.0.1:
+    resolution:
+      {
+        integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==,
+      }
+    dev: false
 
   /buffer-from/1.1.2:
     resolution:
@@ -16499,13 +16672,11 @@ packages:
       }
     dev: false
 
-  /clipanion/3.2.0_typanion@3.13.0:
+  /clipanion/3.2.0:
     resolution:
       {
         integrity: sha512-XaPQiJQZKbyaaDbv5yR/cAt/ORfZfENkr4wGQj+Go/Uf/65ofTQBCPirgWFeJctZW24V3mxrFiEnEmqBflrJYA==,
       }
-    peerDependencies:
-      typanion: '*'
     dependencies:
       typanion: 3.13.0
     dev: false
@@ -17976,6 +18147,15 @@ packages:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
     dev: true
+
+  /ecdsa-sig-formatter/1.0.11:
+    resolution:
+      {
+        integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
+      }
+    dependencies:
+      safe-buffer: 5.2.1
+    dev: false
 
   /ee-first/1.1.1:
     resolution:
@@ -20605,6 +20785,14 @@ packages:
       }
     engines: { node: '>= 10.x' }
 
+  /graphql/16.8.1:
+    resolution:
+      {
+        integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==,
+      }
+    engines: { node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0 }
+    dev: false
+
   /gray-matter/4.0.3:
     resolution:
       {
@@ -21683,7 +21871,6 @@ packages:
       whatwg-fetch: 3.6.2
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /isomorphic-fetch/3.0.0_encoding@0.1.13:
     resolution:
@@ -22715,6 +22902,25 @@ packages:
     engines: { node: '>=10.0.0' }
     dev: false
 
+  /jsonwebtoken/9.0.2:
+    resolution:
+      {
+        integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==,
+      }
+    engines: { node: '>=12', npm: '>=6' }
+    dependencies:
+      jws: 3.2.2
+      lodash.includes: 4.3.0
+      lodash.isboolean: 3.0.3
+      lodash.isinteger: 4.0.4
+      lodash.isnumber: 3.0.3
+      lodash.isplainobject: 4.0.6
+      lodash.isstring: 4.0.1
+      lodash.once: 4.1.1
+      ms: 2.1.3
+      semver: 7.5.2
+    dev: false
+
   /jsprim/2.0.2:
     resolution:
       {
@@ -22738,6 +22944,27 @@ packages:
       array-includes: 3.1.6
       object.assign: 4.1.4
     dev: true
+
+  /jwa/1.4.1:
+    resolution:
+      {
+        integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==,
+      }
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: false
+
+  /jws/3.2.2:
+    resolution:
+      {
+        integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==,
+      }
+    dependencies:
+      jwa: 1.4.1
+      safe-buffer: 5.2.1
+    dev: false
 
   /keyv/4.5.2:
     resolution:
@@ -23034,10 +23261,45 @@ packages:
       }
     dev: false
 
+  /lodash.includes/4.3.0:
+    resolution:
+      {
+        integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==,
+      }
+    dev: false
+
+  /lodash.isboolean/3.0.3:
+    resolution:
+      {
+        integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==,
+      }
+    dev: false
+
+  /lodash.isinteger/4.0.4:
+    resolution:
+      {
+        integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==,
+      }
+    dev: false
+
+  /lodash.isnumber/3.0.3:
+    resolution:
+      {
+        integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==,
+      }
+    dev: false
+
   /lodash.isplainobject/4.0.6:
     resolution:
       {
         integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==,
+      }
+    dev: false
+
+  /lodash.isstring/4.0.1:
+    resolution:
+      {
+        integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==,
       }
     dev: false
 
@@ -23052,7 +23314,6 @@ packages:
       {
         integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
       }
-    dev: true
 
   /lodash.pad/4.5.1:
     resolution:
@@ -26046,21 +26307,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /postcss-import/14.1.0_postcss@8.4.14:
-    resolution:
-      {
-        integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==,
-      }
-    engines: { node: '>=10.0.0' }
-    peerDependencies:
-      postcss: ^8.0.0
-    dependencies:
-      postcss: 8.4.14
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.2
-    dev: false
-
   /postcss-import/14.1.0_postcss@8.4.18:
     resolution:
       {
@@ -26074,6 +26320,7 @@ packages:
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.2
+    dev: true
 
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution:
@@ -26090,6 +26337,20 @@ packages:
       resolve: 1.22.2
     dev: true
 
+  /postcss-import/14.1.0_postcss@8.4.23:
+    resolution:
+      {
+        integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==,
+      }
+    engines: { node: '>=10.0.0' }
+    peerDependencies:
+      postcss: ^8.0.0
+    dependencies:
+      postcss: 8.4.23
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.2
+
   /postcss-import/15.1.0_postcss@8.4.23:
     resolution:
       {
@@ -26104,7 +26365,7 @@ packages:
       read-cache: 1.0.0
       resolve: 1.22.2
 
-  /postcss-js/4.0.0_postcss@8.4.14:
+  /postcss-js/4.0.0_postcss@8.4.23:
     resolution:
       {
         integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==,
@@ -26114,20 +26375,7 @@ packages:
       postcss: ^8.3.3
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.14
-    dev: false
-
-  /postcss-js/4.0.0_postcss@8.4.18:
-    resolution:
-      {
-        integrity: sha512-77QESFBwgX4irogGVPgQ5s07vLvFqWr228qZY+w6lW599cRlK/HmnlivnnVUxkjHnCu4J16PDMHcH+e+2HbvTQ==,
-      }
-    engines: { node: ^12 || ^14 || >= 16 }
-    peerDependencies:
-      postcss: ^8.3.3
-    dependencies:
-      camelcase-css: 2.0.1
-      postcss: 8.4.18
+      postcss: 8.4.23
 
   /postcss-js/4.0.1_postcss@8.4.23:
     resolution:
@@ -26161,7 +26409,7 @@ packages:
       yaml: 1.10.2
     dev: false
 
-  /postcss-load-config/3.1.4_postcss@8.4.18:
+  /postcss-load-config/3.1.4_postcss@8.4.23:
     resolution:
       {
         integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==,
@@ -26177,7 +26425,7 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.18
+      postcss: 8.4.23
       yaml: 1.10.2
 
   /postcss-load-config/4.0.1_postcss@8.4.23:
@@ -26199,7 +26447,7 @@ packages:
       postcss: 8.4.23
       yaml: 2.2.2
 
-  /postcss-nested/6.0.0_postcss@8.4.14:
+  /postcss-nested/6.0.0_postcss@8.4.23:
     resolution:
       {
         integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==,
@@ -26208,20 +26456,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.14
-      postcss-selector-parser: 6.0.11
-    dev: false
-
-  /postcss-nested/6.0.0_postcss@8.4.18:
-    resolution:
-      {
-        integrity: sha512-0DkamqrPcmkBDsLn+vQDIrtkSbNkv5AD/M322ySo9kqFkCIYklym2xEmWkwo+Y3/qZo34tzEPNUw4y7yMCdv5w==,
-      }
-    engines: { node: '>=12.0' }
-    peerDependencies:
-      postcss: ^8.2.14
-    dependencies:
-      postcss: 8.4.18
+      postcss: 8.4.23
       postcss-selector-parser: 6.0.11
 
   /postcss-nested/6.0.1_postcss@8.4.23:
@@ -26312,6 +26547,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /postcss/8.4.21:
     resolution:
@@ -29092,15 +29328,13 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /tailwindcss/3.2.7_postcss@8.4.14:
+  /tailwindcss/3.2.7:
     resolution:
       {
         integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==,
       }
     engines: { node: '>=12.13.0' }
     hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
     dependencies:
       arg: 5.0.2
       chokidar: 3.5.3
@@ -29116,48 +29350,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.14
-      postcss-import: 14.1.0_postcss@8.4.14
-      postcss-js: 4.0.0_postcss@8.4.14
-      postcss-load-config: 3.1.4_postcss@8.4.14
-      postcss-nested: 6.0.0_postcss@8.4.14
-      postcss-selector-parser: 6.0.11
-      postcss-value-parser: 4.2.0
-      quick-lru: 5.1.1
-      resolve: 1.22.1
-    transitivePeerDependencies:
-      - ts-node
-    dev: false
-
-  /tailwindcss/3.2.7_postcss@8.4.18:
-    resolution:
-      {
-        integrity: sha512-B6DLqJzc21x7wntlH/GsZwEXTBttVSl1FtCzC8WP4oBc/NKef7kaax5jeihkkCEWc831/5NDJ9gRNDK6NEioQQ==,
-      }
-    engines: { node: '>=12.13.0' }
-    hasBin: true
-    peerDependencies:
-      postcss: ^8.0.9
-    dependencies:
-      arg: 5.0.2
-      chokidar: 3.5.3
-      color-name: 1.1.4
-      detective: 5.2.1
-      didyoumean: 1.2.2
-      dlv: 1.1.3
-      fast-glob: 3.2.12
-      glob-parent: 6.0.2
-      is-glob: 4.0.3
-      lilconfig: 2.0.6
-      micromatch: 4.0.5
-      normalize-path: 3.0.0
-      object-hash: 3.0.0
-      picocolors: 1.0.0
-      postcss: 8.4.18
-      postcss-import: 14.1.0_postcss@8.4.18
-      postcss-js: 4.0.0_postcss@8.4.18
-      postcss-load-config: 3.1.4_postcss@8.4.18
-      postcss-nested: 6.0.0_postcss@8.4.18
+      postcss: 8.4.23
+      postcss-import: 14.1.0_postcss@8.4.23
+      postcss-js: 4.0.0_postcss@8.4.23
+      postcss-load-config: 3.1.4_postcss@8.4.23
+      postcss-nested: 6.0.0_postcss@8.4.23
       postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
       quick-lru: 5.1.1
@@ -30253,6 +30450,16 @@ packages:
       '@types/unist': 2.0.6
       unist-util-is: 5.1.1
       unist-util-visit-parents: 5.1.3
+    dev: false
+
+  /universal-github-app-jwt/1.1.1:
+    resolution:
+      {
+        integrity: sha512-G33RTLrIBMFmlDV4u4CBF7dh71eWwykck4XgaxaIVeZKOYZRAAxvcGMRFTUclVY6xoUPQvO4Ne5wKGxYm/Yy9w==,
+      }
+    dependencies:
+      '@types/jsonwebtoken': 9.0.5
+      jsonwebtoken: 9.0.2
     dev: false
 
   /universal-user-agent/6.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,7 +151,7 @@ importers:
       puppeteer: 18.2.1
       tailwindcss: 3.2.7
       typescript: 4.8.4
-      vite: 4.3.9
+      vite: 4.3.9_@types+node@14.18.29
       vitest: 0.32.2
 
   examples/tina-self-hosted-demo:
@@ -190,7 +190,7 @@ importers:
       '@tinacms/datalayer': link:../../packages/@tinacms/datalayer
       date-fns: 2.28.0
       mongodb-level: 0.0.3
-      next: 13.4.19_biqbaboplfbrettd7655fr4n2y
+      next: 13.4.19_ob7c7ogpcitikph4afkm5ompve
       next-auth: 4.22.1_m2l4knchnqa6bzxbbtfxlzoxdy
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -273,7 +273,7 @@ importers:
       date-fns: 2.28.0
       graphql: 15.8.0
       mongodb-level: 0.0.3
-      next: 13.4.1_biqbaboplfbrettd7655fr4n2y
+      next: 13.4.1_ob7c7ogpcitikph4afkm5ompve
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-icons: 4.7.1_react@18.2.0
@@ -383,7 +383,7 @@ importers:
       jest: 29.5.0
       jest-diff: 29.5.0
       jest-matcher-utils: 29.5.0
-      next: 12.2.4_sfoxds7t5ydpegc3knd667wn6m
+      next: 12.2.4_jwwbyf6bqqo33kynjdqdtopnc4
       nodemon: 2.0.19
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
@@ -1313,8 +1313,8 @@ importers:
       tinacms: workspace:*
       typescript: 4.3.5
     devDependencies:
-      '@clerk/backend': 0.31.3
-      '@clerk/clerk-js': 4.56.2
+      '@clerk/backend': 0.31.3_react@18.2.0
+      '@clerk/clerk-js': 4.56.2_biqbaboplfbrettd7655fr4n2y
       '@tinacms/scripts': link:../@tinacms/scripts
       '@types/node': 16.6.1
       tinacms: link:../tinacms
@@ -1322,7 +1322,6 @@ importers:
 
   packages/tinacms-gitprovider-github:
     specifiers:
-      '@octokit/auth-app': ^6.0.1
       '@octokit/rest': ^19.0.7
       '@tinacms/datalayer': workspace:*
       '@tinacms/graphql': workspace:*
@@ -1332,7 +1331,6 @@ importers:
       js-base64: ^3.7.4
       lodash-es: 4.17.21
     dependencies:
-      '@octokit/auth-app': 6.0.1
       '@octokit/rest': 19.0.7
       graphql: 16.8.1
       js-base64: 3.7.5
@@ -6602,14 +6600,14 @@ packages:
       prettier: 2.8.4
     dev: true
 
-  /@clerk/backend/0.31.3:
+  /@clerk/backend/0.31.3_react@18.2.0:
     resolution:
       {
         integrity: sha512-0SbpwG7q6eEnVH/Shj86LFDM/zvVT6ToVodZLKawPxwzMqXBhrSNMdPQn9Al7w2522NesL/apR64npY7FnI2vA==,
       }
     engines: { node: '>=14' }
     dependencies:
-      '@clerk/shared': 1.0.0
+      '@clerk/shared': 1.0.0_react@18.2.0
       '@clerk/types': 3.57.0
       '@peculiar/webcrypto': 1.4.1
       '@types/node': 16.18.6
@@ -6622,7 +6620,7 @@ packages:
       - react
     dev: true
 
-  /@clerk/clerk-js/4.56.2:
+  /@clerk/clerk-js/4.56.2_biqbaboplfbrettd7655fr4n2y:
     resolution:
       {
         integrity: sha512-t1dQnW/UD+SKjMqAYmWQj4HX3EWTb3uK4CMEMQ0FFG4fOOMzPwIhoKZkWe5wIxkwZ/TMIvzGqTL94jMMy9ysJQ==,
@@ -6630,20 +6628,21 @@ packages:
     peerDependencies:
       react: '>=18'
     dependencies:
-      '@clerk/localizations': 1.25.0
-      '@clerk/shared': 0.22.0
+      '@clerk/localizations': 1.25.0_react@18.2.0
+      '@clerk/shared': 0.22.0_react@18.2.0
       '@clerk/types': 3.50.0
       '@emotion/cache': 11.10.5
-      '@emotion/react': 11.10.5
-      '@floating-ui/react': 0.19.0
+      '@emotion/react': 11.10.5_react@18.2.0
+      '@floating-ui/react': 0.19.0_biqbaboplfbrettd7655fr4n2y
       '@zxcvbn-ts/core': 2.2.1
       '@zxcvbn-ts/language-common': 3.0.2
       browser-tabs-lock: 1.2.15
       copy-to-clipboard: 3.3.3
       core-js: 3.26.1
       dequal: 2.0.3
-      qrcode.react: 3.1.0
+      qrcode.react: 3.1.0_react@18.2.0
       qs: 6.11.0
+      react: 18.2.0
       regenerator-runtime: 0.13.11
     transitivePeerDependencies:
       - '@babel/core'
@@ -6651,7 +6650,7 @@ packages:
       - react-dom
     dev: true
 
-  /@clerk/localizations/1.25.0:
+  /@clerk/localizations/1.25.0_react@18.2.0:
     resolution:
       {
         integrity: sha512-D0rfAP/tl46i6jz6VgizvKlF8xSUJJ+ZWyec88rPTd8yylOSZXxIQUHgaXp8gTgXJtTz84rTyZyFpBJN+vqWcQ==,
@@ -6661,9 +6660,10 @@ packages:
       react: '>=16'
     dependencies:
       '@clerk/types': 3.50.0
+      react: 18.2.0
     dev: true
 
-  /@clerk/shared/0.22.0:
+  /@clerk/shared/0.22.0_react@18.2.0:
     resolution:
       {
         integrity: sha512-AHPypu9gZ3v44PRqiMA56c+YNLc2IzLaPUyiYFYU+xeH/R+wqzGp7OxZoZr/kmzgA8taiVl/bjixWgpuZwzI3A==,
@@ -6673,10 +6673,11 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.1
-      swr: 2.2.0
+      react: 18.2.0
+      swr: 2.2.0_react@18.2.0
     dev: true
 
-  /@clerk/shared/1.0.0:
+  /@clerk/shared/1.0.0_react@18.2.0:
     resolution:
       {
         integrity: sha512-KsI4bp7T0ql6byiXeiRf/qgCNuJRhrFPdZ7gLxY4zQpe9MRZT5FsX5miYVklkfLGVw9UT0XxYo91zcT2cRmRig==,
@@ -6689,7 +6690,8 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       js-cookie: 3.0.1
-      swr: 2.2.0
+      react: 18.2.0
+      swr: 2.2.0_react@18.2.0
     dev: true
 
   /@clerk/types/3.50.0:
@@ -6903,7 +6905,7 @@ packages:
       }
     dev: true
 
-  /@emotion/react/11.10.5:
+  /@emotion/react/11.10.5_react@18.2.0:
     resolution:
       {
         integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==,
@@ -6922,10 +6924,11 @@ packages:
       '@emotion/babel-plugin': 11.11.0
       '@emotion/cache': 11.10.5
       '@emotion/serialize': 1.1.2
-      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1
+      '@emotion/use-insertion-effect-with-fallbacks': 1.0.1_react@18.2.0
       '@emotion/utils': 1.2.1
       '@emotion/weak-memoize': 0.3.1
       hoist-non-react-statics: 3.3.2
+      react: 18.2.0
     dev: true
 
   /@emotion/serialize/1.1.2:
@@ -6955,13 +6958,15 @@ packages:
       }
     dev: true
 
-  /@emotion/use-insertion-effect-with-fallbacks/1.0.1:
+  /@emotion/use-insertion-effect-with-fallbacks/1.0.1_react@18.2.0:
     resolution:
       {
         integrity: sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==,
       }
     peerDependencies:
       react: '>=16.8.0'
+    dependencies:
+      react: 18.2.0
     dev: true
 
   /@emotion/utils/1.2.1:
@@ -7624,7 +7629,7 @@ packages:
     dependencies:
       '@floating-ui/core': 1.3.1
 
-  /@floating-ui/react-dom/1.3.0:
+  /@floating-ui/react-dom/1.3.0_biqbaboplfbrettd7655fr4n2y:
     resolution:
       {
         integrity: sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==,
@@ -7634,6 +7639,8 @@ packages:
       react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 1.4.4
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
     dev: true
 
   /@floating-ui/react-dom/1.3.0_sfoxds7t5ydpegc3knd667wn6m:
@@ -7664,7 +7671,7 @@ packages:
       react-dom: 17.0.2_react@17.0.2
     dev: false
 
-  /@floating-ui/react/0.19.0:
+  /@floating-ui/react/0.19.0_biqbaboplfbrettd7655fr4n2y:
     resolution:
       {
         integrity: sha512-fgYvN4ksCi5OvmPXkyOT8o5a8PSKHMzPHt+9mR6KYWdF16IAjWRLZPAAziI2sznaWT23drRFrYw64wdvYqqaQw==,
@@ -7673,8 +7680,10 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
     dependencies:
-      '@floating-ui/react-dom': 1.3.0
+      '@floating-ui/react-dom': 1.3.0_biqbaboplfbrettd7655fr4n2y
       aria-hidden: 1.2.3
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
       tabbable: 6.1.2
     dev: true
 
@@ -9489,68 +9498,6 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.13.0
 
-  /@octokit/auth-app/6.0.1:
-    resolution:
-      {
-        integrity: sha512-tjCD4nzQNZgmLH62+PSnTF6eGerisFgV4v6euhqJik6yWV96e1ZiiGj+NXIqbgnpjLmtnBqVUrNyGKu3DoGEGA==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/auth-oauth-app': 7.0.1
-      '@octokit/auth-oauth-user': 4.0.1
-      '@octokit/request': 8.1.6
-      '@octokit/request-error': 5.0.1
-      '@octokit/types': 12.3.0
-      deprecation: 2.3.1
-      lru-cache: 10.0.0
-      universal-github-app-jwt: 1.1.1
-      universal-user-agent: 6.0.0
-    dev: false
-
-  /@octokit/auth-oauth-app/7.0.1:
-    resolution:
-      {
-        integrity: sha512-RE0KK0DCjCHXHlQBoubwlLijXEKfhMhKm9gO56xYvFmP1QTMb+vvwRPmQLLx0V+5AvV9N9I3lr1WyTzwL3rMDg==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/auth-oauth-device': 6.0.1
-      '@octokit/auth-oauth-user': 4.0.1
-      '@octokit/request': 8.1.6
-      '@octokit/types': 12.3.0
-      '@types/btoa-lite': 1.0.2
-      btoa-lite: 1.0.0
-      universal-user-agent: 6.0.0
-    dev: false
-
-  /@octokit/auth-oauth-device/6.0.1:
-    resolution:
-      {
-        integrity: sha512-yxU0rkL65QkjbqQedgVx3gmW7YM5fF+r5uaSj9tM/cQGVqloXcqP2xK90eTyYvl29arFVCW8Vz4H/t47mL0ELw==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/oauth-methods': 4.0.1
-      '@octokit/request': 8.1.6
-      '@octokit/types': 12.3.0
-      universal-user-agent: 6.0.0
-    dev: false
-
-  /@octokit/auth-oauth-user/4.0.1:
-    resolution:
-      {
-        integrity: sha512-N94wWW09d0hleCnrO5wt5MxekatqEJ4zf+1vSe8MKMrhZ7gAXKFOKrDEZW2INltvBWJCyDUELgGRv8gfErH1Iw==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/auth-oauth-device': 6.0.1
-      '@octokit/oauth-methods': 4.0.1
-      '@octokit/request': 8.1.6
-      '@octokit/types': 12.3.0
-      btoa-lite: 1.0.0
-      universal-user-agent: 6.0.0
-    dev: false
-
   /@octokit/auth-token/3.0.3:
     resolution:
       {
@@ -9591,17 +9538,6 @@ packages:
       universal-user-agent: 6.0.0
     dev: false
 
-  /@octokit/endpoint/9.0.4:
-    resolution:
-      {
-        integrity: sha512-DWPLtr1Kz3tv8L0UvXTDP1fNwM0S+z6EJpRcvH66orY6Eld4XBMCSYsaWp4xIm61jTWxK68BrR7ibO+vSDnZqw==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/types': 12.3.0
-      universal-user-agent: 6.0.0
-    dev: false
-
   /@octokit/graphql/5.0.5:
     resolution:
       {
@@ -9616,39 +9552,10 @@ packages:
       - encoding
     dev: false
 
-  /@octokit/oauth-authorization-url/6.0.2:
-    resolution:
-      {
-        integrity: sha512-CdoJukjXXxqLNK4y/VOiVzQVjibqoj/xHgInekviUJV73y/BSIcwvJ/4aNHPBPKcPWFnd4/lO9uqRV65jXhcLA==,
-      }
-    engines: { node: '>= 18' }
-    dev: false
-
-  /@octokit/oauth-methods/4.0.1:
-    resolution:
-      {
-        integrity: sha512-1NdTGCoBHyD6J0n2WGXg9+yDLZrRNZ0moTEex/LSPr49m530WNKcCfXDghofYptr3st3eTii+EHoG5k/o+vbtw==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/oauth-authorization-url': 6.0.2
-      '@octokit/request': 8.1.6
-      '@octokit/request-error': 5.0.1
-      '@octokit/types': 12.3.0
-      btoa-lite: 1.0.0
-    dev: false
-
   /@octokit/openapi-types/16.0.0:
     resolution:
       {
         integrity: sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==,
-      }
-    dev: false
-
-  /@octokit/openapi-types/19.1.0:
-    resolution:
-      {
-        integrity: sha512-6G+ywGClliGQwRsjvqVYpklIfa7oRPA0vyhPQG/1Feh+B+wU0vGH1JiJ5T25d3g1JZYBHzR2qefLi9x8Gt+cpw==,
       }
     dev: false
 
@@ -9702,18 +9609,6 @@ packages:
       once: 1.4.0
     dev: false
 
-  /@octokit/request-error/5.0.1:
-    resolution:
-      {
-        integrity: sha512-X7pnyTMV7MgtGmiXBwmO6M5kIPrntOXdyKZLigNfQWSEQzVxR4a4vo49vJjTWX70mPndj8KhfT4Dx+2Ng3vnBQ==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/types': 12.3.0
-      deprecation: 2.3.1
-      once: 1.4.0
-    dev: false
-
   /@octokit/request/6.2.3:
     resolution:
       {
@@ -9731,19 +9626,6 @@ packages:
       - encoding
     dev: false
 
-  /@octokit/request/8.1.6:
-    resolution:
-      {
-        integrity: sha512-YhPaGml3ncZC1NfXpP3WZ7iliL1ap6tLkAp6MvbK2fTTPytzVUyUesBBogcdMm86uRYO5rHaM1xIWxigWZ17MQ==,
-      }
-    engines: { node: '>= 18' }
-    dependencies:
-      '@octokit/endpoint': 9.0.4
-      '@octokit/request-error': 5.0.1
-      '@octokit/types': 12.3.0
-      universal-user-agent: 6.0.0
-    dev: false
-
   /@octokit/rest/19.0.7:
     resolution:
       {
@@ -9757,15 +9639,6 @@ packages:
       '@octokit/plugin-rest-endpoint-methods': 7.0.1_@octokit+core@4.2.0
     transitivePeerDependencies:
       - encoding
-    dev: false
-
-  /@octokit/types/12.3.0:
-    resolution:
-      {
-        integrity: sha512-nJ8X2HRr234q3w/FcovDlA+ttUU4m1eJAourvfUUtwAWeqL8AsyRqfnLvVnYn3NFbUnsmzQCzLNdFerPwdmcDQ==,
-      }
-    dependencies:
-      '@octokit/openapi-types': 19.1.0
     dev: false
 
   /@octokit/types/9.0.0:
@@ -11809,13 +11682,6 @@ packages:
       }
     dev: true
 
-  /@types/btoa-lite/1.0.2:
-    resolution:
-      {
-        integrity: sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg==,
-      }
-    dev: false
-
   /@types/cacheable-request/6.0.3:
     resolution:
       {
@@ -12190,15 +12056,6 @@ packages:
       }
     dev: true
 
-  /@types/jsonwebtoken/9.0.5:
-    resolution:
-      {
-        integrity: sha512-VRLSGzik+Unrup6BsouBeHsf4d1hOEgYWTm/7Nmw1sXoN1+tRly/Gy/po3yeahnP4jfnQWWAhQAqcNfH7ngOkA==,
-      }
-    dependencies:
-      '@types/node': 17.0.45
-    dev: false
-
   /@types/keyv/3.1.4:
     resolution:
       {
@@ -12438,6 +12295,7 @@ packages:
       {
         integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
       }
+    dev: true
 
   /@types/normalize-package-data/2.4.1:
     resolution:
@@ -16083,26 +15941,12 @@ packages:
       buffer: 5.7.1
     dev: false
 
-  /btoa-lite/1.0.0:
-    resolution:
-      {
-        integrity: sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==,
-      }
-    dev: false
-
   /buffer-crc32/0.2.13:
     resolution:
       {
         integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==,
       }
     dev: true
-
-  /buffer-equal-constant-time/1.0.1:
-    resolution:
-      {
-        integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==,
-      }
-    dev: false
 
   /buffer-from/1.1.2:
     resolution:
@@ -18147,15 +17991,6 @@ packages:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
     dev: true
-
-  /ecdsa-sig-formatter/1.0.11:
-    resolution:
-      {
-        integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
-      }
-    dependencies:
-      safe-buffer: 5.2.1
-    dev: false
 
   /ee-first/1.1.1:
     resolution:
@@ -22902,25 +22737,6 @@ packages:
     engines: { node: '>=10.0.0' }
     dev: false
 
-  /jsonwebtoken/9.0.2:
-    resolution:
-      {
-        integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==,
-      }
-    engines: { node: '>=12', npm: '>=6' }
-    dependencies:
-      jws: 3.2.2
-      lodash.includes: 4.3.0
-      lodash.isboolean: 3.0.3
-      lodash.isinteger: 4.0.4
-      lodash.isnumber: 3.0.3
-      lodash.isplainobject: 4.0.6
-      lodash.isstring: 4.0.1
-      lodash.once: 4.1.1
-      ms: 2.1.3
-      semver: 7.5.2
-    dev: false
-
   /jsprim/2.0.2:
     resolution:
       {
@@ -22944,27 +22760,6 @@ packages:
       array-includes: 3.1.6
       object.assign: 4.1.4
     dev: true
-
-  /jwa/1.4.1:
-    resolution:
-      {
-        integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==,
-      }
-    dependencies:
-      buffer-equal-constant-time: 1.0.1
-      ecdsa-sig-formatter: 1.0.11
-      safe-buffer: 5.2.1
-    dev: false
-
-  /jws/3.2.2:
-    resolution:
-      {
-        integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==,
-      }
-    dependencies:
-      jwa: 1.4.1
-      safe-buffer: 5.2.1
-    dev: false
 
   /keyv/4.5.2:
     resolution:
@@ -23261,45 +23056,10 @@ packages:
       }
     dev: false
 
-  /lodash.includes/4.3.0:
-    resolution:
-      {
-        integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==,
-      }
-    dev: false
-
-  /lodash.isboolean/3.0.3:
-    resolution:
-      {
-        integrity: sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==,
-      }
-    dev: false
-
-  /lodash.isinteger/4.0.4:
-    resolution:
-      {
-        integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==,
-      }
-    dev: false
-
-  /lodash.isnumber/3.0.3:
-    resolution:
-      {
-        integrity: sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==,
-      }
-    dev: false
-
   /lodash.isplainobject/4.0.6:
     resolution:
       {
         integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==,
-      }
-    dev: false
-
-  /lodash.isstring/4.0.1:
-    resolution:
-      {
-        integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==,
       }
     dev: false
 
@@ -23314,6 +23074,7 @@ packages:
       {
         integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==,
       }
+    dev: true
 
   /lodash.pad/4.5.1:
     resolution:
@@ -25211,7 +24972,7 @@ packages:
       '@panva/hkdf': 1.1.1
       cookie: 0.5.0
       jose: 4.14.4
-      next: 13.4.19_biqbaboplfbrettd7655fr4n2y
+      next: 13.4.19_ob7c7ogpcitikph4afkm5ompve
       oauth: 0.9.15
       openid-client: 5.4.3
       preact: 10.16.0
@@ -25268,6 +25029,54 @@ packages:
       - '@babel/core'
       - babel-plugin-macros
     dev: false
+
+  /next/12.2.4_jwwbyf6bqqo33kynjdqdtopnc4:
+    resolution:
+      {
+        integrity: sha512-b1xlxEozmAWokAXzXsi5vlmU/IfJcFNIJA8dpU5UdkFbyDPio8wwb8mAQ/Y7rGtfTgG/t/u49BiyEA+xAgFvow==,
+      }
+    engines: { node: '>=12.22.0' }
+    hasBin: true
+    peerDependencies:
+      fibers: '>= 3.1.0'
+      node-sass: ^6.0.0 || ^7.0.0
+      react: ^17.0.2 || ^18.0.0-0
+      react-dom: ^17.0.2 || ^18.0.0-0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      fibers:
+        optional: true
+      node-sass:
+        optional: true
+      sass:
+        optional: true
+    dependencies:
+      '@next/env': 12.2.4
+      '@swc/helpers': 0.4.3
+      caniuse-lite: 1.0.30001457
+      postcss: 8.4.14
+      react: 17.0.2
+      react-dom: 17.0.2_react@17.0.2
+      styled-jsx: 5.0.2_coafctnpqrjgkkni74retiib34
+      use-sync-external-store: 1.2.0_react@17.0.2
+    optionalDependencies:
+      '@next/swc-android-arm-eabi': 12.2.4
+      '@next/swc-android-arm64': 12.2.4
+      '@next/swc-darwin-arm64': 12.2.4
+      '@next/swc-darwin-x64': 12.2.4
+      '@next/swc-freebsd-x64': 12.2.4
+      '@next/swc-linux-arm-gnueabihf': 12.2.4
+      '@next/swc-linux-arm64-gnu': 12.2.4
+      '@next/swc-linux-arm64-musl': 12.2.4
+      '@next/swc-linux-x64-gnu': 12.2.4
+      '@next/swc-linux-x64-musl': 12.2.4
+      '@next/swc-win32-arm64-msvc': 12.2.4
+      '@next/swc-win32-ia32-msvc': 12.2.4
+      '@next/swc-win32-x64-msvc': 12.2.4
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+    dev: true
 
   /next/12.2.4_sfoxds7t5ydpegc3knd667wn6m:
     resolution:
@@ -25364,7 +25173,7 @@ packages:
       - babel-plugin-macros
     dev: true
 
-  /next/13.4.19_biqbaboplfbrettd7655fr4n2y:
+  /next/13.4.19_ob7c7ogpcitikph4afkm5ompve:
     resolution:
       {
         integrity: sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==,
@@ -25389,7 +25198,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.1_react@18.2.0
+      styled-jsx: 5.1.1_qtefitxdtuns7alwqkv5zjdjiy
       watchpack: 2.4.0
       zod: 3.21.4
     optionalDependencies:
@@ -25407,7 +25216,7 @@ packages:
       - babel-plugin-macros
     dev: false
 
-  /next/13.4.1_biqbaboplfbrettd7655fr4n2y:
+  /next/13.4.1_ob7c7ogpcitikph4afkm5ompve:
     resolution:
       {
         integrity: sha512-JBw2kAIyhKDpjhEWvNVoFeIzNp9xNxg8wrthDOtMctfn3EpqGCmW0FSviNyGgOSOSn6zDaX48pmvbdf6X2W9xA==,
@@ -25438,7 +25247,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      styled-jsx: 5.1.1_react@18.2.0
+      styled-jsx: 5.1.1_qtefitxdtuns7alwqkv5zjdjiy
       zod: 3.21.4
     optionalDependencies:
       '@next/swc-darwin-arm64': 13.4.1
@@ -26982,13 +26791,15 @@ packages:
     engines: { node: '>=0.6.0', teleport: '>=0.2.0' }
     dev: false
 
-  /qrcode.react/3.1.0:
+  /qrcode.react/3.1.0_react@18.2.0:
     resolution:
       {
         integrity: sha512-oyF+Urr3oAMUG/OiOuONL3HXM+53wvuH3mtIWQrYmsXoAq0DkvZp2RYUWFSMFtbdOpuS++9v+WAkzNVkMlNW6Q==,
       }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      react: 18.2.0
     dev: true
 
   /qs/6.10.3:
@@ -29100,6 +28911,26 @@ packages:
       tslib: 2.6.2
     dev: false
 
+  /styled-jsx/5.0.2_coafctnpqrjgkkni74retiib34:
+    resolution:
+      {
+        integrity: sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==,
+      }
+    engines: { node: '>= 12.0.0' }
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+    dependencies:
+      '@babel/core': 7.22.5
+      react: 17.0.2
+    dev: true
+
   /styled-jsx/5.0.2_react@17.0.2:
     resolution:
       {
@@ -29156,7 +28987,7 @@ packages:
       react: 18.2.0
     dev: true
 
-  /styled-jsx/5.1.1_react@18.2.0:
+  /styled-jsx/5.1.1_qtefitxdtuns7alwqkv5zjdjiy:
     resolution:
       {
         integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==,
@@ -29172,6 +29003,7 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
+      '@babel/core': 7.22.5
       client-only: 0.0.1
       react: 18.2.0
     dev: false
@@ -29286,7 +29118,7 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /swr/2.2.0:
+  /swr/2.2.0_react@18.2.0:
     resolution:
       {
         integrity: sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==,
@@ -29294,7 +29126,8 @@ packages:
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      use-sync-external-store: 1.2.0
+      react: 18.2.0
+      use-sync-external-store: 1.2.0_react@18.2.0
     dev: true
 
   /synckit/0.8.5:
@@ -30452,16 +30285,6 @@ packages:
       unist-util-visit-parents: 5.1.3
     dev: false
 
-  /universal-github-app-jwt/1.1.1:
-    resolution:
-      {
-        integrity: sha512-G33RTLrIBMFmlDV4u4CBF7dh71eWwykck4XgaxaIVeZKOYZRAAxvcGMRFTUclVY6xoUPQvO4Ne5wKGxYm/Yy9w==,
-      }
-    dependencies:
-      '@types/jsonwebtoken': 9.0.5
-      jsonwebtoken: 9.0.2
-    dev: false
-
   /universal-user-agent/6.0.0:
     resolution:
       {
@@ -30711,15 +30534,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /use-sync-external-store/1.2.0:
-    resolution:
-      {
-        integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dev: true
-
   /use-sync-external-store/1.2.0_react@17.0.2:
     resolution:
       {
@@ -30965,6 +30779,7 @@ packages:
       rollup: 3.25.1
     optionalDependencies:
       fsevents: 2.3.2
+    dev: false
 
   /vite/4.3.9_@types+node@14.18.21:
     resolution:


### PR DESCRIPTION
# TinaCMS GitHub Bridge

The `GitHubBridge` is intended to support self-hosting with separate content repositories (e.g. one central code repository that is able to build multiple sites

This will also help provide a path to better support reindexing for self-hosted projects (i.e. keeping the data layer updated when changes are pushed directly via git, rather than made through the Tina UI)

## Background

- See the excellent information @logan-anderson provided in this discussion thread: https://github.com/tinacms/tinacms/discussions/3589#discussioncomment-4960323
- And the further details in this issue: https://github.com/tinacms/tinacms/issues/3609, including this video overview of the key components to consider: https://www.loom.com/share/c7d1c4f5bda04ec3a1dacff2a03efac1
- Follows on from earlier PR attempts #3936 and #3830 

## Additional notes

- One important caveat is that this approach could lead to GitHub rate limiting errors on certain projects, particularly larger sites with lots of pages/files
- The ability to pass `tinaFilesConfig` is intended to support multi-tenant projects where the Tina folder lives in the code repository so the content repositories do not need to contain any Tina folders or files at all. In this case the `GitHubBridge` will defer to the `FilesystemBridge` to retrieve the auto-generated Tina files, so those files do not need to be committed or tracked in the content repositories. This is particularly useful when multiple content repositories/sites are built from a central code repository.
- Regarding the implementation, I've added the new `GitHubBridge` to the `tinacms-gitprovider-github` package given it already has `@octokit/rest` installed, and to avoid a proliferation of separate GitHub-related packages in the `tinacms` monorepo. Let me know if you'd prefer a separate package just for the GitHubBridge and I can restructure these updates.

## Documentation

See the new sections added to the latest version of the `README` for the `tinacms-gitprovider-github` package here: https://github.com/tinacms/tinacms/blob/2ddccfa4969c183c15a2647bff3d4dd57aa7b141/packages/tinacms-gitprovider-github/README.md

