### PR TITLE
Publish workflow - use github app generated token to allow bot to fire push/pull_request events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - changeset-release/main
   pull_request:
     types: [opened, synchronize, reopened, labeled]
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,11 +43,13 @@ jobs:
         run: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
       - name: Release to @dev channel
         if: matrix.channel == 'dev'
         run: |
           pnpm version:snapshot
           pnpm run publish:beta
+
       - name: Publish
         if: matrix.channel == 'latest'
         run: |
@@ -61,10 +63,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Generate GitHub App token
+        uses: tibdex/github-app-token@v2
+        if: matrix.channel == 'latest'
+        id: generate-token
+        with:
+          # uses https://github.com/organizations/tinacms/settings/apps/release-bot-allow-prs-and-push
+          app_id: ${{ secrets.BOT_APP_ID }}
+          private_key: ${{ secrets.BOT_APP_SECRET }}
+
       - name: Create release pull request
         uses: changesets/action@v1
         if: matrix.channel == 'latest'
         with:
           version: pnpm run version
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
Using a GitHub App to generate tokens on demand - this will allow the bot to create/rebase release PRs and emit the push/pull_request events as required.
Tokens will have:
- Repo - Contents: R+W
- Repo - Pull requests: R+W
- Org - Maintainers: R