### PR TITLE
✏️ Typo - Rename CreateBranchModel to CreateBranchModal

### DIFF
--- a/.changeset/brave-bobcats-flash.md
+++ b/.changeset/brave-bobcats-flash.md
@@ -1,0 +1,6 @@
+---
+"tinacms": patch
+---
+
+- ✏️ Rename `CreateBranchModel` to `CreateBranchModal`
+- Add Deprecation no `CreateBranchModel`

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -9,7 +9,7 @@ import type { Collection, TinaField } from '@tinacms/schema-tools';
 import {
   BaseTextField,
   Button,
-  CreateBranchModel,
+  CreateBranchModal,
   CursorPaginator,
   Input,
   Message,
@@ -395,7 +395,7 @@ const CollectionListPage = () => {
                       )}
                     {/* Editorial workflow  */}
                     {deleteModalOpen && cms.api.tina.usingProtectedBranch() && (
-                      <CreateBranchModel
+                      <CreateBranchModal
                         crudType='delete'
                         relativePath={`${collectionExtra.path}/${vars.relativePath}`}
                         values={vars}

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -397,7 +397,7 @@ const CollectionListPage = () => {
                     {deleteModalOpen && cms.api.tina.usingProtectedBranch() && (
                       <CreateBranchModal
                         crudType='delete'
-                        relativePath={`${collectionExtra.path}/${vars.relativePath}`}
+                        path={`${collectionExtra.path}/${vars.relativePath}`}
                         values={vars}
                         close={() => setDeleteModalOpen(false)}
                         safeSubmit={async () => {

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -209,7 +209,7 @@ export const FormBuilder: FC<FormBuilderProps> = ({
               <CreateBranchModal
                 safeSubmit={safeSubmit}
                 crudType={tinaForm.crudType}
-                relativePath={tinaForm.relativePath}
+                path={tinaForm.relativePath}
                 values={tinaForm.values}
                 close={() => setCreateBranchModalOpen(false)}
               />

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -206,7 +206,7 @@ export const FormBuilder: FC<FormBuilderProps> = ({
         return (
           <>
             {createBranchModalOpen && (
-              <CreateBranchModel
+              <CreateBranchModal
                 safeSubmit={safeSubmit}
                 crudType={tinaForm.crudType}
                 relativePath={tinaForm.relativePath}
@@ -391,6 +391,10 @@ const getAnimationProps = (animateStatus) => {
       : {};
 };
 
+/**
+ * @deprecated
+ * Original misspelt version of CreateBranchModal
+ */
 export const CreateBranchModel = ({
   close,
   safeSubmit,
@@ -403,6 +407,28 @@ export const CreateBranchModel = ({
   relativePath: string;
   values: Record<string, unknown>;
   crudType: string;
+}) => (
+  <CreateBranchModal
+    close={close}
+    safeSubmit={safeSubmit}
+    path={relativePath}
+    values={values}
+    crudType={crudType}
+  />
+);
+
+export const CreateBranchModal = ({
+  close,
+  safeSubmit,
+  path,
+  values,
+  crudType,
+}: {
+  safeSubmit: () => Promise<void>;
+  close: () => void;
+  path: string;
+  values: Record<string, unknown>;
+  crudType: string;
 }) => {
   const cms = useCMS();
   const tinaApi = cms.api.tina;
@@ -412,7 +438,7 @@ export const CreateBranchModel = ({
 
   const onCreateBranch = (newBranchName) => {
     localStorage.setItem('tina.createBranchState', 'starting');
-    localStorage.setItem('tina.createBranchState.fullPath', relativePath);
+    localStorage.setItem('tina.createBranchState.fullPath', path);
     localStorage.setItem(
       'tina.createBranchState.values',
       JSON.stringify(values)


### PR DESCRIPTION
This change:

- Corrects the spelling of `CreateBranchModel` to `CreateBranchModal` throughout TinaCMS.
- Renames the `relativePath` property to `path` - this is to minimize future confusion about the path, which is not relative to any collection.

As the original `CreateBranchModel` was publicly exposed, a wrapper type is added with a deprecated warning.
