### PR TITLE
fix import for react-use

### DIFF
--- a/.changeset/stupid-radios-jump.md
+++ b/.changeset/stupid-radios-jump.md
@@ -1,0 +1,8 @@
+---
+'@tinacms/starter': patch
+'@tinacms/graphql': patch
+'next-2024': patch
+'tinacms': patch
+---
+
+fix import react-use to default import

--- a/.changeset/stupid-radios-jump.md
+++ b/.changeset/stupid-radios-jump.md
@@ -7,3 +7,4 @@
 
 Fixes for React 19 support
  - change react-use import statements to default import method
+ - Fixed deprecated API from headless UI in the experimental example

--- a/.changeset/stupid-radios-jump.md
+++ b/.changeset/stupid-radios-jump.md
@@ -5,4 +5,4 @@
 'tinacms': patch
 ---
 
-fix import react-use to default import
+Fixes for React 19 support - fix import react-use using default import method

--- a/.changeset/stupid-radios-jump.md
+++ b/.changeset/stupid-radios-jump.md
@@ -6,5 +6,5 @@
 ---
 
 Fixes for React 19 support
- - change react-use import statements to default import method
+ - Change react-use import statements to default import method
  - Fixed deprecated API from headless UI in the experimental example

--- a/.changeset/stupid-radios-jump.md
+++ b/.changeset/stupid-radios-jump.md
@@ -5,4 +5,5 @@
 'tinacms': patch
 ---
 
-Fixes for React 19 support - fix import react-use using default import method
+Fixes for React 19 support
+ - change react-use import statements to default import method

--- a/experimental-examples/tina-cloud-starter/components/layout/footer/rawRenderer.tsx
+++ b/experimental-examples/tina-cloud-starter/components/layout/footer/rawRenderer.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { Fragment, useState } from 'react'
-import { Dialog, Transition } from '@headlessui/react'
+import {
+  Dialog,
+  DialogPanel,
+  Transition,
+  TransitionChild,
+} from '@headlessui/react'
 import { useTheme } from '..'
 
 export const RawRenderer = ({ rawData, parentColor }) => {
@@ -50,7 +55,7 @@ export const RawRenderer = ({ rawData, parentColor }) => {
           onClose={closeModal}
         >
           <div className="min-h-screen max-h-screen px-4 py-12 text-center flex flex-col items-center justify-center">
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               enterFrom="opacity-0"
@@ -60,11 +65,11 @@ export const RawRenderer = ({ rawData, parentColor }) => {
               leaveTo="opacity-0"
             >
               <div className="">
-                <Dialog.Overlay className="fixed inset-0 bg-gradient-to-br from-gray-800 to-gray-1000 opacity-80" />
+                <DialogPanel className="fixed inset-0 bg-gradient-to-br from-gray-800 to-gray-1000 opacity-80" />
               </div>
-            </Transition.Child>
+            </TransitionChild>
 
-            <Transition.Child
+            <TransitionChild
               as={Fragment}
               enter="ease-out duration-300"
               enterFrom="opacity-0 scale-95"
@@ -85,7 +90,7 @@ export const RawRenderer = ({ rawData, parentColor }) => {
                   Great, thanks!
                 </button>
               </div>
-            </Transition.Child>
+            </TransitionChild>
           </div>
         </Dialog>
       </Transition>

--- a/packages/tinacms/src/toolkit/react-datetime/DateTime.jsx
+++ b/packages/tinacms/src/toolkit/react-datetime/DateTime.jsx
@@ -5,7 +5,7 @@ import MonthsView from './views/MonthsView'
 import YearsView from './views/YearsView'
 import TimeView from './views/TimeView'
 import React, { useRef } from 'react'
-import { useClickAway } from 'react-use'
+import useClickAway from 'react-use/lib/useClickAway'
 
 const viewModes = {
   YEARS: 'years',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,7 +78,7 @@ importers:
                 version: 3.7.7
             next:
                 specifier: ^14.2.18
-                version: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -112,7 +112,7 @@ importers:
                 version: link:../../packages/@tinacms/cli
             next:
                 specifier: ^14.2.18
-                version: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -161,7 +161,7 @@ importers:
                 version: 0.0.4(mongodb@4.17.2(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0)))
             next:
                 specifier: ^14.2.18
-                version: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -231,7 +231,7 @@ importers:
                 version: 10.9.3
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             next-themes:
                 specifier: ^0.3.0
                 version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -295,13 +295,13 @@ importers:
                 version: 2.30.0
             mongodb-level:
                 specifier: ^0.0.3
-                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.692.0))
+                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0))
             next:
                 specifier: ^14.2.18
                 version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             next-auth:
                 specifier: ^4.24.10
-                version: 4.24.10(next@14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 4.24.10(next@14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -365,7 +365,7 @@ importers:
         dependencies:
             next:
                 specifier: ^14.2.18
-                version: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -414,10 +414,10 @@ importers:
                 version: 15.8.0
             mongodb-level:
                 specifier: ^0.0.3
-                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0))
+                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.692.0))
             next:
                 specifier: ^14.2.18
-                version: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -428,8 +428,8 @@ importers:
                 specifier: ^4.12.0
                 version: 4.12.0(react@18.3.1)
             tinacms:
-                specifier: workspace:*
-                version: link:../../packages/tinacms
+                specifier: '*'
+                version: 0.0.0-d7c745e-20250102002342(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3)
             typescript:
                 specifier: ^5.6.3
                 version: 5.6.3
@@ -542,7 +542,7 @@ importers:
                 version: 29.7.0(@types/node@22.9.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.9.0)(typescript@5.6.3))
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: 18.3.1
                 version: 18.3.1
@@ -1341,7 +1341,7 @@ importers:
                 version: 22.9.0
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -1378,7 +1378,7 @@ importers:
                 version: 22.9.0
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -1418,7 +1418,7 @@ importers:
                 version: 18.3.12
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -1716,7 +1716,7 @@ importers:
                 version: 0.7.0
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -1756,7 +1756,7 @@ importers:
                 version: link:../@tinacms/scripts
             next:
                 specifier: 14.2.10
-                version: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             next-auth:
                 specifier: 4.24.7
                 version: 4.24.7(next@14.2.10(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1823,7 +1823,7 @@ importers:
                 version: 1.7.5
             next:
                 specifier: ^14.2.18
-                version: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -7019,6 +7019,33 @@ packages:
         resolution:
             {
                 integrity: sha512-T0HO+VrU9VbLRiEx/kH4+gwGMHNMIGkp0Pok+p0I33saOOLyhfGvwOKQgvt2qkxzQEV2L5MtGB8EnW4r5d3CqQ==,
+            }
+
+    '@tinacms/graphql@0.0.0-d7c745e-20250102002342':
+        resolution:
+            {
+                integrity: sha512-QiFcP6BDD2GSeEBH1q8RIK/OMLjyMK7PN++b9PS59c0drjTUM0YrohCbQ46KL3BNoISmqm6BZ3QSqHFCZfK9wA==,
+            }
+
+    '@tinacms/mdx@0.0.0-d7c745e-20250102002342':
+        resolution:
+            {
+                integrity: sha512-/HKi2mhsYXDYElhWJvmop0Ne3wwBQwX9DYcUWmtnYJiCRekiimEeF87KE84Eeb8ahJ5VUz+1Mhw6gH5tx6O04Q==,
+            }
+
+    '@tinacms/schema-tools@1.6.9':
+        resolution:
+            {
+                integrity: sha512-NrbXN3Z8g1+O5Llmtd59Ovz+U7YiiTuXF67gzQ6zx3MXASZHeENXTuxMhjJ0lL9fa81uZEBtiNudYA//vIQp2A==,
+            }
+        peerDependencies:
+            react: '>=16.14.0'
+            yup: ^0.32.0
+
+    '@tinacms/search@0.0.0-d7c745e-20250102002342':
+        resolution:
+            {
+                integrity: sha512-MjxLBV7IgVxLmVMLWCdkrVSZxI9uj/Z1whj107+M0Z4ZYGbOefwPuGsEj84ppV9fezDZMQExz7e+z6xgXfXhng==,
             }
 
     '@tootallnate/quickjs-emscripten@0.23.0':
@@ -17820,6 +17847,15 @@ packages:
                 integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==,
             }
 
+    tinacms@0.0.0-d7c745e-20250102002342:
+        resolution:
+            {
+                integrity: sha512-57YLypqznYcjoO3i0KYGFq3hNc1rdebUIhSa1ggTz1c20SJhEjdfsIlwaS+jx96E/Zk1ee/PEWgkFhaIUdXA5g==,
+            }
+        peerDependencies:
+            react: '>=16.14.0'
+            react-dom: '>=16.14.0'
+
     tiny-case@1.0.3:
         resolution:
             {
@@ -24142,6 +24178,144 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
+    '@tinacms/graphql@0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)':
+        dependencies:
+            '@iarna/toml': 2.2.5
+            '@tinacms/mdx': 0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@0.32.11)
+            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@0.32.11)
+            abstract-level: 1.0.4
+            date-fns: 2.30.0
+            fast-glob: 3.3.2
+            fs-extra: 11.2.0
+            glob-parent: 6.0.2
+            graphql: 15.8.0
+            gray-matter: 4.0.3
+            isomorphic-git: 1.27.1
+            js-sha1: 0.6.0
+            js-yaml: 3.14.1
+            jsonpath-plus: 10.1.0
+            lodash.clonedeep: 4.5.0
+            lodash.set: 4.3.2
+            lodash.uniqby: 4.7.0
+            many-level: 2.0.0
+            micromatch: 4.0.8
+            normalize-path: 3.0.0
+            readable-stream: 4.5.2
+            scmp: 2.1.0
+            yup: 0.32.11
+        transitivePeerDependencies:
+            - react
+            - supports-color
+            - typescript
+
+    '@tinacms/mdx@0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@0.32.11)':
+        dependencies:
+            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@0.32.11)
+            acorn: 8.8.2
+            ccount: 2.0.1
+            estree-util-is-identifier-name: 2.1.0
+            lodash.flatten: 4.4.0
+            mdast-util-compact: 4.1.1
+            mdast-util-directive: 2.2.4
+            mdast-util-from-markdown: 1.3.0
+            mdast-util-gfm: 2.0.2
+            mdast-util-mdx-jsx: 2.1.2
+            mdast-util-to-markdown: 1.5.0
+            micromark-extension-gfm: 2.0.3
+            micromark-factory-mdx-expression: 1.0.7
+            micromark-factory-space: 1.0.0
+            micromark-factory-whitespace: 1.0.0
+            micromark-util-character: 1.1.0
+            micromark-util-symbol: 1.0.1
+            micromark-util-types: 1.0.2
+            parse-entities: 4.0.1
+            prettier: 2.8.8
+            remark: 14.0.2
+            remark-gfm: 2.0.0
+            remark-mdx: 2.3.0
+            stringify-entities: 4.0.3
+            typedoc: 0.26.11(typescript@5.6.3)
+            unist-util-source: 4.0.2
+            unist-util-stringify-position: 3.0.3
+            unist-util-visit: 4.1.2
+            uvu: 0.5.6
+            vfile-message: 3.1.4
+        transitivePeerDependencies:
+            - react
+            - supports-color
+            - typescript
+            - yup
+
+    '@tinacms/mdx@0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@1.4.0)':
+        dependencies:
+            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@1.4.0)
+            acorn: 8.8.2
+            ccount: 2.0.1
+            estree-util-is-identifier-name: 2.1.0
+            lodash.flatten: 4.4.0
+            mdast-util-compact: 4.1.1
+            mdast-util-directive: 2.2.4
+            mdast-util-from-markdown: 1.3.0
+            mdast-util-gfm: 2.0.2
+            mdast-util-mdx-jsx: 2.1.2
+            mdast-util-to-markdown: 1.5.0
+            micromark-extension-gfm: 2.0.3
+            micromark-factory-mdx-expression: 1.0.7
+            micromark-factory-space: 1.0.0
+            micromark-factory-whitespace: 1.0.0
+            micromark-util-character: 1.1.0
+            micromark-util-symbol: 1.0.1
+            micromark-util-types: 1.0.2
+            parse-entities: 4.0.1
+            prettier: 2.8.8
+            remark: 14.0.2
+            remark-gfm: 2.0.0
+            remark-mdx: 2.3.0
+            stringify-entities: 4.0.3
+            typedoc: 0.26.11(typescript@5.6.3)
+            unist-util-source: 4.0.2
+            unist-util-stringify-position: 3.0.3
+            unist-util-visit: 4.1.2
+            uvu: 0.5.6
+            vfile-message: 3.1.4
+        transitivePeerDependencies:
+            - react
+            - supports-color
+            - typescript
+            - yup
+
+    '@tinacms/schema-tools@1.6.9(react@18.3.1)(yup@0.32.11)':
+        dependencies:
+            picomatch-browser: 2.2.6
+            react: 18.3.1
+            url-pattern: 1.0.3
+            yup: 0.32.11
+            zod: 3.23.8
+
+    '@tinacms/schema-tools@1.6.9(react@18.3.1)(yup@1.4.0)':
+        dependencies:
+            picomatch-browser: 2.2.6
+            react: 18.3.1
+            url-pattern: 1.0.3
+            yup: 1.4.0
+            zod: 3.23.8
+
+    '@tinacms/search@0.0.0-d7c745e-20250102002342(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3)(yup@1.4.0)':
+        dependencies:
+            '@tinacms/graphql': 0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)
+            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@1.4.0)
+            memory-level: 1.0.0
+            search-index: 4.0.0(abstract-level@1.0.4)
+            sqlite-level: 1.2.0(sucrase@3.35.0)
+            stopword: 3.1.1
+        transitivePeerDependencies:
+            - abstract-level
+            - react
+            - sucrase
+            - supports-color
+            - typescript
+            - yup
+
     '@tootallnate/quickjs-emscripten@0.23.0': {}
 
     '@trysound/sax@0.2.0': {}
@@ -27195,7 +27369,7 @@ snapshots:
             eslint-plugin-jsx-a11y: 6.10.2(eslint@7.32.0)
             eslint-plugin-react: 7.37.2(eslint@7.32.0)
             eslint-plugin-react-hooks: 4.6.2(eslint@7.32.0)
-            next: 14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            next: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
         optionalDependencies:
             typescript: 5.6.3
         transitivePeerDependencies:
@@ -27229,7 +27403,7 @@ snapshots:
             '@typescript-eslint/parser': 5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3)
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
-            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-jsx-a11y: 6.10.2(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-react: 7.37.2(eslint@9.14.0(jiti@1.21.6))
@@ -27271,7 +27445,7 @@ snapshots:
             debug: 4.3.7(supports-color@5.5.0)
             enhanced-resolve: 5.17.1
             eslint: 8.24.0
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
             fast-glob: 3.3.2
             get-tsconfig: 4.8.1
             is-bun-module: 1.2.1
@@ -27284,13 +27458,13 @@ snapshots:
             - eslint-import-resolver-webpack
             - supports-color
 
-    eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
+    eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)):
         dependencies:
             '@nolyfill/is-core-module': 1.0.39
             debug: 4.3.7(supports-color@5.5.0)
             enhanced-resolve: 5.17.1
             eslint: 9.14.0(jiti@1.21.6)
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
             fast-glob: 3.3.2
             get-tsconfig: 4.8.1
             is-bun-module: 1.2.1
@@ -27314,7 +27488,7 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0):
+    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0):
         dependencies:
             debug: 3.2.7
         optionalDependencies:
@@ -27325,14 +27499,14 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
+    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
         dependencies:
             debug: 3.2.7
         optionalDependencies:
             '@typescript-eslint/parser': 5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3)
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
-            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6))
         transitivePeerDependencies:
             - supports-color
 
@@ -27376,7 +27550,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 8.24.0
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
             hasown: 2.0.2
             is-core-module: 2.15.1
             is-glob: 4.0.3
@@ -27405,7 +27579,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
             hasown: 2.0.2
             is-core-module: 2.15.1
             is-glob: 4.0.3
@@ -30358,7 +30532,7 @@ snapshots:
 
     netmask@2.0.2: {}
 
-    next-auth@4.24.10(next@14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    next-auth@4.24.10(next@14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
         dependencies:
             '@babel/runtime': 7.26.0
             '@panva/hkdf': 1.2.1
@@ -30379,7 +30553,7 @@ snapshots:
             '@panva/hkdf': 1.2.1
             cookie: 0.5.0
             jose: 4.15.9
-            next: 14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            next: 14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             oauth: 0.9.15
             openid-client: 5.7.0
             preact: 10.24.3
@@ -30393,7 +30567,7 @@ snapshots:
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
 
-    next@14.2.10(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    next@14.2.10(@babel/core@7.26.0)(@playwright/test@1.48.2)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
         dependencies:
             '@next/env': 14.2.10
             '@swc/helpers': 0.5.5
@@ -30403,7 +30577,7 @@ snapshots:
             postcss: 8.4.31
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
-            styled-jsx: 5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1)
+            styled-jsx: 5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1)
         optionalDependencies:
             '@next/swc-darwin-arm64': 14.2.10
             '@next/swc-darwin-x64': 14.2.10
@@ -30429,33 +30603,7 @@ snapshots:
             postcss: 8.4.31
             react: 18.3.1
             react-dom: 18.3.1(react@18.3.1)
-            styled-jsx: 5.1.1(@babel/core@7.26.0)(react@18.3.1)
-        optionalDependencies:
-            '@next/swc-darwin-arm64': 14.2.18
-            '@next/swc-darwin-x64': 14.2.18
-            '@next/swc-linux-arm64-gnu': 14.2.18
-            '@next/swc-linux-arm64-musl': 14.2.18
-            '@next/swc-linux-x64-gnu': 14.2.18
-            '@next/swc-linux-x64-musl': 14.2.18
-            '@next/swc-win32-arm64-msvc': 14.2.18
-            '@next/swc-win32-ia32-msvc': 14.2.18
-            '@next/swc-win32-x64-msvc': 14.2.18
-            '@playwright/test': 1.48.2
-        transitivePeerDependencies:
-            - '@babel/core'
-            - babel-plugin-macros
-
-    next@14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-        dependencies:
-            '@next/env': 14.2.18
-            '@swc/helpers': 0.5.5
-            busboy: 1.6.0
-            caniuse-lite: 1.0.30001680
-            graceful-fs: 4.2.11
-            postcss: 8.4.31
-            react: 18.3.1
-            react-dom: 18.3.1(react@18.3.1)
-            styled-jsx: 5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1)
+            styled-jsx: 5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1)
         optionalDependencies:
             '@next/swc-darwin-arm64': 14.2.18
             '@next/swc-darwin-x64': 14.2.18
@@ -32045,18 +32193,12 @@ snapshots:
             hey-listen: 1.0.8
             tslib: 2.8.1
 
-    styled-jsx@5.1.1(@babel/core@7.26.0)(react@18.3.1):
+    styled-jsx@5.1.1(@babel/core@7.26.0)(babel-plugin-macros@3.1.0)(react@18.3.1):
         dependencies:
             client-only: 0.0.1
             react: 18.3.1
         optionalDependencies:
             '@babel/core': 7.26.0
-
-    styled-jsx@5.1.1(babel-plugin-macros@3.1.0)(react@18.3.1):
-        dependencies:
-            client-only: 0.0.1
-            react: 18.3.1
-        optionalDependencies:
             babel-plugin-macros: 3.1.0
 
     stylis@4.1.3: {}
@@ -32218,6 +32360,92 @@ snapshots:
     throttle-debounce@3.0.1: {}
 
     through@2.3.8: {}
+
+    tinacms@0.0.0-d7c745e-20250102002342(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3):
+        dependencies:
+            '@ariakit/react': 0.4.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@floating-ui/dom': 1.6.12
+            '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@graphql-inspector/core': 6.2.0(graphql@15.8.0)
+            '@headlessui/react': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@heroicons/react': 1.0.6(react@18.3.1)
+            '@monaco-editor/react': 4.4.5(monaco-editor@0.31.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-checkbox': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-dialog': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-dropdown-menu': 2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-popover': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-separator': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-slot': 1.1.0(@types/react@18.3.12)(react@18.3.1)
+            '@radix-ui/react-toolbar': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@radix-ui/react-tooltip': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            '@react-hook/window-size': 3.1.1(react@18.3.1)
+            '@tinacms/mdx': 0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@1.4.0)
+            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@1.4.0)
+            '@tinacms/search': 0.0.0-d7c745e-20250102002342(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3)(yup@1.4.0)
+            '@udecode/cn': 33.0.0(@types/react@18.3.12)(class-variance-authority@0.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)
+            '@udecode/plate': 36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-autoformat': 36.5.6(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-block-quote': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-code-block': 36.5.6(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-combobox': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-common': 36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-floating': 36.3.8(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-heading': 36.0.12(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-indent-list': 36.5.2(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-link': 36.5.9(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-list': 36.5.2(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-paragraph': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-resizable': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-slash-command': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            '@udecode/plate-table': 36.5.8(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
+            class-variance-authority: 0.7.0
+            clsx: 2.1.1
+            cmdk: 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            color-string: 1.9.1
+            crypto-js: 4.2.0
+            date-fns: 2.30.0
+            final-form: 4.20.10
+            final-form-arrays: 3.1.0(final-form@4.20.10)
+            final-form-set-field-data: 1.0.2(final-form@4.20.10)
+            graphql: 15.8.0
+            graphql-tag: 2.12.6(graphql@15.8.0)
+            is-hotkey: 0.2.0
+            lodash.get: 4.4.2
+            lodash.set: 4.3.2
+            lucide-react: 0.424.0(react@18.3.1)
+            mermaid: 9.3.0
+            moment: 2.29.4
+            monaco-editor: 0.31.0
+            prism-react-renderer: 2.4.0(react@18.3.1)
+            prop-types: 15.7.2
+            react: 18.3.1
+            react-beautiful-dnd: 13.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            react-color: 2.19.3(react@18.3.1)
+            react-datetime: 3.2.0(moment@2.29.4)(react@18.3.1)
+            react-dom: 18.3.1(react@18.3.1)
+            react-dropzone: 14.2.3(react@18.3.1)
+            react-final-form: 6.5.9(final-form@4.20.10)(react@18.3.1)
+            react-icons: 5.3.0(react@18.3.1)
+            react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+            slate: 0.103.0
+            slate-history: 0.100.0(slate@0.103.0)
+            slate-hyperscript: 0.100.0(slate@0.103.0)
+            slate-react: 0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0)
+            tailwind-merge: 2.5.4
+            webfontloader: 1.6.28
+            yup: 1.4.0
+            zod: 3.23.8
+        transitivePeerDependencies:
+            - '@types/react'
+            - '@types/react-dom'
+            - abstract-level
+            - immer
+            - react-native
+            - scheduler
+            - sucrase
+            - supports-color
+            - typescript
 
     tiny-case@1.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -295,13 +295,13 @@ importers:
                 version: 2.30.0
             mongodb-level:
                 specifier: ^0.0.3
-                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0))
+                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.692.0))
             next:
                 specifier: ^14.2.18
                 version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             next-auth:
                 specifier: ^4.24.10
-                version: 4.24.10(next@14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+                version: 4.24.10(next@14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
             react:
                 specifier: ^18.3.1
                 version: 18.3.1
@@ -414,7 +414,7 @@ importers:
                 version: 15.8.0
             mongodb-level:
                 specifier: ^0.0.3
-                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.692.0))
+                version: 0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.693.0))
             next:
                 specifier: ^14.2.18
                 version: 14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -428,8 +428,8 @@ importers:
                 specifier: ^4.12.0
                 version: 4.12.0(react@18.3.1)
             tinacms:
-                specifier: '*'
-                version: 0.0.0-d7c745e-20250102002342(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3)
+                specifier: workspace:*
+                version: link:../../packages/tinacms
             typescript:
                 specifier: ^5.6.3
                 version: 5.6.3
@@ -7019,33 +7019,6 @@ packages:
         resolution:
             {
                 integrity: sha512-T0HO+VrU9VbLRiEx/kH4+gwGMHNMIGkp0Pok+p0I33saOOLyhfGvwOKQgvt2qkxzQEV2L5MtGB8EnW4r5d3CqQ==,
-            }
-
-    '@tinacms/graphql@0.0.0-d7c745e-20250102002342':
-        resolution:
-            {
-                integrity: sha512-QiFcP6BDD2GSeEBH1q8RIK/OMLjyMK7PN++b9PS59c0drjTUM0YrohCbQ46KL3BNoISmqm6BZ3QSqHFCZfK9wA==,
-            }
-
-    '@tinacms/mdx@0.0.0-d7c745e-20250102002342':
-        resolution:
-            {
-                integrity: sha512-/HKi2mhsYXDYElhWJvmop0Ne3wwBQwX9DYcUWmtnYJiCRekiimEeF87KE84Eeb8ahJ5VUz+1Mhw6gH5tx6O04Q==,
-            }
-
-    '@tinacms/schema-tools@1.6.9':
-        resolution:
-            {
-                integrity: sha512-NrbXN3Z8g1+O5Llmtd59Ovz+U7YiiTuXF67gzQ6zx3MXASZHeENXTuxMhjJ0lL9fa81uZEBtiNudYA//vIQp2A==,
-            }
-        peerDependencies:
-            react: '>=16.14.0'
-            yup: ^0.32.0
-
-    '@tinacms/search@0.0.0-d7c745e-20250102002342':
-        resolution:
-            {
-                integrity: sha512-MjxLBV7IgVxLmVMLWCdkrVSZxI9uj/Z1whj107+M0Z4ZYGbOefwPuGsEj84ppV9fezDZMQExz7e+z6xgXfXhng==,
             }
 
     '@tootallnate/quickjs-emscripten@0.23.0':
@@ -17847,15 +17820,6 @@ packages:
                 integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==,
             }
 
-    tinacms@0.0.0-d7c745e-20250102002342:
-        resolution:
-            {
-                integrity: sha512-57YLypqznYcjoO3i0KYGFq3hNc1rdebUIhSa1ggTz1c20SJhEjdfsIlwaS+jx96E/Zk1ee/PEWgkFhaIUdXA5g==,
-            }
-        peerDependencies:
-            react: '>=16.14.0'
-            react-dom: '>=16.14.0'
-
     tiny-case@1.0.3:
         resolution:
             {
@@ -24178,144 +24142,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    '@tinacms/graphql@0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)':
-        dependencies:
-            '@iarna/toml': 2.2.5
-            '@tinacms/mdx': 0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@0.32.11)
-            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@0.32.11)
-            abstract-level: 1.0.4
-            date-fns: 2.30.0
-            fast-glob: 3.3.2
-            fs-extra: 11.2.0
-            glob-parent: 6.0.2
-            graphql: 15.8.0
-            gray-matter: 4.0.3
-            isomorphic-git: 1.27.1
-            js-sha1: 0.6.0
-            js-yaml: 3.14.1
-            jsonpath-plus: 10.1.0
-            lodash.clonedeep: 4.5.0
-            lodash.set: 4.3.2
-            lodash.uniqby: 4.7.0
-            many-level: 2.0.0
-            micromatch: 4.0.8
-            normalize-path: 3.0.0
-            readable-stream: 4.5.2
-            scmp: 2.1.0
-            yup: 0.32.11
-        transitivePeerDependencies:
-            - react
-            - supports-color
-            - typescript
-
-    '@tinacms/mdx@0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@0.32.11)':
-        dependencies:
-            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@0.32.11)
-            acorn: 8.8.2
-            ccount: 2.0.1
-            estree-util-is-identifier-name: 2.1.0
-            lodash.flatten: 4.4.0
-            mdast-util-compact: 4.1.1
-            mdast-util-directive: 2.2.4
-            mdast-util-from-markdown: 1.3.0
-            mdast-util-gfm: 2.0.2
-            mdast-util-mdx-jsx: 2.1.2
-            mdast-util-to-markdown: 1.5.0
-            micromark-extension-gfm: 2.0.3
-            micromark-factory-mdx-expression: 1.0.7
-            micromark-factory-space: 1.0.0
-            micromark-factory-whitespace: 1.0.0
-            micromark-util-character: 1.1.0
-            micromark-util-symbol: 1.0.1
-            micromark-util-types: 1.0.2
-            parse-entities: 4.0.1
-            prettier: 2.8.8
-            remark: 14.0.2
-            remark-gfm: 2.0.0
-            remark-mdx: 2.3.0
-            stringify-entities: 4.0.3
-            typedoc: 0.26.11(typescript@5.6.3)
-            unist-util-source: 4.0.2
-            unist-util-stringify-position: 3.0.3
-            unist-util-visit: 4.1.2
-            uvu: 0.5.6
-            vfile-message: 3.1.4
-        transitivePeerDependencies:
-            - react
-            - supports-color
-            - typescript
-            - yup
-
-    '@tinacms/mdx@0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@1.4.0)':
-        dependencies:
-            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@1.4.0)
-            acorn: 8.8.2
-            ccount: 2.0.1
-            estree-util-is-identifier-name: 2.1.0
-            lodash.flatten: 4.4.0
-            mdast-util-compact: 4.1.1
-            mdast-util-directive: 2.2.4
-            mdast-util-from-markdown: 1.3.0
-            mdast-util-gfm: 2.0.2
-            mdast-util-mdx-jsx: 2.1.2
-            mdast-util-to-markdown: 1.5.0
-            micromark-extension-gfm: 2.0.3
-            micromark-factory-mdx-expression: 1.0.7
-            micromark-factory-space: 1.0.0
-            micromark-factory-whitespace: 1.0.0
-            micromark-util-character: 1.1.0
-            micromark-util-symbol: 1.0.1
-            micromark-util-types: 1.0.2
-            parse-entities: 4.0.1
-            prettier: 2.8.8
-            remark: 14.0.2
-            remark-gfm: 2.0.0
-            remark-mdx: 2.3.0
-            stringify-entities: 4.0.3
-            typedoc: 0.26.11(typescript@5.6.3)
-            unist-util-source: 4.0.2
-            unist-util-stringify-position: 3.0.3
-            unist-util-visit: 4.1.2
-            uvu: 0.5.6
-            vfile-message: 3.1.4
-        transitivePeerDependencies:
-            - react
-            - supports-color
-            - typescript
-            - yup
-
-    '@tinacms/schema-tools@1.6.9(react@18.3.1)(yup@0.32.11)':
-        dependencies:
-            picomatch-browser: 2.2.6
-            react: 18.3.1
-            url-pattern: 1.0.3
-            yup: 0.32.11
-            zod: 3.23.8
-
-    '@tinacms/schema-tools@1.6.9(react@18.3.1)(yup@1.4.0)':
-        dependencies:
-            picomatch-browser: 2.2.6
-            react: 18.3.1
-            url-pattern: 1.0.3
-            yup: 1.4.0
-            zod: 3.23.8
-
-    '@tinacms/search@0.0.0-d7c745e-20250102002342(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3)(yup@1.4.0)':
-        dependencies:
-            '@tinacms/graphql': 0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)
-            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@1.4.0)
-            memory-level: 1.0.0
-            search-index: 4.0.0(abstract-level@1.0.4)
-            sqlite-level: 1.2.0(sucrase@3.35.0)
-            stopword: 3.1.1
-        transitivePeerDependencies:
-            - abstract-level
-            - react
-            - sucrase
-            - supports-color
-            - typescript
-            - yup
-
     '@tootallnate/quickjs-emscripten@0.23.0': {}
 
     '@trysound/sax@0.2.0': {}
@@ -27384,7 +27210,7 @@ snapshots:
             eslint: 8.24.0
             eslint-import-resolver-node: 0.3.9
             eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0)
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
             eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
             eslint-plugin-react: 7.37.2(eslint@8.24.0)
             eslint-plugin-react-hooks: 4.6.2(eslint@8.24.0)
@@ -27403,8 +27229,8 @@ snapshots:
             '@typescript-eslint/parser': 5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3)
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
-            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6))
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-jsx-a11y: 6.10.2(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-react: 7.37.2(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-react-hooks: 4.6.2(eslint@9.14.0(jiti@1.21.6))
@@ -27445,32 +27271,32 @@ snapshots:
             debug: 4.3.7(supports-color@5.5.0)
             enhanced-resolve: 5.17.1
             eslint: 8.24.0
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
             fast-glob: 3.3.2
             get-tsconfig: 4.8.1
             is-bun-module: 1.2.1
             is-glob: 4.0.3
         optionalDependencies:
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
         transitivePeerDependencies:
             - '@typescript-eslint/parser'
             - eslint-import-resolver-node
             - eslint-import-resolver-webpack
             - supports-color
 
-    eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6)):
+    eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
         dependencies:
             '@nolyfill/is-core-module': 1.0.39
             debug: 4.3.7(supports-color@5.5.0)
             enhanced-resolve: 5.17.1
             eslint: 9.14.0(jiti@1.21.6)
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
             fast-glob: 3.3.2
             get-tsconfig: 4.8.1
             is-bun-module: 1.2.1
             is-glob: 4.0.3
         optionalDependencies:
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
         transitivePeerDependencies:
             - '@typescript-eslint/parser'
             - eslint-import-resolver-node
@@ -27488,7 +27314,7 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0):
+    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0):
         dependencies:
             debug: 3.2.7
         optionalDependencies:
@@ -27499,14 +27325,14 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
+    eslint-module-utils@2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
         dependencies:
             debug: 3.2.7
         optionalDependencies:
             '@typescript-eslint/parser': 5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3)
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
-            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0)(eslint@9.14.0(jiti@1.21.6))
+            eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
         transitivePeerDependencies:
             - supports-color
 
@@ -27539,7 +27365,7 @@ snapshots:
             - eslint-import-resolver-webpack
             - supports-color
 
-    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0):
+    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0):
         dependencies:
             '@rtsao/scc': 1.1.0
             array-includes: 3.1.8
@@ -27550,7 +27376,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 8.24.0
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
             hasown: 2.0.2
             is-core-module: 2.15.1
             is-glob: 4.0.3
@@ -27568,7 +27394,7 @@ snapshots:
             - eslint-import-resolver-webpack
             - supports-color
 
-    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
+    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
         dependencies:
             '@rtsao/scc': 1.1.0
             array-includes: 3.1.8
@@ -27579,7 +27405,7 @@ snapshots:
             doctrine: 2.1.0
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
-            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
+            eslint-module-utils: 2.12.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
             hasown: 2.0.2
             is-core-module: 2.15.1
             is-glob: 4.0.3
@@ -30532,7 +30358,7 @@ snapshots:
 
     netmask@2.0.2: {}
 
-    next-auth@4.24.10(next@14.2.18(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    next-auth@4.24.10(next@14.2.18(@babel/core@7.26.0)(@playwright/test@1.48.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
         dependencies:
             '@babel/runtime': 7.26.0
             '@panva/hkdf': 1.2.1
@@ -32360,92 +32186,6 @@ snapshots:
     throttle-debounce@3.0.1: {}
 
     through@2.3.8: {}
-
-    tinacms@0.0.0-d7c745e-20250102002342(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3):
-        dependencies:
-            '@ariakit/react': 0.4.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@floating-ui/dom': 1.6.12
-            '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@graphql-inspector/core': 6.2.0(graphql@15.8.0)
-            '@headlessui/react': 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@heroicons/react': 1.0.6(react@18.3.1)
-            '@monaco-editor/react': 4.4.5(monaco-editor@0.31.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-checkbox': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-dialog': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-dropdown-menu': 2.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-popover': 1.1.2(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-separator': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-slot': 1.1.0(@types/react@18.3.12)(react@18.3.1)
-            '@radix-ui/react-toolbar': 1.1.0(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@radix-ui/react-tooltip': 1.1.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            '@react-hook/window-size': 3.1.1(react@18.3.1)
-            '@tinacms/mdx': 0.0.0-d7c745e-20250102002342(react@18.3.1)(typescript@5.6.3)(yup@1.4.0)
-            '@tinacms/schema-tools': 1.6.9(react@18.3.1)(yup@1.4.0)
-            '@tinacms/search': 0.0.0-d7c745e-20250102002342(react@18.3.1)(sucrase@3.35.0)(typescript@5.6.3)(yup@1.4.0)
-            '@udecode/cn': 33.0.0(@types/react@18.3.12)(class-variance-authority@0.7.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwind-merge@2.5.4)
-            '@udecode/plate': 36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-autoformat': 36.5.6(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-block-quote': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-code-block': 36.5.6(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-combobox': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-common': 36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-floating': 36.3.8(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-heading': 36.0.12(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-indent-list': 36.5.2(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-link': 36.5.9(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-list': 36.5.2(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-paragraph': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-resizable': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-slash-command': 36.0.0(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            '@udecode/plate-table': 36.5.8(@udecode/plate-common@36.5.9(@types/react@18.3.12)(immer@10.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.25.0)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate-history@0.100.0(slate@0.103.0))(slate-hyperscript@0.100.0(slate@0.103.0))(slate-react@0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0))(slate@0.103.0)
-            class-variance-authority: 0.7.0
-            clsx: 2.1.1
-            cmdk: 1.0.4(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            color-string: 1.9.1
-            crypto-js: 4.2.0
-            date-fns: 2.30.0
-            final-form: 4.20.10
-            final-form-arrays: 3.1.0(final-form@4.20.10)
-            final-form-set-field-data: 1.0.2(final-form@4.20.10)
-            graphql: 15.8.0
-            graphql-tag: 2.12.6(graphql@15.8.0)
-            is-hotkey: 0.2.0
-            lodash.get: 4.4.2
-            lodash.set: 4.3.2
-            lucide-react: 0.424.0(react@18.3.1)
-            mermaid: 9.3.0
-            moment: 2.29.4
-            monaco-editor: 0.31.0
-            prism-react-renderer: 2.4.0(react@18.3.1)
-            prop-types: 15.7.2
-            react: 18.3.1
-            react-beautiful-dnd: 13.1.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            react-color: 2.19.3(react@18.3.1)
-            react-datetime: 3.2.0(moment@2.29.4)(react@18.3.1)
-            react-dom: 18.3.1(react@18.3.1)
-            react-dropzone: 14.2.3(react@18.3.1)
-            react-final-form: 6.5.9(final-form@4.20.10)(react@18.3.1)
-            react-icons: 5.3.0(react@18.3.1)
-            react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            react-use: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-            slate: 0.103.0
-            slate-history: 0.100.0(slate@0.103.0)
-            slate-hyperscript: 0.100.0(slate@0.103.0)
-            slate-react: 0.107.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(slate@0.103.0)
-            tailwind-merge: 2.5.4
-            webfontloader: 1.6.28
-            yup: 1.4.0
-            zod: 3.23.8
-        transitivePeerDependencies:
-            - '@types/react'
-            - '@types/react-dom'
-            - abstract-level
-            - immer
-            - react-native
-            - scheduler
-            - sucrase
-            - supports-color
-            - typescript
 
     tiny-case@1.0.3: {}
 


### PR DESCRIPTION
- fix import "react-use" from name import to default import, as per https://stackoverflow.com/questions/78361013/getting-this-error-syntaxerror-named-export-useclickaway-not-found-in-nextj
- fix deprecated API in example project
