### PR TITLE
♻️ Remove `latest` - set to specific version

### DIFF
--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          hugo-version: 0.139.4
         if: ${{ matrix.template == 'tina-hugo-starter' }}
 
       - name: Setup build tokens


### PR DESCRIPTION
- Fixes https://github.com/tinacms/tinacms/issues/5376 (Hugo Failing Build) 
- Related Issue: https://github.com/peaceiris/actions-hugo/issues/652


Changes the **hugo-version**: from `latest` to `0.139.4`

✅ Tested and is working again ([See the Action](https://github.com/tinacms/tinacms/actions/runs/12363482399/job/34504881805))