### PR TITLE
🐛 Media Manager - Fix raw markdown button styling

### DIFF
--- a/.changeset/giant-snakes-work.md
+++ b/.changeset/giant-snakes-work.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/app': patch
+---
+
+Fix markdown editor button styling

--- a/packages/@tinacms/app/src/fields/rich-text/monaco/index.tsx
+++ b/packages/@tinacms/app/src/fields/rich-text/monaco/index.tsx
@@ -160,9 +160,9 @@ export const RawEditor = (props: RichTextType) => {
 
   return (
     <div className="relative">
-      <div className="sticky top-1 w-full flex justify-between mb-2 z-50 max-w-full">
+      <div className="sticky top-1 w-full flex justify-between mb-2 z-50 max-w-full bg-white">
         <Button onClick={() => props.setRawMode(false)}>
-          View in rich-text editor
+          View in rich-text editor 📝
         </Button>
         <ErrorMessage error={error} />
       </div>
@@ -222,7 +222,7 @@ const Button = (props) => {
         props.align === 'left'
           ? 'rounded-l-md border-r-0'
           : 'rounded-r-md border-l-0'
-      } shadow rounded-md bg-white cursor-pointer relative inline-flex items-center px-2 py-2 border border-gray-200 hover:text-white text-sm font-medium transition-all ease-out duration-150 hover:bg-blue-500 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500`}
+      } flex justify-center w-full shadow rounded-md bg-white cursor-pointer relative inline-flex items-center px-2 py-2 border border-gray-200 hover:text-white text-sm font-medium transition-all ease-out duration-150 hover:bg-blue-500 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500`}
       type="button"
       onClick={props.onClick}
     >


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
Fixes #4678.

I have opted to keep the behaviour of the raw markdown button inline (sticky) with the rich-text editor toolbar for consistency.

<img width="1614" alt="image" src="https://github.com/user-attachments/assets/60aaf43f-1a47-497d-87b1-25db559a3529">

**Figure: Markdown button styling fixed and refactored**

<img width="1580" alt="image" src="https://github.com/user-attachments/assets/84b429d9-47ea-4896-adbb-f7713c626c05">

**Figure: Rich-text editor toolbar being sticky**