### PR TITLE
feat: allow customization of media type in media manager

### DIFF
--- a/.changeset/tidy-hornets-cross.md
+++ b/.changeset/tidy-hornets-cross.md
@@ -1,0 +1,6 @@
+---
+'@tinacms/schema-tools': patch
+'tinacms': patch
+---
+
+Allow customization of accepted media types in media manager

--- a/examples/basic-iframe/tina/config.js
+++ b/examples/basic-iframe/tina/config.js
@@ -64,6 +64,7 @@ export default defineConfig({
       mediaRoot: 'uploads',
       publicFolder: 'public',
     },
+    accept: ['image/jpeg', 'video/mp4'],
   },
   schema: {
     collections: [

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -631,6 +631,7 @@ export interface Config<
          */
         loadCustomStore: () => Promise<Store>
         tina?: never
+        accept?: string | string[]
       }
     | {
         /**
@@ -653,6 +654,7 @@ export interface Config<
           static?: boolean
         }
         loadCustomStore?: never
+        accept?: string | string[]
       }
   search?: (
     | {

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Media } from '@toolkit/core'
-import { BiFolder, BiFile } from 'react-icons/bi'
-import { isImage } from './utils'
+import { BiFolder, BiFile, BiMovie } from 'react-icons/bi'
+import { isImage, isVideo } from './utils'
 
 interface MediaItemProps {
   item: Media & { new?: boolean }
@@ -10,7 +10,12 @@ interface MediaItemProps {
 }
 
 export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
-  const FileIcon = item.type === 'dir' ? BiFolder : BiFile
+  let FileIcon = BiFile
+  if (item.type === 'dir') {
+    FileIcon = BiFolder
+  } else if (isVideo(item.src)) {
+    FileIcon = BiMovie
+  }
   const thumbnail = (item.thumbnails || {})['75x75']
   return (
     <li
@@ -53,7 +58,12 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
 }
 
 export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
-  const FileIcon = item.type === 'dir' ? BiFolder : BiFile
+  let FileIcon = BiFile
+  if (item.type === 'dir') {
+    FileIcon = BiFolder
+  } else if (isVideo(item.src)) {
+    FileIcon = BiMovie
+  }
   const thumbnail = (item.thumbnails || {})['400x400']
   return (
     <li

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -234,10 +234,16 @@ export function MediaPicker({
   }
 
   const [uploading, setUploading] = useState(false)
+  const accept = Array.isArray(
+    cms.api.tina.schema.schema?.config?.media?.accept
+  )
+    ? cms.api.tina.schema.schema?.config?.media?.accept.join(',')
+    : cms.api.tina.schema.schema?.config?.media?.accept
   const { getRootProps, getInputProps, isDragActive } = useDropzone({
     accept: dropzoneAcceptFromString(
-      cms.media.accept || DEFAULT_MEDIA_UPLOAD_TYPES
+      accept || cms.media.accept || DEFAULT_MEDIA_UPLOAD_TYPES
     ),
+    maxSize: cms.media.maxSize,
     multiple: true,
     onDrop: async (files, fileRejections) => {
       try {

--- a/packages/tinacms/src/toolkit/components/media/utils.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.ts
@@ -25,6 +25,10 @@ export const isImage = (filename: string): boolean => {
   return /\.(gif|jpg|jpeg|tiff|png|svg|webp|avif)(\?.*)?$/i.test(filename)
 }
 
+export const isVideo = (filename: string): boolean => {
+  return /\.(mp4|webm|ogg|m4v|mov|avi|flv|mkv)(\?.*)?$/i.test(filename)
+}
+
 export const absoluteImgURL = (str: string) => {
   if (str.startsWith('http')) return str
   return `${window.location.origin}${str}`

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -105,6 +105,9 @@ export class TinaMediaStore implements MediaStore {
 
   accept = DEFAULT_MEDIA_UPLOAD_TYPES
 
+  // allow up to 100MB uploads
+  maxSize = 100 * 1024 * 1024
+
   private async persist_cloud(media: MediaUploadOptions[]): Promise<Media[]> {
     const newFiles: Media[] = []
 

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -55,6 +55,12 @@ export interface MediaStore {
    * that describes what kind of files the Media Store will accept.
    */
   accept: string
+
+  /**
+   * The maximum size of a file that can be uploaded.
+   */
+  maxSize?: number
+
   /**
    * Uploads a set of files to the Media Store and
    * returns a Promise containing the Media objects
@@ -143,6 +149,10 @@ export class MediaManager implements MediaStore {
 
   get accept() {
     return this.store.accept
+  }
+
+  get maxSize() {
+    return this.store.maxSize || undefined
   }
 
   async persist(files: MediaUploadOptions[]): Promise<Media[]> {


### PR DESCRIPTION
# what 

- Add media config option to allow overriding the default accepted media types
- Set a default size limit of 100MB on the tina media store
- Update UI to show movie icon for video files

TODO
- [ ] update documentation
- [ ] deploy server side size limit