### PR TITLE
fix: #4566: empty folders not showing

### DIFF
--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -470,7 +470,6 @@ export class Database {
     collectionName?: string
   ) => {
     await this.initLevel()
-    const isGitKeep = filepath.endsWith('.gitkeep')
 
     try {
       if (SYSTEM_FILES.includes(filepath)) {
@@ -514,7 +513,9 @@ export class Database {
           }
         }
 
-        const stringifiedFile = isGitKeep
+        const stringifiedFile = filepath.endsWith(
+          `.gitkeep.${collection.format || 'md'}`
+        )
           ? ''
           : await this.stringifyFile(filepath, dataFields, collection)
 

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -714,7 +714,7 @@ export class Resolver {
     const collection = await this.tinaSchema.getCollection(collectionLookup)
     let realPath = path.join(collection?.path, args.relativePath)
     if (isFolderCreation) {
-      realPath = `${realPath}/.gitkeep`
+      realPath = `${realPath}/.gitkeep.${collection.format || 'md'}`
     }
     const alreadyExists = await this.database.documentExists(realPath)
 

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -106,11 +106,13 @@ export class TinaSchema {
   public getCollectionByFullPath = (filepath: string) => {
     const fileExtension = filepath.split('.').pop()
     const normalizedPath = filepath.replace(/\\/g, '/')
-    const isGitKeep = normalizedPath.endsWith('.gitkeep')
 
     const possibleCollections = this.getCollections().filter((collection) => {
       // filter out file extensions that don't match the collection format
-      if (!isGitKeep && fileExtension !== (collection.format || 'md')) {
+      if (
+        !normalizedPath.endsWith(`.gitkeep.${collection.format || 'md'}`) &&
+        fileExtension !== (collection.format || 'md')
+      ) {
         return false
       }
       if (collection?.match?.include || collection?.match?.exclude) {


### PR DESCRIPTION
Adds collection format suffix so new .gitkeep folders in empty folders are visible