### PR TITLE
fix: ensure existing indexes for doc are removed before reindexing

### DIFF
--- a/.changeset/four-seals-develop.md
+++ b/.changeset/four-seals-develop.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix indexContentByPaths to delete existing indexes if they exist


### PR DESCRIPTION
Fixes: https://github.com/tinacms/tinacloud/issues/2603

Fix issue where existing indexes are not removed prior to reindexing via the `indexContentByPaths` database method