### PR TITLE
refactor: support a range of node versions instead of specific versions.

### DIFF
--- a/.changeset/green-trees-join.md
+++ b/.changeset/green-trees-join.md
@@ -1,0 +1,5 @@
+---
+"create-tina-app": patch
+---
+
+refactor: support a range of node versions instead of specific versions.

--- a/packages/create-tina-app/src/util/preRunChecks.ts
+++ b/packages/create-tina-app/src/util/preRunChecks.ts
@@ -1,19 +1,23 @@
 import { log } from './logger'
 
-export const SUPPORTED_NODE_VERSIONS = ['18', '20', '22']
+const SUPPORTED_NODE_VERSION_BOUNDS = { oldest: 18, latest: 22 }
+const SUPPORTED_NODE_VERSION_RANGE: number[] = [
+  ...Array(SUPPORTED_NODE_VERSION_BOUNDS.latest).keys(),
+].map((i) => i + SUPPORTED_NODE_VERSION_BOUNDS.oldest)
+const isSupported = SUPPORTED_NODE_VERSION_RANGE.some((version) =>
+  process.version.startsWith(`v${version}`)
+)
 
 export function preRunChecks() {
   checkSupportedNodeVersion()
 }
 
 function checkSupportedNodeVersion() {
-  if (
-    !SUPPORTED_NODE_VERSIONS.some((version) =>
-      process.version.startsWith(`v${version}`)
-    )
-  ) {
+  if (!isSupported) {
     log.warn(
-      `Version ${process.version} of Node.js is not supported in create-tina-app, please update to the latest LTS version. See https://nodejs.org/en/download/ for more details.`
+      `Node ${process.version} is not supported by create-tina-app. ` +
+        `Please update to be within v${SUPPORTED_NODE_VERSION_BOUNDS.oldest}-v${SUPPORTED_NODE_VERSION_BOUNDS.latest}. ` +
+        `See https://nodejs.org/en/download/ for more details.`
     )
   }
 }


### PR DESCRIPTION
as per my conversation with @JackDevAU, we will only display a message if you're outside of the supported versions as opposed to specific versions.

relates to https://github.com/tinacms/tinacloud/issues/2422