### PR TITLE
Add fetch options to generated client

### DIFF
--- a/.changeset/eighty-doors-visit.md
+++ b/.changeset/eighty-doors-visit.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/cli': patch
+'tinacms': patch
+---
+
+Add fetch options to generated client

--- a/packages/@tinacms/cli/src/next/codegen/codegen/plugin.ts
+++ b/packages/@tinacms/cli/src/next/codegen/codegen/plugin.ts
@@ -14,12 +14,18 @@ import { createClient, TinaClient } from "tinacms/dist/client";
 
 const generateRequester = (
   client: TinaClient,
-  options?: { branch?: string }
 ) => {
   const requester: (
     doc: any,
     vars?: any,
-    options?: { branch?: string },
+    options?: {
+      branch?: string,
+      /**
+       * Aside from \`method\` and \`body\`, all fetch options are passed
+       * through to underlying fetch request
+       */
+      fetchOptions?: Omit<Parameters<typeof fetch>[1], 'body' | 'method'>,
+    },
     client
   ) => Promise<any> = async (doc, vars, options) => {
     let url = client.apiUrl
@@ -31,7 +37,7 @@ const generateRequester = (
       query: doc,
       variables: vars,
       url,
-    })
+    }, options)
 
     return { data: data?.data, errors: data?.errors, query: doc, variables: vars || {} }
   }
@@ -54,11 +60,8 @@ export const ExperimentalGetTinaClient = () =>
 
 export const queries = (
   client: TinaClient,
-  options?: {
-    branch?: string
-  }
 ) => {
-  const requester = generateRequester(client, options)
+  const requester = generateRequester(client)
   return getSdk(requester)
 }
 `


### PR DESCRIPTION
You can now pass through `fetchOptions` to the generated client request. This is especially useful for working with the [Next.js app router](https://nextjs.org/docs/app/building-your-application/data-fetching/fetching-caching-and-revalidating#fetching-data-on-the-server-with-fetch).


```ts
  const tinaProps = await client.queries.contentQuery(
    {
      relativePath: `${params.filename}.md`,
    },
    {
      fetchOptions: {
        headers: { 'x-hello': 'world' },
        cache: 'force-cache'
      },
    }
  )
```