### PR TITLE
📦 Package Management – Punycode Warnings

### DIFF
--- a/.changeset/silly-wasps-return.md
+++ b/.changeset/silly-wasps-return.md
@@ -1,0 +1,5 @@
+---
+'tinacms': minor
+---
+
+Punycode errors have been circumvented by overriding the underlying dependencies used by eslint

--- a/package.json
+++ b/package.json
@@ -48,5 +48,11 @@
 		"typescript": "^5.6.3",
 		"vite": "^4.5.5"
 	},
+    "pnpm": {
+		"overrides": {
+			"ajv": "^8.17.1",
+            "whatwg-url": "^14.0.0"
+		}
+	},
 	"packageManager": "pnpm@9.13.2"
 }

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
 	},
     "pnpm": {
 		"overrides": {
-			"ajv": "^8.17.1",
             "whatwg-url": "^14.0.0"
 		}
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,10 @@ settings:
     autoInstallPeers: true
     excludeLinksFromLockfile: false
 
+overrides:
+    ajv: ^8.17.1
+    whatwg-url: ^14.0.0
+
 importers:
     .:
         devDependencies:
@@ -9069,12 +9073,6 @@ packages:
             }
         engines: { node: '>= 14' }
 
-    ajv@6.12.6:
-        resolution:
-            {
-                integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
-            }
-
     ajv@8.17.1:
         resolution:
             {
@@ -13948,12 +13946,6 @@ packages:
                 integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
             }
 
-    json-schema-traverse@0.4.1:
-        resolution:
-            {
-                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
-            }
-
     json-schema-traverse@1.0.0:
         resolution:
             {
@@ -14243,12 +14235,6 @@ packages:
         resolution:
             {
                 integrity: sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==,
-            }
-
-    lodash.sortby@4.7.0:
-        resolution:
-            {
-                integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==,
             }
 
     lodash.startcase@4.4.0:
@@ -18255,24 +18241,12 @@ packages:
             }
         hasBin: true
 
-    tr46@0.0.3:
+    tr46@5.0.0:
         resolution:
             {
-                integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==,
+                integrity: sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==,
             }
-
-    tr46@1.0.1:
-        resolution:
-            {
-                integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==,
-            }
-
-    tr46@3.0.0:
-        resolution:
-            {
-                integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==,
-            }
-        engines: { node: '>=12' }
+        engines: { node: '>=18' }
 
     transform-markdown-links@2.1.0:
         resolution:
@@ -18953,12 +18927,6 @@ packages:
                 integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==,
             }
 
-    uri-js@4.4.1:
-        resolution:
-            {
-                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
-            }
-
     url-pattern@1.0.3:
         resolution:
             {
@@ -19359,18 +19327,6 @@ packages:
                 integrity: sha512-Egb0oFEga6f+nSgasH3E0M405Pzn6y3/9tOVanv/DLfa1YBIgcv90L18YyWnvXkRbIM17v5Kv6IT2N6g1x5tvQ==,
             }
 
-    webidl-conversions@3.0.1:
-        resolution:
-            {
-                integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==,
-            }
-
-    webidl-conversions@4.0.2:
-        resolution:
-            {
-                integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==,
-            }
-
     webidl-conversions@7.0.0:
         resolution:
             {
@@ -19391,24 +19347,12 @@ packages:
             }
         engines: { node: '>=12' }
 
-    whatwg-url@11.0.0:
+    whatwg-url@14.1.1:
         resolution:
             {
-                integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==,
+                integrity: sha512-mDGf9diDad/giZ/Sm9Xi2YcyzaFpbdLpJPr+E9fSkyQ7KpQD4SdFcugkRQYzhmfI4KeV4Qpnn2sKPdo+kmsgRQ==,
             }
-        engines: { node: '>=12' }
-
-    whatwg-url@5.0.0:
-        resolution:
-            {
-                integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==,
-            }
-
-    whatwg-url@7.1.0:
-        resolution:
-            {
-                integrity: sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg==,
-            }
+        engines: { node: '>=18' }
 
     which-boxed-primitive@1.0.2:
         resolution:
@@ -22527,7 +22471,7 @@ snapshots:
 
     '@eslint/eslintrc@0.4.3':
         dependencies:
-            ajv: 6.12.6
+            ajv: 8.17.1
             debug: 4.3.7(supports-color@5.5.0)
             espree: 7.3.1
             globals: 13.24.0
@@ -22541,7 +22485,7 @@ snapshots:
 
     '@eslint/eslintrc@1.4.1':
         dependencies:
-            ajv: 6.12.6
+            ajv: 8.17.1
             debug: 4.3.7(supports-color@5.5.0)
             espree: 9.6.1
             globals: 13.24.0
@@ -22555,7 +22499,7 @@ snapshots:
 
     '@eslint/eslintrc@2.1.4':
         dependencies:
-            ajv: 6.12.6
+            ajv: 8.17.1
             debug: 4.3.7(supports-color@5.5.0)
             espree: 9.6.1
             globals: 13.24.0
@@ -22569,7 +22513,7 @@ snapshots:
 
     '@eslint/eslintrc@3.1.0':
         dependencies:
-            ajv: 6.12.6
+            ajv: 8.17.1
             debug: 4.3.7(supports-color@5.5.0)
             espree: 10.3.0
             globals: 14.0.0
@@ -26016,13 +25960,6 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
-    ajv@6.12.6:
-        dependencies:
-            fast-deep-equal: 3.1.3
-            fast-json-stable-stringify: 2.1.0
-            json-schema-traverse: 0.4.1
-            uri-js: 4.4.1
-
     ajv@8.17.1:
         dependencies:
             fast-deep-equal: 3.1.3
@@ -28090,7 +28027,7 @@ snapshots:
             '@babel/code-frame': 7.12.11
             '@eslint/eslintrc': 0.4.3
             '@humanwhocodes/config-array': 0.5.0
-            ajv: 6.12.6
+            ajv: 8.17.1
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -28136,7 +28073,7 @@ snapshots:
             '@humanwhocodes/config-array': 0.10.7
             '@humanwhocodes/gitignore-to-minimatch': 1.0.2
             '@humanwhocodes/module-importer': 1.0.1
-            ajv: 6.12.6
+            ajv: 8.17.1
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -28184,7 +28121,7 @@ snapshots:
             '@humanwhocodes/module-importer': 1.0.1
             '@nodelib/fs.walk': 1.2.8
             '@ungap/structured-clone': 1.2.0
-            ajv: 6.12.6
+            ajv: 8.17.1
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -28231,7 +28168,7 @@ snapshots:
             '@humanwhocodes/retry': 0.4.1
             '@types/estree': 1.0.6
             '@types/json-schema': 7.0.15
-            ajv: 6.12.6
+            ajv: 8.17.1
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -29708,8 +29645,6 @@ snapshots:
 
     json-parse-even-better-errors@2.3.1: {}
 
-    json-schema-traverse@0.4.1: {}
-
     json-schema-traverse@1.0.0: {}
 
     json-stable-stringify-without-jsonify@1.0.1: {}
@@ -29840,8 +29775,6 @@ snapshots:
     lodash.merge@4.6.2: {}
 
     lodash.set@4.3.2: {}
-
-    lodash.sortby@4.7.0: {}
 
     lodash.startcase@4.4.0: {}
 
@@ -30724,7 +30657,7 @@ snapshots:
     mongodb-connection-string-url@2.6.0:
         dependencies:
             '@types/whatwg-url': 8.2.2
-            whatwg-url: 11.0.0
+            whatwg-url: 14.1.1
 
     mongodb-level@0.0.3(@aws-sdk/client-sso-oidc@3.693.0(@aws-sdk/client-sts@3.692.0)):
         dependencies:
@@ -30929,7 +30862,7 @@ snapshots:
 
     node-fetch@2.7.0:
         dependencies:
-            whatwg-url: 5.0.0
+            whatwg-url: 14.1.1
 
     node-int64@0.4.0: {}
 
@@ -32306,7 +32239,7 @@ snapshots:
 
     source-map@0.8.0-beta.0:
         dependencies:
-            whatwg-url: 7.1.0
+            whatwg-url: 14.1.1
 
     space-separated-tokens@2.0.2: {}
 
@@ -32733,13 +32666,7 @@ snapshots:
 
     touch@3.1.1: {}
 
-    tr46@0.0.3: {}
-
-    tr46@1.0.1:
-        dependencies:
-            punycode: 2.3.1
-
-    tr46@3.0.0:
+    tr46@5.0.0:
         dependencies:
             punycode: 2.3.1
 
@@ -33149,10 +33076,6 @@ snapshots:
         dependencies:
             tslib: 2.8.1
 
-    uri-js@4.4.1:
-        dependencies:
-            punycode: 2.3.1
-
     url-pattern@1.0.3: {}
 
     urlpattern-polyfill@10.0.0: {}
@@ -33425,31 +33348,16 @@ snapshots:
 
     webfontloader@1.6.28: {}
 
-    webidl-conversions@3.0.1: {}
-
-    webidl-conversions@4.0.2: {}
-
     webidl-conversions@7.0.0: {}
 
     whatwg-fetch@3.6.20: {}
 
     whatwg-mimetype@3.0.0: {}
 
-    whatwg-url@11.0.0:
+    whatwg-url@14.1.1:
         dependencies:
-            tr46: 3.0.0
+            tr46: 5.0.0
             webidl-conversions: 7.0.0
-
-    whatwg-url@5.0.0:
-        dependencies:
-            tr46: 0.0.3
-            webidl-conversions: 3.0.1
-
-    whatwg-url@7.1.0:
-        dependencies:
-            lodash.sortby: 4.7.0
-            tr46: 1.0.1
-            webidl-conversions: 4.0.2
 
     which-boxed-primitive@1.0.2:
         dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ settings:
     excludeLinksFromLockfile: false
 
 overrides:
-    ajv: ^8.17.1
     whatwg-url: ^14.0.0
 
 importers:
@@ -9073,6 +9072,12 @@ packages:
             }
         engines: { node: '>= 14' }
 
+    ajv@6.12.6:
+        resolution:
+            {
+                integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+            }
+
     ajv@8.17.1:
         resolution:
             {
@@ -13944,6 +13949,12 @@ packages:
         resolution:
             {
                 integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+            }
+
+    json-schema-traverse@0.4.1:
+        resolution:
+            {
+                integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
             }
 
     json-schema-traverse@1.0.0:
@@ -18927,6 +18938,12 @@ packages:
                 integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==,
             }
 
+    uri-js@4.4.1:
+        resolution:
+            {
+                integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+            }
+
     url-pattern@1.0.3:
         resolution:
             {
@@ -22471,7 +22488,7 @@ snapshots:
 
     '@eslint/eslintrc@0.4.3':
         dependencies:
-            ajv: 8.17.1
+            ajv: 6.12.6
             debug: 4.3.7(supports-color@5.5.0)
             espree: 7.3.1
             globals: 13.24.0
@@ -22485,7 +22502,7 @@ snapshots:
 
     '@eslint/eslintrc@1.4.1':
         dependencies:
-            ajv: 8.17.1
+            ajv: 6.12.6
             debug: 4.3.7(supports-color@5.5.0)
             espree: 9.6.1
             globals: 13.24.0
@@ -22499,7 +22516,7 @@ snapshots:
 
     '@eslint/eslintrc@2.1.4':
         dependencies:
-            ajv: 8.17.1
+            ajv: 6.12.6
             debug: 4.3.7(supports-color@5.5.0)
             espree: 9.6.1
             globals: 13.24.0
@@ -22513,7 +22530,7 @@ snapshots:
 
     '@eslint/eslintrc@3.1.0':
         dependencies:
-            ajv: 8.17.1
+            ajv: 6.12.6
             debug: 4.3.7(supports-color@5.5.0)
             espree: 10.3.0
             globals: 14.0.0
@@ -25960,6 +25977,13 @@ snapshots:
         transitivePeerDependencies:
             - supports-color
 
+    ajv@6.12.6:
+        dependencies:
+            fast-deep-equal: 3.1.3
+            fast-json-stable-stringify: 2.1.0
+            json-schema-traverse: 0.4.1
+            uri-js: 4.4.1
+
     ajv@8.17.1:
         dependencies:
             fast-deep-equal: 3.1.3
@@ -27616,7 +27640,7 @@ snapshots:
             eslint: 8.24.0
             eslint-import-resolver-node: 0.3.9
             eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0)
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
             eslint-plugin-jsx-a11y: 6.10.2(eslint@8.24.0)
             eslint-plugin-react: 7.37.2(eslint@8.24.0)
             eslint-plugin-react-hooks: 4.6.2(eslint@8.24.0)
@@ -27636,7 +27660,7 @@ snapshots:
             eslint: 9.14.0(jiti@1.21.6)
             eslint-import-resolver-node: 0.3.9
             eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-jsx-a11y: 6.10.2(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-react: 7.37.2(eslint@9.14.0(jiti@1.21.6))
             eslint-plugin-react-hooks: 4.6.2(eslint@9.14.0(jiti@1.21.6))
@@ -27683,7 +27707,7 @@ snapshots:
             is-bun-module: 1.2.1
             is-glob: 4.0.3
         optionalDependencies:
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0)
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0)
         transitivePeerDependencies:
             - '@typescript-eslint/parser'
             - eslint-import-resolver-node
@@ -27702,7 +27726,7 @@ snapshots:
             is-bun-module: 1.2.1
             is-glob: 4.0.3
         optionalDependencies:
-            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6))
+            eslint-plugin-import: 2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6))
         transitivePeerDependencies:
             - '@typescript-eslint/parser'
             - eslint-import-resolver-node
@@ -27771,7 +27795,7 @@ snapshots:
             - eslint-import-resolver-webpack
             - supports-color
 
-    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint@8.24.0))(eslint@8.24.0))(eslint@8.24.0):
+    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@8.24.0):
         dependencies:
             '@rtsao/scc': 1.1.0
             array-includes: 3.1.8
@@ -27800,7 +27824,7 @@ snapshots:
             - eslint-import-resolver-webpack
             - supports-color
 
-    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)))(eslint@9.14.0(jiti@1.21.6)):
+    eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.14.0(jiti@1.21.6))(typescript@5.6.3))(eslint-import-resolver-typescript@3.6.3)(eslint@9.14.0(jiti@1.21.6)):
         dependencies:
             '@rtsao/scc': 1.1.0
             array-includes: 3.1.8
@@ -28027,7 +28051,7 @@ snapshots:
             '@babel/code-frame': 7.12.11
             '@eslint/eslintrc': 0.4.3
             '@humanwhocodes/config-array': 0.5.0
-            ajv: 8.17.1
+            ajv: 6.12.6
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -28073,7 +28097,7 @@ snapshots:
             '@humanwhocodes/config-array': 0.10.7
             '@humanwhocodes/gitignore-to-minimatch': 1.0.2
             '@humanwhocodes/module-importer': 1.0.1
-            ajv: 8.17.1
+            ajv: 6.12.6
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -28121,7 +28145,7 @@ snapshots:
             '@humanwhocodes/module-importer': 1.0.1
             '@nodelib/fs.walk': 1.2.8
             '@ungap/structured-clone': 1.2.0
-            ajv: 8.17.1
+            ajv: 6.12.6
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -28168,7 +28192,7 @@ snapshots:
             '@humanwhocodes/retry': 0.4.1
             '@types/estree': 1.0.6
             '@types/json-schema': 7.0.15
-            ajv: 8.17.1
+            ajv: 6.12.6
             chalk: 4.1.2
             cross-spawn: 7.0.5
             debug: 4.3.7(supports-color@5.5.0)
@@ -29644,6 +29668,8 @@ snapshots:
     json-buffer@3.0.1: {}
 
     json-parse-even-better-errors@2.3.1: {}
+
+    json-schema-traverse@0.4.1: {}
 
     json-schema-traverse@1.0.0: {}
 
@@ -33075,6 +33101,10 @@ snapshots:
     upper-case@2.0.2:
         dependencies:
             tslib: 2.8.1
+
+    uri-js@4.4.1:
+        dependencies:
+            punycode: 2.3.1
 
     url-pattern@1.0.3: {}
 


### PR DESCRIPTION
Users who run the starter get an ugly punycode depreciation warning in Node 21+:

![punycode](https://github.com/user-attachments/assets/476395bc-d093-42cb-892d-ba981e9300a1)

This warning comes about as punycode version is old, but also used be packaged along with node but now is a seperate package.

Looks like eslint is using old dependencies and won't resolve the issue:

https://github.com/eslint/eslint/issues/17720

Check out the current esling package JSON – https://www.npmjs.com/package/eslint?activeTab=code

It uses "ajv": "^6.12.4", which they refuse to update... this package uses an old whatwg-url (URL parsing algorithms) version which contains the punycode issue. 

This is the smallest package change that hits the inner dependency and updates it to a version that uses punycode correctly.