### PR TITLE
💄 UI/UX - modify form saved indicator

### DIFF
--- a/.changeset/big-seahorses-marry.md
+++ b/.changeset/big-seahorses-marry.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/app': patch
+'tinacms': patch
+---
+
+updated 'file has changes' indicator ui

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -279,18 +279,15 @@ export const FormStatus = ({ pristine }) => {
     <div className="flex flex-0 items-center">
       {!pristine && (
         <>
-          <span className="w-3 h-3 flex-0 rounded-full bg-yellow-300 border border-yellow-400 mr-2"></span>{' '}
-          <p className="text-gray-500 text-xs leading-tight whitespace-nowrap">
+          <p className="text-gray-500 text-xs leading-tight whitespace-nowrap mr-2">
             Unsaved Changes
           </p>
+          <span className="w-3 h-3 flex-0 rounded-full bg-red-300 border border-red-400"></span>{' '}
         </>
       )}
       {pristine && (
         <>
-          <span className="w-3 h-3 flex-0 rounded-full bg-green-300 border border-green-400 mr-2"></span>{' '}
-          <p className="text-gray-500 text-xs leading-tight whitespace-nowrap">
-            No Changes
-          </p>
+          <span className="w-3 h-3 flex-0 rounded-full bg-green-300 border border-green-400"></span>{' '}
         </>
       )}
     </div>


### PR DESCRIPTION
- removed 'no changes' text as it was misleading if you were working on a branch with some saved commits
- move save/unsaved indicator to the right
- change 'unsaved' indicator color to red to make it more prominent


![CleanShot 2024-07-10 at 11 30 44](https://github.com/tinacms/tinacms/assets/600044/111f00d1-ad6d-40c3-a767-7b1ab2b80c3e)
