### PR TITLE
cms - fix broken link in error

### DIFF
--- a/.changeset/early-drinks-smoke.md
+++ b/.changeset/early-drinks-smoke.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+CMS - Fix broken link in error message of CMS startup. Broken link was replaced by https://tina.io/docs/tina-cloud/overview

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -162,7 +162,7 @@ export const TinaCMSProvider2 = ({
       !schema.config.contentApiUrlOverride)
   ) {
     throw new Error(
-      'Invalid setup. See https://tina.io/docs/tina-cloud/connecting-site/ for more information.'
+      'Invalid setup. See https://tina.io/docs/tina-cloud/overview for more information.'
     )
   }
 


### PR DESCRIPTION
same fix as #4601

Nick found a good replacement for this broken link https://tina.io/docs/tina-cloud/overview
