### PR TITLE
🐛 Media Manager - Fix Cloudinary not accepting video uploads

### DIFF
--- a/.changeset/tame-mirrors-begin.md
+++ b/.changeset/tame-mirrors-begin.md
@@ -1,0 +1,5 @@
+---
+'next-tinacms-cloudinary': patch
+---
+
+Add support to upload non-image files to Cloudinary

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -77,6 +77,7 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
     folder: directory.replace(/^\//, ''),
     use_filename: true,
     overwrite: false,
+    resource_type: 'auto',
   })
 
   res.json(result)

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -72,15 +72,19 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
 
   const { directory } = req.body
 
-  //@ts-ignore
-  const result = await cloudinary.uploader.upload(req.file.path, {
-    folder: directory.replace(/^\//, ''),
-    use_filename: true,
-    overwrite: false,
-    resource_type: 'auto',
-  })
+  try {
+    //@ts-ignore
+    const result = await cloudinary.uploader.upload(req.file.path, {
+      folder: directory.replace(/^\//, ''),
+      use_filename: true,
+      overwrite: false,
+      resource_type: 'auto',
+    })
 
-  res.json(result)
+    res.json(result)
+  } catch (error) {
+    res.status(error.http_code).json({ message: error.message })
+  }
 }
 
 async function listMedia(


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
Fixes #4657. 

Cloudinary was only accepting image uploads and the error message given to the user was very bad.

![image](https://github.com/user-attachments/assets/f4b352d6-83c9-4f13-af38-8faa0e41f993)
**Figure: MKV video uploaded to Cloudinary using the Media Manager**

![image](https://github.com/user-attachments/assets/cf83214d-a8b9-45d5-88b5-341b1ade7aa6)
**Figure: Fixed error message**