### PR TITLE
Fix inline rich-text templates with nested object or list fields

### DIFF
--- a/.changeset/twenty-dodos-protect.md
+++ b/.changeset/twenty-dodos-protect.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+Fixes an issue where it was impossible to navigate to nested fields (e.g. object fields or list items) when editing the values for a rich-text template when that template was configured to be inline: true

--- a/packages/tinacms/src/toolkit/forms/form.ts
+++ b/packages/tinacms/src/toolkit/forms/form.ts
@@ -461,7 +461,9 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
             }),
           }
         } else {
-          const childrenIndex = namePathIndex + 1
+          const childrenIndex = namePath.findIndex(
+            (value) => value === 'children'
+          )
           // Find the props for the next item, ignoring parent 'props'
           const propsIndex =
             namePath
@@ -471,7 +473,7 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
           const item = getIn(value, itemName)
           const props = item.props
           const templateString = item.name
-          const currentPathIndex = namePathIndex + 3
+          const currentPathIndex = namePathIndex + Math.max(propsIndex, 3)
           const isLastItem = currentPathIndex + 1 === namePath.length
           const template = field.templates.find(
             (t) => t.name === templateString
@@ -506,7 +508,9 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
             }
           }
           if (!isLastItem) {
-            if (currentPathIndex === namePath.length) {
+            // The `propsIndex` is set to 0 when the namePath does NOT include 'props'
+            // e.g. when navigating from a rich-text template back to the parent field
+            if (currentPathIndex === namePath.length || propsIndex === 0) {
               return {
                 ...formOrObjectField,
                 name: namePath.slice(0, namePathIndex).join('.'),
@@ -526,7 +530,8 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
               formOrObjectField: template,
               values: props,
               namePath,
-              namePathIndex: namePathIndex + 4,
+              namePathIndex:
+                namePathIndex + Math.max(4, childrenIndex + propsIndex),
             })
           }
           if (!template) {


### PR DESCRIPTION
## Summary

This PR fixes an issue where it was impossible to navigate to nested fields (e.g. object fields or list items) when editing the values for a rich-text template when that template was configured to be `inline: true`

https://www.loom.com/share/085f1aa40af742a5a7d8b8168760c52b

## Additional notes

- This PR resolves #4074 and adds tests to prevent regressions
    - I think the bug from the original issue was resolved for non-inline rich-text templates by this PR: #4044. However, the bug remained for inline rich-text templates
- Specifically the issue broke the editing process for rich-text templates that:
    - were designated to be `inline: true`
    - had a nested list field OR a nested object field
