### PR TITLE
fix: branch switcher bug when branch has been deleted

### DIFF
--- a/.changeset/healthy-elephants-impress.md
+++ b/.changeset/healthy-elephants-impress.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Fix issue with editorial workflow when last branch does not exist resulting in an error

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,22 @@ jobs:
       - name: Build Types
         run: pnpm types
 
+      - name: Test
+        run: pnpm test
+
+      - name: Lint
+        if: matrix.os == 'ubuntu-latest'
+        run: pnpm lint
+
+      - name: Format
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          pnpm format
+          git diff --exit-code
+
+      - name: Check Tina lock changes
+        run: pnpm diff-tina-lock
+
       - name: Set NPMRC
         run: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > .npmrc
         env:
@@ -82,18 +98,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
-      - name: Test
-        run: pnpm test
-
-      - name: Lint
-        if: matrix.os == 'ubuntu-latest'
-        run: pnpm lint
-
-      - name: Format
-        if: matrix.os == 'ubuntu-latest'
-        run: |
-          pnpm format
-          git diff --exit-code
-
-      - name: Check Tina lock changes
-        run: pnpm diff-tina-lock

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -323,7 +323,6 @@ export const TinaCloudProvider = (
     'tinacms-current-branch',
     baseBranch
   );
-  console.log({ currentBranch });
   useTinaAuthRedirect();
   const cms = React.useMemo(
     () =>
@@ -473,12 +472,9 @@ export const TinaCloudProvider = (
           client.usingEditorialWorkflow = true;
           client.protectedBranches = project.protectedBranches;
 
-          console.log('currentBranch', currentBranch);
-          console.log(project.metadata[currentBranch]);
           // if the current branch is not in the metadata,
           // switch to the default branch
           if (!project.metadata[currentBranch]) {
-            console.log('resetting to default branch', project.defaultBranch);
             setCurrentBranch(project.defaultBranch || 'main');
           }
         }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -323,6 +323,7 @@ export const TinaCloudProvider = (
     'tinacms-current-branch',
     baseBranch
   );
+  console.log({ currentBranch });
   useTinaAuthRedirect();
   const cms = React.useMemo(
     () =>
@@ -472,9 +473,12 @@ export const TinaCloudProvider = (
           client.usingEditorialWorkflow = true;
           client.protectedBranches = project.protectedBranches;
 
+          console.log('currentBranch', currentBranch);
+          console.log(project.metadata[currentBranch]);
           // if the current branch is not in the metadata,
           // switch to the default branch
           if (!project.metadata[currentBranch]) {
+            console.log('resetting to default branch', project.defaultBranch);
             setCurrentBranch(project.defaultBranch || 'main');
           }
         }

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -1,28 +1,28 @@
-import { ModalBuilder } from './AuthModal';
-import React, { useEffect, useState } from 'react';
 import {
   BaseTextField,
-  TinaCMS,
-  TinaProvider,
-  MediaStore,
-  BranchSwitcherPlugin,
   Branch,
   BranchDataProvider,
-  useLocalStorage,
+  BranchSwitcherPlugin,
   DummyMediaStore,
-  TinaMediaStore,
+  MediaStore,
   StaticMedia,
+  TinaCMS,
+  TinaMediaStore,
+  TinaProvider,
+  useLocalStorage,
 } from '@tinacms/toolkit';
+import React, { useEffect, useState } from 'react';
+import { ModalBuilder } from './AuthModal';
 
+import { TinaAdminApi } from '../admin/api';
 import {
   Client,
   LocalSearchClient,
   TinaCMSSearchClient,
   TinaIOConfig,
 } from '../internalClient';
-import { useTinaAuthRedirect } from './useTinaAuthRedirect';
 import { CreateClientProps, createClient } from '../utils';
-import { TinaAdminApi } from '../admin/api';
+import { useTinaAuthRedirect } from './useTinaAuthRedirect';
 
 type ModalNames = null | 'authenticate' | 'error';
 
@@ -471,6 +471,12 @@ export const TinaCloudProvider = (
           cms.flags.set('branch-switcher', true);
           client.usingEditorialWorkflow = true;
           client.protectedBranches = project.protectedBranches;
+
+          // if the current branch is not in the metadata,
+          // switch to the default branch
+          if (!project.metadata[currentBranch]) {
+            setCurrentBranch(project.defaultBranch || 'main');
+          }
         }
       });
     };

--- a/packages/tinacms/src/auth/TinaCloudProvider.tsx
+++ b/packages/tinacms/src/auth/TinaCloudProvider.tsx
@@ -494,7 +494,7 @@ export const TinaCloudProvider = (
       }
     });
     return unsubscribe;
-  }, [isTinaCloud, cms]);
+  }, [currentBranch, isTinaCloud, cms]);
 
   return (
     <SessionProvider basePath='/api/tina/auth'>


### PR DESCRIPTION
Fixes #5557 

When using editorial workflow and accessing the admin and the last accessed branch no longer exists, branch switcher should reset instead of trying to load the branch that doesn't exist