### PR TITLE
Changeling - ignore example projects

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,8 @@
     "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
       "onlyUpdatePeerDependentsWhenOutOfRange": true
     },
-    "ignore": []
+    "ignore": [
+      "@examples/*",
+      "@experimental-examples/*"
+    ]
   }

--- a/examples/basic-iframe/package.json
+++ b/examples/basic-iframe/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "starter-basic-iframe",
+	"name": "@examples/starter-basic-iframe",
 	"private": true,
 	"scripts": {
 		"dev": "tinacms dev --noTelemetry -c \"next dev\"",

--- a/examples/empty/package.json
+++ b/examples/empty/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "starter-empty",
+	"name": "@examples/starter-empty",
 	"private": true,
 	"scripts": {
 		"dev": "next dev",

--- a/examples/kitchen-sink/package.json
+++ b/examples/kitchen-sink/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "e2e-next",
+	"name": "@examples/e2e-next",
 	"version": "0.1.99",
 	"private": true,
 	"scripts": {

--- a/examples/next-2024/package.json
+++ b/examples/next-2024/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "next-2024",
+	"name": "@examples/next-2024",
 	"version": "0.1.27",
 	"private": true,
 	"scripts": {

--- a/examples/tina-self-hosted-demo/package.json
+++ b/examples/tina-self-hosted-demo/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@tinacms/self-hosted-starter",
+	"name": "@examples/self-hosted-starter",
 	"version": "0.1.83",
 	"private": true,
 	"scripts": {

--- a/experimental-examples/kitchen-sink/package.json
+++ b/experimental-examples/kitchen-sink/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "kitchen-sink-starter",
+	"name": "@experimental-examples/kitchen-sink-starter",
 	"private": true,
 	"scripts": {
 		"dev": "tinacms dev -c \"next dev\"",

--- a/experimental-examples/tina-cloud-starter/package.json
+++ b/experimental-examples/tina-cloud-starter/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tinacms/starter",
+  "name": "@experimental-examples/starter",
   "version": "0.1.64",
   "private": true,
   "scripts": {


### PR DESCRIPTION
This pull request introduces changes to organize and namespace example projects more effectively by updating their package names and configuring the changeset tool to ignore specific namespaces. The most important changes include renaming packages under `examples` and `experimental-examples` directories and updating the `.changeset/config.json` file to exclude these namespaces from versioning.

### Namespacing Example Projects:

* Updated package names in the `examples` directory to use the `@examples` namespace. This change affects the following files:
  - `examples/basic-iframe/package.json` (`starter-basic-iframe` → `@examples/starter-basic-iframe`)
  - `examples/empty/package.json` (`starter-empty` → `@examples/starter-empty`)
  - `examples/kitchen-sink/package.json` (`e2e-next` → `@examples/e2e-next`)
  - `examples/next-2024/package.json` (`next-2024` → `@examples/next-2024`)
  - `examples/tina-self-hosted-demo/package.json` (`@tinacms/self-hosted-starter` → `@examples/self-hosted-starter`)

* Updated package names in the `experimental-examples` directory to use the `@experimental-examples` namespace. This change affects the following files:
  - `experimental-examples/kitchen-sink/package.json` (`kitchen-sink-starter` → `@experimental-examples/kitchen-sink-starter`)
  - `experimental-examples/tina-cloud-starter/package.json` (`@tinacms/starter` → `@experimental-examples/starter`)

### Changeset Configuration:

* Updated `.changeset/config.json` to ignore the `@examples/*` and `@experimental-examples/*` namespaces during versioning. This ensures that changes to these packages do not trigger unnecessary version bumps.