### PR TITLE
Add PNPM to the "build all templates" GitHub action

### DIFF
--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -29,6 +29,14 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
+      - uses: pnpm/action-setup@v4
+        name: Install pnpm
+        if: ${{ matrix.package-manager == pnpm }}
+        id: pnpm-install
+        with:
+          package_json_file: package.json
+          run_install: false
+
       - name: Run create-tina-app
         run: |
           npx create-tina-app@latest template-repo --pkg-manager ${{ matrix.package-manager }} --template ${{ matrix.template }}


### PR DESCRIPTION
PNPM isn't installed within the GitHub action and therefore when it's used the action will fail.