### PR TITLE
Fix delete Block Icon not showing up in Safari

### DIFF
--- a/.changeset/sharp-beans-change.md
+++ b/.changeset/sharp-beans-change.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Fixes a styling issue where the delete Block Icon was invisible when using Safari (Browser)

--- a/packages/tinacms/src/toolkit/fields/plugins/group-list-field-plugin.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/group-list-field-plugin.tsx
@@ -266,12 +266,13 @@ export const ItemHeader = ({
 export const ItemDeleteButton = ({ onClick, disabled = false }) => {
   return (
     <button
-      className={`w-8 px-1 py-2.5 flex items-center justify-center hover:bg-gray-50 text-gray-200 hover:text-red-500 ${
-        disabled && 'pointer-events-none opacity-30 cursor-not-allowed'
+      type="button"
+      className={`w-8 px-1 py-2.5 flex items-center justify-center text-gray-200 hover:opacity-100 opacity-30 hover:bg-gray-50 ${
+        disabled && 'cursor-not-allowed'
       }`}
       onClick={onClick}
     >
-      <TrashIcon className="fill-current transition-colors ease-out duration-100" />
+      <TrashIcon className="h-5 w-auto fill-current text-red-500 transition-colors duration-150 ease-out" />
     </button>
   )
 }

--- a/packages/tinacms/src/toolkit/fields/plugins/group-list-field-plugin.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/group-list-field-plugin.tsx
@@ -268,7 +268,7 @@ export const ItemDeleteButton = ({ onClick, disabled = false }) => {
     <button
       type="button"
       className={`w-8 px-1 py-2.5 flex items-center justify-center text-gray-200 hover:opacity-100 opacity-30 hover:bg-gray-50 ${
-        disabled && 'cursor-not-allowed'
+        disabled && 'pointer-events-none opacity-30 cursor-not-allowed'
       }`}
       onClick={onClick}
     >


### PR DESCRIPTION
Fixes #5261

![2024-11-06 14 00 46](https://github.com/user-attachments/assets/bb405bb5-61ac-4c23-94bb-7b0b293edac4)
**Figure: Delete Icon correctly showing on Safari**