### PR TITLE
♻️ TinaCMS - Remove unnecessary use of @react-hook/window-size

### DIFF
--- a/.changeset/nasty-gifts-cheat.md
+++ b/.changeset/nasty-gifts-cheat.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Remove unnecessary usage of @react-hook/window-size

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -21,7 +21,6 @@ import { LocalWarning } from '@tinacms/toolkit'
 import { PageWrapper } from '../components/Page'
 import { TinaAdminApi } from '../api'
 import type { TinaCMS } from '@tinacms/toolkit'
-import { useWindowWidth } from '@react-hook/window-size'
 import { FaLock, FaUnlock } from 'react-icons/fa'
 import { useCollectionFolder } from './utils'
 import { ErrorDialog } from '../components/ErrorDialog'
@@ -329,11 +328,6 @@ export const RenderForm = ({
     })
   }, [cms, collection, mutationInfo])
 
-  const navBreakpoint = 1279
-  const windowWidth = useWindowWidth()
-  const renderNavToggle = windowWidth < navBreakpoint + 1
-  const headerPadding = renderNavToggle ? 'px-20' : 'px-12'
-
   React.useEffect(() => {
     cms.dispatch({ type: 'forms:add', value: form })
     cms.dispatch({ type: 'forms:set-active-form-id', value: form.id })
@@ -355,7 +349,7 @@ export const RenderForm = ({
         {cms?.api?.tina?.isLocalMode ? <LocalWarning /> : <BillingWarning />}
 
         <div
-          className={`pt-10 xl:pt-3 pb-10 xl:pb-4 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center ${headerPadding}`}
+          className={`pt-10 xl:pt-3 pb-10 xl:pb-4 px-20 xl:px-12 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center`}
         >
           <div className="w-full flex gap-1.5 justify-between items-center">
             <Link

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -9,7 +9,6 @@ import { LocalWarning } from '@tinacms/toolkit'
 import { PageWrapper } from '../components/Page'
 import { TinaAdminApi } from '../api'
 import type { TinaCMS } from '@tinacms/toolkit'
-import { useWindowWidth } from '@react-hook/window-size'
 import { useCollectionFolder } from './utils'
 import { ErrorDialog } from '../components/ErrorDialog'
 
@@ -148,11 +147,6 @@ const RenderForm = ({
     })
   }, [cms, document, relativePath, collection, mutationInfo])
 
-  const navBreakpoint = 1279
-  const windowWidth = useWindowWidth()
-  const renderNavToggle = windowWidth < navBreakpoint + 1
-  const headerPadding = renderNavToggle ? 'px-20' : 'px-12'
-
   React.useEffect(() => {
     cms.dispatch({ type: 'forms:add', value: form })
     cms.dispatch({ type: 'forms:set-active-form-id', value: form.id })
@@ -172,7 +166,7 @@ const RenderForm = ({
     <>
       {cms?.api?.tina?.isLocalMode ? <LocalWarning /> : <BillingWarning />}
       <div
-        className={`pt-10 xl:pt-3 pb-10 xl:pb-4 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center ${headerPadding}`}
+        className={`pt-10 xl:pt-3 pb-10 xl:pb-4 px-20 xl:px-12 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center`}
       >
         <div className="w-full flex gap-1.5 justify-between items-center">
           <Link

--- a/packages/tinacms/src/admin/pages/ScreenPage.tsx
+++ b/packages/tinacms/src/admin/pages/ScreenPage.tsx
@@ -9,14 +9,9 @@ import type { TinaCMS, ScreenPlugin } from '@tinacms/toolkit'
 
 import GetCMS from '../components/GetCMS'
 import { slugify } from '../components/Sidebar'
-import { useWindowWidth } from '@react-hook/window-size'
 
 const ScreenPage = () => {
   const { screenName } = useParams()
-
-  const navBreakpoint = 1000
-  const windowWidth = useWindowWidth()
-  const renderNavToggle = windowWidth < navBreakpoint + 1
 
   return (
     <GetCMS>
@@ -32,11 +27,11 @@ const ScreenPage = () => {
             ) : (
               <BillingWarning />
             )}
-            {renderNavToggle && (
-              <div className={`py-5 border-b border-gray-200 bg-white pl-18`}>
-                {selectedScreen.name}
-              </div>
-            )}
+            <div
+              className={`xl:hidden py-5 border-b border-gray-200 bg-white pl-18`}
+            >
+              {selectedScreen.name}
+            </div>
             <div className="flex-1 overflow-y-auto relative flex flex-col items-stretch justify-between">
               <selectedScreen.Component close={() => {}} />
             </div>

--- a/packages/tinacms/src/toolkit/plugin-branch-switcher/branch-banner.tsx
+++ b/packages/tinacms/src/toolkit/plugin-branch-switcher/branch-banner.tsx
@@ -8,7 +8,6 @@ import {
 import { useBranchData } from './branch-data'
 import { BranchModal } from './branch-modal'
 import { Button } from '@toolkit/styles'
-import { useWindowWidth } from '@react-hook/window-size'
 import { useCMS } from '@toolkit/react-tinacms/use-cms'
 
 // trim 'tina/' prefix from branch name
@@ -23,9 +22,6 @@ export const BranchBanner = () => {
   const { currentBranch } = useBranchData()
   const isProtected = cms.api.tina.usingProtectedBranch()
 
-  const navBreakpoint = 1000
-  const windowWidth = useWindowWidth()
-  const renderNavToggle = windowWidth < navBreakpoint + 1
   const previewFunction = cms.api.tina.schema?.config?.config?.ui?.previewUrl
   const branch = decodeURIComponent(cms.api.tina.branch)
   const previewUrl = previewFunction ? previewFunction({ branch })?.url : null
@@ -33,9 +29,7 @@ export const BranchBanner = () => {
   return (
     <>
       <div
-        className={`w-full bg-white flex items-center gap-2 -mb-px border-b border-gray-100 py-3 pr-4 ${
-          renderNavToggle ? 'pl-20' : 'pl-4'
-        }`}
+        className={`w-full bg-white flex items-center gap-2 -mb-px border-b border-gray-100 py-3 pr-4 pl-20 xl:pl-4`}
       >
         <Button
           variant={isProtected ? 'primary' : 'white'}

--- a/packages/tinacms/src/toolkit/react-sidebar/components/sidebar.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/sidebar.tsx
@@ -30,7 +30,7 @@ export const SidebarContext = React.createContext<any>(null)
 
 export const minPreviewWidth = 440
 export const minSidebarWidth = 360
-export const navBreakpoint = 1000
+export const navBreakpoint = 1279
 
 const LOCALSTATEKEY = 'tina.sidebarState'
 const LOCALWIDTHKEY = 'tina.sidebarWidth'


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
Fixes #4627.

There were a few places where @react-hook/window-size was being used to alter styling that could have been done using css. These have been reduced down to one line of css styling. 

Note: It has been kept in places when the conditional rendering is complex (e.g. sidebar.ts and Sidebar.ts)

I have also converted the remainding navBreakpoints from 1000px to 1279px to be inline with our xl screen breakpoint.