### PR TITLE
Stop mdx tests from hanging

### DIFF
--- a/packages/@tinacms/mdx/package.json
+++ b/packages/@tinacms/mdx/package.json
@@ -31,9 +31,9 @@
 		"build": "tinacms-scripts build",
 		"docs": "typedoc --plugin typedoc-plugin-markdown src/parse/plate.ts --theme markdown && concat-md --decrease-title-levels --dir-name-as-title docs > spec.md",
 		"serve": "nodemon dist/server.js",
-		"test": "vitest",
+		"test": "vitest run",
 		"coverage": "vitest run --coverage",
-		"test-watch": "jest --watch"
+		"test-watch": "vitest"
 	},
 	"dependencies": {
 		"@tinacms/schema-tools": "workspace:*",


### PR DESCRIPTION
This PR fixes an issue where the mdx tests would hang after completion due to `vitest` by default watching.