### PR TITLE
feat: more detailed error logging

### DIFF
--- a/.changeset/brave-apes-breathe.md
+++ b/.changeset/brave-apes-breathe.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Add detailed logging of version and indexing information on schema errors

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -597,10 +597,10 @@ export class BuildCommand extends BaseCommand {
         if (config?.branch) {
           errorMessage += `        Branch: ${config.branch}, Client ID: ${config.clientId}\n`
         }
-        errorMessage += `        Local graphql version: ${configManager.getTinaGraphQLVersion()} Remote graphql version: ${remoteVersion}\n`
-        errorMessage += `        Last index: ${new Date(
+        errorMessage += `        Local GraphQL version: ${configManager.getTinaGraphQLVersion()} / Remote GraphQL version: ${remoteVersion}\n`
+        errorMessage += `        Last indexed at: ${new Date(
           timestamp
-        ).toLocaleString()} / ${new Date(timestamp).toUTCString()}\n`
+        ).toUTCString()}\n`
         throw new Error(errorMessage)
       }
     } catch (e) {
@@ -687,9 +687,9 @@ export class BuildCommand extends BaseCommand {
       if (config?.branch) {
         errorMessage += `        Branch: ${config.branch}, Client ID: ${config.clientId}\n`
       }
-      errorMessage += `        Last index: ${new Date(
+      errorMessage += `        Last indexed at: ${new Date(
         timestamp
-      ).toLocaleString()} / ${new Date(timestamp).toUTCString()}\n`
+      ).toUTCString()}\n`
       throw new Error(errorMessage)
     }
   }

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -185,7 +185,7 @@ export class BuildCommand extends BaseCommand {
       this.skipCloudChecks || configManager.hasSelfHostedConfig()
 
     if (!skipCloudChecks) {
-      const { hasUpstream } = await this.checkClientInfo(
+      const { hasUpstream, timestamp } = await this.checkClientInfo(
         configManager,
         codegen.productionUrl,
         this.previewBaseBranch
@@ -213,14 +213,16 @@ export class BuildCommand extends BaseCommand {
       await this.checkGraphqlSchema(
         configManager,
         database,
-        codegen.productionUrl
+        codegen.productionUrl,
+        timestamp
       )
       await this.checkTinaSchema(
         configManager,
         database,
         codegen.productionUrl,
         this.previewName,
-        this.verbose
+        this.verbose,
+        timestamp
       )
     }
 
@@ -351,7 +353,7 @@ export class BuildCommand extends BaseCommand {
     configManager: ConfigManager,
     apiURL: string,
     previewBaseBranch?: string
-  ): Promise<{ hasUpstream: boolean }> {
+  ): Promise<{ hasUpstream: boolean; timestamp: number }> {
     const { config } = configManager
     const token = config.token
     const { clientId, branch, host } = parseURL(apiURL)
@@ -364,11 +366,13 @@ export class BuildCommand extends BaseCommand {
     // Check the client information
     let branchKnown = false
     let hasUpstream = false
+    let timestamp: number
     try {
       const res = await request({
         token,
         url,
       })
+      timestamp = res.timestamp || 0
       bar.tick({
         prog: '✅',
       })
@@ -414,6 +418,7 @@ export class BuildCommand extends BaseCommand {
       })
       return {
         hasUpstream,
+        timestamp,
       }
     }
 
@@ -544,7 +549,8 @@ export class BuildCommand extends BaseCommand {
   async checkGraphqlSchema(
     configManager: ConfigManager,
     database: Database,
-    apiURL: string
+    apiURL: string,
+    timestamp: number
   ) {
     const bar = new Progress(
       'Checking local GraphQL Schema matches server. :prog',
@@ -554,7 +560,7 @@ export class BuildCommand extends BaseCommand {
     const token = config.token
 
     // Get the remote schema from the graphql endpoint
-    const remoteSchema = await fetchRemoteGraphqlSchema({
+    const { remoteSchema, remoteVersion } = await fetchRemoteGraphqlSchema({
       url: apiURL,
       token,
     })
@@ -587,9 +593,14 @@ export class BuildCommand extends BaseCommand {
           prog: '❌',
         })
         let errorMessage = `The local GraphQL schema doesn't match the remote GraphQL schema. Please push up your changes to GitHub to update your remote GraphQL schema.`
+        errorMessage += `\n\nAdditional info:\n\n`
         if (config?.branch) {
-          errorMessage += `\n\nAdditional info: Branch: ${config.branch}, Client ID: ${config.clientId} `
+          errorMessage += `        Branch: ${config.branch}, Client ID: ${config.clientId}\n`
         }
+        errorMessage += `        Local graphql version: ${configManager.getTinaGraphQLVersion()} Remote graphql version: ${remoteVersion}\n`
+        errorMessage += `        Last index: ${new Date(
+          timestamp
+        ).toLocaleString()} / ${new Date(timestamp).toUTCString()}\n`
         throw new Error(errorMessage)
       }
     } catch (e) {
@@ -614,7 +625,8 @@ export class BuildCommand extends BaseCommand {
     database: Database,
     apiURL: string,
     previewName: string,
-    verbose: boolean
+    verbose: boolean,
+    timestamp: number
   ) {
     const bar = new Progress(
       'Checking local Tina Schema matches server. :prog',
@@ -671,9 +683,13 @@ export class BuildCommand extends BaseCommand {
         prog: '❌',
       })
       let errorMessage = `The local Tina schema doesn't match the remote Tina schema. Please push up your changes to GitHub to update your remote tina schema.`
+      errorMessage += `\n\nAdditional info:\n\n`
       if (config?.branch) {
-        errorMessage += `\n\nAdditional info: Branch: ${config.branch}, Client ID: ${config.clientId} `
+        errorMessage += `        Branch: ${config.branch}, Client ID: ${config.clientId}\n`
       }
+      errorMessage += `        Last index: ${new Date(
+        timestamp
+      ).toLocaleString()} / ${new Date(timestamp).toUTCString()}\n`
       throw new Error(errorMessage)
     }
   }
@@ -757,7 +773,10 @@ export const fetchRemoteGraphqlSchema = async ({
     body,
   })
   const data = await res.json()
-  return data?.data
+  return {
+    remoteSchema: data?.data,
+    remoteVersion: res.headers.get('tinacms-grapqhl-version'),
+  }
 }
 
 export const fetchSchemaSha = async ({


### PR DESCRIPTION
# Error logging improvements

- Output @tinacms/graphql local and remote graphql version 
- Output timestamp of last indexing event

Example output when graphql schema doesn't match:
```
Starting Tina build
Checking clientId and token. ✅
Checking branch is on Tina Cloud. ✅
Checking indexing process in Tina Cloud... ✅

Checking local GraphQL Schema matches server. ❌
Error: The local GraphQL schema doesn't match the remote GraphQL schema. Please push up your changes to GitHub to update your remote GraphQL schema.

Additional info:

        Branch: main, Client ID: 7700bd76-ee7b-4676-aab6-361dea3d30d4
        Local GraphQL version: 1.5 / Remote GraphQL version: 1.5
        Last index: Sat, 26 Oct 2024 01:15:39 GMT
```