### PR TITLE
feat: media-manager: add async error handle for media upload

### DIFF
--- a/.changeset/tender-hounds-smell.md
+++ b/.changeset/tender-hounds-smell.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Media Manager: Update Tina media manager to report any errors that occur during asset upload / delete operations

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -341,6 +341,20 @@ mutation addPendingDocumentMutation(
     return val as TinaCloudProject
   }
 
+  async getRequestStatus(requestId: string): Promise<{
+    error: boolean
+    message?: string
+  }> {
+    const res = await this.authProvider.fetchWithToken(
+      `${this.contentApiBase}/request-status/${this.clientId}/${requestId}`,
+      {
+        method: 'GET',
+      }
+    )
+    const val = await res.json()
+    return val
+  }
+
   async createPullRequest({
     baseBranch,
     branch,

--- a/packages/tinacms/src/toolkit/components/media/modal.tsx
+++ b/packages/tinacms/src/toolkit/components/media/modal.tsx
@@ -45,8 +45,13 @@ export const DeleteModal = ({
             variant="danger"
             onClick={async () => {
               setProcessing(true)
-              await deleteFunc()
-              close()
+              try {
+                await deleteFunc()
+              } catch (e) {
+                console.error(e)
+              } finally {
+                close()
+              }
             }}
           >
             <span className="mr-1">Delete</span>

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -133,7 +133,7 @@ export class TinaMediaStore implements MediaStore {
           throw new Error(message)
         }
 
-        const { signedUrl } = await res.json()
+        const { signedUrl, requestId } = await res.json()
         if (!signedUrl) {
           throw new Error('Unexpected error generating upload url')
         }
@@ -157,6 +157,22 @@ export class TinaMediaStore implements MediaStore {
             throw new Error(`Upload error: '${matches[2]}'`)
           }
         }
+
+        while (true) {
+          // sleep for 1 second
+          await new Promise((resolve) => setTimeout(resolve, 1000))
+
+          const { error, message } = await this.api.getRequestStatus(requestId)
+          if (error !== undefined) {
+            if (error) {
+              throw new Error(message)
+            } else {
+              // success
+              break
+            }
+          }
+        }
+
         const src = `https://assets.tina.io/${this.api.clientId}/${path}`
 
         newFiles.push({

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -158,6 +158,7 @@ export class TinaMediaStore implements MediaStore {
           }
         }
 
+        const now = Date.now()
         while (true) {
           // sleep for 1 second
           await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -170,6 +171,10 @@ export class TinaMediaStore implements MediaStore {
               // success
               break
             }
+          }
+
+          if (Date.now() - now > 30000) {
+            throw new Error('Time out waiting for upload to complete')
           }
         }
 

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -158,7 +158,7 @@ export class TinaMediaStore implements MediaStore {
           }
         }
 
-        const now = Date.now()
+        const updateStartTime = Date.now()
         while (true) {
           // sleep for 1 second
           await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -173,7 +173,7 @@ export class TinaMediaStore implements MediaStore {
             }
           }
 
-          if (Date.now() - now > 30000) {
+          if (Date.now() - updateStartTime > 30000) {
             throw new Error('Time out waiting for upload to complete')
           }
         }
@@ -423,7 +423,7 @@ export class TinaMediaStore implements MediaStore {
         if (res.status == 200) {
           const { requestId } = await res.json()
 
-          const now = Date.now()
+          const deleteStartTime = Date.now()
           while (true) {
             // sleep for 1 second
             await new Promise((resolve) => setTimeout(resolve, 1000))
@@ -440,8 +440,8 @@ export class TinaMediaStore implements MediaStore {
               }
             }
 
-            if (Date.now() - now > 30000) {
-              throw new Error('Time out waiting for upload to complete')
+            if (Date.now() - deleteStartTime > 30000) {
+              throw new Error('Time out waiting for delete to complete')
             }
           }
         } else {


### PR DESCRIPTION
Leverage the new request-status endpoint in TinaCloud media manager for upload and delete requests so that async errors are surfaced to the user.

Also fixes media manager UI to close the delete confirmation modal regardless of whether an error occurs (instead of it staying open when an error occurs)