### PR TITLE
Add missing `s3:ListBucket` policy

### DIFF
--- a/packages/next-tinacms-s3/README.md
+++ b/packages/next-tinacms-s3/README.md
@@ -37,6 +37,7 @@ You need to setup S3 Bucket and IAM user correctly.
 
     "s3:ListBucket",
     "s3:PutObject",
+    "s3:PutObjectAcl",
     "s3:DeleteObject"
 
 - The S3 bucket should have ACLs enabled.
@@ -71,6 +72,15 @@ You need to setup S3 Bucket and IAM user correctly.
                     "s3:DeleteObject"
                 ],
                 "Resource": "arn:aws:s3:::<S3-Bucket-NAME>/*"
+            },
+            {
+                "Sid": "ListBucket",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "<ARN of the IAM user>"
+                },
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::<S3-Bucket-NAME>"
             }
         ]
     }


### PR DESCRIPTION
I was following the [custom media store for S3 docs](https://tina.io/docs/reference/media/external/s3/) and noticed four things:

### 1. `tina-lock.json` must be commited to the repository at the same time as the media store changes

Otherwise the production deployment on tina.cloud will continue to prefix all media files with `https://asset.tina.io/` + `clientId`. See [discussion in discord](https://discord.com/channels/835168149439643678/1256612728257384511).

As the `tina-lock.json` file in general seems to be pretty crucial but the first time I actually came across it was while running [into the issue described in discord](https://discord.com/channels/835168149439643678/1256612728257384511) I think there might even be better places to mention it. For the time being I have added it to the relevant part of the documentation via a seperate PR here: https://github.com/tinacms/tina.io/pull/1872

### 2. The required permissions are not properly being displayed:
<img width="772" alt="image" src="https://github.com/tinacms/tinacms/assets/11058666/d4e127b6-8d43-4b3a-97bc-535015fc805b">

The markdown:

```
"s3:ListBucket", "s3:PutObject", "s3:DeleteObject"
```

is turned into this html:
```
<p>"s3<listbucket></listbucket>",
"s3<putobject></putobject>",
"s3<deleteobject></deleteobject>"</p>
```

Not sure how to fix this unfortunately.

### 3. There is a conflict between the "minimum required" permissions and the suggested bucket policy.

The docs say the minimum required permissions are:

1. `s3:ListBucket`
2. `s3:PutObject`
3. `s3:DeleteObject`

Yet the [suggested bucket policy also specifies](https://github.com/tinacms/tinacms/blob/main/packages/next-tinacms-s3/README.md?plain=1#L70) `s3:PutObjectAcl` so I would either add it to the required permissions or remove it from the suggested bucket policy if it's not actually being used or required.

### 4. The suggested bucket policy is missing a `s3:ListBucket` permission

If I don't add this to the bucket policy I get `Access denied` errors when trying to list all media within the bucket via the Tina Media Manager:

```diff,
+            {
+                "Sid": "ListBucket",
+                "Effect": "Allow",
+                "Principal": {
+                    "AWS": "<ARN of the IAM user>"
+                },
+                "Action": "s3:ListBucket",
+                "Resource": "arn:aws:s3:::<S3-Bucket-NAME>"
+            }
```