### PR TITLE
feat: Added `bun` package manager

### DIFF
--- a/.changeset/ten-years-cheat.md
+++ b/.changeset/ten-years-cheat.md
@@ -1,0 +1,6 @@
+---
+"create-tina-app": patch
+---
+
+feat: Added `bun` package manager.
+fix: Removed dead code from `install` method.

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -18,6 +18,11 @@ import { log, TextStyles } from './util/logger';
 import { exit } from 'node:process';
 import validate from 'validate-npm-package-name';
 
+/**
+ * The available package managers a user can use.
+ * To add a new supported package manager, add the usage command to this list.
+ * The `PackageManager` type will be automatically updated as a result.
+ */
 const PKG_MANAGERS = ['npm', 'yarn', 'pnpm', 'bun'] as const;
 export type PackageManager = (typeof PKG_MANAGERS)[number];
 

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -68,8 +68,7 @@ export async function run() {
     template = TEMPLATES.find((_template) => _template.value === template);
     if (!template) {
       log.err(
-        `The provided template '${
-          opts.template
+        `The provided template '${opts.template
         }' is invalid. Please provide one of the following: ${TEMPLATES.map(
           (x) => x.value
         )}`
@@ -187,22 +186,22 @@ export async function run() {
 
   if (template.value === 'tina-hugo-starter')
     log.warn(
-      'Hugo is required for this starter. Install it: https://gohugo.io/installation/'
+      `Hugo is required for this starter. Install it via ${TextStyles.link('https://gohugo.io/installation/')}.`
     );
 
   log.log(TextStyles.bold('\nTo launch your app, run:\n'));
   log.cmd(`cd ${appName}\n${pkgManager} run dev`);
   log.log(`\nNext steps:
     • 📝 Edit some content on ${TextStyles.link(
-      'http://localhost:3000'
-    )} (See ${TextStyles.link('https://tina.io/docs/using-tina-editor')})
+    'http://localhost:3000'
+  )} (See ${TextStyles.link('https://tina.io/docs/using-tina-editor')})
     • 📖 Learn the basics: ${TextStyles.link('https://tina.io/docs/schema/')}
     • 🖌️ Extend Tina with custom field components: ${TextStyles.link(
-      'https://tina.io/docs/advanced/extending-tina/'
-    )}
+    'https://tina.io/docs/advanced/extending-tina/'
+  )}
     • 🚀 Deploy to Production: ${TextStyles.link(
-      'https://tina.io/docs/tina-cloud/'
-    )}
+    'https://tina.io/docs/tina-cloud/'
+  )}
   `);
 }
 

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -68,7 +68,8 @@ export async function run() {
     template = TEMPLATES.find((_template) => _template.value === template);
     if (!template) {
       log.err(
-        `The provided template '${opts.template
+        `The provided template '${
+          opts.template
         }' is invalid. Please provide one of the following: ${TEMPLATES.map(
           (x) => x.value
         )}`
@@ -193,15 +194,15 @@ export async function run() {
   log.cmd(`cd ${appName}\n${pkgManager} run dev`);
   log.log(`\nNext steps:
     • 📝 Edit some content on ${TextStyles.link(
-    'http://localhost:3000'
-  )} (See ${TextStyles.link('https://tina.io/docs/using-tina-editor')})
+      'http://localhost:3000'
+    )} (See ${TextStyles.link('https://tina.io/docs/using-tina-editor')})
     • 📖 Learn the basics: ${TextStyles.link('https://tina.io/docs/schema/')}
     • 🖌️ Extend Tina with custom field components: ${TextStyles.link(
-    'https://tina.io/docs/advanced/extending-tina/'
-  )}
+      'https://tina.io/docs/advanced/extending-tina/'
+    )}
     • 🚀 Deploy to Production: ${TextStyles.link(
-    'https://tina.io/docs/tina-cloud/'
-  )}
+      'https://tina.io/docs/tina-cloud/'
+    )}
   `);
 }
 

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -18,7 +18,8 @@ import { log, TextStyles } from './util/logger';
 import { exit } from 'node:process';
 import validate from 'validate-npm-package-name';
 
-export const PKG_MANAGERS = ['npm', 'yarn', 'pnpm'];
+const PKG_MANAGERS = ['npm', 'yarn', 'pnpm', 'bun'] as const;
+export type PackageManager = (typeof PKG_MANAGERS)[number];
 
 export async function run() {
   preRunChecks();
@@ -165,7 +166,7 @@ export async function run() {
   }
 
   log.info('Installing packages.');
-  await install(rootDir, null, { packageManager: pkgManager, isOnline: true });
+  await install(pkgManager as PackageManager);
 
   log.info('Initializing git repository.');
   try {

--- a/packages/create-tina-app/src/util/checkPkgManagers.ts
+++ b/packages/create-tina-app/src/util/checkPkgManagers.ts
@@ -1,7 +1,7 @@
 import { exec } from 'child_process';
-import { PKG_MANAGERS } from '..';
+import { PackageManager } from '..';
 
-export async function checkPackageExists(name: (typeof PKG_MANAGERS)[number]) {
+export async function checkPackageExists(name: PackageManager) {
   try {
     await new Promise((resolve, reject) => {
       exec(`${name} -v`, (error, stdout, stderr) => {

--- a/packages/create-tina-app/src/util/install.ts
+++ b/packages/create-tina-app/src/util/install.ts
@@ -1,116 +1,20 @@
 import spawn from 'cross-spawn';
-import { log } from './logger';
-
-interface InstallArgs {
-  /**
-   * The package manager to use (yarn, npm, pnpm).
-   */
-  packageManager: 'yarn' | 'npm' | 'pnpm';
-  /**
-   * Indicate whether there is an active Internet connection.
-   */
-  isOnline: boolean;
-  /**
-   * Indicate whether the given dependencies are devDependencies.
-   */
-  devDependencies?: boolean;
-}
+import { PackageManager } from '..';
 
 /**
- * Spawn a package manager installation with Yarn, NPM, or PNPM.
+ * Spawn a package manager installation.
  *
  * @returns A Promise that resolves once the installation is finished.
  */
-export function install(
-  root: string,
-  dependencies: string[] | null,
-  { packageManager, isOnline, devDependencies }: InstallArgs
-): Promise<void> {
-  /**
-   * Package manager-specific command-line flags.
-   */
-  const npmFlags: string[] = [];
-  const yarnFlags: string[] = [];
-  const pnpmFlags: string[] = [];
-
-  /**
-   * Return a Promise that resolves once the installation is finished.
-   */
+export function install(packageManager: PackageManager): Promise<void> {
   return new Promise((resolve, reject) => {
-    let args: string[];
-    const command: string = packageManager;
-
-    if (dependencies?.length) {
-      /**
-       * If there are dependencies, run a variation of `{packageManager} add`.
-       */
-      switch (packageManager) {
-        case 'yarn':
-          /**
-           * Call `yarn add --exact (--offline)? (-D)? ...`.
-           */
-          args = ['add', '--exact'];
-          if (!isOnline) args.push('--offline');
-          args.push('--cwd', root);
-          if (devDependencies) args.push('--dev');
-          args.push(...dependencies);
-          break;
-        case 'npm':
-          /**
-           * Call `npm install [--save|--save-dev] ...`.
-           */
-          args = ['install', '--save-exact'];
-          args.push(devDependencies ? '--save-dev' : '--save');
-          args.push(...dependencies);
-          break;
-        case 'pnpm':
-          /**
-           * Call `pnpm add (--offline)? (-D)? ...`.
-           */
-          args = ['add'];
-          if (!isOnline) args.push('--offline');
-          args.push('--save-exact');
-          if (devDependencies) args.push('-D');
-          args.push(...dependencies);
-          break;
-      }
-    } else {
-      /**
-       * If there are no dependencies, run a variation of `{packageManager} install`.
-       */
-      args = ['install'];
-      if (!isOnline) {
-        log.warn('You appear to be offline.');
-        if (packageManager === 'yarn') {
-          log.warn('Falling back to the local Yarn cache.');
-          args.push('--offline');
-        }
-      }
-    }
-    /**
-     * Add any package manager-specific flags.
-     */
-    switch (packageManager) {
-      case 'yarn':
-        args.push(...yarnFlags);
-        break;
-      case 'npm':
-        args.push(...npmFlags);
-        break;
-      case 'pnpm':
-        args.push(...pnpmFlags);
-        break;
-    }
-    /**
-     * Spawn the installation process.
-     */
-    const child = spawn(command, args, {
+    const child = spawn(packageManager, ['install'], {
       stdio: 'inherit',
       env: { ...process.env, ADBLOCK: '1', DISABLE_OPENCOLLECTIVE: '1' },
     });
     child.on('close', (code) => {
       if (code !== 0) {
-        reject({ command: `${command} ${args.join(' ')}` });
+        reject({ command: `${packageManager} install` });
         return;
       }
       resolve();


### PR DESCRIPTION
This PR adds the `bun` package manager to the `create-tina-app` CLI tool.
It also cleans up a bunch of dead code related to the package manager install
command.
