### PR TITLE
fix: filter gitkeep

### DIFF
--- a/.changeset/rare-phones-exercise.md
+++ b/.changeset/rare-phones-exercise.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Filter .gitkeep.\* files during indexing


### PR DESCRIPTION
# Problem

Discord user `jcole` reported `.gitkeep.md` files were being included in query results which was then breaking because they did not conform to the collection schema.

# Solution

Filter .gitkeep files during indexing