### PR TITLE
fix: double encoding media urls

### DIFF
--- a/.changeset/rude-pigs-pretend.md
+++ b/.changeset/rude-pigs-pretend.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Fix bug when encoding media manager image urls with special characters

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -4,14 +4,9 @@ import { DummyMediaStore } from './media-store.default'
 const encodeUrlIfNeeded = (url: string) => {
   if (url) {
     try {
-      const parsed = new URL(url)
-      parsed.pathname = parsed.pathname
-        .split('/')
-        .filter((part) => part !== '')
-        .map(encodeURIComponent)
-        .join('/')
-      return parsed.toString()
+      return new URL(url).toString()
     } catch (e) {
+      // If URL parsing fails, return the original URL
       return url
     }
   } else {


### PR DESCRIPTION
# problem

Media manager urls with special characters are broken #5513

# solution

Fix encoding function. The URL object already encodes url parts, so the function can just return the url from the object