### PR TITLE
feat: add support for slatejson parser in RichTextField

### DIFF
--- a/.changeset/silent-pens-destroy.md
+++ b/.changeset/silent-pens-destroy.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/schema-tools": minor
+"@tinacms/mdx": minor
+---
+
+Rich text parsers - adds support for slate serialization in json

--- a/packages/@tinacms/mdx/src/next/tests/slatejson/field.ts
+++ b/packages/@tinacms/mdx/src/next/tests/slatejson/field.ts
@@ -1,0 +1,8 @@
+import { RichTextField } from '@tinacms/schema-tools';
+
+export const field: RichTextField = {
+  name: 'unstructured',
+  label: 'Unstructured Content',
+  type: 'rich-text',
+  parser: { type: 'slatejson' },
+};

--- a/packages/@tinacms/mdx/src/next/tests/slatejson/index.test.ts
+++ b/packages/@tinacms/mdx/src/next/tests/slatejson/index.test.ts
@@ -1,0 +1,19 @@
+import { expect, it } from 'vitest';
+import { parseMDX } from '../../../parse';
+import type * as Plate from '../../../parse/plate';
+import { formatMdxForPersistence } from '../../../stringify';
+import * as util from '../util';
+import { field } from './field';
+import input from './node.json?raw';
+
+it('matches input', () => {
+  const tree = parseMDX(input, field, (v) => v);
+  expect(tree).toBeTypeOf('object');
+  //   expect(util.print(tree)).toMatchFile(input);
+
+  const rootElement = formatMdxForPersistence(tree, field, (v) => v);
+  expect(rootElement).toBeTypeOf('object');
+  expect(util.print(rootElement as Plate.RootElement)).toMatchFile(
+    util.nodePath(__dirname)
+  );
+});

--- a/packages/@tinacms/mdx/src/next/tests/slatejson/node.json
+++ b/packages/@tinacms/mdx/src/next/tests/slatejson/node.json
@@ -1,0 +1,14 @@
+{
+  "type": "root",
+  "children": [
+    {
+      "type": "p",
+      "children": [
+        {
+          "type": "text",
+          "text": "This is a test paragraph."
+        }
+      ]
+    }
+  ]
+}

--- a/packages/@tinacms/mdx/src/parse/index.ts
+++ b/packages/@tinacms/mdx/src/parse/index.ts
@@ -4,20 +4,20 @@
 
 */
 
-import { remark } from 'remark';
-import remarkMdx, { type Root } from 'remark-mdx';
-import { gfm } from 'micromark-extension-gfm';
-import { gfmFromMarkdown } from 'mdast-util-gfm';
-import remarkGfm from 'remark-gfm';
-import { parseMDX as parseMDXNext } from '../next';
-import { fromMarkdown } from 'mdast-util-from-markdown';
-import { remarkToSlate, RichTextParseError } from './remarkToPlate';
 import type { RichTextType } from '@tinacms/schema-tools';
-import type * as Plate from './plate';
-import { directiveFromMarkdown } from '../extensions/tina-shortcodes/from-markdown';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { gfmFromMarkdown } from 'mdast-util-gfm';
+import { gfm } from 'micromark-extension-gfm';
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+import remarkMdx, { type Root } from 'remark-mdx';
 import { tinaDirective } from '../extensions/tina-shortcodes/extension';
+import { directiveFromMarkdown } from '../extensions/tina-shortcodes/from-markdown';
+import { parseMDX as parseMDXNext } from '../next';
 import type { Pattern } from '../stringify';
 import { parseShortcode } from './parseShortcode';
+import type * as Plate from './plate';
+import { RichTextParseError, remarkToSlate } from './remarkToPlate';
 /**
  * ### Convert the MDXAST into an API-friendly format
  *
@@ -107,8 +107,13 @@ export const parseMDX = (
   }
   let tree: Root | null;
   try {
-    if (field.parser?.type === 'markdown') {
-      return parseMDXNext(value, field, imageCallback);
+    switch (field.parser?.type) {
+      case 'markdown':
+        return parseMDXNext(value, field, imageCallback);
+      case 'slatejson':
+        // Assuming `value` is a JSON string, parse it into an object
+        const parsedValue = JSON.parse(value);
+        return parsedValue as Plate.RootElement;
     }
     let preprocessedString = value;
     const templatesWithMatchers = field.templates?.filter(

--- a/packages/@tinacms/mdx/src/stringify/acorn.ts
+++ b/packages/@tinacms/mdx/src/stringify/acorn.ts
@@ -1,22 +1,16 @@
-/**
-
-
-
-*/
-// @ts-ignore Fix this by updating prettier
-import prettier from 'prettier/esm/standalone.mjs';
-// @ts-ignore Fix this by updating prettier
-import parser from 'prettier/esm/parser-espree.mjs';
 import type {
   RichTextField,
   RichTextTemplate,
-  ObjectField,
   TinaField,
 } from '@tinacms/schema-tools';
-import type { MdxJsxAttribute } from 'mdast-util-mdx-jsx';
-import * as Plate from '../parse/plate';
 import type * as Md from 'mdast';
-import { rootElement, stringifyMDX } from '.';
+import type { MdxJsxAttribute } from 'mdast-util-mdx-jsx';
+// @ts-ignore Fix this by updating prettier
+import parser from 'prettier/esm/parser-espree.mjs';
+// @ts-ignore Fix this by updating prettier
+import prettier from 'prettier/esm/standalone.mjs';
+import { formatMdxForPersistence, rootElement, stringifyMDX } from '.';
+import * as Plate from '../parse/plate';
 
 export const stringifyPropsInline = (
   element: Plate.MdxInlineElement,
@@ -352,7 +346,11 @@ const findAndTransformNestedRichText = (
         (value) => value.type === 'root' && Array.isArray(value.children),
         `Nested rich-text element is not a valid shape for field ${field.name}`
       );
-      parentValue[field.name] = stringifyMDX(value, field, imageCallback);
+      parentValue[field.name] = formatMdxForPersistence(
+        value,
+        field,
+        imageCallback
+      );
       break;
     }
     case 'object': {

--- a/packages/@tinacms/mdx/src/stringify/index.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.ts
@@ -1,24 +1,18 @@
-/**
-
-
-
-*/
-
-import { Handlers, toMarkdown } from 'mdast-util-to-markdown';
-import { text } from 'mdast-util-to-markdown/lib/handle/text';
-import { gfmToMarkdown } from 'mdast-util-gfm';
-import {
-  mdxJsxToMarkdown,
-  MdxJsxTextElement,
-  MdxJsxFlowElement,
-} from 'mdast-util-mdx-jsx';
-import { stringifyMDX as stringifyMDXNext } from '../next';
 import type { RichTextType } from '@tinacms/schema-tools';
 import type * as Md from 'mdast';
-import type * as Plate from '../parse/plate';
-import { eat } from './marks';
-import { stringifyProps } from './acorn';
+import { gfmToMarkdown } from 'mdast-util-gfm';
+import {
+  MdxJsxFlowElement,
+  MdxJsxTextElement,
+  mdxJsxToMarkdown,
+} from 'mdast-util-mdx-jsx';
+import { Handlers, toMarkdown } from 'mdast-util-to-markdown';
+import { text } from 'mdast-util-to-markdown/lib/handle/text';
 import { directiveToMarkdown } from '../extensions/tina-shortcodes/to-markdown';
+import { stringifyMDX as stringifyMDXNext } from '../next';
+import type * as Plate from '../parse/plate';
+import { stringifyProps } from './acorn';
+import { eat } from './marks';
 import { stringifyShortcode } from './stringifyShortcode';
 
 declare module 'mdast' {
@@ -37,11 +31,22 @@ declare module 'mdast' {
   }
 }
 
+export const formatMdxForPersistence = (
+  value: Plate.RootElement,
+  field: RichTextType,
+  imageCallback: (url: string) => string
+): Plate.RootElement | string | undefined => {
+  if (field.parser?.type === 'slatejson') {
+    return value;
+  }
+  return stringifyMDX(value, field, imageCallback);
+};
+
 export const stringifyMDX = (
   value: Plate.RootElement,
   field: RichTextType,
   imageCallback: (url: string) => string
-) => {
+): string | undefined => {
   if (field.parser?.type === 'markdown') {
     return stringifyMDXNext(value, field, imageCallback);
   }

--- a/packages/@tinacms/mdx/{
  "type": "root",
  "children": [
    {
      "type": "p",
      "children": [
        { 
            "type": "text","text": "This is a test paragraph." }
      ]
    }
  ]
}

+++ b/packages/@tinacms/mdx/{
  "type": "root",
  "children": [
    {
      "type": "p",
      "children": [
        { 
            "type": "text","text": "This is a test paragraph." }
      ]
    }
  ]
}

@@ -1,0 +1,1 @@
+"{\n  \"type\": \"root\",\n  \"children\": [\n    {\n      \"type\": \"p\",\n      \"children\": [\n        { \n            \"type\": \"text\",\"text\": \"This is a test paragraph.\" }\n      ]\n    }\n  ]\n}\n"

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -317,6 +317,7 @@ export type RichTextField<WithNamespace extends boolean = false> = (
      * Specify `"markdown"` if you're having problems with Tina parsing your content.
      */
     parser?:
+      | { type: 'mdx' }
       | {
           type: 'markdown';
           /**
@@ -325,7 +326,12 @@ export type RichTextField<WithNamespace extends boolean = false> = (
            */
           skipEscaping?: 'all' | 'html' | 'none';
         }
-      | { type: 'mdx' };
+      | {
+          /**
+           * Returns the native Slate.js document as JSON. Ideal to retain the pure editor content structure.
+           */
+          type: 'slatejson';
+        };
   };
 export type RichTextTemplate<WithNamespace extends boolean = false> =
   Template<WithNamespace> & {

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -328,7 +328,7 @@ export type RichTextField<WithNamespace extends boolean = false> = (
         }
       | {
           /**
-           * Returns the native Slate.js document as JSON. Ideal to retain the pure editor content structure.
+           * Experimental: Returns the native Slate.js document as JSON. Ideal to retain the pure editor content structure.
            */
           type: 'slatejson';
         };


### PR DESCRIPTION
This pull request introduces support for Slate.js JSON serialization in the TinaCMS rich text parsers, along with various updates to parsing and stringifying logic to accommodate the new format. Key changes include adding a new parser type (`slatejson`), updating the parsing and stringifying functions, and adding tests and sample data for the new functionality.

### New Feature: Slate.js JSON Serialization
* Added a new parser type, `slatejson`, to the `RichTextField` type, allowing the use of Slate.js JSON as a serialization format for rich text content. (`packages/@tinacms/schema-tools/src/types/index.ts`, [[1]](diffhunk://#diff-88b24591b0c36f508270e9ae261e94ea2770198c387d66a95b2fe1620810bde3R320) [[2]](diffhunk://#diff-88b24591b0c36f508270e9ae261e94ea2770198c387d66a95b2fe1620810bde3L328-R334)
* Introduced a new field configuration and test case for the `slatejson` parser in the `@tinacms/mdx` package. (`packages/@tinacms/mdx/src/next/tests/slatejson/field.ts`, [[1]](diffhunk://#diff-db9c7cb569341776adff3f286967e84d23cfebb4a23e9634a97776bf66cb96e3R1-R8); `packages/@tinacms/mdx/src/next/tests/slatejson/index.test.ts`, [[2]](diffhunk://#diff-8086cf6cd978470420b2339c5a74d3c1c3caf74289cf1d249d7bca6aa0cf6849R1-R19)

### Parsing Updates
* Updated the `parseMDX` function to handle the `slatejson` parser, parsing JSON strings into Slate.js document objects. (`packages/@tinacms/mdx/src/parse/index.ts`, [packages/@tinacms/mdx/src/parse/index.tsL110-R116](diffhunk://#diff-0db3aaad1ae1113adaa1ad7397dd3bf384f60e69822ea5e39d735daa5c853683L110-R116))

### Stringifying Updates
* Added the `formatMdxForPersistence` function to handle serialization of Slate.js JSON documents, ensuring compatibility with the `slatejson` parser. (`packages/@tinacms/mdx/src/stringify/index.ts`, [packages/@tinacms/mdx/src/stringify/index.tsR34-R49](diffhunk://#diff-3e37344df91fa280c70fea5871af4f7133e146859100fd53837871fe0c1e026eR34-R49))
* Updated the `findAndTransformNestedRichText` function to use `formatMdxForPersistence` for nested rich text elements. (`packages/@tinacms/mdx/src/stringify/acorn.ts`, [packages/@tinacms/mdx/src/stringify/acorn.tsL355-R353](diffhunk://#diff-c02ff7c0e3a37ecb172e103142bdef1f9bc91a346d16dbdf3f55c3db5b242be7L355-R353))

### Testing and Sample Data
* Added a sample JSON file representing a Slate.js document for testing purposes. (`packages/@tinacms/mdx/src/next/tests/slatejson/node.json`, [packages/@tinacms/mdx/src/next/tests/slatejson/node.jsonR1-R14](diffhunk://#diff-56f94a395595ecd4efaf4004528ddf40a18e5b2690f87e6d84dc7f25c349440fR1-R14))
* Created a test case to validate the parsing and stringifying of Slate.js JSON documents. (`packages/@tinacms/mdx/src/next/tests/slatejson/index.test.ts`, [packages/@tinacms/mdx/src/next/tests/slatejson/index.test.tsR1-R19](diffhunk://#diff-8086cf6cd978470420b2339c5a74d3c1c3caf74289cf1d249d7bca6aa0cf6849R1-R19))