### PR TITLE
release - publish GitHub releases + release notes to Tina.io

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs.
+# More information can be found at http://editorconfig.org
+
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+indent_style = space
+indent_size = 2
+
+[*.{js,jsx,ts,tsx}]
+indent_size = 2

--- a/.github/workflows/main-generate-release-notes.yml
+++ b/.github/workflows/main-generate-release-notes.yml
@@ -1,0 +1,49 @@
+name: Generate Release Notes
+
+on:
+  push:
+    tags:
+      - 'tinacms@*'
+
+jobs:
+  push-release-notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get release info
+        id: release-info
+        run: |
+          release_info=$(gh release view "${{ github.ref_name }}" --json body,createdAt)
+          release_body=$(echo "$release_info" | jq -r .body)
+          release_created_at=$(echo "$release_info" | jq -r .createdAt)
+          echo "notes=$release_body" >> $GITHUB_OUTPUT
+          echo "created_at=$release_created_at" >> $GITHUB_OUTPUT
+
+          release_tag="${{ github.ref_name }}"
+          # replace "tina@v" with "v" to match the version number
+          release_tag=$(echo "$release_tag" | sed 's/tinacms@/v/')
+          echo "version=$release_tag" >> $GITHUB_OUTPUT
+
+      - name: Generate a token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          # uses https://github.com/organizations/tinacms/settings/apps/release-bot-allow-prs-and-push
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_SECRET }}
+          owner: tinacms
+          repositories: tina.io
+
+      - name: Publish release notes
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          repo: tinacms/tina.io
+          ref: main
+          workflow: dispatch-create-whats-new-page.yml
+          inputs: |
+            {
+              "project": "TinaCloud",
+              "versionNumber": "${{ steps.release-info.outputs.version }}",
+              "dateReleased": "${{ steps.release-info.outputs.created_at }}",
+              "releaseNotes": ${{ steps.release-info.outputs.notes }}
+            }
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,23 +79,13 @@ jobs:
           pnpm version:snapshot
           pnpm run publish:beta
 
-      - name: Publish
-        if: matrix.channel == 'latest'
-        run: |
-          pnpm run publish
-
-      - name: Push tags
-        if: matrix.channel == 'latest'
-        run: |
-          pnpm push-tags
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN }}
-          NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
-
-      - name: Create release pull request
+      - name: Create release pull request or publish packages
         uses: changesets/action@v1
+        id: changesets
         if: matrix.channel == 'latest'
         with:
           version: pnpm run version
+          publish: pnpm run publish
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token || secrets.GITHUB_TOKEN  }}


### PR DESCRIPTION
`publish.yml` - simplifies the "latest" strategy + creates GitHub releases

`main-generate-release-notes.yml` | when new tinacms@* tags are created - grab the release notes and publish them on Tina.io