### PR TITLE
Disable sourcemap generation 

### DIFF
--- a/.changeset/orange-bottles-agree.md
+++ b/.changeset/orange-bottles-agree.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/cli": patch
+"@tinacms/scripts": patch
+---
+
+Disable sourcemap generation (reduce HEAP consumption on build)

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -226,20 +226,20 @@ export const createConfig = async ({
       host: configManager.config?.build?.host ?? false,
       watch: noWatch
         ? {
-            ignored: ['**/*'],
-          }
+          ignored: ['**/*'],
+        }
         : {
-            // Ignore everything except for the alias fields we specified above
-            ignored: [
-              `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx|_graphql.json)`,
-            ],
-          },
+          // Ignore everything except for the alias fields we specified above
+          ignored: [
+            `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx|_graphql.json)`,
+          ],
+        },
       fs: {
         strict: false,
       },
     },
     build: {
-      sourcemap: true,
+      sourcemap: false,
       outDir: configManager.outputFolderPath,
       emptyOutDir: true,
       rollupOptions: rollupOptions,

--- a/packages/@tinacms/cli/src/next/vite/index.ts
+++ b/packages/@tinacms/cli/src/next/vite/index.ts
@@ -226,14 +226,14 @@ export const createConfig = async ({
       host: configManager.config?.build?.host ?? false,
       watch: noWatch
         ? {
-          ignored: ['**/*'],
-        }
+            ignored: ['**/*'],
+          }
         : {
-          // Ignore everything except for the alias fields we specified above
-          ignored: [
-            `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx|_graphql.json)`,
-          ],
-        },
+            // Ignore everything except for the alias fields we specified above
+            ignored: [
+              `${configManager.tinaFolderPath}/**/!(config.prebuild.jsx|_graphql.json)`,
+            ],
+          },
       fs: {
         strict: false,
       },

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -80,9 +80,8 @@ const registerCommands = (commands: Command[], noHelp = false) => {
         console.log('\nCommands:');
         const optionTag = ' [options]';
         command.subCommands.forEach((subcommand, i) => {
-          const commandStr = `${subcommand.command}${
-            (subcommand.options || []).length ? optionTag : ''
-          }`;
+          const commandStr = `${subcommand.command}${(subcommand.options || []).length ? optionTag : ''
+            }`;
 
           const padLength =
             Math.max(...command.subCommands.map((sub) => sub.command.length)) +
@@ -268,7 +267,7 @@ export async function init(args: any) {
 
   program.usage('command [options]');
   // error on unknown commands
-  program.on('command:*', function () {
+  program.on('command:*', function() {
     console.error(
       'Invalid command: %s\nSee --help for a list of available commands.',
       args.join(' ')
@@ -276,7 +275,7 @@ export async function init(args: any) {
     process.exit(1);
   });
 
-  program.on('--help', function () {
+  program.on('--help', function() {
     console.log(`
 You can get help on any command with "-h" or "--help".
 e.g: "forestry types:gen --help"
@@ -439,7 +438,7 @@ export const buildIt = async (entryPoint, packageJSON) => {
       },
       outDir: outInfo.outdir,
       emptyOutDir: false, // we build multiple files in to the dir
-      sourcemap: true, // true | 'inline' (note: inline will go straight into your bundle size)
+      sourcemap: false, // true | 'inline' (note: inline will go straight into your bundle size)
       rollupOptions: {
         onwarn(warning, warn) {
           if (warning.code === 'MODULE_LEVEL_DIRECTIVE') {

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -80,8 +80,9 @@ const registerCommands = (commands: Command[], noHelp = false) => {
         console.log('\nCommands:');
         const optionTag = ' [options]';
         command.subCommands.forEach((subcommand, i) => {
-          const commandStr = `${subcommand.command}${(subcommand.options || []).length ? optionTag : ''
-            }`;
+          const commandStr = `${subcommand.command}${
+            (subcommand.options || []).length ? optionTag : ''
+          }`;
 
           const padLength =
             Math.max(...command.subCommands.map((sub) => sub.command.length)) +
@@ -267,7 +268,7 @@ export async function init(args: any) {
 
   program.usage('command [options]');
   // error on unknown commands
-  program.on('command:*', function() {
+  program.on('command:*', function () {
     console.error(
       'Invalid command: %s\nSee --help for a list of available commands.',
       args.join(' ')
@@ -275,7 +276,7 @@ export async function init(args: any) {
     process.exit(1);
   });
 
-  program.on('--help', function() {
+  program.on('--help', function () {
     console.log(`
 You can get help on any command with "-h" or "--help".
 e.g: "forestry types:gen --help"


### PR DESCRIPTION
This pull request includes changes to modify the source map generation settings and fix formatting issues in the codebase. The most important changes are grouped below by theme.

### Source Map Configuration Updates:
* [`packages/@tinacms/cli/src/next/vite/index.ts`](diffhunk://#diff-b1fda4e536e3c44a60ad0d8b39e7c8922e76a9d25745084ae2d5140042719e8dL242-R242): Changed `sourcemap` setting in the `build` configuration from `true` to `false` to disable source map generation.
* [`packages/@tinacms/scripts/src/index.ts`](diffhunk://#diff-a9a90706203d9df28f641832cd8977957afe053167ca6c9b92240cd6431e87ebL442-R441): Updated the `sourcemap` setting in the `buildIt` function to `false`, disabling source map generation for builds.

### Code Formatting Fix:
* [`packages/@tinacms/scripts/src/index.ts`](diffhunk://#diff-a9a90706203d9df28f641832cd8977957afe053167ca6c9b92240cd6431e87ebL83-R83): Fixed formatting in the `registerCommands` function to improve readability by adjusting how the `commandStr` is constructed.