### PR TITLE
add rtl support for field labels and descriptions

### DIFF
--- a/.changeset/brave-icons-allow.md
+++ b/.changeset/brave-icons-allow.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Supports rtl direction in textfield, textarea and all field's labels and descriptions

--- a/packages/tinacms/src/toolkit/fields/components/text-field.tsx
+++ b/packages/tinacms/src/toolkit/fields/components/text-field.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { getDirection } from '../field-utils'
 
 type a = React.DetailedHTMLProps<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -23,6 +24,7 @@ export const BaseTextField = React.forwardRef<
       className={`${textFieldClasses} ${
         disabled ? disabledClasses : ''
       } ${className}`}
+      dir={getDirection(rest.value)}
       {...rest}
     />
   )

--- a/packages/tinacms/src/toolkit/fields/components/textarea.tsx
+++ b/packages/tinacms/src/toolkit/fields/components/textarea.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { getDirection } from '../field-utils'
 
 type a = React.DetailedHTMLProps<
   React.InputHTMLAttributes<HTMLInputElement>,
@@ -19,6 +20,7 @@ export const TextArea = React.forwardRef<
       className="shadow-inner text-base px-3 py-2 text-gray-600 resize-y focus:shadow-outline focus:border-blue-500 block w-full border border-gray-200 focus:text-gray-900 rounded-md"
       ref={ref}
       style={{ minHeight: '160px' }}
+      dir={getDirection(props.value)}
     />
   )
 })

--- a/packages/tinacms/src/toolkit/fields/field-utils.ts
+++ b/packages/tinacms/src/toolkit/fields/field-utils.ts
@@ -1,0 +1,12 @@
+export const hasRTLChar = (text: string): boolean => {
+  return /[\u0600-\u06ef]/g.test(text)
+}
+
+export const getDirection = (
+  value: number | string | boolean | readonly string[]
+) => {
+  if (typeof value === 'string') {
+    return hasRTLChar(value) ? 'rtl' : 'ltr'
+  }
+  return 'unset'
+}

--- a/packages/tinacms/src/toolkit/fields/plugins/wrap-field-with-meta.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/wrap-field-with-meta.tsx
@@ -3,6 +3,7 @@ import { FieldProps } from './field-props'
 import { useEvent } from '@toolkit/react-core/use-cms-event'
 import { FieldHoverEvent, FieldFocusEvent } from '@toolkit/fields/field-events'
 import { Form } from '@toolkit/forms'
+import { getDirection } from '../field-utils'
 
 export type InputFieldType<ExtraFieldProps, InputProps> =
   FieldProps<InputProps> & ExtraFieldProps
@@ -82,7 +83,10 @@ export const FieldMeta = ({
       onMouseOver={() => setHoveredField({ id: tinaForm.id, fieldName: name })}
       onMouseOut={() => setHoveredField({ id: null, fieldName: null })}
       onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
-      style={{ zIndex: index ? 1000 - index : undefined }}
+      style={{
+        zIndex: index ? 1000 - index : undefined,
+        direction: getDirection(label),
+      }}
       {...props}
     >
       {(label !== false || description) && (


### PR DESCRIPTION
We are using tinacms for our site and because our native language is **persian** ,our content has **RTL** direction.  but the dashboard does not look good enough when we have rtl content.
In this PR i've added rtl support for labels ,descriptions and also in value of textfields and textareas.

before these changes, admin dashboard fields looked like this:

![before](https://github.com/tinacms/tinacms/assets/68024175/c6f6641d-05a3-405c-b3a2-607b0151f4b0)


here is how result looks like:

![5](https://github.com/tinacms/tinacms/assets/68024175/dc2eb2f2-7c77-46ca-8abc-45716247d1ea)

 please tell me if you think there is better way to improve this issue.
