### PR TITLE
Log graphql patch versions on error

### DIFF
--- a/.changeset/friendly-pants-drop.md
+++ b/.changeset/friendly-pants-drop.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/cli": patch
+---
+
+Adds the patch version into the graphql errors when building a project.
+

--- a/.changeset/friendly-pants-drop.md
+++ b/.changeset/friendly-pants-drop.md
@@ -1,5 +1,5 @@
 ---
-"@tinacms/cli": patch
+"@tinacms/cli": minor
 ---
 
 Adds the patch version into the graphql errors when building a project.

--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -209,7 +209,8 @@ export class Codegen {
     const branch = this.configManager.config?.branch
     const clientId = this.configManager.config?.clientId
     const token = this.configManager.config?.token
-    const version = this.configManager.getTinaGraphQLVersion()
+    const fullVersion = this.configManager.getTinaGraphQLVersion()
+    const version = `${fullVersion.major}.${fullVersion.minor}`
     const baseUrl =
       this.configManager.config.tinaioConfig?.contentApiUrlOverride ||
       `https://${TINA_HOST}`

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -561,10 +561,11 @@ export class BuildCommand extends BaseCommand {
     const token = config.token
 
     // Get the remote schema from the graphql endpoint
-    const { remoteSchema, remoteAppVersion } = await fetchRemoteGraphqlSchema({
-      url: apiURL,
-      token,
-    })
+    const { remoteSchema, remoteProjectVersion } =
+      await fetchRemoteGraphqlSchema({
+        url: apiURL,
+        token,
+      })
 
     if (!remoteSchema) {
       bar.tick({
@@ -607,7 +608,7 @@ export class BuildCommand extends BaseCommand {
         if (config?.branch) {
           errorMessage += `\tBranch: ${config.branch}, Client ID: ${config.clientId}\n`
         }
-        errorMessage += `\tLocal GraphQL version: ${tinaGraphQLVersion.fullVersion} / Remote GraphQL version: ${remoteAppVersion}\n`
+        errorMessage += `\tLocal GraphQL version: ${tinaGraphQLVersion.fullVersion} / Remote GraphQL version: ${remoteProjectVersion}\n`
         errorMessage += `\tLast indexed at: ${new Date(
           timestamp
         ).toUTCString()}\n`
@@ -788,7 +789,7 @@ export const fetchRemoteGraphqlSchema = async ({
   return {
     remoteSchema: data?.data,
     remoteRuntimeVersion: res.headers.get('tinacms-grapqhl-runtime-version'),
-    remoteAppVersion: res.headers.get('tinacms-grapqhl-project-version'),
+    remoteProjectVersion: res.headers.get('tinacms-grapqhl-project-version'),
   }
 }
 

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -788,7 +788,7 @@ export const fetchRemoteGraphqlSchema = async ({
   return {
     remoteSchema: data?.data,
     remoteRuntimeVersion: res.headers.get('tinacms-grapqhl-runtime-version'),
-    remoteAppVersion: res.headers.get('tinacms-grapqhl-app-version'),
+    remoteAppVersion: res.headers.get('tinacms-grapqhl-project-version'),
   }
 }
 

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -788,7 +788,7 @@ export const fetchRemoteGraphqlSchema = async ({
   const data = await res.json()
   return {
     remoteSchema: data?.data,
-    remoteRuntimeVersion: res.headers.get('tinacms-graphql-runtime-version'),
+    remoteRuntimeVersion: res.headers.get('tinacms-grapqhl-version'),
     remoteProjectVersion: res.headers.get('tinacms-graphql-project-version'),
   }
 }

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -788,8 +788,8 @@ export const fetchRemoteGraphqlSchema = async ({
   const data = await res.json()
   return {
     remoteSchema: data?.data,
-    remoteRuntimeVersion: res.headers.get('tinacms-grapqhl-runtime-version'),
-    remoteProjectVersion: res.headers.get('tinacms-grapqhl-project-version'),
+    remoteRuntimeVersion: res.headers.get('tinacms-graphql-runtime-version'),
+    remoteProjectVersion: res.headers.get('tinacms-graphql-project-version'),
   }
 }
 

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -561,7 +561,7 @@ export class BuildCommand extends BaseCommand {
     const token = config.token
 
     // Get the remote schema from the graphql endpoint
-    const { remoteSchema, remoteVersion } = await fetchRemoteGraphqlSchema({
+    const { remoteSchema, remoteAppVersion } = await fetchRemoteGraphqlSchema({
       url: apiURL,
       token,
     })
@@ -607,7 +607,7 @@ export class BuildCommand extends BaseCommand {
         if (config?.branch) {
           errorMessage += `\tBranch: ${config.branch}, Client ID: ${config.clientId}\n`
         }
-        errorMessage += `\tLocal GraphQL version: ${tinaGraphQLVersion.fullVersion} / Remote GraphQL version: ${remoteVersion}\n`
+        errorMessage += `\tLocal GraphQL version: ${tinaGraphQLVersion.fullVersion} / Remote GraphQL version: ${remoteAppVersion}\n`
         errorMessage += `\tLast indexed at: ${new Date(
           timestamp
         ).toUTCString()}\n`
@@ -783,10 +783,12 @@ export const fetchRemoteGraphqlSchema = async ({
     headers,
     body,
   })
+
   const data = await res.json()
   return {
     remoteSchema: data?.data,
-    remoteVersion: res.headers.get('tinacms-grapqhl-version'),
+    remoteRuntimeVersion: res.headers.get('tinacms-grapqhl-runtime-version'),
+    remoteAppVersion: res.headers.get('tinacms-grapqhl-app-version'),
   }
 }
 

--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -598,6 +598,7 @@ export class BuildCommand extends BaseCommand {
         const reason = diffResult[0].message
         const errorLevel = diffResult[0].criticality.level
         const faqLink = getFaqLink(type)
+        const tinaGraphQLVersion = configManager.getTinaGraphQLVersion()
 
         let errorMessage = `The local GraphQL schema doesn't match the remote GraphQL schema. Please push up your changes to GitHub to update your remote GraphQL schema. ${
           faqLink && `\nCheck out '${faqLink}' for possible solutions.`
@@ -606,7 +607,7 @@ export class BuildCommand extends BaseCommand {
         if (config?.branch) {
           errorMessage += `\tBranch: ${config.branch}, Client ID: ${config.clientId}\n`
         }
-        errorMessage += `\tLocal GraphQL version: ${configManager.getTinaGraphQLVersion()} / Remote GraphQL version: ${remoteVersion}\n`
+        errorMessage += `\tLocal GraphQL version: ${tinaGraphQLVersion.fullVersion} / Remote GraphQL version: ${remoteVersion}\n`
         errorMessage += `\tLast indexed at: ${new Date(
           timestamp
         ).toUTCString()}\n`

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -290,22 +290,31 @@ export class ConfigManager {
     )
   }
 
-  getTinaGraphQLVersion() {
+  getTinaGraphQLVersion(): {
+    fullVersion: string
+    major: string
+    minor: string
+    patch: string
+  } {
     if (this.tinaGraphQLVersionFromCLI) {
-      return this.tinaGraphQLVersionFromCLI
+      const version = this.tinaGraphQLVersionFromCLI.split('.')
+      return {
+        fullVersion: this.tinaGraphQLVersionFromCLI,
+        major: version[0] || 'x',
+        minor: version[1] || 'x',
+        patch: version[2] || 'x',
+      }
     }
     const generatedSchema = fs.readJSONSync(this.generatedSchemaJSONPath)
     if (
       !generatedSchema ||
-      !(typeof generatedSchema?.version !== 'undefined') ||
-      !(typeof generatedSchema?.version?.major === 'string') ||
-      !(typeof generatedSchema?.version?.minor === 'string')
+      !(typeof generatedSchema?.version !== 'undefined')
     ) {
       throw new Error(
         `Can not find Tina GraphQL version in ${this.generatedSchemaJSONPath}`
       )
     }
-    return `${generatedSchema.version.major}.${generatedSchema.version.minor}`
+    return generatedSchema.version
   }
 
   printGeneratedClientFilePath() {

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -182,6 +182,8 @@ export const createConfig = async ({
     basePath = configManager.config.build.basePath
   }
 
+  const fullVersion = configManager.getTinaGraphQLVersion()
+  const version = `${fullVersion.major}.${fullVersion.minor}`
   const config: InlineConfig = {
     root: configManager.spaRootPath,
     base: `/${basePath ? `${normalizePath(basePath)}/` : ''}${normalizePath(
@@ -212,7 +214,7 @@ export const createConfig = async ({
       'process.platform': `"${process.platform}"`,
       __API_URL__: `"${apiURL}"`,
       __BASE_PATH__: `"${configManager.config?.build?.basePath || ''}"`,
-      __TINA_GRAPHQL_VERSION__: `"${configManager.getTinaGraphQLVersion()}"`,
+      __TINA_GRAPHQL_VERSION__: version,
     },
     logLevel: 'error', // Vite import warnings are noisy
     optimizeDeps: {


### PR DESCRIPTION
This PR adds the patch version into the graphql errors when building a project.

This PR relies on the changes made in https://github.com/tinacms/tinacloud/pull/2459