### PR TITLE
fix: add mongodb library as a dependency when using the mongo level adapter

### DIFF
--- a/.changeset/thin-carpets-marry.md
+++ b/.changeset/thin-carpets-marry.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Add mongodb to deps when using the mongo adapter

--- a/packages/@tinacms/cli/src/cmds/init/prompts/databaseAdapter.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/databaseAdapter.ts
@@ -36,6 +36,11 @@ const supportedDatabaseAdapters: {
         imported: ['MongodbLevel'],
         packageName: 'mongodb-level',
       },
+      {
+        from: 'mongodb',
+        imported: [], // not explicitly imported
+        packageName: 'mongodb',
+      },
     ],
   },
   other: {

--- a/packages/@tinacms/cli/src/cmds/init/prompts/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/index.ts
@@ -155,7 +155,11 @@ export const makeImportString = (imports?: ImportStatement[]) => {
   if (!imports) {
     return ''
   }
-  return imports
+  const filtered = imports.filter((x) => x.imported.length > 0)
+  if (filtered.length === 0) {
+    return ''
+  }
+  return filtered
     .map((x) => {
       return `import { ${x.imported.join(',')} } from '${x.from}'`
     })


### PR DESCRIPTION
Noticed an issue where when using the mongo adapter on windows, it is bundling the non-windows version of the mongodb driver which doesn't work (instead of building it for windows). This updates the cli init to add mongodb as a separate dependency so that the correct version of the driver is used.