### PR TITLE
🚧 WIP - ⚡ Reliability - Introduce concurrent connection limit

### DIFF
--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -102,6 +102,7 @@
 		"@udecode/plate-slash-command": "^36.0.0",
 		"@udecode/plate-table": "36.5.8",
 		"async-lock": "^1.4.1",
+		"async-sema": "^3.1.1",
 		"class-variance-authority": "^0.7.0",
 		"clsx": "^2.1.1",
 		"cmdk": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1579,6 +1579,9 @@ importers:
             async-lock:
                 specifier: ^1.4.1
                 version: 1.4.1
+            async-sema:
+                specifier: ^3.1.1
+                version: 3.1.1
             class-variance-authority:
                 specifier: ^0.7.0
                 version: 0.7.0
@@ -9346,6 +9349,12 @@ packages:
         resolution:
             {
                 integrity: sha512-Az2ZTpuytrtqENulXwO3GGv1Bztugx6TT37NIo7imr/Qo0gsYiGtSdBa2B6fsXhTpVZDNfu1Qn3pk531e3q+nQ==,
+            }
+
+    async-sema@3.1.1:
+        resolution:
+            {
+                integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==,
             }
 
     async@3.2.6:
@@ -26186,6 +26195,8 @@ snapshots:
     astral-regex@2.0.0: {}
 
     async-lock@1.4.1: {}
+
+    async-sema@3.1.1: {}
 
     async@3.2.6: {}
 


### PR DESCRIPTION
This change introduces a concurrent connection limit to reduce the chance of the client being unnecessarily throttled. This should improve the reliability of a typical developer's experience.

As semaphores are required for concurrency control, this change will add the [async-sema](https://www.npmjs.com/package/async-sema) library to the dependencies.