### PR TITLE
feat: update build command to detect tina cloud projects configured with upstream and conditionally synchronize schema

### DIFF
--- a/.changeset/silly-ducks-shake.md
+++ b/.changeset/silly-ducks-shake.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Update CLI build command to support separate content repo schema synchronization


### PR DESCRIPTION
# what

For tina cloud projects configured as content repos (with an upstream project holding the schema), adds a step to the build process which synchronizes the upstream schema to the content repo project and reindexes (if necessary).