### PR TITLE
fix: consider the remote schema to be the old and local to be new.

### DIFF
--- a/packages/@tinacms/cli/src/next/commands/build-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/build-command/index.ts
@@ -591,7 +591,7 @@ export class BuildCommand extends BaseCommand {
     const localSchemaDocument = await database.getGraphQLSchemaFromBridge();
     const localGraphqlSchema = buildASTSchema(localSchemaDocument);
     try {
-      const diffResult = await diff(localGraphqlSchema, remoteGqlSchema);
+      const diffResult = await diff(remoteGqlSchema, localGraphqlSchema);
 
       if (diffResult.length === 0) {
         bar.tick({


### PR DESCRIPTION
This pr fixes the comparison during the schema diff check. Previously, the remote was considered the new schema and local the old. This has been reversed in this pr.
