### PR TITLE
🐛 Bug - Protect 'window' reference

### DIFF
--- a/.changeset/poor-pears-joke.md
+++ b/.changeset/poor-pears-joke.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+- Correct 'window' variable definition test

--- a/packages/tinacms/src/unifiedClient/index.ts
+++ b/packages/tinacms/src/unifiedClient/index.ts
@@ -60,7 +60,7 @@ export class TinaClient<GenQueries> {
     try {
       if (
         this.cacheDir &&
-        window === undefined &&
+        typeof window === 'undefined' &&
         typeof require !== 'undefined'
       ) {
         const { NodeCache } = await import('../cache/node-cache')


### PR DESCRIPTION
The following error message is seen when attempting to build [tina-cloud-starter](https://github.com/tinacms/tina-cloud-starter/) with the `tinacms` 2.2.8:

```
   Collecting page data  ...ReferenceError: window is not defined
    at i.init (/home/ncn/Source/Tina/tina-cloud-starter/.next/server/chunks/631.js:3:93620)
    at i.request (/home/ncn/Source/Tina/tina-cloud-starter/.next/server/chunks/631.js:3:93848)
    at /home/ncn/Source/Tina/tina-cloud-starter/.next/server/chunks/752.js:384:143
    at Object.postConnection (/home/ncn/Source/Tina/tina-cloud-starter/.next/server/chunks/752.js:384:703)
    at Object.d [as generateStaticParams] (/home/ncn/Source/Tina/tina-cloud-starter/.next/server/app/posts/[...filename]/page.js:1:94459)
    at buildParams (/home/ncn/Source/Tina/tina-cloud-starter/node_modules/.pnpm/next@14.2.7_@babel+core@7.25.2_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/build/utils.js:1026:58)
    at buildParams (/home/ncn/Source/Tina/tina-cloud-starter/node_modules/.pnpm/next@14.2.7_@babel+core@7.25.2_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/build/utils.js:1020:28)
    at /home/ncn/Source/Tina/tina-cloud-starter/node_modules/.pnpm/next@14.2.7_@babel+core@7.25.2_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/build/utils.js:1043:39
    at AsyncLocalStorage.run (node:async_hooks:338:14)
    at Object.wrap (/home/ncn/Source/Tina/tina-cloud-starter/node_modules/.pnpm/next@14.2.7_@babel+core@7.25.2_react-dom@18.3.1_react@18.3.1__react@18.3.1/node_modules/next/dist/server/async-storage/static-generation-async-storage-wrapper.js:49:24)
```

Though it is not clear that TinaCMS is the root cause, @JackDevAU and I have noted that there is a potential for 'window' to be referenced when it is not available. This change protects that reference with a `typeof` expression.