### PR TITLE
fix: encode media urls to prevent invalid characters from breaking links

### DIFF
--- a/.changeset/witty-buses-film.md
+++ b/.changeset/witty-buses-film.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Encode urls in media manager to prevent unsafe characters from breaking images

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -1,6 +1,14 @@
 import { EventBus } from './event'
 import { DummyMediaStore } from './media-store.default'
 
+const encodeUrlIfNeeded = (url: string) => {
+  if (url) {
+    return url.split('/').map(encodeURIComponent).join('/')
+  } else {
+    return url
+  }
+}
+
 /**
  * Represents an individual file in the MediaStore
  */
@@ -199,6 +207,16 @@ export class MediaManager implements MediaStore {
     try {
       this.events.dispatch({ type: 'media:list:start', ...options })
       const media = await this.store.list(options)
+      media.items = media.items.map((item) => {
+        if (item.type === 'dir') {
+          return item
+        }
+        return {
+          ...item,
+          src: encodeUrlIfNeeded(item.src),
+        }
+      })
+
       this.events.dispatch({ type: 'media:list:success', ...options, media })
       return media
     } catch (error) {

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -3,7 +3,18 @@ import { DummyMediaStore } from './media-store.default'
 
 const encodeUrlIfNeeded = (url: string) => {
   if (url) {
-    return url.split('/').map(encodeURIComponent).join('/')
+    try {
+      const parsed = new URL(url)
+      parsed.pathname = parsed.pathname
+        .split('/')
+        .filter((part) => part !== '')
+        .map(encodeURIComponent)
+        .join('/')
+      return parsed.toString()
+    } catch (e) {
+      console.error('Failed to parse URL:', e)
+      return url
+    }
   } else {
     return url
   }
@@ -210,6 +221,11 @@ export class MediaManager implements MediaStore {
       media.items = media.items.map((item) => {
         if (item.type === 'dir') {
           return item
+        }
+        if (item.thumbnails) {
+          for (const [size, src] of Object.entries(item.thumbnails)) {
+            item.thumbnails[size] = encodeUrlIfNeeded(src)
+          }
         }
         return {
           ...item,


### PR DESCRIPTION
Update MediaManager to encode image paths in the list() function to prevent broken links.

Fixes #5449 