### PR TITLE
Add rollup option to ignore "MODULE_LEVEL_DIRECTIVE"

### DIFF
--- a/.changeset/grumpy-horses-talk.md
+++ b/.changeset/grumpy-horses-talk.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/cli": patch
+"@tinacms/scripts": patch
+---
+
+Add rollup option to ignore "MODULE_LEVEL_DIRECTIVE"

--- a/packages/@tinacms/cli/src/next/commands/build-command/server.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/server.ts
@@ -41,6 +41,14 @@ export const buildProductionSpa = async (
     database,
     apiURL,
     noWatch: true,
+    rollupOptions: {
+      onwarn(warning, warn) {
+        if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+          return
+        }
+        warn(warning)
+      },
+    },
   })
   return build(config)
 }

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/index.ts
@@ -38,6 +38,12 @@ export const createDevServer = async (
        */
       rollupOptions: {
         input: configManager.spaMainPath,
+        onwarn(warning, warn) {
+          if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+            return
+          }
+          warn(warning)
+        },
       },
     })
   )

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -333,6 +333,12 @@ export const buildIt = async (entryPoint, packageJSON) => {
       emptyOutDir: false, // we build multiple files in to the dir
       sourcemap: false, // true | 'inline' (note: inline will go straight into your bundle size)
       rollupOptions: {
+        onwarn(warning, warn) {
+          if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {
+            return
+          }
+          warn(warning)
+        },
         // /**
         //  * FIXME: rollup-plugin-node-polyfills is only needed for node targets
         //  */


### PR DESCRIPTION
Hides warnings about `MODULE_LEVEL_DIRECTIVE` that are being spammed in the console. 