### PR TITLE
fix: #5395 call setOpen instead of window.close

### DIFF
--- a/.changeset/ten-frogs-wait.md
+++ b/.changeset/ten-frogs-wait.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix issue where browser was being closed when adding an embed in the rich text editor

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/templates-toolbar-button.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/templates-toolbar-button.tsx
@@ -62,7 +62,7 @@ const EmbedButton: React.FC<EmbedButtonProps> = ({ editor, templates }) => {
             key={template.name}
             onMouseDown={(e) => {
               e.preventDefault()
-              close()
+              setOpen(false)
               insertMDX(editor, template)
             }}
             className={''}


### PR DESCRIPTION
As reported in #5395 when adding an embed in the rich text editor, the browser window sometimes closes. Instead of calling `[window.]close()`, we should be calling `setOpen(false)`