### PR TITLE
Add `graphqlQueriesPath` customisation option to the `config.client`

### DIFF
--- a/.changeset/bright-books-hope.md
+++ b/.changeset/bright-books-hope.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/schema-tools': patch
+'@tinacms/cli': patch
+---
+
+Add a new graphqlQueriesPath customisation option to the config.client when defining a Tina site. In particular this is useful for mono-repos needing to support custom queries within each package/sub-folder as well as shared base queries at the root level.

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -153,10 +153,6 @@ export class ConfigManager {
       this.generatedFolderPath,
       'types.d.ts'
     )
-    this.userQueriesAndFragmentsGlob = path.join(
-      this.tinaFolderPath,
-      'queries/**/*.{graphql,gql}'
-    )
     this.generatedQueriesAndFragmentsGlob = path.join(
       this.generatedFolderPath,
       '*.{graphql,gql}'
@@ -231,6 +227,11 @@ export class ConfigManager {
     const fullLocalContentPath = path.join(
       this.tinaFolderPath,
       this.config.localContentPath || ''
+    )
+
+    this.userQueriesAndFragmentsGlob = path.join(
+      this.config.client?.graphqlQueriesPath ?? this.tinaFolderPath,
+      'queries/**/*.{graphql,gql}'
     )
 
     if (this.config.localContentPath) {

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -575,6 +575,15 @@ export interface Config<
      * @default 'throw'
      */
     errorPolicy?: 'throw' | 'include'
+    /**
+     * The path to where your custom GraphQL /queries folder can be found
+     * Supports files with the following extensions: *.{graphql,gql}
+     * One use case is to support patterns matching multiple folder paths
+     * e.g. if working in a monorepo and needing to support custom queries
+     * within each sub-folder as well as shared base queries at the root.
+     * That can be achieved with a value like: `root-path/{sub-path/,}tina`
+     */
+    graphqlQueriesPath?: string
   }
   /**
    *


### PR DESCRIPTION
## Notes

- In particular this is useful for mono-repos needing to support custom queries within each package/sub-folder as well as shared base queries at the root level.
- This configuration option is intended to allow users to provide a path to where their custom GraphQL /queries folder(s) can be found.
    - It supports files with the following extensions: `*.{graphql,gql}`
    - One use case is to support patterns matching multiple folder paths, e.g. if working in a mono-repo and needing to support custom queries within each package/sub-folder as well as shared base queries at the root level. An example of that can be achieved by setting the `graphqlQueriesPath` customisation option to a value like the following:
        ```ts
        root-path/{sub-path/,}tina`
        ```
- Heads up @logan-anderson this is one of the small tweaks we discussed (though to be honest I haven't tested it in this exact format - we just set the `userQueriesAndFragmentsGlob` value directly in our code via a Yarn patch, so this is the first attempt by properly exposing a config option). No dramas if this doesn't suit with your plans though!
