### PR TITLE
fix: set null for empty values in NumberInput and DateField

### DIFF
--- a/.changeset/little-penguins-bow.md
+++ b/.changeset/little-penguins-bow.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Fixes an issue where setting empty values in `NumberInput` and `DateField` would throw errors. (https://github.com/tinacms/tinacms/issues/2445)

--- a/packages/tinacms/src/toolkit/fields/components/number-input.tsx
+++ b/packages/tinacms/src/toolkit/fields/components/number-input.tsx
@@ -20,7 +20,7 @@ export const NumberInput: React.FC<NumberProps> = ({
     value={value}
     onChange={(event) => {
       const inputValue = event.target.value
-      const newValue = inputValue === '' ? null : inputValue
+      const newValue = inputValue === '' ? undefined : inputValue
       if (onChange) {
         const syntheticEvent = {
           ...event,

--- a/packages/tinacms/src/toolkit/fields/components/number-input.tsx
+++ b/packages/tinacms/src/toolkit/fields/components/number-input.tsx
@@ -13,4 +13,24 @@ export const NumberInput: React.FC<NumberProps> = ({
   onChange,
   value,
   step,
-}) => <Input type="number" step={step} value={value} onChange={onChange} />
+}) => (
+  <Input
+    type="number"
+    step={step}
+    value={value}
+    onChange={(event) => {
+      const inputValue = event.target.value
+      const newValue = inputValue === '' ? null : inputValue
+      if (onChange) {
+        const syntheticEvent = {
+          ...event,
+          target: {
+            ...event.target,
+            value: newValue,
+          },
+        }
+        onChange(syntheticEvent as React.ChangeEvent<HTMLInputElement>)
+      }
+    }}
+  />
+)

--- a/packages/tinacms/src/toolkit/fields/plugins/date-field-plugin.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/date-field-plugin.tsx
@@ -16,7 +16,10 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
       <>
         <ReactDateTimeWithStyles
           value={input.value}
-          onChange={input.onChange}
+          onChange={(value) => {
+            const newValue = value === '' ? null : value
+            input.onChange(newValue)
+          }}
           dateFormat={dateFormat || DEFAULT_DATE_DISPLAY_FORMAT}
           timeFormat={timeFormat || false}
           inputProps={{ className: textFieldClasses }}

--- a/packages/tinacms/src/toolkit/fields/plugins/date-field-plugin.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/date-field-plugin.tsx
@@ -17,7 +17,7 @@ export const DateField = wrapFieldsWithMeta<InputProps, DatetimepickerProps>(
         <ReactDateTimeWithStyles
           value={input.value}
           onChange={(value) => {
-            const newValue = value === '' ? null : value
+            const newValue = value === '' ? undefined : value
             input.onChange(newValue)
           }}
           dateFormat={dateFormat || DEFAULT_DATE_DISPLAY_FORMAT}


### PR DESCRIPTION
Fix #2445
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->
