### PR TITLE
🚧 WIP - ♻️ Refactor - Use Form.id instead of Form.relativePath

### DIFF
--- a/.changeset/khaki-toes-tell.md
+++ b/.changeset/khaki-toes-tell.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+♻️ Refactor - Use Form.id instead of Form.relativePath, mark FormOptions.relativePath and Form.relativePath as deprecated

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -262,7 +262,7 @@ export const RenderForm = ({
             folderName && !filename?.startsWith('/') ? `/${folderName}/` : '/';
 
           // keeps the forms relative path in sync with the filename
-          form.relativePath =
+          form.id =
             schemaCollection.path +
             appendFolder +
             `${filename}.${schemaCollection.format || 'md'}`;

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -114,14 +114,14 @@ export const FormBuilder: FC<FormBuilderProps> = ({
   const schema: TinaSchema = cms.api.tina.schema;
 
   React.useEffect(() => {
-    const collection = schema.getCollectionByFullPath(tinaForm.relativePath);
+    const collection = schema.getCollectionByFullPath(tinaForm.id);
     if (collection?.ui?.beforeSubmit) {
       tinaForm.beforeSubmit = (values: any) =>
         collection.ui.beforeSubmit({ cms, form: tinaForm, values });
     } else {
       tinaForm.beforeSubmit = undefined;
     }
-  }, [tinaForm.relativePath]);
+  }, [tinaForm.id]);
 
   const moveArrayItem = React.useCallback(
     (result: DropResult) => {
@@ -209,7 +209,7 @@ export const FormBuilder: FC<FormBuilderProps> = ({
               <CreateBranchModal
                 safeSubmit={safeSubmit}
                 crudType={tinaForm.crudType}
-                path={tinaForm.relativePath}
+                path={tinaForm.id}
                 values={tinaForm.values}
                 close={() => setCreateBranchModalOpen(false)}
               />

--- a/packages/tinacms/src/toolkit/forms/form.ts
+++ b/packages/tinacms/src/toolkit/forms/form.ts
@@ -37,6 +37,12 @@ export interface FormOptions<S, F extends Field = AnyField> extends Config<S> {
   extraSubscribeValues?: FormSubscription;
   queries?: string[];
   crudType?: 'create' | 'update';
+
+  /**
+   * @deprecated
+   * Misleading name as per https://github.com/tinacms/tinacms/issues/5686#issuecomment-2899840518
+   * Use id property instead.
+   */
   relativePath?: string;
 }
 
@@ -56,7 +62,14 @@ export class Form<S = any, F extends Field = AnyField> implements Plugin {
   queries: string[];
   global: GlobalOptions | null = null;
   loading: boolean = false;
+
+  /**
+   * @deprecated
+   * Misleading name as per https://github.com/tinacms/tinacms/issues/5686#issuecomment-2899840518
+   * Use id property instead.
+   */
   relativePath: string;
+
   crudType?: 'create' | 'update';
   beforeSubmit?: (values: S) => Promise<void | S>;
 


### PR DESCRIPTION
This change:

- Marks `Form.relativePath` and `FormOptions.relativePath` as deprecated.
- Refactors TinaCMS to use `Form.id` instead of `Form.relativePath`.

This purpose of this change is to clarify the usage of 'relativePath', as described in the comment at https://github.com/tinacms/tinacms/issues/5686#issuecomment-2899840518
