### PR TITLE
ℹ️ CLI Prompts – Superficial CLI updates email task

### DIFF
--- a/.changeset/metal-meals-fail.md
+++ b/.changeset/metal-meals-fail.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': minor
+---
+
+Updated the CLI initialisation routine text as per feedback, to improve clarity.

--- a/.changeset/metal-meals-fail.md
+++ b/.changeset/metal-meals-fail.md
@@ -1,5 +1,5 @@
 ---
-'@tinacms/cli': minor
+'@tinacms/cli': patch
 ---
 
 Updated the CLI initialisation routine text as per feedback, to improve clarity.

--- a/packages/@tinacms/cli/src/next/commands/baseCommands.ts
+++ b/packages/@tinacms/cli/src/next/commands/baseCommands.ts
@@ -58,7 +58,9 @@ export abstract class BaseCommand extends Command {
     let subProc: ChildProcess | undefined
     if (this.subCommand) {
       subProc = await startSubprocess2({ command: this.subCommand })
-      logger.info(`Starting subprocess: ${chalk.cyan(this.subCommand)}`)
+      logger.info(
+        `Running web application with command: ${chalk.cyan(this.subCommand)}`
+      )
     }
     function exitHandler(options, exitCode) {
       if (subProc) {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -57,7 +57,7 @@ export class DevCommand extends BaseCommand {
       rootPath: this.rootPath,
       legacyNoSDK: this.noSDK,
     })
-    logger.info('Starting Tina Dev Server')
+    logger.info('🦙 TinaCMS Dev Server is initializing...')
     this.logDeprecationWarnings()
 
     // Initialize the host TCP server
@@ -211,7 +211,7 @@ export class DevCommand extends BaseCommand {
         configManager.config.search && searchIndexer
       )
       chokidar.watch(configManager.watchList).on('change', async () => {
-        logger.info(`Tina config change detected, rebuilding`)
+        logger.info(`TinaCMS config change detected, rebuilding...`)
         await setup({ firstTime: false })
         // The setup process results in an update to the prebuild file
         // But Vite doesn't reload when it's changed for some reason
@@ -232,7 +232,7 @@ export class DevCommand extends BaseCommand {
     const summaryItems = [
       {
         emoji: '🦙',
-        heading: 'Tina Config',
+        heading: 'TinaCMS URLs',
         subItems: [
           {
             key: 'CMS',
@@ -269,7 +269,7 @@ export class DevCommand extends BaseCommand {
     }
 
     summary({
-      heading: 'Tina Dev Server is running...',
+      heading: '✅ 🦙 TinaCMS Dev Server is active:',
       items: [
         ...summaryItems,
         // {


### PR DESCRIPTION
I have an email: Solliance: Installing TinaCMS - 🌸 improving the command prompt #2

Adam had some comments about the CLI updates:

```
Hey Isaac 👋 
 
See while Paul was installing TinaCMS, when he looked at his Command Prompt - he thought he was blocked when he was not. In the history you will see Paul said:
   >got these warnings attached in pic below.
   >Paul

I think it should make it clearer what the next step is. These changes should help.

1. Arrow #1 - Change from
     Starting Tina Dev Server
    To
     TinaCMS 🦙 Dev Server is initialing...

2. Arrow #2 - Change from
     Tina Dev Server is running...
     To
      TinaCMS 🦙 Dev Server is starting:

3. Arrow #3 - Change from
     Starting subprocess:
   To
     ✅ TinaCMS 🦙 is up and running...

4. Do you think the green tick is enough? (I think so)
     Or do we need more of what to do next? 
       Eg.  "✅ Successful. Now go to your browser and type xxx"
```

Took some liberties, to keep each process step correct. But hopefully it's not a but clearer.

Replaced...

        Starting Tina Dev Server
    To
        🦙 TinaCMS Dev Server is initializing...

...

         Tina Dev Server is running...
     To
         ✅ 🦙 TinaCMS Dev Server is active:

...

         Starting subprocess:
     To
         Running web application with command: