### PR TITLE
Remove the console.log for failing to encode a url

### DIFF
--- a/.changeset/spicy-queens-flow.md
+++ b/.changeset/spicy-queens-flow.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Remove the console.log for failing to encode a url

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -12,7 +12,6 @@ const encodeUrlIfNeeded = (url: string) => {
         .join('/')
       return parsed.toString()
     } catch (e) {
-      console.error('Failed to parse URL:', e)
       return url
     }
   } else {


### PR DESCRIPTION
Remove the console.error that occurs after not parsing a url. 

![image](https://github.com/user-attachments/assets/d7330f98-6188-4c15-9981-118274a01c3f)
**Figure: Console error in browser**