### PR TITLE
🔥 Deletion - Remove 'pnpm serve' from @tinacms/graphql package

### DIFF
--- a/packages/@tinacms/graphql/package.json
+++ b/packages/@tinacms/graphql/package.json
@@ -1,88 +1,88 @@
 {
-    "name": "@tinacms/graphql",
-    "version": "1.5.16",
-    "main": "dist/index.js",
-    "module": "dist/index.mjs",
-    "typings": "dist/index.d.ts",
-    "files": [
-        "package.json",
-        "dist"
-    ],
-    "exports": {
-        "import": "./dist/index.mjs",
-        "require": "./dist/index.js"
-    },
-    "license": "SEE LICENSE IN LICENSE",
-    "buildConfig": {
-        "entryPoints": [
-            {
-                "name": "src/index.ts",
-                "target": "node",
-                "bundle": []
-            }
-        ]
-    },
-    "scripts": {
-        "types": "pnpm tsc",
-        "build": "tinacms-scripts build",
-        "docs": "pnpm typedoc",
-        "test": "vitest run",
-        "test-watch": "vitest"
-    },
-    "dependencies": {
-        "@iarna/toml": "^2.2.5",
-        "@tinacms/mdx": "workspace:*",
-        "@tinacms/schema-tools": "workspace:*",
-        "abstract-level": "^1.0.4",
-        "date-fns": "^2.30.0",
-        "fast-glob": "^3.3.3",
-        "fs-extra": "^11.3.0",
-        "glob-parent": "^6.0.2",
-        "graphql": "15.8.0",
-        "gray-matter": "^4.0.3",
-        "isomorphic-git": "^1.29.0",
-        "js-sha1": "^0.6.0",
-        "js-yaml": "^3.14.1",
-        "jsonpath-plus": "10.1.0",
-        "lodash.clonedeep": "^4.5.0",
-        "lodash.set": "^4.3.2",
-        "lodash.uniqby": "^4.7.0",
-        "many-level": "^2.0.0",
-        "micromatch": "4.0.8",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.7.0",
-        "scmp": "^2.1.0",
-        "yup": "^0.32.11"
-    },
-    "publishConfig": {
-        "registry": "https://registry.npmjs.org"
-    },
-    "repository": {
-        "url": "https://github.com/tinacms/tinacms.git",
-        "directory": "packages/tina-graphql"
-    },
-    "devDependencies": {
-        "@tinacms/schema-tools": "workspace:*",
-        "@tinacms/scripts": "workspace:*",
-        "@types/cors": "^2.8.17",
-        "@types/estree": "^0.0.50",
-        "@types/express": "^4.17.21",
-        "@types/fs-extra": "^9.0.13",
-        "@types/js-yaml": "^3.12.10",
-        "@types/lodash.camelcase": "^4.3.9",
-        "@types/lodash.upperfirst": "^4.3.9",
-        "@types/lru-cache": "^5.1.1",
-        "@types/mdast": "^3.0.15",
-        "@types/micromatch": "^4.0.9",
-        "@types/node": "^22.13.1",
-        "@types/normalize-path": "^3.0.2",
-        "@types/ws": "^7.4.7",
-        "@types/yup": "^0.29.14",
-        "jest-file-snapshot": "^0.5.0",
-        "memory-level": "^1.0.0",
-        "typescript": "^5.7.3",
-        "vite": "^4.5.9",
-        "vitest": "^0.32.4",
-        "zod": "^3.24.2"
-    }
+	"name": "@tinacms/graphql",
+	"version": "1.5.16",
+	"main": "dist/index.js",
+	"module": "dist/index.mjs",
+	"typings": "dist/index.d.ts",
+	"files": [
+		"package.json",
+		"dist"
+	],
+	"exports": {
+		"import": "./dist/index.mjs",
+		"require": "./dist/index.js"
+	},
+	"license": "SEE LICENSE IN LICENSE",
+	"buildConfig": {
+		"entryPoints": [
+			{
+				"name": "src/index.ts",
+				"target": "node",
+				"bundle": []
+			}
+		]
+	},
+	"scripts": {
+		"types": "pnpm tsc",
+		"build": "tinacms-scripts build",
+		"docs": "pnpm typedoc",
+		"test": "vitest run",
+		"test-watch": "vitest"
+	},
+	"dependencies": {
+		"@iarna/toml": "^2.2.5",
+		"@tinacms/mdx": "workspace:*",
+		"@tinacms/schema-tools": "workspace:*",
+		"abstract-level": "^1.0.4",
+		"date-fns": "^2.30.0",
+		"fast-glob": "^3.3.3",
+		"fs-extra": "^11.3.0",
+		"glob-parent": "^6.0.2",
+		"graphql": "15.8.0",
+		"gray-matter": "^4.0.3",
+		"isomorphic-git": "^1.29.0",
+		"js-sha1": "^0.6.0",
+		"js-yaml": "^3.14.1",
+		"jsonpath-plus": "10.1.0",
+		"lodash.clonedeep": "^4.5.0",
+		"lodash.set": "^4.3.2",
+		"lodash.uniqby": "^4.7.0",
+		"many-level": "^2.0.0",
+		"micromatch": "4.0.8",
+		"normalize-path": "^3.0.0",
+		"readable-stream": "^4.7.0",
+		"scmp": "^2.1.0",
+		"yup": "^0.32.11"
+	},
+	"publishConfig": {
+		"registry": "https://registry.npmjs.org"
+	},
+	"repository": {
+		"url": "https://github.com/tinacms/tinacms.git",
+		"directory": "packages/tina-graphql"
+	},
+	"devDependencies": {
+		"@tinacms/schema-tools": "workspace:*",
+		"@tinacms/scripts": "workspace:*",
+		"@types/cors": "^2.8.17",
+		"@types/estree": "^0.0.50",
+		"@types/express": "^4.17.21",
+		"@types/fs-extra": "^9.0.13",
+		"@types/js-yaml": "^3.12.10",
+		"@types/lodash.camelcase": "^4.3.9",
+		"@types/lodash.upperfirst": "^4.3.9",
+		"@types/lru-cache": "^5.1.1",
+		"@types/mdast": "^3.0.15",
+		"@types/micromatch": "^4.0.9",
+		"@types/node": "^22.13.1",
+		"@types/normalize-path": "^3.0.2",
+		"@types/ws": "^7.4.7",
+		"@types/yup": "^0.29.14",
+		"jest-file-snapshot": "^0.5.0",
+		"memory-level": "^1.0.0",
+		"typescript": "^5.7.3",
+		"vite": "^4.5.9",
+		"vitest": "^0.32.4",
+		"zod": "^3.24.2"
+	}
 }

--- a/packages/@tinacms/graphql/package.json
+++ b/packages/@tinacms/graphql/package.json
@@ -1,90 +1,88 @@
 {
-	"name": "@tinacms/graphql",
-	"version": "1.5.16",
-	"main": "dist/index.js",
-	"module": "dist/index.mjs",
-	"typings": "dist/index.d.ts",
-	"files": [
-		"package.json",
-		"dist"
-	],
-	"exports": {
-		"import": "./dist/index.mjs",
-		"require": "./dist/index.js"
-	},
-	"license": "SEE LICENSE IN LICENSE",
-	"buildConfig": {
-		"entryPoints": [
-			{
-				"name": "src/index.ts",
-				"target": "node",
-				"bundle": []
-			}
-		]
-	},
-	"scripts": {
-		"types": "pnpm tsc",
-		"build": "tinacms-scripts build",
-		"docs": "pnpm typedoc",
-		"serve": "pnpm nodemon dist/server.js",
-		"test": "vitest run",
-		"test-watch": "vitest"
-	},
-	"dependencies": {
-		"@iarna/toml": "^2.2.5",
-		"@tinacms/mdx": "workspace:*",
-		"@tinacms/schema-tools": "workspace:*",
-		"abstract-level": "^1.0.4",
-		"date-fns": "^2.30.0",
-		"fast-glob": "^3.3.3",
-		"fs-extra": "^11.3.0",
-		"glob-parent": "^6.0.2",
-		"graphql": "15.8.0",
-		"gray-matter": "^4.0.3",
-		"isomorphic-git": "^1.29.0",
-		"js-sha1": "^0.6.0",
-		"js-yaml": "^3.14.1",
-		"jsonpath-plus": "10.1.0",
-		"lodash.clonedeep": "^4.5.0",
-		"lodash.set": "^4.3.2",
-		"lodash.uniqby": "^4.7.0",
-		"many-level": "^2.0.0",
-		"micromatch": "4.0.8",
-		"normalize-path": "^3.0.0",
-		"readable-stream": "^4.7.0",
-		"scmp": "^2.1.0",
-		"yup": "^0.32.11"
-	},
-	"publishConfig": {
-		"registry": "https://registry.npmjs.org"
-	},
-	"repository": {
-		"url": "https://github.com/tinacms/tinacms.git",
-		"directory": "packages/tina-graphql"
-	},
-	"devDependencies": {
-		"@tinacms/schema-tools": "workspace:*",
-		"@tinacms/scripts": "workspace:*",
-		"@types/cors": "^2.8.17",
-		"@types/estree": "^0.0.50",
-		"@types/express": "^4.17.21",
-		"@types/fs-extra": "^9.0.13",
-		"@types/js-yaml": "^3.12.10",
-		"@types/lodash.camelcase": "^4.3.9",
-		"@types/lodash.upperfirst": "^4.3.9",
-		"@types/lru-cache": "^5.1.1",
-		"@types/mdast": "^3.0.15",
-		"@types/micromatch": "^4.0.9",
-		"@types/node": "^22.13.1",
-		"@types/normalize-path": "^3.0.2",
-		"@types/ws": "^7.4.7",
-		"@types/yup": "^0.29.14",
-		"jest-file-snapshot": "^0.5.0",
-		"memory-level": "^1.0.0",
-		"nodemon": "3.1.4",
-		"typescript": "^5.7.3",
-		"vite": "^4.5.9",
-		"vitest": "^0.32.4",
-		"zod": "^3.24.2"
-	}
+    "name": "@tinacms/graphql",
+    "version": "1.5.16",
+    "main": "dist/index.js",
+    "module": "dist/index.mjs",
+    "typings": "dist/index.d.ts",
+    "files": [
+        "package.json",
+        "dist"
+    ],
+    "exports": {
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.js"
+    },
+    "license": "SEE LICENSE IN LICENSE",
+    "buildConfig": {
+        "entryPoints": [
+            {
+                "name": "src/index.ts",
+                "target": "node",
+                "bundle": []
+            }
+        ]
+    },
+    "scripts": {
+        "types": "pnpm tsc",
+        "build": "tinacms-scripts build",
+        "docs": "pnpm typedoc",
+        "test": "vitest run",
+        "test-watch": "vitest"
+    },
+    "dependencies": {
+        "@iarna/toml": "^2.2.5",
+        "@tinacms/mdx": "workspace:*",
+        "@tinacms/schema-tools": "workspace:*",
+        "abstract-level": "^1.0.4",
+        "date-fns": "^2.30.0",
+        "fast-glob": "^3.3.3",
+        "fs-extra": "^11.3.0",
+        "glob-parent": "^6.0.2",
+        "graphql": "15.8.0",
+        "gray-matter": "^4.0.3",
+        "isomorphic-git": "^1.29.0",
+        "js-sha1": "^0.6.0",
+        "js-yaml": "^3.14.1",
+        "jsonpath-plus": "10.1.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.set": "^4.3.2",
+        "lodash.uniqby": "^4.7.0",
+        "many-level": "^2.0.0",
+        "micromatch": "4.0.8",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.7.0",
+        "scmp": "^2.1.0",
+        "yup": "^0.32.11"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org"
+    },
+    "repository": {
+        "url": "https://github.com/tinacms/tinacms.git",
+        "directory": "packages/tina-graphql"
+    },
+    "devDependencies": {
+        "@tinacms/schema-tools": "workspace:*",
+        "@tinacms/scripts": "workspace:*",
+        "@types/cors": "^2.8.17",
+        "@types/estree": "^0.0.50",
+        "@types/express": "^4.17.21",
+        "@types/fs-extra": "^9.0.13",
+        "@types/js-yaml": "^3.12.10",
+        "@types/lodash.camelcase": "^4.3.9",
+        "@types/lodash.upperfirst": "^4.3.9",
+        "@types/lru-cache": "^5.1.1",
+        "@types/mdast": "^3.0.15",
+        "@types/micromatch": "^4.0.9",
+        "@types/node": "^22.13.1",
+        "@types/normalize-path": "^3.0.2",
+        "@types/ws": "^7.4.7",
+        "@types/yup": "^0.29.14",
+        "jest-file-snapshot": "^0.5.0",
+        "memory-level": "^1.0.0",
+        "typescript": "^5.7.3",
+        "vite": "^4.5.9",
+        "vitest": "^0.32.4",
+        "zod": "^3.24.2"
+    }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -934,9 +934,6 @@ importers:
       memory-level:
         specifier: ^1.0.0
         version: 1.0.0
-      nodemon:
-        specifier: 3.1.4
-        version: 3.1.4
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -8684,9 +8681,6 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore-by-default@1.0.1:
-    resolution: {integrity: sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==}
-
   ignore@4.0.6:
     resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
     engines: {node: '>= 4'}
@@ -10145,11 +10139,6 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  nodemon@3.1.4:
-    resolution: {integrity: sha512-wjPBbFhtpJwmIeY2yP7QF+UKzPfltVGtfce1g/bB15/8vCGZj8uxD62b/b9M9/WVgme0NZudpownKN+c0plXlQ==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   non-layered-tidy-tree-layout@2.0.2:
     resolution: {integrity: sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==}
 
@@ -10655,9 +10644,6 @@ packages:
 
   pseudomap@1.0.2:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
-
-  pstree.remy@1.1.8:
-    resolution: {integrity: sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==}
 
   pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
@@ -11267,10 +11253,6 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  simple-update-notifier@2.0.0:
-    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
-    engines: {node: '>=10'}
-
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -11725,10 +11707,6 @@ packages:
   toposort@2.0.2:
     resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
 
-  touch@3.1.1:
-    resolution: {integrity: sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==}
-    hasBin: true
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
@@ -12023,9 +12001,6 @@ packages:
   unc-path-regex@0.1.2:
     resolution: {integrity: sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==}
     engines: {node: '>=0.10.0'}
-
-  undefsafe@2.0.5:
-    resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
 
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
@@ -13316,7 +13291,7 @@ snapshots:
       '@babel/traverse': 7.26.9
       '@babel/types': 7.26.9
       convert-source-map: 2.0.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -13368,7 +13343,7 @@ snapshots:
       '@babel/core': 7.26.9
       '@babel/helper-compilation-targets': 7.26.5
       '@babel/helper-plugin-utils': 7.26.5
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.10
     transitivePeerDependencies:
@@ -14089,7 +14064,7 @@ snapshots:
       '@babel/parser': 7.26.9
       '@babel/template': 7.26.9
       '@babel/types': 7.26.9
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -14772,7 +14747,7 @@ snapshots:
   '@eslint/config-array@0.19.2':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -14784,7 +14759,7 @@ snapshots:
   '@eslint/eslintrc@0.4.3':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       espree: 7.3.1
       globals: 13.24.0
       ignore: 4.0.6
@@ -14798,7 +14773,7 @@ snapshots:
   '@eslint/eslintrc@1.4.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -14812,7 +14787,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -14826,7 +14801,7 @@ snapshots:
   '@eslint/eslintrc@3.3.0':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       espree: 10.3.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -15151,7 +15126,7 @@ snapshots:
   '@humanwhocodes/config-array@0.10.7':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15159,7 +15134,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15167,7 +15142,7 @@ snapshots:
   '@humanwhocodes/config-array@0.5.0':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -15773,7 +15748,7 @@ snapshots:
 
   '@puppeteer/browsers@2.6.1':
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -16861,7 +16836,7 @@ snapshots:
   '@textlint/markdown-to-ast@12.6.1':
     dependencies:
       '@textlint/ast-node-types': 12.6.1
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       mdast-util-gfm-autolink-literal: 0.1.3
       remark-footnotes: 3.0.0
       remark-frontmatter: 3.0.0
@@ -17299,7 +17274,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -17318,7 +17293,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 9.21.0(jiti@1.21.7)
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -17335,7 +17310,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 7.32.0
     optionalDependencies:
       typescript: 5.7.3
@@ -17347,7 +17322,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 8.24.0
     optionalDependencies:
       typescript: 5.7.3
@@ -17359,7 +17334,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.7.3
@@ -17371,7 +17346,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 9.21.0(jiti@1.21.7)
     optionalDependencies:
       typescript: 5.7.3
@@ -17392,7 +17367,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 8.57.1
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
@@ -17404,7 +17379,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.7.3)
       '@typescript-eslint/utils': 5.62.0(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 9.21.0(jiti@1.21.7)
       tsutils: 3.21.0(typescript@5.7.3)
     optionalDependencies:
@@ -17420,7 +17395,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/visitor-keys': 4.33.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
@@ -17434,7 +17409,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.1
@@ -19440,11 +19415,9 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
-  debug@4.4.0(supports-color@5.5.0):
+  debug@4.4.0:
     dependencies:
       ms: 2.1.3
-    optionalDependencies:
-      supports-color: 5.5.0
 
   decamelize-keys@1.1.1:
     dependencies:
@@ -19999,7 +19972,7 @@ snapshots:
 
   eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.31.0(eslint@7.32.0))(eslint@7.32.0):
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       eslint: 7.32.0
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@4.33.0(eslint@7.32.0)(typescript@5.7.3))(eslint-import-resolver-typescript@2.7.1)(eslint@7.32.0)
       glob: 7.2.3
@@ -20012,7 +19985,7 @@ snapshots:
   eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(@typescript-eslint/parser@5.62.0(eslint@9.21.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.21.0(jiti@1.21.7)))(eslint@9.21.0(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       enhanced-resolve: 5.18.1
       eslint: 9.21.0(jiti@1.21.7)
       get-tsconfig: 4.10.0
@@ -20027,7 +20000,7 @@ snapshots:
   eslint-import-resolver-typescript@3.8.3(eslint-plugin-import@2.31.0(eslint@8.24.0))(eslint@8.24.0):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       enhanced-resolve: 5.18.1
       eslint: 8.24.0
       get-tsconfig: 4.10.0
@@ -20334,7 +20307,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       doctrine: 3.0.0
       enquirer: 2.4.1
       escape-string-regexp: 4.0.0
@@ -20380,7 +20353,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20428,7 +20401,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20475,7 +20448,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       escape-string-regexp: 4.0.0
       eslint-scope: 8.2.0
       eslint-visitor-keys: 4.2.0
@@ -20644,7 +20617,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -20950,7 +20923,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.0.5
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -21182,14 +21155,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
     transitivePeerDependencies:
       - supports-color
 
@@ -21214,8 +21187,6 @@ snapshots:
       harmony-reflect: 1.6.2
 
   ieee754@1.2.1: {}
-
-  ignore-by-default@1.0.1: {}
 
   ignore@4.0.6: {}
 
@@ -21529,7 +21500,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -22133,7 +22104,7 @@ snapshots:
   log4js@6.9.1:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       flatted: 3.3.3
       rfdc: 1.4.1
       streamroller: 3.1.5
@@ -22896,7 +22867,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -22904,7 +22875,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       decode-named-character-reference: 1.0.2
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.0.0
@@ -23193,19 +23164,6 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  nodemon@3.1.4:
-    dependencies:
-      chokidar: 3.6.0
-      debug: 4.4.0(supports-color@5.5.0)
-      ignore-by-default: 1.0.1
-      minimatch: 3.1.2
-      pstree.remy: 1.1.8
-      semver: 7.7.1
-      simple-update-notifier: 2.0.0
-      supports-color: 5.5.0
-      touch: 3.1.1
-      undefsafe: 2.0.5
-
   non-layered-tidy-tree-layout@2.0.2: {}
 
   normalize-package-data@2.5.0:
@@ -23378,7 +23336,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       get-uri: 6.0.4
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -23722,7 +23680,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -23738,8 +23696,6 @@ snapshots:
 
   pseudomap@1.0.2: {}
 
-  pstree.remy@1.1.8: {}
-
   pump@3.0.2:
     dependencies:
       end-of-stream: 1.4.4
@@ -23753,7 +23709,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.6.1
       chromium-bidi: 0.11.0(devtools-protocol@0.0.1367902)
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       devtools-protocol: 0.0.1367902
       typed-query-selector: 2.12.0
       ws: 8.18.1
@@ -24527,10 +24483,6 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
 
-  simple-update-notifier@2.0.0:
-    dependencies:
-      semver: 7.7.1
-
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -24588,7 +24540,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       socks: 2.8.4
     transitivePeerDependencies:
       - supports-color
@@ -24697,7 +24649,7 @@ snapshots:
   streamroller@3.1.5:
     dependencies:
       date-format: 4.0.14
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       fs-extra: 8.1.0
     transitivePeerDependencies:
       - supports-color
@@ -25053,8 +25005,6 @@ snapshots:
 
   toposort@2.0.2: {}
 
-  touch@3.1.1: {}
-
   tr46@0.0.3: {}
 
   tr46@1.0.1:
@@ -25168,7 +25118,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       esbuild: 0.25.0
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -25340,8 +25290,6 @@ snapshots:
       through: 2.3.8
 
   unc-path-regex@0.1.2: {}
-
-  undefsafe@2.0.5: {}
 
   underscore@1.13.7: {}
 
@@ -25599,7 +25547,7 @@ snapshots:
   vite-node@0.32.4(@types/node@22.13.5):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       mlly: 1.7.4
       pathe: 1.1.2
       picocolors: 1.1.1
@@ -25617,7 +25565,7 @@ snapshots:
   vite-node@2.1.9(@types/node@22.13.5):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 1.1.2
       vite: 5.4.14(@types/node@22.13.5)
@@ -25664,7 +25612,7 @@ snapshots:
       acorn-walk: 8.3.4
       cac: 6.7.14
       chai: 4.5.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       local-pkg: 0.4.3
       magic-string: 0.30.17
       pathe: 1.1.2
@@ -25698,7 +25646,7 @@ snapshots:
       '@vitest/spy': 2.1.9
       '@vitest/utils': 2.1.9
       chai: 5.2.0
-      debug: 4.4.0(supports-color@5.5.0)
+      debug: 4.4.0
       expect-type: 1.1.0
       magic-string: 0.30.17
       pathe: 1.1.2


### PR DESCRIPTION
While documenting the @tinacms/graphql package, I found that the `pnpm serve` command no longer works.

This change:

- Removes the `pnpm serve` command
- Removes the dev dependency on `nodemon` within the @tinacms/graphql package