### PR TITLE
feat: dedupe format types by moving them into schema-tools

### DIFF
--- a/.changeset/metal-spies-wonder.md
+++ b/.changeset/metal-spies-wonder.md
@@ -1,0 +1,7 @@
+---
+"@tinacms/cli": patch
+"@tinacms/graphql": patch
+"@tinacms/schema-tools": patch
+---
+
+feat: dedupe format types by moving them into schema-tools

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
@@ -3,7 +3,12 @@ import path from 'path';
 import yaml from 'js-yaml';
 import minimatch from 'minimatch';
 import { parseFile, stringifyFile } from '@tinacms/graphql';
-import type { Collection, TinaField, ContentFormat, ContentFrontmatterFormat } from '@tinacms/schema-tools';
+import type {
+  Collection,
+  TinaField,
+  ContentFormat,
+  ContentFrontmatterFormat,
+} from '@tinacms/schema-tools';
 import { CONTENT_FORMATS } from '@tinacms/schema-tools';
 import { getFieldsFromTemplates, parseSections } from './util';
 import { logger } from '../../logger';

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
@@ -3,7 +3,8 @@ import path from 'path';
 import yaml from 'js-yaml';
 import minimatch from 'minimatch';
 import { parseFile, stringifyFile } from '@tinacms/graphql';
-import type { Collection, TinaField, UITemplate } from '@tinacms/schema-tools';
+import type { Collection, TinaField, ContentFormat, ContentFrontmatterFormat } from '@tinacms/schema-tools';
+import { CONTENT_FORMATS } from '@tinacms/schema-tools';
 import { getFieldsFromTemplates, parseSections } from './util';
 import { logger } from '../../logger';
 import { dangerText, linkText, warnText } from '../../utils/theme';
@@ -49,12 +50,11 @@ const transformForestryMatchToTinaMatch = (match: string) => {
 
   return newMatch;
 };
-type Ext = 'mdx' | 'md' | 'json' | 'yaml' | 'yml' | 'toml';
 
-function checkExt(ext: string): Ext | false {
-  const extReal = ext.replace('.', '');
-  if (['mdx', 'md', 'json', 'yaml', 'yml', 'toml'].includes(extReal)) {
-    return extReal as Ext;
+function checkExt(ext: string): ContentFormat | false {
+  const extReal = ext.replace('.', '') as ContentFormat;
+  if (CONTENT_FORMATS.includes(extReal)) {
+    return extReal;
   } else {
     return false;
   }
@@ -92,7 +92,7 @@ export const generateAllTemplates = async ({
 };
 
 const generateCollectionFromForestrySection = (args: {
-  frontMatterFormat?: 'yaml' | 'toml' | 'json';
+  frontMatterFormat?: ContentFrontmatterFormat;
   section: {
     templates?: string[];
     label?: string;
@@ -122,7 +122,7 @@ const generateCollectionFromForestrySection = (args: {
   if (section.read_only) return;
 
   // find the document format
-  let format: Ext = 'md';
+  let format: ContentFormat = 'md';
   if (section.new_doc_ext) {
     const ext = checkExt(section.new_doc_ext);
     if (ext) {
@@ -345,7 +345,7 @@ export const generateCollections = async ({
   usingTypescript,
   frontMatterFormat,
 }: {
-  frontMatterFormat?: 'toml' | 'yaml' | 'json';
+  frontMatterFormat?: ContentFrontmatterFormat;
   pathToForestryConfig: string;
   usingTypescript: boolean;
 }) => {
@@ -395,7 +395,7 @@ const rewriteTemplateKeysInDocs = (args: {
     }
   >;
   markdownParseConfig?: {
-    frontmatterFormat?: 'toml' | 'yaml' | 'json';
+    frontmatterFormat?: ContentFrontmatterFormat;
     frontmatterDelimiters?: [string, string] | string;
   };
 }) => {

--- a/packages/@tinacms/cli/src/cmds/init/apply.ts
+++ b/packages/@tinacms/cli/src/cmds/init/apply.ts
@@ -9,7 +9,6 @@ import {
   indentText,
   linkText,
   logText,
-  neutralText,
   titleText,
 } from '../../utils/theme';
 import { Telemetry } from '@tinacms/metrics';
@@ -31,6 +30,7 @@ import {
 } from './index';
 import { Config } from './prompts';
 import { addSelfHostedTinaAuthToConfig } from './codegen';
+import { ContentFrontmatterFormat } from '@tinacms/schema-tools';
 
 async function apply({
   env,
@@ -219,7 +219,7 @@ const forestryMigrate = async ({
 }: {
   usingTypescript: boolean;
   pathToForestryConfig: string;
-  frontMatterFormat: 'yaml' | 'toml' | 'json';
+  frontMatterFormat: ContentFrontmatterFormat;
 }) => {
   const { collections, importStatements, templateCode } =
     await generateCollections({

--- a/packages/@tinacms/cli/src/cmds/init/detectEnvironment.ts
+++ b/packages/@tinacms/cli/src/cmds/init/detectEnvironment.ts
@@ -174,7 +174,9 @@ const detectEnvironment = async ({
     const hugoConfigPath = path.join(rootPath, 'config.toml');
     if (await fs.pathExists(hugoConfigPath)) {
       const hugoConfig = await fs.readFile(hugoConfigPath, 'utf8');
-      const metaDataFormat = hugoConfig.toString().match(/metaDataFormat = "(.*)"/)?.[1];
+      const metaDataFormat = hugoConfig
+        .toString()
+        .match(/metaDataFormat = "(.*)"/)?.[1];
       if (
         metaDataFormat &&
         (metaDataFormat === 'yaml' ||

--- a/packages/@tinacms/cli/src/cmds/init/detectEnvironment.ts
+++ b/packages/@tinacms/cli/src/cmds/init/detectEnvironment.ts
@@ -1,7 +1,8 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { logger } from '../../logger';
-import { FrontmatterFormat, GeneratedFile, InitEnvironment } from './index';
+import { GeneratedFile, InitEnvironment } from './index';
+import { ContentFrontmatterFormat } from '@tinacms/schema-tools';
 
 const checkGitignoreForItem = async ({
   baseDir,
@@ -168,12 +169,12 @@ const detectEnvironment = async ({
     (await checkGitignoreForItem({ baseDir, line: '.env.tina' }));
   const hasGitIgnoreEnv =
     hasGitIgnore && (await checkGitignoreForItem({ baseDir, line: '.env' }));
-  let frontMatterFormat: FrontmatterFormat;
+  let frontMatterFormat: ContentFrontmatterFormat;
   if (hasForestryConfig) {
     const hugoConfigPath = path.join(rootPath, 'config.toml');
     if (await fs.pathExists(hugoConfigPath)) {
       const hugoConfig = await fs.readFile(hugoConfigPath, 'utf8');
-      const metaDataFormat = hugoConfig.match(/metaDataFormat = "(.*)"/)?.[1];
+      const metaDataFormat = hugoConfig.toString().match(/metaDataFormat = "(.*)"/)?.[1];
       if (
         metaDataFormat &&
         (metaDataFormat === 'yaml' ||

--- a/packages/@tinacms/cli/src/cmds/init/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/index.ts
@@ -9,6 +9,7 @@ import configure from './configure';
 import { CLICommand } from '../index';
 import apply from './apply';
 import { Config } from './prompts';
+import { ContentFrontmatterFormat } from '@tinacms/schema-tools';
 
 export interface Framework {
   name: 'next' | 'hugo' | 'jekyll' | 'other';
@@ -42,12 +43,10 @@ export type GeneratedFile = {
   };
 };
 
-export type FrontmatterFormat = 'yaml' | 'toml' | 'json';
-
 export type InitEnvironment = {
   hasTinaDeps: boolean;
   forestryConfigExists: boolean;
-  frontMatterFormat: FrontmatterFormat;
+  frontMatterFormat: ContentFrontmatterFormat;
   gitIgnoreExists: boolean;
   gitIgnoreNodeModulesExists: boolean;
   gitIgnoreTinaEnvExists: boolean;

--- a/packages/@tinacms/cli/src/cmds/init/prompts/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/index.ts
@@ -3,6 +3,7 @@ import type { PromptObject } from 'prompts';
 import { Framework, InitEnvironment } from '../';
 import { linkText, logText } from '../../../utils/theme';
 import { Config, ImportStatement } from './types';
+import { ContentFrontmatterFormat } from '@tinacms/schema-tools';
 
 export * from './askTinaCloudSetup';
 export * from './types';
@@ -90,7 +91,7 @@ export const askForestryMigrate = async ({
   const answers = await prompts(questions);
   return answers as {
     forestryMigrate: boolean;
-    frontMatterFormat?: 'yaml' | 'toml' | 'json';
+    frontMatterFormat?: ContentFrontmatterFormat;
   };
 };
 

--- a/packages/@tinacms/cli/src/cmds/init/prompts/types.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/types.ts
@@ -7,7 +7,7 @@ export type Config = {
   framework: Framework;
   packageManager: 'pnpm' | 'yarn' | 'npm';
   forestryMigrate: boolean;
-  frontMatterFormat?: ContentFrontmatterFormat
+  frontMatterFormat?: ContentFrontmatterFormat;
   hosting?: 'tina-cloud' | 'self-host';
   gitProvider?: PromptGitProvider;
   databaseAdapter?: PromptDatabaseAdapter;

--- a/packages/@tinacms/cli/src/cmds/init/prompts/types.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/types.ts
@@ -1,3 +1,4 @@
+import { ContentFrontmatterFormat } from '@tinacms/schema-tools';
 import { Framework, GeneratedFileType } from '../';
 
 export type Config = {
@@ -6,7 +7,7 @@ export type Config = {
   framework: Framework;
   packageManager: 'pnpm' | 'yarn' | 'npm';
   forestryMigrate: boolean;
-  frontMatterFormat?: 'yaml' | 'toml' | 'json';
+  frontMatterFormat?: ContentFrontmatterFormat
   hosting?: 'tina-cloud' | 'self-host';
   gitProvider?: PromptGitProvider;
   databaseAdapter?: PromptDatabaseAdapter;

--- a/packages/@tinacms/graphql/src/database/util.ts
+++ b/packages/@tinacms/graphql/src/database/util.ts
@@ -1,7 +1,3 @@
-/**
-
-*/
-
 import * as yup from 'yup';
 import toml from '@iarna/toml';
 import yaml from 'js-yaml';
@@ -18,6 +14,7 @@ import micromatch from 'micromatch';
 import { Bridge } from './bridge';
 import path from 'path';
 import { replaceNameOverrides } from './alias-utils';
+import { ContentFormat, ContentFrontmatterFormat } from '@tinacms/schema-tools';
 
 export { normalizePath };
 
@@ -30,11 +27,11 @@ const matterEngines = {
 
 export const stringifyFile = (
   content: object,
-  format: FormatType | string, // FIXME
+  format: ContentFormat | string, // FIXME
   /** For non-polymorphic documents we don't need the template key */
   keepTemplateKey: boolean,
   markdownParseConfig?: {
-    frontmatterFormat?: 'toml' | 'yaml' | 'json';
+    frontmatterFormat?: ContentFrontmatterFormat;
     frontmatterDelimiters?: [string, string] | string;
   }
 ): string => {
@@ -87,10 +84,10 @@ export const stringifyFile = (
 
 export const parseFile = <T extends object>(
   content: string,
-  format: FormatType | string, // FIXME
+  format: ContentFormat | string, // FIXME
   yupSchema: (args: typeof yup) => yup.ObjectSchema<any>,
   markdownParseConfig?: {
-    frontmatterFormat?: 'toml' | 'yaml' | 'json';
+    frontmatterFormat?: ContentFrontmatterFormat;
     frontmatterDelimiters?: [string, string] | string;
   }
 ): T => {
@@ -134,8 +131,6 @@ export const parseFile = <T extends object>(
   }
   throw new Error(`Must specify a valid format, got ${format}`);
 };
-
-export type FormatType = 'json' | 'md' | 'mdx' | 'markdown';
 
 export const atob = (b64Encoded: string) => {
   return Buffer.from(b64Encoded, 'base64').toString();

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -1,7 +1,15 @@
 import type { FC } from 'react';
 import type React from 'react';
 
-export const CONTENT_FORMATS = ['mdx', 'md', 'markdown', 'json', 'yaml', 'yml', 'toml'] as const;
+export const CONTENT_FORMATS = [
+  'mdx',
+  'md',
+  'markdown',
+  'json',
+  'yaml',
+  'yml',
+  'toml',
+] as const;
 export type ContentFormat = (typeof CONTENT_FORMATS)[number];
 
 export type ContentFrontmatterFormat = 'yaml' | 'toml' | 'json';

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -1,5 +1,10 @@
-import type { FC, ReactNode } from 'react';
+import type { FC } from 'react';
 import type React from 'react';
+
+export const CONTENT_FORMATS = ['mdx', 'md', 'markdown', 'json', 'yaml', 'yml', 'toml'] as const;
+export type ContentFormat = (typeof CONTENT_FORMATS)[number];
+
+export type ContentFrontmatterFormat = 'yaml' | 'toml' | 'json';
 
 type Meta = {
   active?: boolean;
@@ -782,7 +787,7 @@ interface BaseCollection {
   name: string;
   path: string;
   indexes?: IndexType[];
-  format?: 'json' | 'md' | 'markdown' | 'mdx' | 'yaml' | 'yml' | 'toml';
+  format?: ContentFormat;
   ui?: UICollection;
   /**
    * @deprecated - use `ui.defaultItem` on the each `template` instead
@@ -791,7 +796,7 @@ interface BaseCollection {
   /**
    * This format will be used to parse the markdown frontmatter
    */
-  frontmatterFormat?: 'yaml' | 'toml' | 'json';
+  frontmatterFormat?: ContentFrontmatterFormat;
   /**
    * The delimiters used to parse the frontmatter.
    */

--- a/packages/@tinacms/schema-tools/src/validate/schema.ts
+++ b/packages/@tinacms/schema-tools/src/validate/schema.ts
@@ -7,15 +7,7 @@ import {
   duplicateCollectionErrorMessage,
   duplicateFieldErrorMessage,
 } from './util';
-const FORMATS = [
-  'json',
-  'md',
-  'markdown',
-  'mdx',
-  'toml',
-  'yaml',
-  'yml',
-] as const;
+import { CONTENT_FORMATS } from '../types/index';
 
 const Template = z
   .object({
@@ -60,7 +52,7 @@ export const CollectionBaseSchema = z.object({
         });
       }
     }),
-  format: z.enum(FORMATS).optional(),
+  format: z.enum(CONTENT_FORMATS).optional(),
   isAuthCollection: z.boolean().optional(),
   isDetached: z.boolean().optional(),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^4.5.9
-        version: 4.5.9(@types/node@22.13.5)
+        version: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
 
   examples/basic-iframe:
     dependencies:
@@ -88,6 +88,19 @@ importers:
         specifier: '7'
         version: 7.32.0
 
+  examples/brookjeynes.dev:
+    dependencies:
+      tinacms:
+        specifier: workspace:*
+        version: link:../../packages/tinacms
+    devDependencies:
+      '@tinacms/cli':
+        specifier: workspace:*
+        version: link:../../packages/@tinacms/cli
+      '@types/node':
+        specifier: ^22.14.1
+        version: 22.15.17
+
   examples/empty:
     dependencies:
       '@tinacms/cli':
@@ -129,7 +142,7 @@ importers:
         version: 2.2.0(react@18.3.1)
       '@tailwindcss/typography':
         specifier: ^0.5.16
-        version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))
+        version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))
       '@tinacms/datalayer':
         specifier: workspace:*
         version: link:../../packages/@tinacms/datalayer
@@ -190,16 +203,16 @@ importers:
         version: 23.11.1(typescript@5.7.3)
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+        version: 3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
       vite:
         specifier: ^4.5.9
-        version: 4.5.9(@types/node@22.13.5)
+        version: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
       vitest:
         specifier: ^0.32.4
-        version: 0.32.4(happy-dom@15.10.2)(playwright@1.50.1)
+        version: 0.32.4(happy-dom@15.10.2)(playwright@1.50.1)(terser@5.39.0)
 
   examples/next-2024:
     dependencies:
@@ -479,7 +492,7 @@ importers:
     dependencies:
       '@graphiql/toolkit':
         specifier: 0.8.4
-        version: 0.8.4(@types/node@22.13.5)(graphql@15.8.0)
+        version: 0.8.4(@types/node@22.15.17)(graphql@15.8.0)
       '@headlessui/react':
         specifier: 2.1.8
         version: 2.1.8(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -497,7 +510,7 @@ importers:
         version: 4.20.10
       graphiql:
         specifier: 3.0.0-alpha.1
-        version: 3.0.0-alpha.1(@codemirror/language@6.0.0)(@types/node@22.13.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.0.0-alpha.1(@codemirror/language@6.0.0)(@types/node@22.15.17)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: 15.8.0
         version: 15.8.0
@@ -537,7 +550,7 @@ importers:
         version: link:../scripts
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+        version: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       next:
         specifier: 14.2.10
         version: 14.2.10(@babel/core@7.26.9)(@playwright/test@1.50.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -585,13 +598,13 @@ importers:
         version: 8.1.0(typescript@5.7.3)
       '@tailwindcss/aspect-ratio':
         specifier: ^0.4.2
-        version: 0.4.2(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))
+        version: 0.4.2(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))
       '@tailwindcss/container-queries':
         specifier: ^0.1.1
-        version: 0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))
+        version: 0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))
       '@tailwindcss/typography':
         specifier: ^0.5.16
-        version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))
+        version: 0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))
       '@tinacms/app':
         specifier: workspace:*
         version: link:../app
@@ -609,7 +622,7 @@ importers:
         version: link:../search
       '@vitejs/plugin-react':
         specifier: 3.1.0
-        version: 3.1.0(vite@4.5.9(@types/node@22.13.5))
+        version: 3.1.0(vite@4.5.9(@types/node@22.15.17)(terser@5.39.0))
       altair-express-middleware:
         specifier: ^7.3.6
         version: 7.3.6
@@ -693,7 +706,7 @@ importers:
         version: 4.7.0
       tailwindcss:
         specifier: ^3.4.17
-        version: 3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+        version: 3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       tinacms:
         specifier: workspace:*
         version: link:../../tinacms
@@ -705,7 +718,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^4.5.9
-        version: 4.5.9(@types/node@22.13.5)
+        version: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
       yup:
         specifier: ^1.6.1
         version: 1.6.1
@@ -763,7 +776,13 @@ importers:
         version: 0.32.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+        version: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
+
+  packages/@tinacms/common:
+    devDependencies:
+      typescript:
+        specifier: ^4.7.4
+        version: 4.9.5
 
   packages/@tinacms/datalayer:
     dependencies:
@@ -945,10 +964,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^4.5.9
-        version: 4.5.9(@types/node@22.13.5)
+        version: 4.5.9(@types/node@22.13.5)(terser@5.39.0)
       vitest:
         specifier: ^0.32.4
-        version: 0.32.4(happy-dom@15.10.2)(playwright@1.50.1)
+        version: 0.32.4(happy-dom@15.10.2)(playwright@1.50.1)(terser@5.39.0)
       zod:
         specifier: ^3.24.2
         version: 3.24.2
@@ -1087,10 +1106,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^4.5.9
-        version: 4.5.9(@types/node@22.13.5)
+        version: 4.5.9(@types/node@22.13.5)(terser@5.39.0)
       vitest:
         specifier: ^0.32.4
-        version: 0.32.4(happy-dom@15.10.2)(playwright@1.50.1)
+        version: 0.32.4(happy-dom@15.10.2)(playwright@1.50.1)(terser@5.39.0)
 
   packages/@tinacms/metrics:
     dependencies:
@@ -1112,7 +1131,7 @@ importers:
         version: 11.3.0
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+        version: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1146,13 +1165,13 @@ importers:
         version: 0.29.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+        version: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       react:
         specifier: ^18.3.1
         version: 18.3.1
       ts-jest:
         specifier: ^29.2.5
-        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))(typescript@5.7.3)
+        version: 29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))(typescript@5.7.3)
       typescript:
         specifier: ^5.7.3
         version: 5.7.3
@@ -1164,7 +1183,7 @@ importers:
     dependencies:
       '@sucrase/jest-plugin':
         specifier: ^3.0.0
-        version: 3.0.0(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))(sucrase@3.35.0)
+        version: 3.0.0(jest@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))(sucrase@3.35.0)
       chalk:
         specifier: ^4.1.2
         version: 4.1.2
@@ -1191,7 +1210,7 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^4.5.9
-        version: 4.5.9(@types/node@22.13.5)
+        version: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
 
   packages/@tinacms/search:
     dependencies:
@@ -1784,10 +1803,10 @@ importers:
         version: 5.7.3
       vite:
         specifier: ^5.4.14
-        version: 5.4.14(@types/node@22.13.5)
+        version: 5.4.14(@types/node@22.13.5)(terser@5.39.0)
       vitest:
         specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.13.5)(happy-dom@15.10.2)
+        version: 2.1.9(@types/node@22.13.5)(happy-dom@15.10.2)(terser@5.39.0)
 
   packages/tinacms-authjs:
     dependencies:
@@ -4103,6 +4122,9 @@ packages:
     resolution: {integrity: sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/source-map@0.3.6':
+    resolution: {integrity: sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==}
+
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
 
@@ -5628,6 +5650,9 @@ packages:
   '@types/node@22.13.5':
     resolution: {integrity: sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==}
 
+  '@types/node@22.15.17':
+    resolution: {integrity: sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==}
+
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
 
@@ -7112,6 +7137,9 @@ packages:
   commander@12.1.0:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
+
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -11316,6 +11344,9 @@ packages:
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
 
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
   source-map@0.5.6:
     resolution: {integrity: sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==}
     engines: {node: '>=0.10.0'}
@@ -11619,6 +11650,11 @@ packages:
   term-vector@1.0.1:
     resolution: {integrity: sha512-BGbMdDB2Kx40sUaGj7iS5xKnLreqIR+dqFvEOaRl63DjMG+5DSOT9ZecWreQepbiIxrBesb88O1P916xk+ixIA==}
     engines: {node: '>=6'}
+
+  terser@5.39.0:
+    resolution: {integrity: sha512-LBAhFyLho16harJoWMg/nZsQYgTrg5jXOn2nCYjRUcZZEdE3qa2zb8QEDRUGVZBW4rlazf2fxkg8tztybTaqWw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -11974,6 +12010,11 @@ packages:
     peerDependencies:
       typescript: 4.6.x || 4.7.x || 4.8.x || 4.9.x || 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x
 
+  typescript@4.9.5:
+    resolution: {integrity: sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==}
+    engines: {node: '>=4.2.0'}
+    hasBin: true
+
   typescript@5.7.3:
     resolution: {integrity: sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==}
     engines: {node: '>=14.17'}
@@ -12013,6 +12054,9 @@ packages:
 
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
@@ -14880,9 +14924,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@graphiql/react@0.18.0(@codemirror/language@6.0.0)(@types/node@22.13.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@graphiql/react@0.18.0(@codemirror/language@6.0.0)(@types/node@22.15.17)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@graphiql/toolkit': 0.8.4(@types/node@22.13.5)(graphql@15.8.0)
+      '@graphiql/toolkit': 0.8.4(@types/node@22.15.17)(graphql@15.8.0)
       '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dropdown-menu': 2.1.6(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -14907,11 +14951,11 @@ snapshots:
       - '@types/react-dom'
       - graphql-ws
 
-  '@graphiql/toolkit@0.8.4(@types/node@22.13.5)(graphql@15.8.0)':
+  '@graphiql/toolkit@0.8.4(@types/node@22.15.17)(graphql@15.8.0)':
     dependencies:
       '@n1ru4l/push-pull-async-iterable-iterator': 3.2.0
       graphql: 15.8.0
-      meros: 1.3.0(@types/node@22.13.5)
+      meros: 1.3.0(@types/node@22.15.17)
     transitivePeerDependencies:
       - '@types/node'
 
@@ -15272,7 +15316,7 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
@@ -15285,14 +15329,49 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      jest-config: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      jest-haste-map: 29.7.0
+      jest-message-util: 29.7.0
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-resolve-dependencies: 29.7.0
+      jest-runner: 29.7.0
+      jest-runtime: 29.7.0
+      jest-snapshot: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      jest-watcher: 29.7.0
+      micromatch: 4.0.8
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-ansi: 6.0.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  '@jest/core@29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))':
+    dependencies:
+      '@jest/console': 29.7.0
+      '@jest/reporters': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      '@types/node': 22.15.17
+      ansi-escapes: 4.3.2
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-changed-files: 29.7.0
+      jest-config: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -15317,7 +15396,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -15335,7 +15414,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -15357,7 +15436,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -15433,7 +15512,7 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       '@types/yargs': 15.0.19
       chalk: 4.1.2
 
@@ -15442,7 +15521,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -15455,6 +15534,12 @@ snapshots:
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/set-array@1.2.1': {}
+
+  '@jridgewell/source-map@0.3.6':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.8
+      '@jridgewell/trace-mapping': 0.3.25
+    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
@@ -16668,9 +16753,9 @@ snapshots:
       '@smithy/types': 4.1.0
       tslib: 2.8.1
 
-  '@sucrase/jest-plugin@3.0.0(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))(sucrase@3.35.0)':
+  '@sucrase/jest-plugin@3.0.0(jest@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))(sucrase@3.35.0)':
     dependencies:
-      jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      jest: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       sucrase: 3.35.0
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.26.9)':
@@ -16777,13 +16862,13 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
-  '@tailwindcss/aspect-ratio@0.4.2(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))':
+  '@tailwindcss/aspect-ratio@0.4.2(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))':
     dependencies:
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
 
-  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))':
+  '@tailwindcss/container-queries@0.1.1(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))':
     dependencies:
-      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
 
   '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))':
     dependencies:
@@ -16792,6 +16877,14 @@ snapshots:
       lodash.merge: 4.6.2
       postcss-selector-parser: 6.0.10
       tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
 
   '@tanstack/react-virtual@3.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -16898,7 +16991,7 @@ snapshots:
   '@types/body-parser@1.19.5':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/braces@3.0.5': {}
 
@@ -16912,7 +17005,7 @@ snapshots:
 
   '@types/cli-spinner@0.2.3':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/codemirror@0.0.90':
     dependencies:
@@ -16926,11 +17019,11 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/cors@2.8.17':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/cors@2.8.5':
     dependencies:
@@ -16938,7 +17031,7 @@ snapshots:
 
   '@types/cross-spawn@6.0.6':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/crypto-js@3.1.47': {}
 
@@ -16973,7 +17066,7 @@ snapshots:
 
   '@types/express-serve-static-core@4.19.6':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       '@types/qs': 6.9.18
       '@types/range-parser': 1.2.7
       '@types/send': 0.17.4
@@ -16990,15 +17083,15 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/fs-extra@9.0.13':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/hast@2.3.10':
     dependencies:
@@ -17063,7 +17156,7 @@ snapshots:
 
   '@types/jsonfile@6.1.4':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/level-codec@9.0.4': {}
 
@@ -17079,11 +17172,11 @@ snapshots:
     dependencies:
       '@types/abstract-leveldown': 7.2.5
       '@types/level-errors': 3.0.2
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/listr@0.14.2':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       rxjs: 6.6.7
 
   '@types/lodash.camelcase@4.3.9':
@@ -17146,6 +17239,10 @@ snapshots:
     dependencies:
       undici-types: 6.20.0
 
+  '@types/node@22.15.17':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/normalize-package-data@2.4.4': {}
 
   '@types/normalize-path@3.0.2': {}
@@ -17160,11 +17257,11 @@ snapshots:
 
   '@types/progress@2.0.7':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/prompts@2.4.9':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       kleur: 3.0.3
 
   '@types/prop-types@15.7.14': {}
@@ -17211,12 +17308,12 @@ snapshots:
   '@types/send@0.17.4':
     dependencies:
       '@types/mime': 1.3.5
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/serve-static@1.15.7':
     dependencies:
       '@types/http-errors': 2.0.4
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       '@types/send': 0.17.4
 
   '@types/stack-utils@2.0.3': {}
@@ -17229,7 +17326,7 @@ snapshots:
 
   '@types/tar@6.1.13':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       minipass: 4.2.8
 
   '@types/tern@0.23.9':
@@ -17244,12 +17341,12 @@ snapshots:
 
   '@types/whatwg-url@8.2.2':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       '@types/webidl-conversions': 7.0.3
 
   '@types/ws@7.4.7':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   '@types/yargs-parser@21.0.3': {}
 
@@ -17263,7 +17360,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
     optional: true
 
   '@types/yup@0.29.14': {}
@@ -18117,14 +18214,14 @@ snapshots:
 
   '@vercel/stega@0.0.5': {}
 
-  '@vitejs/plugin-react@3.1.0(vite@4.5.9(@types/node@22.13.5))':
+  '@vitejs/plugin-react@3.1.0(vite@4.5.9(@types/node@22.15.17)(terser@5.39.0))':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.9)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.9)
       magic-string: 0.27.0
       react-refresh: 0.14.2
-      vite: 4.5.9(@types/node@22.13.5)
+      vite: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18141,13 +18238,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 1.2.0
 
-  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@22.13.5))':
+  '@vitest/mocker@2.1.9(vite@5.4.14(@types/node@22.13.5)(terser@5.39.0))':
     dependencies:
       '@vitest/spy': 2.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 5.4.14(@types/node@22.13.5)
+      vite: 5.4.14(@types/node@22.13.5)(terser@5.39.0)
 
   '@vitest/pretty-format@2.1.9':
     dependencies:
@@ -18995,6 +19092,9 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@2.20.3:
+    optional: true
+
   commander@4.1.1: {}
 
   commander@7.2.0: {}
@@ -19115,6 +19215,21 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-config: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -21009,10 +21124,10 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphiql@3.0.0-alpha.1(@codemirror/language@6.0.0)(@types/node@22.13.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  graphiql@3.0.0-alpha.1(@codemirror/language@6.0.0)(@types/node@22.15.17)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@graphiql/react': 0.18.0(@codemirror/language@6.0.0)(@types/node@22.13.5)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@graphiql/toolkit': 0.8.4(@types/node@22.13.5)(graphql@15.8.0)
+      '@graphiql/react': 0.18.0(@codemirror/language@6.0.0)(@types/node@22.15.17)(@types/react-dom@18.3.5(@types/react@18.3.18))(@types/react@18.3.18)(graphql@15.8.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@graphiql/toolkit': 0.8.4(@types/node@22.15.17)(graphql@15.8.0)
       graphql: 15.8.0
       graphql-language-service: 5.3.0(graphql@15.8.0)
       markdown-it: 12.3.2
@@ -21556,7 +21671,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3(babel-plugin-macros@3.1.0)
@@ -21595,6 +21710,25 @@ snapshots:
       - supports-color
       - ts-node
 
+  jest-cli@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-config@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)):
     dependencies:
       '@babel/core': 7.26.9
@@ -21622,6 +21756,68 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.5
       ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.7.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)):
+    dependencies:
+      '@babel/core': 7.26.9
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.9)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.15.17
+      ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.7.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)):
+    dependencies:
+      '@babel/core': 7.26.9
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.26.9)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.15.17
+      ts-node: 10.9.2(@types/node@22.15.17)(typescript@5.7.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -21671,7 +21867,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -21701,7 +21897,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -21747,7 +21943,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -21782,7 +21978,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -21810,7 +22006,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       chalk: 4.1.2
       cjs-module-lexer: 1.4.3
       collect-v8-coverage: 1.0.2
@@ -21856,7 +22052,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -21875,7 +22071,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -21884,7 +22080,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -21895,6 +22091,18 @@ snapshots:
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -22548,9 +22756,9 @@ snapshots:
       stylis: 4.3.6
       uuid: 9.0.1
 
-  meros@1.3.0(@types/node@22.13.5):
+  meros@1.3.0(@types/node@22.15.17):
     optionalDependencies:
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
 
   methods@1.1.2: {}
 
@@ -23525,6 +23733,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.3
       ts-node: 10.9.2(@types/node@22.13.5)(typescript@5.7.3)
+
+  postcss-load-config@4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)):
+    dependencies:
+      lilconfig: 3.1.3
+      yaml: 2.7.0
+    optionalDependencies:
+      postcss: 8.5.3
+      ts-node: 10.9.2(@types/node@22.15.17)(typescript@5.7.3)
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.3)(yaml@2.7.0):
     dependencies:
@@ -24562,6 +24778,12 @@ snapshots:
       buffer-from: 1.1.2
       source-map: 0.6.1
 
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+    optional: true
+
   source-map@0.5.6: {}
 
   source-map@0.5.7: {}
@@ -24891,6 +25113,33 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
+  tailwindcss@3.4.17(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.3
+      postcss-import: 15.1.0(postcss@8.5.3)
+      postcss-js: 4.0.1(postcss@8.5.3)
+      postcss-load-config: 4.0.2(postcss@8.5.3)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
+      postcss-nested: 6.2.0(postcss@8.5.3)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.10
+      sucrase: 3.35.0
+    transitivePeerDependencies:
+      - ts-node
+
   tapable@2.2.1: {}
 
   tar-fs@2.1.2:
@@ -24936,6 +25185,14 @@ snapshots:
   term-size@2.2.1: {}
 
   term-vector@1.0.1: {}
+
+  terser@5.39.0:
+    dependencies:
+      '@jridgewell/source-map': 0.3.6
+      acorn: 8.8.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    optional: true
 
   test-exclude@6.0.0:
     dependencies:
@@ -25052,12 +25309,12 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3)))(typescript@5.7.3):
+  ts-jest@29.2.6(@babel/core@7.26.9)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.26.9))(jest@29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3)))(typescript@5.7.3):
     dependencies:
       bs-logger: 0.2.6
       ejs: 3.1.10
       fast-json-stable-stringify: 2.1.0
-      jest: 29.7.0(@types/node@22.13.5)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.13.5)(typescript@5.7.3))
+      jest: 29.7.0(@types/node@22.15.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3))
       jest-util: 29.7.0
       json5: 2.2.3
       lodash.memoize: 4.1.2
@@ -25088,6 +25345,25 @@ snapshots:
       typescript: 5.7.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  ts-node@10.9.2(@types/node@22.15.17)(typescript@5.7.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.15.17
+      acorn: 8.8.2
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.7.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optional: true
 
   tsc-alias@1.8.11:
     dependencies:
@@ -25269,6 +25545,8 @@ snapshots:
       typescript: 5.7.3
       yaml: 2.7.0
 
+  typescript@4.9.5: {}
+
   typescript@5.7.3: {}
 
   ua-parser-js@1.0.40: {}
@@ -25299,6 +25577,8 @@ snapshots:
   underscore@1.13.7: {}
 
   undici-types@6.20.0: {}
+
+  undici-types@6.21.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -25549,14 +25829,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite-node@0.32.4(@types/node@22.13.5):
+  vite-node@0.32.4(@types/node@22.15.17)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       mlly: 1.7.4
       pathe: 1.1.2
       picocolors: 1.1.1
-      vite: 4.5.9(@types/node@22.13.5)
+      vite: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25567,13 +25847,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@2.1.9(@types/node@22.13.5):
+  vite-node@2.1.9(@types/node@22.13.5)(terser@5.39.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 1.1.2
-      vite: 5.4.14(@types/node@22.13.5)
+      vite: 5.4.14(@types/node@22.13.5)(terser@5.39.0)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -25585,7 +25865,7 @@ snapshots:
       - supports-color
       - terser
 
-  vite@4.5.9(@types/node@22.13.5):
+  vite@4.5.9(@types/node@22.13.5)(terser@5.39.0):
     dependencies:
       esbuild: 0.18.20
       postcss: 8.5.3
@@ -25593,8 +25873,19 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.5
       fsevents: 2.3.3
+      terser: 5.39.0
 
-  vite@5.4.14(@types/node@22.13.5):
+  vite@4.5.9(@types/node@22.15.17)(terser@5.39.0):
+    dependencies:
+      esbuild: 0.18.20
+      postcss: 8.5.3
+      rollup: 3.29.5
+    optionalDependencies:
+      '@types/node': 22.15.17
+      fsevents: 2.3.3
+      terser: 5.39.0
+
+  vite@5.4.14(@types/node@22.13.5)(terser@5.39.0):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.3
@@ -25602,12 +25893,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.5
       fsevents: 2.3.3
+      terser: 5.39.0
 
-  vitest@0.32.4(happy-dom@15.10.2)(playwright@1.50.1):
+  vitest@0.32.4(happy-dom@15.10.2)(playwright@1.50.1)(terser@5.39.0):
     dependencies:
       '@types/chai': 4.3.20
       '@types/chai-subset': 1.3.5
-      '@types/node': 22.13.5
+      '@types/node': 22.15.17
       '@vitest/expect': 0.32.4
       '@vitest/runner': 0.32.4
       '@vitest/snapshot': 0.32.4
@@ -25626,8 +25918,8 @@ snapshots:
       strip-literal: 1.3.0
       tinybench: 2.9.0
       tinypool: 0.5.0
-      vite: 4.5.9(@types/node@22.13.5)
-      vite-node: 0.32.4(@types/node@22.13.5)
+      vite: 4.5.9(@types/node@22.15.17)(terser@5.39.0)
+      vite-node: 0.32.4(@types/node@22.15.17)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       happy-dom: 15.10.2
@@ -25641,10 +25933,10 @@ snapshots:
       - supports-color
       - terser
 
-  vitest@2.1.9(@types/node@22.13.5)(happy-dom@15.10.2):
+  vitest@2.1.9(@types/node@22.13.5)(happy-dom@15.10.2)(terser@5.39.0):
     dependencies:
       '@vitest/expect': 2.1.9
-      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@22.13.5))
+      '@vitest/mocker': 2.1.9(vite@5.4.14(@types/node@22.13.5)(terser@5.39.0))
       '@vitest/pretty-format': 2.1.9
       '@vitest/runner': 2.1.9
       '@vitest/snapshot': 2.1.9
@@ -25660,8 +25952,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 1.2.0
-      vite: 5.4.14(@types/node@22.13.5)
-      vite-node: 2.1.9(@types/node@22.13.5)
+      vite: 5.4.14(@types/node@22.13.5)(terser@5.39.0)
+      vite-node: 2.1.9(@types/node@22.13.5)(terser@5.39.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.13.5


### PR DESCRIPTION
This PR dedupes format and content types by moving them into `@tinacms/schema-tools`.

This superseeds #5633  