### PR TITLE
Rev-package-versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,8 @@ jobs:
         if: >
           matrix.os == 'ubuntu-latest' &&
           github.event_name == 'pull_request' &&
-          contains(github.event.pull_request.labels.*.name, 'tagged')
+          contains(github.event.pull_request.labels.*.name, 'tagged') &&
+          github.event.pull_request.title != 'Version Packages'
         continue-on-error: true
         run: |
           echo running on branch ${BRANCH_NAME}

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -20,5 +20,5 @@
 		"@types/node": "^22.13.1",
 		"eslint": "7"
 	},
-	"version": "0.0.28"
+	"version": "0.0.29"
 }

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "e2e-next",
-	"version": "0.1.96",
+	"version": "0.1.97",
 	"private": true,
 	"scripts": {
 		"dev": "MONOREPO_DEV=true tinacms dev -c \"next dev\"",

--- a/examples/next-2024/package.json
+++ b/examples/next-2024/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "next-2024",
-	"version": "0.1.24",
+	"version": "0.1.25",
 	"private": true,
 	"scripts": {
 		"dev": "TINA_PUBLIC_IS_LOCAL=true tinacms dev -c \"next dev\"",

--- a/examples/tina-self-hosted-demo/package.json
+++ b/examples/tina-self-hosted-demo/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/self-hosted-starter",
-	"version": "0.1.80",
+	"version": "0.1.81",
 	"private": true,
 	"scripts": {
 		"dev": "TINA_PUBLIC_IS_LOCAL=true tinacms dev -c \"next dev\"",

--- a/experimental-examples/tina-cloud-starter/package.json
+++ b/experimental-examples/tina-cloud-starter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinacms/starter",
-  "version": "0.1.61",
+  "version": "0.1.62",
   "private": true,
   "scripts": {
     "dev": "tinacms dev -c \"next dev\"",

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/app",
-	"version": "2.2.3",
+	"version": "2.2.4",
 	"main": "src/main.tsx",
 	"license": "Apache-2.0",
 	"devDependencies": {

--- a/packages/@tinacms/cli/package.json
+++ b/packages/@tinacms/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/cli",
-	"version": "1.9.3",
+	"version": "1.9.4",
 	"main": "dist/index.js",
 	"typings": "dist/index.d.ts",
 	"files": [

--- a/packages/@tinacms/datalayer/package.json
+++ b/packages/@tinacms/datalayer/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/datalayer",
-	"version": "1.3.14",
+	"version": "1.3.15",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"typings": "dist/index",

--- a/packages/@tinacms/graphql/package.json
+++ b/packages/@tinacms/graphql/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/graphql",
-	"version": "1.5.14",
+	"version": "1.5.15",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"typings": "dist/index.d.ts",

--- a/packages/@tinacms/search/package.json
+++ b/packages/@tinacms/search/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/search",
-	"version": "1.0.41",
+	"version": "1.0.42",
 	"main": "dist/index.js",
 	"module": "dist/index-client.mjs",
 	"typings": "dist/index.d.ts",

--- a/packages/@tinacms/vercel-previews/package.json
+++ b/packages/@tinacms/vercel-previews/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tinacms/vercel-previews",
-	"version": "0.0.61",
+	"version": "0.0.62",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",
 	"module": "./dist/index.mjs",

--- a/packages/next-tinacms-azure/package.json
+++ b/packages/next-tinacms-azure/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "next-tinacms-azure",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",

--- a/packages/next-tinacms-cloudinary/package.json
+++ b/packages/next-tinacms-cloudinary/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "next-tinacms-cloudinary",
-	"version": "13.0.3",
+	"version": "13.0.4",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"files": [

--- a/packages/next-tinacms-dos/package.json
+++ b/packages/next-tinacms-dos/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "next-tinacms-dos",
-	"version": "10.0.3",
+	"version": "10.0.4",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"files": [

--- a/packages/next-tinacms-s3/package.json
+++ b/packages/next-tinacms-s3/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "next-tinacms-s3",
-	"version": "10.0.3",
+	"version": "10.0.4",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"files": [

--- a/packages/tinacms-authjs/package.json
+++ b/packages/tinacms-authjs/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tinacms-authjs",
-	"version": "10.0.3",
+	"version": "10.0.4",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"files": [

--- a/packages/tinacms-clerk/package.json
+++ b/packages/tinacms-clerk/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tinacms-clerk",
-	"version": "10.0.3",
+	"version": "10.0.4",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"files": [

--- a/packages/tinacms-gitprovider-github/package.json
+++ b/packages/tinacms-gitprovider-github/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tinacms-gitprovider-github",
-	"version": "2.0.14",
+	"version": "2.0.15",
 	"main": "dist/index.js",
 	"module": "dist/index.mjs",
 	"files": [

--- a/packages/tinacms/package.json
+++ b/packages/tinacms/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tinacms",
-	"version": "2.7.3",
+	"version": "2.7.4",
 	"main": "dist/index.js",
 	"module": "./dist/index.mjs",
 	"exports": {


### PR DESCRIPTION
I Accidentally published packages by tagging the 'Version Packages' PR, so I deprecated the published versions.

This pull request includes a series of version bumps across multiple `package.json` files and a modification to a GitHub workflow. The changes ensure that dependencies are up to date and refine the workflow conditions.

### Workflow Update:
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L90-R91): Added a condition to exclude pull requests with the title 'Version Packages' from triggering the workflow.
