### PR TITLE
feat: allow bare hash string to be inserted as url

### DIFF
--- a/.changeset/curvy-planes-invite.md
+++ b/.changeset/curvy-planes-invite.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Allow bare hash strings to be inserted as urls

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/transforms/is-url.test.ts
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/transforms/is-url.test.ts
@@ -1,0 +1,53 @@
+import { isUrl } from './is-url'
+
+describe('isUrl', () => {
+  test('validates full URLs with protocol', () => {
+    expect(isUrl('http://example.com')).toBe(true)
+    expect(isUrl('https://example.com')).toBe(true)
+    expect(isUrl('ftp://example.com')).toBe(true)
+  })
+
+  test('validates localhost URLs', () => {
+    expect(isUrl('http://localhost')).toBe(true)
+    expect(isUrl('http://localhost:3000')).toBe(true)
+  })
+
+  test('validates non-localhost domain URLs', () => {
+    expect(isUrl('http://example.com')).toBe(true)
+    expect(isUrl('https://example.co.uk')).toBe(true)
+  })
+
+  test('validates email links', () => {
+    expect(isUrl('mailto:someone@example.com')).toBe(true)
+    expect(isUrl('mailto:someone@example.com?subject=Hello')).toBe(true)
+  })
+
+  test('validates local URLs', () => {
+    expect(isUrl('/path/to/resource')).toBe(true)
+    expect(isUrl('/another/path')).toBe(true)
+  })
+
+  test('invalidates non-URLs and malformed URLs', () => {
+    expect(isUrl('not a url')).toBe(false)
+    expect(isUrl('http://')).toBe(false)
+    expect(isUrl('ftp://')).toBe(false)
+    expect(isUrl('http://.com')).toBe(false)
+  })
+
+  test('handles non-string inputs gracefully', () => {
+    expect(isUrl(123)).toBe(false)
+    expect(isUrl(null)).toBe(false)
+    expect(isUrl(undefined)).toBe(false)
+    expect(isUrl({})).toBe(false)
+  })
+
+  test('invalidates URLs without protocol if not a local URL', () => {
+    expect(isUrl('example.com')).toBe(false)
+    expect(isUrl('www.example.com')).toBe(false)
+  })
+
+  test('validates bare hash links', () => {
+    expect(isUrl('#foo')).toBe(true)
+    expect(isUrl('#section1')).toBe(true)
+  })
+})

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/transforms/is-url.test.ts
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/transforms/is-url.test.ts
@@ -12,11 +12,6 @@ describe('isUrl', () => {
     expect(isUrl('http://localhost:3000')).toBe(true)
   })
 
-  test('validates non-localhost domain URLs', () => {
-    expect(isUrl('http://example.com')).toBe(true)
-    expect(isUrl('https://example.co.uk')).toBe(true)
-  })
-
   test('validates email links', () => {
     expect(isUrl('mailto:someone@example.com')).toBe(true)
     expect(isUrl('mailto:someone@example.com?subject=Hello')).toBe(true)

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/transforms/is-url.ts
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/transforms/is-url.ts
@@ -15,6 +15,11 @@ export const isUrl = (string: any) => {
     return false
   }
 
+  // Check if the string is a bare hash link
+  if (string.startsWith('#')) {
+    return true
+  }
+
   const generalMatch = string.match(protocolAndDomainRE)
   const emailLinkMatch = string.match(emailLintRE)
   const localUrlMatch = string.match(localUrlRE) // Check for local URL match


### PR DESCRIPTION
# Problem

jadenadams124124 on discord reports that a bare hash like `#foobar` can not be inserted as a link for links to anchor tags in the same document

# Solution

Add support for inserting bare hash
