### PR TITLE
fix: normalize cache dir to avoid unescaped characters breaking esbuild

### DIFF
--- a/.changeset/plenty-ants-argue.md
+++ b/.changeset/plenty-ants-argue.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix cacheDir path generation on Windows to avoid unescaped characters breaking esbuild

--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -7,6 +7,7 @@ import { transform } from 'esbuild'
 import { ConfigManager } from '../config-manager'
 import type { TinaSchema } from '@tinacms/schema-tools'
 import { mapUserFields } from '@tinacms/graphql'
+import normalizePath from 'normalize-path'
 export const TINA_HOST = 'content.tinajs.io'
 
 export class Codegen {
@@ -350,7 +351,9 @@ export default databaseClient;
 import { queries } from "./types";
 export const client = createClient({ ${
       this.noClientBuildCache === false
-        ? `cacheDir: '${this.configManager.generatedCachePath}', `
+        ? `cacheDir: '${normalizePath(
+            this.configManager.generatedCachePath
+          )}', `
         : ''
     }url: '${apiURL}', token: '${token}', queries, ${
       errorPolicy ? `errorPolicy: '${errorPolicy}'` : ''


### PR DESCRIPTION
Fix #4779 caused by not escaping backslashes on windows