### PR TITLE
🐛 TinaCMS - Collections - Fix header styling for smaller screens

### DIFF
--- a/.changeset/nasty-cherries-pump.md
+++ b/.changeset/nasty-cherries-pump.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix collections header styling for smaller screens

--- a/packages/tinacms/src/admin/components/Page.tsx
+++ b/packages/tinacms/src/admin/components/Page.tsx
@@ -49,7 +49,7 @@ export const PageHeader = ({
       {isLocalMode && <LocalWarning />}
       {!isLocalMode && <BillingWarning />}
 
-      <div className="pt-16 lg:pt-12 px-12">
+      <div className="pt-16 xl:pt-12 px-12">
         <div className="w-full mx-auto max-w-screen-xl">
           <div className="w-full flex justify-between items-end">
             {children}

--- a/packages/tinacms/src/admin/components/Page.tsx
+++ b/packages/tinacms/src/admin/components/Page.tsx
@@ -49,7 +49,7 @@ export const PageHeader = ({
       {isLocalMode && <LocalWarning />}
       {!isLocalMode && <BillingWarning />}
 
-      <div className="pt-12 px-12">
+      <div className="pt-16 lg:pt-12 px-12">
         <div className="w-full mx-auto max-w-screen-xl">
           <div className="w-full flex justify-between items-end">
             {children}

--- a/packages/tinacms/src/admin/components/Sidebar.tsx
+++ b/packages/tinacms/src/admin/components/Sidebar.tsx
@@ -36,7 +36,7 @@ const Sidebar = ({ cms }: { cms: TinaCMS }) => {
   const [menuIsOpen, setMenuIsOpen] = React.useState(false)
 
   const isLocalMode = cms.api?.tina?.isLocalMode
-  const navBreakpoint = 1000
+  const navBreakpoint = 1029
   const windowWidth = useWindowWidth()
   const renderDesktopNav = windowWidth > navBreakpoint
   const activeScreens = screens.filter(

--- a/packages/tinacms/src/admin/components/Sidebar.tsx
+++ b/packages/tinacms/src/admin/components/Sidebar.tsx
@@ -36,7 +36,7 @@ const Sidebar = ({ cms }: { cms: TinaCMS }) => {
   const [menuIsOpen, setMenuIsOpen] = React.useState(false)
 
   const isLocalMode = cms.api?.tina?.isLocalMode
-  const navBreakpoint = 1029
+  const navBreakpoint = 1279
   const windowWidth = useWindowWidth()
   const renderDesktopNav = windowWidth > navBreakpoint
   const activeScreens = screens.filter(

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -378,7 +378,7 @@ const DefaultWrapper = ({
 }) => {
   return (
     <Layout>
-      <div className="flex items-stretch h-screen overflow-hidden">
+      <div className="flex items-stretch h-dvh overflow-hidden">
         <Sidebar cms={cms} />
         <div className="w-full relative">{children}</div>
       </div>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -469,8 +469,8 @@ const CollectionListPage = () => {
                             ? collection.label
                             : collection.name}
                         </h3>
-                        <div className="flex flex-col lg:flex-row justify-between items-center lg:items-end pt-2">
-                          <div className="flex gap-4 items-start">
+                        <div className="flex flex-col lg:flex-row justify-between lg:items-end pt-2">
+                          <div className="flex flex-col md:flex-row gap-2 md:gap-4 items-start">
                             {fields?.length > 0 && (
                               <>
                                 {!search && (

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -296,7 +296,6 @@ const CollectionListPage = () => {
                 reFetchCollection,
                 collectionExtra: Collection<true>
               ) => {
-                const totalCount = collection.documents.totalCount
                 const documents = collection.documents.edges
                 const admin: TinaAdminApi = cms.api.admin
                 const pageInfo = collection.documents.pageInfo
@@ -464,15 +463,14 @@ const CollectionListPage = () => {
                     )}
 
                     <PageHeader isLocalMode={cms?.api?.tina?.isLocalMode}>
-                      <div className="w-full grid grid-flow-col items-end gap-4">
-                        <div className="flex flex-col gap-4">
-                          <h3 className="font-sans text-2xl text-gray-700">
-                            {collection.label
-                              ? collection.label
-                              : collection.name}
-                          </h3>
-
-                          <div className="flex gap-4 items-start flex-wrap">
+                      <div className="w-full">
+                        <h3 className="font-sans text-2xl text-gray-700">
+                          {collection.label
+                            ? collection.label
+                            : collection.name}
+                        </h3>
+                        <div className="flex justify-between pt-2">
+                          <div className="flex gap-4 items-start">
                             {fields?.length > 0 && (
                               <>
                                 {!search && (
@@ -567,58 +565,58 @@ const CollectionListPage = () => {
                               )}
                             </div>
                           </div>
-                        </div>
-                        <div className="flex self-end	justify-self-end">
-                          {!collection.templates && allowCreate && (
-                            <>
-                              {allowCreateNestedFolder && (
+                          <div className="flex flex-row items-end">
+                            {!collection.templates && allowCreate && (
+                              <>
+                                {allowCreateNestedFolder && (
+                                  <Link
+                                    onMouseDown={(evt) => {
+                                      setVars((old) => ({
+                                        ...old,
+                                        collection: collectionName,
+                                        folderName: '',
+                                      }))
+                                      setFolderModalOpen(true)
+                                      evt.stopPropagation()
+                                    }}
+                                    to="/collections/new-folder"
+                                    className="icon-parent inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-blue-500 bg-white hover:bg-[#f1f5f9] focus:ring-white focus:ring-blue-500 text-sm h-10 px-6 mr-4"
+                                  >
+                                    <FaFolder className="mr-2" />
+                                    Add Folder{' '}
+                                  </Link>
+                                )}
                                 <Link
-                                  onMouseDown={(evt) => {
-                                    setVars((old) => ({
-                                      ...old,
-                                      collection: collectionName,
-                                      folderName: '',
-                                    }))
-                                    setFolderModalOpen(true)
-                                    evt.stopPropagation()
-                                  }}
-                                  to="/collections/new-folder"
-                                  className="icon-parent inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-blue-500 bg-white hover:bg-[#f1f5f9] focus:ring-white focus:ring-blue-500 text-sm h-10 px-6 mr-4"
+                                  to={`/${
+                                    folder.fullyQualifiedName
+                                      ? [
+                                          'collections',
+                                          'new',
+                                          collectionName,
+                                          '~',
+                                          folder.name,
+                                        ].join('/')
+                                      : [
+                                          'collections',
+                                          'new',
+                                          collectionName,
+                                        ].join('/')
+                                  }`}
+                                  className="inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-white bg-blue-500 hover:bg-blue-600 text-sm h-10 px-6"
                                 >
-                                  <FaFolder className="mr-2" />
-                                  Add Folder{' '}
+                                  <FaFile className="mr-2" />
+                                  Add Files{' '}
                                 </Link>
-                              )}
-                              <Link
-                                to={`/${
-                                  folder.fullyQualifiedName
-                                    ? [
-                                        'collections',
-                                        'new',
-                                        collectionName,
-                                        '~',
-                                        folder.name,
-                                      ].join('/')
-                                    : [
-                                        'collections',
-                                        'new',
-                                        collectionName,
-                                      ].join('/')
-                                }`}
-                                className="inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-white bg-blue-500 hover:bg-blue-600 text-sm h-10 px-6"
-                              >
-                                <FaFile className="mr-2" />
-                                Add Files{' '}
-                              </Link>
-                            </>
-                          )}
-                          {collection.templates && allowCreate && (
-                            <TemplateMenu
-                              collectionName={collectionName}
-                              templates={collection.templates}
-                              folder={folder}
-                            />
-                          )}
+                              </>
+                            )}
+                            {collection.templates && allowCreate && (
+                              <TemplateMenu
+                                collectionName={collectionName}
+                                templates={collection.templates}
+                                folder={folder}
+                              />
+                            )}
+                          </div>
                         </div>
                       </div>
                     </PageHeader>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -954,8 +954,8 @@ const SearchInput = ({
       >
         Search
       </label>
-      <div className="flex flex-wrap items-center gap-3">
-        <div className="flex-1 min-w-[200px]">
+      <div className="flex flex-col md:flex-row items-start md:items-center w-full md:w-auto gap-3">
+        <div className="flex-1 min-w-[200px] w-full md:w-auto">
           <Input
             type="text"
             name="search"
@@ -966,13 +966,14 @@ const SearchInput = ({
             }}
           />
         </div>
-        <div className="flex gap-3">
+        <div className="flex w-full md:w-auto gap-3">
           <Button
             onClick={() => {
               setSearch(searchInput)
               setSearchLoaded(false)
             }}
             variant="primary"
+            className="w-full md:w-auto"
           >
             Search <BiSearch className="w-5 h-full ml-1.5 opacity-70" />
           </Button>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -469,7 +469,7 @@ const CollectionListPage = () => {
                             ? collection.label
                             : collection.name}
                         </h3>
-                        <div className="flex justify-between pt-2">
+                        <div className="flex flex-col lg:flex-row justify-between items-center lg:items-end pt-2">
                           <div className="flex gap-4 items-start">
                             {fields?.length > 0 && (
                               <>
@@ -565,7 +565,7 @@ const CollectionListPage = () => {
                               )}
                             </div>
                           </div>
-                          <div className="flex flex-row items-end">
+                          <div className="flex flex-row items-end pt-4 lg:pt-0">
                             {!collection.templates && allowCreate && (
                               <>
                                 {allowCreateNestedFolder && (

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -565,7 +565,7 @@ const CollectionListPage = () => {
                               )}
                             </div>
                           </div>
-                          <div className="flex flex-col sm:flex-row items-start sm:items-end gap-2 sm:gap-0 pt-4 lg:pt-0">
+                          <div className="flex flex-col md:flex-row items-start md:items-end gap-2 md:gap-0 pt-4 lg:pt-0">
                             {!collection.templates && allowCreate && (
                               <>
                                 {allowCreateNestedFolder && (
@@ -580,7 +580,7 @@ const CollectionListPage = () => {
                                       evt.stopPropagation()
                                     }}
                                     to="/collections/new-folder"
-                                    className="icon-parent inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-blue-500 bg-white hover:bg-[#f1f5f9] focus:ring-white focus:ring-blue-500 text-sm h-10 px-6 mr-4"
+                                    className="icon-parent inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-blue-500 bg-white hover:bg-[#f1f5f9] focus:ring-white focus:ring-blue-500 w-full md:w-auto text-sm h-10 px-6 mr-4"
                                   >
                                     <FaFolder className="mr-2" />
                                     Add Folder{' '}
@@ -602,7 +602,7 @@ const CollectionListPage = () => {
                                           collectionName,
                                         ].join('/')
                                   }`}
-                                  className="inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-white bg-blue-500 hover:bg-blue-600 text-sm h-10 px-6"
+                                  className="inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded-full justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-white bg-blue-500 hover:bg-blue-600 w-full md:w-auto text-sm h-10 px-6"
                                 >
                                   <FaFile className="mr-2" />
                                   Add Files{' '}

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -565,7 +565,7 @@ const CollectionListPage = () => {
                               )}
                             </div>
                           </div>
-                          <div className="flex flex-row items-end pt-4 lg:pt-0">
+                          <div className="flex flex-col sm:flex-row items-start sm:items-end gap-2 sm:gap-0 pt-4 lg:pt-0">
                             {!collection.templates && allowCreate && (
                               <>
                                 {allowCreateNestedFolder && (

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -474,7 +474,7 @@ const CollectionListPage = () => {
                             {fields?.length > 0 && (
                               <>
                                 {!search && (
-                                  <div className="flex flex-col gap-2 items-start">
+                                  <div className="flex flex-col gap-2 items-start w-full md:w-auto">
                                     <label
                                       htmlFor="sort"
                                       className="block font-sans text-xs font-semibold text-gray-500 whitespace-normal"

--- a/packages/tinacms/src/toolkit/fields/components/select.tsx
+++ b/packages/tinacms/src/toolkit/fields/components/select.tsx
@@ -41,7 +41,7 @@ export const Select: React.FC<SelectProps> = ({
   }, [field?.experimental_focusIntent, ref])
 
   return (
-    <div className="relative group">
+    <div className="relative group w-full md:w-auto">
       <select
         id={input.name}
         ref={ref}

--- a/packages/tinacms/src/toolkit/react-sidebar/components/sidebar.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/sidebar.tsx
@@ -628,12 +628,12 @@ const SidebarWrapper = ({ children }) => {
 
   return (
     <div
-      className={`fixed top-0 left-0 h-screen z-base ${
+      className={`fixed top-0 left-0 h-dvh z-base ${
         displayState === 'closed' ? `pointer-events-none` : ``
       }`}
     >
       <div
-        className={`relative h-screen transform flex ${
+        className={`relative h-dvh transform flex ${
           displayState !== 'closed' ? `` : `-translate-x-full`
         } ${
           resizingSidebar

--- a/packages/tinacms/src/toolkit/styles/message.tsx
+++ b/packages/tinacms/src/toolkit/styles/message.tsx
@@ -66,14 +66,16 @@ export const Message = ({
     <div
       className={`rounded-lg border shadow-sm ${sizeClasses[size]} ${containerClasses[type]} ${className}`}
     >
-      <div className="flex items-center gap-2">
-        <MessageIcon
-          type={type}
-          className={`${
-            size === 'small' ? 'w-5' : 'w-6'
-          } h-auto flex-shrink-0 ${iconClasses[type]}`}
-        />
-        <div className={`flex-1 ${textClasses[type]}`}>{children}</div>
+      <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2">
+        <div className="flex items-center gap-2">
+          <MessageIcon
+            type={type}
+            className={`${
+              size === 'small' ? 'w-5' : 'w-6'
+            } h-auto flex-shrink-0 ${iconClasses[type]}`}
+          />
+          <div className={`flex-1 ${textClasses[type]}`}>{children}</div>
+        </div>
         {link && (
           <a
             href={link}


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
Fixes #4613. 
Also fixed some pages that had the h-screen issue and wasn't rendering properly on mobile.

<img width="406" alt="image" src="https://github.com/tinacms/tinacms/assets/41951199/2c224464-19a3-48a0-92b4-c1fe0f888cbc">

**Figure: Collections header on xs screens (320px - 559px)**

<img width="633" alt="image" src="https://github.com/tinacms/tinacms/assets/41951199/1994ab0e-f34b-4040-97a6-6e4c0609351c">

**Figure: Collections header on sm screens (560px - 719px)**

<img width="753" alt="image" src="https://github.com/tinacms/tinacms/assets/41951199/85ea6335-60e7-44ba-bf69-d7da85dc28e2">

**Figure: Collections header on md screens (720px - 1029px)**

<img width="1086" alt="image" src="https://github.com/tinacms/tinacms/assets/41951199/d6620174-68f9-4478-83f2-ef134fc3cfe6">

**Figure: Collections header on lg screens (1030px - 1279px)**

<img width="1322" alt="image" src="https://github.com/tinacms/tinacms/assets/41951199/a80e6e2e-a172-4cfc-a42c-0b4d8d5bb69f">

**Figure: Collections header on xl screens (1280px + )**