### PR TITLE
lock mermaid to 9.3.0 to allow cjs

### DIFF
--- a/.changeset/violet-kings-occur.md
+++ b/.changeset/violet-kings-occur.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+lock mermaid to 9.4.0 to allow cjs

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -110,7 +110,7 @@
 		"lodash.get": "^4.4.2",
 		"lodash.set": "^4.3.2",
 		"lucide-react": "^0.424.0",
-		"mermaid": "^10.9.1",
+		"mermaid": "9.4.0",
 		"moment": "2.29.4",
 		"monaco-editor": "0.31.0",
 		"prism-react-renderer": "^2.4.0",

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -110,7 +110,7 @@
 		"lodash.get": "^4.4.2",
 		"lodash.set": "^4.3.2",
 		"lucide-react": "^0.424.0",
-		"mermaid": "9.4.0",
+		"mermaid": "9.3.0",
 		"moment": "2.29.4",
 		"monaco-editor": "0.31.0",
 		"prism-react-renderer": "^2.4.0",

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/mermaid-element.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/mermaid-element.tsx
@@ -12,7 +12,7 @@ const MermaidElementWithRef = ({ config }) => {
   useEffect(() => {
     if (mermaidRef.current) {
       mermaid.initialize({ startOnLoad: true })
-      mermaid.run()
+      mermaid.init()
     }
   }, [config])
 
@@ -53,7 +53,7 @@ flowchart TD
     --> id2(modify me to see changes!)
     id2 
     --> id3(Click the top button to preview the changes)
-    --> id4(Learn about mermaid diagrams @ mermaid.js.org)`
+    --> id4(Learn about mermaid diagrams - mermaid.js.org)`
 
 export const MermaidElement = withRef<typeof PlateElement>(
   ({ children, nodeProps, element, ...props }, ref) => {
@@ -73,7 +73,7 @@ export const MermaidElement = withRef<typeof PlateElement>(
     }
 
     useEffect(() => {
-      if (mermaid.parse(mermaidConfig as string, { suppressErrors: false })) {
+      if (mermaid.parse(mermaidConfig as string)) {
         setMermaidError(null) // Clear errors on success
       }
     }, [mermaidConfig])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1604,8 +1604,8 @@ importers:
                 specifier: ^0.424.0
                 version: 0.424.0(react@18.3.1)
             mermaid:
-                specifier: 9.4.0
-                version: 9.4.0
+                specifier: 9.3.0
+                version: 9.3.0
             moment:
                 specifier: 2.29.4
                 version: 2.29.4
@@ -10684,12 +10684,6 @@ packages:
                 integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==,
             }
 
-    cose-base@2.2.0:
-        resolution:
-            {
-                integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==,
-            }
-
     cosmiconfig@7.1.0:
         resolution:
             {
@@ -10863,14 +10857,6 @@ packages:
         resolution:
             {
                 integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==,
-            }
-        peerDependencies:
-            cytoscape: ^3.2.0
-
-    cytoscape-fcose@2.2.0:
-        resolution:
-            {
-                integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==,
             }
         peerDependencies:
             cytoscape: ^3.2.0
@@ -11132,10 +11118,10 @@ packages:
                 integrity: sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==,
             }
 
-    dagre-d3-es@7.0.8:
+    dagre-d3-es@7.0.6:
         resolution:
             {
-                integrity: sha512-eykdoYQ4FwCJinEYS0gPL2f2w+BPbSLvnQSJ3Ye1vAoPjdkq6xIMKBv+UkICd3qZE26wBKIn3p+6n0QC7R1LyA==,
+                integrity: sha512-CaaE/nZh205ix+Up4xsnlGmpog5GGm81Upi2+/SBHxwNwrccBb3K51LzjZ1U6hgvOlAEUsVWf1xSTzCyKpJ6+Q==,
             }
 
     damerau-levenshtein@1.0.8:
@@ -11616,10 +11602,10 @@ packages:
             }
         engines: { node: '>= 4' }
 
-    dompurify@2.4.3:
+    dompurify@2.4.1:
         resolution:
             {
-                integrity: sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==,
+                integrity: sha512-ewwFzHzrrneRjxzmK6oVz/rZn9VWspGFRDb4/rRtIsM1n36t9AKma/ye8syCpcw+XJ25kOK/hOG7t1j2I2yBqA==,
             }
 
     dompurify@3.1.6:
@@ -11705,12 +11691,6 @@ packages:
         resolution:
             {
                 integrity: sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==,
-            }
-
-    elkjs@0.8.2:
-        resolution:
-            {
-                integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==,
             }
 
     elkjs@0.9.3:
@@ -14782,12 +14762,6 @@ packages:
                 integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==,
             }
 
-    layout-base@2.0.1:
-        resolution:
-            {
-                integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==,
-            }
-
     lazy-ass@1.6.0:
         resolution:
             {
@@ -15494,10 +15468,10 @@ packages:
                 integrity: sha512-Mx45Obds5W1UkW1nv/7dHRsbfMM1aOKA2+Pxs/IGHNonygDHwmng8xTHyS9z4KWVi0rbko8gjiBmuwwXQ7tiNA==,
             }
 
-    mermaid@9.4.0:
+    mermaid@9.3.0:
         resolution:
             {
-                integrity: sha512-4PWbOND7CNRbjHrdG3WUUGBreKAFVnMhdlPjttuUkeHbCQmAHkwzSh5dGwbrKmXGRaR4uTvfFVYzUcg++h0DkA==,
+                integrity: sha512-mGl0BM19TD/HbU/LmlaZbjBi//tojelg8P/mxD6pPZTAYaI+VawcyBdqRsoUHSc7j71PrMdJ3HBadoQNdvP5cg==,
             }
 
     meros@1.3.0:
@@ -15983,6 +15957,12 @@ packages:
                 integrity: sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==,
             }
         engines: { node: '>=10' }
+
+    moment-mini@2.29.4:
+        resolution:
+            {
+                integrity: sha512-uhXpYwHFeiTbY9KSgPPRoo1nt8OxNVdMVoTBYHfSEKeRkIkwGpO+gERmhuhBtzfaeOyTkykSrm2+noJBgqt3Hg==,
+            }
 
     moment@2.29.4:
         resolution:
@@ -28120,10 +28100,6 @@ snapshots:
         dependencies:
             layout-base: 1.0.2
 
-    cose-base@2.2.0:
-        dependencies:
-            layout-base: 2.0.1
-
     cosmiconfig@7.1.0:
         dependencies:
             '@types/parse-json': 4.0.2
@@ -28324,11 +28300,6 @@ snapshots:
             cose-base: 1.0.3
             cytoscape: 3.30.2
 
-    cytoscape-fcose@2.2.0(cytoscape@3.30.2):
-        dependencies:
-            cose-base: 2.2.0
-            cytoscape: 3.30.2
-
     cytoscape@3.30.2: {}
 
     d3-array@2.12.1:
@@ -28503,7 +28474,7 @@ snapshots:
             d3: 7.9.0
             lodash-es: 4.17.21
 
-    dagre-d3-es@7.0.8:
+    dagre-d3-es@7.0.6:
         dependencies:
             d3: 7.9.0
             lodash-es: 4.17.21
@@ -28751,7 +28722,7 @@ snapshots:
         dependencies:
             domelementtype: 2.3.0
 
-    dompurify@2.4.3: {}
+    dompurify@2.4.1: {}
 
     dompurify@3.1.6: {}
 
@@ -28801,8 +28772,6 @@ snapshots:
             jake: 10.9.2
 
     electron-to-chromium@1.5.4: {}
-
-    elkjs@0.8.2: {}
 
     elkjs@0.9.3: {}
 
@@ -31365,8 +31334,6 @@ snapshots:
 
     layout-base@1.0.2: {}
 
-    layout-base@2.0.1: {}
-
     lazy-ass@1.6.0: {}
 
     level-read-stream@1.1.0(abstract-level@1.0.4):
@@ -31903,22 +31870,17 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    mermaid@9.4.0:
+    mermaid@9.3.0:
         dependencies:
             '@braintree/sanitize-url': 6.0.4
-            cytoscape: 3.30.2
-            cytoscape-cose-bilkent: 4.1.0(cytoscape@3.30.2)
-            cytoscape-fcose: 2.2.0(cytoscape@3.30.2)
             d3: 7.9.0
-            dagre-d3-es: 7.0.8
-            dompurify: 2.4.3
-            elkjs: 0.8.2
+            dagre-d3-es: 7.0.6
+            dompurify: 2.4.1
             khroma: 2.1.0
             lodash-es: 4.17.21
-            moment: 2.29.4
+            moment-mini: 2.29.4
             non-layered-tidy-tree-layout: 2.0.2
             stylis: 4.3.4
-            ts-dedent: 2.2.0
             uuid: 9.0.1
 
     meros@1.3.0(@types/node@22.7.4):
@@ -32346,6 +32308,8 @@ snapshots:
             ufo: 1.5.4
 
     module-error@1.0.2: {}
+
+    moment-mini@2.29.4: {}
 
     moment@2.29.4: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1604,8 +1604,8 @@ importers:
                 specifier: ^0.424.0
                 version: 0.424.0(react@18.3.1)
             mermaid:
-                specifier: ^10.9.1
-                version: 10.9.1
+                specifier: 9.4.0
+                version: 9.4.0
             moment:
                 specifier: 2.29.4
                 version: 2.29.4
@@ -10684,6 +10684,12 @@ packages:
                 integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==,
             }
 
+    cose-base@2.2.0:
+        resolution:
+            {
+                integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==,
+            }
+
     cosmiconfig@7.1.0:
         resolution:
             {
@@ -10857,6 +10863,14 @@ packages:
         resolution:
             {
                 integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==,
+            }
+        peerDependencies:
+            cytoscape: ^3.2.0
+
+    cytoscape-fcose@2.2.0:
+        resolution:
+            {
+                integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==,
             }
         peerDependencies:
             cytoscape: ^3.2.0
@@ -11116,6 +11130,12 @@ packages:
         resolution:
             {
                 integrity: sha512-qTCQmEhcynucuaZgY5/+ti3X/rnszKZhEQH/ZdWdtP1tA/y3VoHJzcVrO9pjjJCNpigfscAtoUB5ONcd2wNn0A==,
+            }
+
+    dagre-d3-es@7.0.8:
+        resolution:
+            {
+                integrity: sha512-eykdoYQ4FwCJinEYS0gPL2f2w+BPbSLvnQSJ3Ye1vAoPjdkq6xIMKBv+UkICd3qZE26wBKIn3p+6n0QC7R1LyA==,
             }
 
     damerau-levenshtein@1.0.8:
@@ -11596,6 +11616,12 @@ packages:
             }
         engines: { node: '>= 4' }
 
+    dompurify@2.4.3:
+        resolution:
+            {
+                integrity: sha512-q6QaLcakcRjebxjg8/+NP+h0rPfatOgOzc46Fst9VAA3jF2ApfKBNKMzdP4DYTqtUMXSCd5pRS/8Po/OmoCHZQ==,
+            }
+
     dompurify@3.1.6:
         resolution:
             {
@@ -11679,6 +11705,12 @@ packages:
         resolution:
             {
                 integrity: sha512-orzA81VqLyIGUEA77YkVA1D+N+nNfl2isJVjjmOyrlxuooZ19ynb+dOlaDTqd/idKRS9lDCSBmtzM+kyCsMnkA==,
+            }
+
+    elkjs@0.8.2:
+        resolution:
+            {
+                integrity: sha512-L6uRgvZTH+4OF5NE/MBbzQx/WYpru1xCBE9respNj6qznEewGUIfhzmm7horWWxbNO2M0WckQypGctR8lH79xQ==,
             }
 
     elkjs@0.9.3:
@@ -14750,6 +14782,12 @@ packages:
                 integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==,
             }
 
+    layout-base@2.0.1:
+        resolution:
+            {
+                integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==,
+            }
+
     lazy-ass@1.6.0:
         resolution:
             {
@@ -15454,6 +15492,12 @@ packages:
         resolution:
             {
                 integrity: sha512-Mx45Obds5W1UkW1nv/7dHRsbfMM1aOKA2+Pxs/IGHNonygDHwmng8xTHyS9z4KWVi0rbko8gjiBmuwwXQ7tiNA==,
+            }
+
+    mermaid@9.4.0:
+        resolution:
+            {
+                integrity: sha512-4PWbOND7CNRbjHrdG3WUUGBreKAFVnMhdlPjttuUkeHbCQmAHkwzSh5dGwbrKmXGRaR4uTvfFVYzUcg++h0DkA==,
             }
 
     meros@1.3.0:
@@ -18691,6 +18735,12 @@ packages:
         resolution:
             {
                 integrity: sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==,
+            }
+
+    stylis@4.3.4:
+        resolution:
+            {
+                integrity: sha512-osIBl6BGUmSfDkyH2mB7EFvCJntXDrLhKjHTRj/rK6xLH0yuPrHULDRQzKokSOD4VoorhtKpfcfW1GAntu8now==,
             }
 
     sucrase@3.35.0:
@@ -28070,6 +28120,10 @@ snapshots:
         dependencies:
             layout-base: 1.0.2
 
+    cose-base@2.2.0:
+        dependencies:
+            layout-base: 2.0.1
+
     cosmiconfig@7.1.0:
         dependencies:
             '@types/parse-json': 4.0.2
@@ -28270,6 +28324,11 @@ snapshots:
             cose-base: 1.0.3
             cytoscape: 3.30.2
 
+    cytoscape-fcose@2.2.0(cytoscape@3.30.2):
+        dependencies:
+            cose-base: 2.2.0
+            cytoscape: 3.30.2
+
     cytoscape@3.30.2: {}
 
     d3-array@2.12.1:
@@ -28440,6 +28499,11 @@ snapshots:
             d3-zoom: 3.0.0
 
     dagre-d3-es@7.0.10:
+        dependencies:
+            d3: 7.9.0
+            lodash-es: 4.17.21
+
+    dagre-d3-es@7.0.8:
         dependencies:
             d3: 7.9.0
             lodash-es: 4.17.21
@@ -28687,6 +28751,8 @@ snapshots:
         dependencies:
             domelementtype: 2.3.0
 
+    dompurify@2.4.3: {}
+
     dompurify@3.1.6: {}
 
     domutils@2.8.0:
@@ -28735,6 +28801,8 @@ snapshots:
             jake: 10.9.2
 
     electron-to-chromium@1.5.4: {}
+
+    elkjs@0.8.2: {}
 
     elkjs@0.9.3: {}
 
@@ -31297,6 +31365,8 @@ snapshots:
 
     layout-base@1.0.2: {}
 
+    layout-base@2.0.1: {}
+
     lazy-ass@1.6.0: {}
 
     level-read-stream@1.1.0(abstract-level@1.0.4):
@@ -31832,6 +31902,24 @@ snapshots:
             web-worker: 1.3.0
         transitivePeerDependencies:
             - supports-color
+
+    mermaid@9.4.0:
+        dependencies:
+            '@braintree/sanitize-url': 6.0.4
+            cytoscape: 3.30.2
+            cytoscape-cose-bilkent: 4.1.0(cytoscape@3.30.2)
+            cytoscape-fcose: 2.2.0(cytoscape@3.30.2)
+            d3: 7.9.0
+            dagre-d3-es: 7.0.8
+            dompurify: 2.4.3
+            elkjs: 0.8.2
+            khroma: 2.1.0
+            lodash-es: 4.17.21
+            moment: 2.29.4
+            non-layered-tidy-tree-layout: 2.0.2
+            stylis: 4.3.4
+            ts-dedent: 2.2.0
+            uuid: 9.0.1
 
     meros@1.3.0(@types/node@22.7.4):
         optionalDependencies:
@@ -34061,6 +34149,8 @@ snapshots:
     stylis@4.1.3: {}
 
     stylis@4.2.0: {}
+
+    stylis@4.3.4: {}
 
     sucrase@3.35.0:
         dependencies:


### PR DESCRIPTION
- Fixes issue with `mermaid` version 10+ moving to pure esm output. (can't use require to import)

```js
Module not found: ESM packages (mermaid) need to be imported. Use 'import' to reference the package instead. https://nextjs.org/docs/messages/import-esm-externals
``` 

[Read more about pure esm](https://gist.github.com/sindresorhus/a39789f98801d908bbc7ff3ecc99d99c)