### PR TITLE
fix: cli init generating broken collections definition

### DIFF
--- a/.changeset/olive-roses-burn.md
+++ b/.changeset/olive-roses-burn.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Fix init bug causing invalid tina config

--- a/.changeset/olive-roses-burn.md
+++ b/.changeset/olive-roses-burn.md
@@ -1,7 +1,5 @@
 ---
 '@tinacms/cli': patch
-'@tinacms/datalayer': patch
-'tinacms-gitprovider-github': patch
 ---
 
 Fix init bug causing invalid tina config

--- a/.changeset/olive-roses-burn.md
+++ b/.changeset/olive-roses-burn.md
@@ -1,5 +1,7 @@
 ---
 '@tinacms/cli': patch
+'@tinacms/datalayer': patch
+'tinacms-gitprovider-github': patch
 ---
 
 Fix init bug causing invalid tina config

--- a/packages/@tinacms/cli/src/cmds/init/templates/config.ts
+++ b/packages/@tinacms/cli/src/cmds/init/templates/config.ts
@@ -36,8 +36,12 @@ const generateCollectionString = (args: ConfigTemplateArgs) => {
   if (args.collections) {
     return args.collections
   }
-  const extraTinaCollections =
+  let extraTinaCollections =
     args.config.authProvider?.extraTinaCollections?.join(',\n')
+
+  if (extraTinaCollections) {
+    extraTinaCollections = extraTinaCollections + ','
+  }
 
   const baseCollections = `[
     ${extraTinaCollections || ''}
@@ -51,7 +55,6 @@ const generateCollectionString = (args: ConfigTemplateArgs) => {
   const nextExampleCollection = `[
     ${extraTinaCollections || ''}
     {
-      ${extraTinaCollections ? `${extraTinaCollections},` : ''}
       name: 'post',
       label: 'Posts',
       path: 'content/posts',


### PR DESCRIPTION
Fix [issue](https://discord.com/channels/835168149439643678/1283410305753288756) reported on discord

When executing self-hosted init, the auth user collection is inserted incorrectly.