### PR TITLE
fix: @tinacms/cli: prevent search config from getting written to lock file

### DIFF
--- a/.changeset/popular-bulldogs-heal.md
+++ b/.changeset/popular-bulldogs-heal.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix tina-lock.json to not include search configuration, including search indexer token

--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -94,6 +94,10 @@ export class Codegen {
       '_graphql.json',
       JSON.stringify(this.graphqlSchemaDoc)
     )
+
+    const { search, ...rest } = this.tinaSchema.schema.config
+    this.tinaSchema.schema.config = rest
+
     // update _schema.json
     await this.writeConfigFile(
       '_schema.json',


### PR DESCRIPTION
# problem

Discord user reported search indexer token is being written to tina-lock.json

# solution

Filter search config from output