### PR TITLE
fix: prevent form submission when searching

### DIFF
--- a/.changeset/hungry-eggs-leave.md
+++ b/.changeset/hungry-eggs-leave.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix issue where clicking Search in the admin UI resulted in a redirect instead of loading the search results

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -981,7 +981,8 @@ const SearchInput = ({
         </div>
         <div className="flex w-full md:w-auto gap-3">
           <Button
-            onClick={() => {
+            onClick={(e) => {
+              e.preventDefault()
               setSearch(searchInput)
               setSearchLoaded(false)
             }}
@@ -993,6 +994,7 @@ const SearchInput = ({
           {search && searchLoaded && (
             <Button
               onClick={() => {
+                e.preventDefault()
                 setSearch('')
                 setSearchInput('')
               }}

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -993,7 +993,7 @@ const SearchInput = ({
           </Button>
           {search && searchLoaded && (
             <Button
-              onClick={() => {
+              onClick={(e) => {
                 e.preventDefault()
                 setSearch('')
                 setSearchInput('')


### PR DESCRIPTION
# Problem

When hitting the search button, the page redirects instead of loading the search results

# Solution

Prevent default to avoid submitting the form