### PR TITLE
feat: cli verification of tina schema mismatch between remote and local

### DIFF
--- a/.changeset/small-ways-switch.md
+++ b/.changeset/small-ways-switch.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Adds additional validation for mismatches of the tina cloud schema and the local version

--- a/.changeset/small-ways-switch.md
+++ b/.changeset/small-ways-switch.md
@@ -2,4 +2,4 @@
 '@tinacms/cli': patch
 ---
 
-Adds additional validation for mismatches of the tina cloud schema and the local version
+Adds additional validation of the local tina schema and the remote version to prevent inconsistent behavior when changes are not committed to the remote GitHub repository. Related issue: https://github.com/tinacms/tinacms/issues/5221

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -214,7 +214,13 @@ export class BuildCommand extends BaseCommand {
         database,
         codegen.productionUrl
       )
-      await this.checkTinaSchema(configManager, database, codegen.productionUrl)
+      await this.checkTinaSchema(
+        configManager,
+        database,
+        codegen.productionUrl,
+        this.previewName,
+        this.verbose
+      )
     }
 
     await buildProductionSpa(configManager, database, codegen.productionUrl)

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -651,34 +651,30 @@ export class BuildCommand extends BaseCommand {
     if (!database.bridge) {
       throw new Error(`No bridge configured`)
     }
-    try {
-      const localTinaSchema = JSON.parse(
-        await database.bridge.get(
-          path.join(database.tinaDirectory, '__generated__', '_schema.json')
-        )
+    const localTinaSchema = JSON.parse(
+      await database.bridge.get(
+        path.join(database.tinaDirectory, '__generated__', '_schema.json')
       )
-      localTinaSchema.version = undefined
-      const localTinaSchemaSha = crypto
-        .createHash('sha256')
-        .update(JSON.stringify(localTinaSchema))
-        .digest('hex')
+    )
+    localTinaSchema.version = undefined
+    const localTinaSchemaSha = crypto
+      .createHash('sha256')
+      .update(JSON.stringify(localTinaSchema))
+      .digest('hex')
 
-      if (localTinaSchemaSha === remoteTinaSchemaSha) {
-        bar.tick({
-          prog: '✅',
-        })
-      } else {
-        bar.tick({
-          prog: '❌',
-        })
-        let errorMessage = `The local Tina schema doesn't match the remote Tina schema. Please push up your changes to GitHub to update your remote tina schema.`
-        if (config?.branch) {
-          errorMessage += `\n\nAdditional info: Branch: ${config.branch}, Client ID: ${config.clientId} `
-        }
-        throw new Error(errorMessage)
+    if (localTinaSchemaSha === remoteTinaSchemaSha) {
+      bar.tick({
+        prog: '✅',
+      })
+    } else {
+      bar.tick({
+        prog: '❌',
+      })
+      let errorMessage = `The local Tina schema doesn't match the remote Tina schema. Please push up your changes to GitHub to update your remote tina schema.`
+      if (config?.branch) {
+        errorMessage += `\n\nAdditional info: Branch: ${config.branch}, Client ID: ${config.clientId} `
       }
-    } catch (e) {
-      throw e
+      throw new Error(errorMessage)
     }
   }
 }

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -783,5 +783,6 @@ export const fetchSchemaSha = async ({
     cache: 'no-cache',
   })
   const data = await res.json()
-  return data?.data
+  console.log({ data })
+  return data?.data || {}
 }

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -2,6 +2,7 @@ import { Command, Option } from 'clipanion'
 import Progress from 'progress'
 import fs from 'fs-extra'
 import crypto from 'crypto'
+import path from 'path'
 import type { ViteDevServer } from 'vite'
 import { buildSchema, type Database, FilesystemBridge } from '@tinacms/graphql'
 import { ConfigManager } from '../../config-manager'
@@ -651,10 +652,11 @@ export class BuildCommand extends BaseCommand {
     if (!database.bridge) {
       throw new Error(`No bridge configured`)
     }
-
     try {
       const localTinaSchema = JSON.parse(
-        await database.bridge.get(configManager.generatedSchemaJSONPath)
+        await database.bridge.get(
+          path.join(database.tinaDirectory, '__generated__', '_schema.json')
+        )
       )
       localTinaSchema.version = undefined
       const localTinaSchemaSha = crypto

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -782,7 +782,5 @@ export const fetchSchemaSha = async ({
     headers,
     cache: 'no-cache',
   })
-  const data = await res.json()
-  console.log({ data })
-  return data?.data || {}
+  return res.json()
 }

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -636,7 +636,6 @@ export class BuildCommand extends BaseCommand {
       url: `https://${host}/db/${clientId}/${previewName || branch}/schemaSha`,
       token,
     })
-    console.log({ remoteTinaSchemaSha })
 
     if (!remoteTinaSchemaSha) {
       bar.tick({
@@ -663,9 +662,8 @@ export class BuildCommand extends BaseCommand {
         .createHash('sha256')
         .update(JSON.stringify(localTinaSchema))
         .digest('hex')
-      console.log({ localTinaSchemaSha })
 
-      if (localTinaSchemaSha !== remoteTinaSchemaSha) {
+      if (localTinaSchemaSha === remoteTinaSchemaSha) {
         bar.tick({
           prog: '✅',
         })
@@ -773,7 +771,6 @@ export const fetchSchemaSha = async ({
   url: string
   token?: string
 }) => {
-  console.log(url)
   const headers = new Headers()
   if (token) {
     headers.append('X-API-KEY', token)


### PR DESCRIPTION
# Problem

If there is a change to the tina schema that doesn't change the graphql schema (changes to a collection path for example) and that change is not pushed to the remote GitHub repository, there can be inconsistent behavior between local dev and production.

# Solution

Compare the local tina schema to the remote tina schema and build time. If differences are detected, alert the user.

Fix #5221 