### PR TITLE
Add `table` to the Schema Tools ToolbarOverrideType list

### DIFF
--- a/.changeset/great-ties-rescue.md
+++ b/.changeset/great-ties-rescue.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/schema-tools": patch
+---
+
+Add `table` to the Schema Tools ToolbarOverrideType list

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -260,7 +260,7 @@ export type PasswordField = (
     type: 'password'
   }
 
-type toolbarItemName =
+type ToolbarOverrideType =
   | 'heading'
   | 'link'
   | 'image'
@@ -274,6 +274,7 @@ type toolbarItemName =
   | 'raw'
   | 'embed'
   | 'mermaid'
+  | 'table'
 type RichTextAst = { type: 'root'; children: Record<string, unknown>[] }
 export type RichTextField<WithNamespace extends boolean = false> = (
   | FieldGeneric<RichTextAst, undefined>
@@ -288,7 +289,7 @@ export type RichTextField<WithNamespace extends boolean = false> = (
      * will be stored as frontmatter
      */
     isBody?: boolean
-    toolbarOverride?: toolbarItemName[]
+    toolbarOverride?: ToolbarOverrideType[]
     templates?: RichTextTemplate<WithNamespace>[]
     /**
      * By default, Tina parses markdown with MDX, this is a more strict parser


### PR DESCRIPTION
Found and reported via https://discord.com/channels/835168149439643678/1299509772395085845

- renames `toolbarItemName` to `ToolbarOverrideType` to make it consistent
- Adds `table` to the ToolbarOverrideType

