### PR TITLE
fix: correctly handle noop renames

### DIFF
--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -845,6 +845,12 @@ export class Resolver {
           collection?.path,
           args.params.relativePath
         )
+
+        // don't update if the paths are the same
+        if (newRealPath === realPath) {
+          return doc
+        }
+
         // Update the document
         await this.database.put(newRealPath, doc._rawData, collection.name)
         // Delete the old document

--- a/packages/tinacms/src/admin/api.ts
+++ b/packages/tinacms/src/admin/api.ts
@@ -16,6 +16,7 @@ export interface FilterArgs {
   filterField: string
   collection?: string
   relativePath?: string
+  relativePathWithoutExtension?: string
   newRelativePath?: string
   startsWith?: string
   endsWith?: string

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -204,6 +204,7 @@ const CollectionListPage = () => {
   const [vars, setVars] = React.useState({
     collection: collectionName,
     relativePath: '',
+    relativePathWithoutExtension: '',
     newRelativePath: '',
     filterField: '',
     folderName: '',
@@ -254,6 +255,7 @@ const CollectionListPage = () => {
       ...old,
       collection: collectionName,
       relativePath: '',
+      relativePathWithoutExtension: '',
       newRelativePath: '',
       filterField: '',
       startsWith: '',
@@ -284,6 +286,7 @@ const CollectionListPage = () => {
                   : {
                       collection: collectionName,
                       relativePath: '',
+                      relativePathWithoutExtension: '',
                       newRelativePath: '',
                       filterField: '',
                       startsWith: '',
@@ -408,7 +411,7 @@ const CollectionListPage = () => {
 
                     {renameModalOpen && (
                       <RenameModal
-                        filename={vars.relativePath}
+                        filename={vars.relativePathWithoutExtension}
                         newRelativePath={vars.newRelativePath}
                         setNewRelativePath={(newRelativePath) => {
                           setVars((vars) => {
@@ -889,6 +892,10 @@ const CollectionListPage = () => {
                                                   setVars((old) => ({
                                                     ...old,
                                                     collection: collectionName,
+                                                    relativePathWithoutExtension:
+                                                      document.node._sys.breadcrumbs.join(
+                                                        '/'
+                                                      ),
                                                     relativePath:
                                                       document.node._sys.breadcrumbs.join(
                                                         '/'
@@ -913,6 +920,10 @@ const CollectionListPage = () => {
                                                   setVars((old) => ({
                                                     ...old,
                                                     collection: collectionName,
+                                                    relativePathWithoutExtension:
+                                                      document.node._sys.breadcrumbs.join(
+                                                        '/'
+                                                      ),
                                                     relativePath:
                                                       document.node._sys.breadcrumbs.join(
                                                         '/'
@@ -1255,6 +1266,7 @@ const RenameModal = ({
               await renameFunc()
               close()
             }}
+            disabled={!newRelativePath || newRelativePath === filename}
           >
             Rename
           </Button>


### PR DESCRIPTION
# problem

Renaming a file to the same name fails. Also, current UI doesn't make it clear whether extension is required or not.

# solution

Add handling in resolver for no-op renames and update UI to prevent renaming to same name. Also don't display extension to user in modal to prevent confusion.