### PR TITLE
fix: handle stringify markdown ast with soft breaks in a paragraph

### DIFF
--- a/packages/@tinacms/mdx/src/stringify/index.test.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import type * as Md from 'mdast'
+import { toTinaMarkdown } from './index'
+import { RichTextField } from '@tinacms/schema-tools'
+
+describe('stringify', () => {
+  describe('toTinaMarkdown', () => {
+    it('should stringify with soft break and trailing empty string', () => {
+      const value = {
+        type: 'root',
+        children: [
+          {
+            type: 'paragraph',
+            children: [
+              { type: 'text', value: 'para1' },
+              { type: 'break' },
+              { type: 'text', value: '' },
+            ],
+          },
+        ],
+      }
+
+      const markdown = toTinaMarkdown(value as Md.Root, {} as RichTextField)
+
+      expect(markdown).toMatchInlineSnapshot(`
+        "para1
+        "
+      `)
+    })
+  })
+})

--- a/packages/@tinacms/mdx/src/stringify/index.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.ts
@@ -133,6 +133,8 @@ export const toTinaMarkdown = (tree: Md.Root, field: RichTextType) => {
     }
     return text(node, parent, context, safeOptions)
   }
+  handlers['break'] = () => '\n'
+
   return toMarkdown(tree, {
     extensions: [
       directiveToMarkdown(patterns),


### PR DESCRIPTION
# what

stringify of markdown ast improperly handles `break` (`soft-break`) nodes causing spurious `\` characters
