### PR TITLE
🐛 Bug - Editorial workflow fails to save from preview when path ends in slash

### DIFF
--- a/packages/tinacms/src/admin/pages/IndexingPage.tsx
+++ b/packages/tinacms/src/admin/pages/IndexingPage.tsx
@@ -5,7 +5,6 @@ import { useSearchParams } from 'react-router-dom';
 import { Client } from '../../internalClient';
 import { TinaAdminApi } from '../api';
 
-// TODO: Scott B styles
 type IndexingState =
   | 'starting'
   | 'indexing'
@@ -104,7 +103,7 @@ export const IndexingPage: FC = () => {
 
           const api = new TinaAdminApi(cms);
           const params = api.schema.transformPayload(collection.name, values);
-          const relativePath = fullPath.replace(`${collection.path}/`, '');
+          const relativePath = pathRelativeToCollection(collection.path, fullPath)
 
           if (await api.isAuthenticated()) {
             if (kind === 'delete') {
@@ -197,3 +196,18 @@ const Wrapper = ({ children }: any) => (
     {children}
   </div>
 );
+
+const pathRelativeToCollection = (collectionPath: string, fullPath: string): string => {
+  const cleanCollectionPath = simplifyPathParts(collectionPath) + '/';
+  const cleanFullPath = simplifyPathParts(fullPath);
+  if (cleanFullPath.startsWith(cleanCollectionPath)) {
+    return cleanFullPath.substring(cleanCollectionPath.length);
+  }
+  throw new Error(`Path ${fullPath} not within collection path ${collectionPath}`)
+}
+
+const simplifyPathParts = (path: string): string => {
+  return path.split('/')
+             .filter((name: string) => name != '')
+             .join('/');
+}


### PR DESCRIPTION
This change rectifies a bug where saving will fail:

- when editorial workflow protections are enabled,
- the collection path ends in '/', and
- the `ui.router` is set on the collection.

The root cause was that, during indexing, path separators were not being processed correctly.

This change improves the path processing to ensure that the collection path is correctly removed from the `fullPath` of the file being modified. It does this by preprocessing the paths to ensure that there are no consecutive slashes and ensuring that both provided paths are non-absolute.