### PR TITLE
🐛 Bug - Reordered indexing to be before watching

### DIFF
--- a/.changeset/famous-planes-yell.md
+++ b/.changeset/famous-planes-yell.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": patch
+---
+
+🐛 Bug - Prevents lookup file disappearing during initial indexing

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -123,10 +123,6 @@ export class DevCommand extends BaseCommand {
           }
         }
 
-        if (!this.noWatch) {
-          this.watchQueries(configManager, async () => await codegen.execute())
-        }
-
         await this.indexContentWithSpinner({
           database,
           graphQLSchema,
@@ -136,6 +132,11 @@ export class DevCommand extends BaseCommand {
         if (!firstTime) {
           logger.error('Re-index complete')
         }
+
+        if (!this.noWatch) {
+          this.watchQueries(configManager, async () => await codegen.execute())
+        }
+
         return { apiURL, database, graphQLSchema, tinaSchema }
       } catch (e) {
         logger.error(`\n\n${dangerText(e.message)}\n`)


### PR DESCRIPTION
The change is intended to prevent builds from failing due to the initial indexing process failing to read a complete lookup file.

It does this by ensuring that the watch process is started *after* the initial indexing process has completed. This prevents:

- A changed file (e.g. frags.gql and queries.gql)...
- Triggering a re-creation of the lookup file...
- While the indexing process is running...
- When it may read an incomplete lookup file and fail.
