### PR TITLE
feat: Sidebar - show whether there are updates available

### DIFF
--- a/.changeset/polite-pans-scream.md
+++ b/.changeset/polite-pans-scream.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Sidebar - display a warning if the user isn't on the latest version

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -568,6 +568,27 @@ mutation addPendingDocumentMutation(
       throw error;
     }
   }
+
+  async getLatestVersion(): Promise<LatestVersionResponse> {
+    // needs to point at production content api as self hosted doesn't have this endpoint
+    const url = 'https://content.tinajs.io/latest-version';
+
+    try {
+      const res = await fetch(url, {
+        method: 'GET',
+      });
+
+      if (!res.ok) {
+        throw new Error(`Failed to fetch latest version: ${res.statusText}`);
+      }
+
+      const data = await res.json();
+      return data as LatestVersionResponse;
+    } catch (error) {
+      console.error('Error fetching latest version:', error);
+      throw error;
+    }
+  }
 }
 
 export const DEFAULT_LOCAL_TINA_GQL_SERVER_URL =
@@ -705,3 +726,10 @@ export class LocalSearchClient implements SearchClient {
     return false;
   }
 }
+
+export type PackageVersionInfo = {
+  version: string;
+  publishedAt: string;
+};
+
+export type LatestVersionResponse = Record<string, PackageVersionInfo>;

--- a/packages/tinacms/src/toolkit/react-sidebar/components/VersionInfo.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/VersionInfo.tsx
@@ -1,9 +1,11 @@
 import { useCMS } from '@toolkit/react-tinacms';
 import formatDistanceToNow from 'date-fns/formatDistanceToNow';
-import { Check, LoaderCircle, X } from 'lucide-react';
+import { Check, LoaderCircle, TriangleAlert } from 'lucide-react';
 import React from 'react';
-import { version as currentVersion } from '../../../../package.json';
+// import { version as currentVersion } from '../../../../package.json';
 import { LatestVersionResponse } from '../../../internalClient';
+
+const currentVersion = '1.0';
 
 export const VersionInfo = () => {
   const cms = useCMS();
@@ -16,8 +18,8 @@ export const VersionInfo = () => {
       try {
         const latestVersion = await cms.api.tina.getLatestVersion();
         setLatestVersionInfo(latestVersion);
-      } catch (error) {
-        console.error('Error fetching version info:', error);
+      } catch {
+        // swallow errors silently since the api call logs them
       }
       setIsLoading(false);
     };
@@ -58,8 +60,8 @@ const LatestVersionWarning = ({
   }
 
   return (
-    <span className='text-red-500'>
-      <X className='w-4 h-4 inline-block mb-px' />
+    <span className='text-yellow-700'>
+      <TriangleAlert className='w-4 h-4 inline-block mb-px' />
       <br />v{latestVersion} published {relativePublishedAt}
     </span>
   );

--- a/packages/tinacms/src/toolkit/react-sidebar/components/VersionInfo.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/VersionInfo.tsx
@@ -1,0 +1,66 @@
+import { useCMS } from '@toolkit/react-tinacms';
+import formatDistanceToNow from 'date-fns/formatDistanceToNow';
+import { Check, LoaderCircle, X } from 'lucide-react';
+import React from 'react';
+import { version as currentVersion } from '../../../../package.json';
+import { LatestVersionResponse } from '../../../internalClient';
+
+export const VersionInfo = () => {
+  const cms = useCMS();
+  const [isLoading, setIsLoading] = React.useState(true);
+  const [latestVersionInfo, setLatestVersionInfo] =
+    React.useState<LatestVersionResponse | null>(null);
+
+  React.useEffect(() => {
+    const fetchVersionInfo = async () => {
+      try {
+        const latestVersion = await cms.api.tina.getLatestVersion();
+        setLatestVersionInfo(latestVersion);
+      } catch (error) {
+        console.error('Error fetching version info:', error);
+      }
+      setIsLoading(false);
+    };
+
+    fetchVersionInfo();
+  }, [cms]);
+
+  return (
+    <span className='font-sans font-light text-xs mb-3 mt-4 text-gray-500'>
+      TinaCMS v{currentVersion + ' '}
+      {isLoading ? (
+        <LoaderCircle className='animate-spin w-4 h-4 inline-block mb-px' />
+      ) : (
+        <LatestVersionWarning latestVersionInfo={latestVersionInfo} />
+      )}
+    </span>
+  );
+};
+
+const LatestVersionWarning = ({
+  latestVersionInfo,
+}: { latestVersionInfo: LatestVersionResponse | null }) => {
+  if (!latestVersionInfo) return null;
+
+  const latestVersion = latestVersionInfo['tinacms']?.version;
+  const relativePublishedAt = latestVersionInfo.tinacms?.publishedAt
+    ? formatDistanceToNow(new Date(latestVersionInfo.tinacms?.publishedAt), {
+        addSuffix: true,
+      })
+    : '';
+
+  if (!latestVersion) {
+    return null;
+  }
+
+  if (latestVersion === currentVersion) {
+    return <Check className='w-4 h-4 inline-block mb-px text-green-500' />;
+  }
+
+  return (
+    <span className='text-red-500'>
+      <X className='w-4 h-4 inline-block mb-px' />
+      <br />v{latestVersion} published {relativePublishedAt}
+    </span>
+  );
+};

--- a/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
@@ -8,8 +8,8 @@ import * as React from 'react';
 import { BiExit, BiMenu } from 'react-icons/bi';
 import { FiInfo } from 'react-icons/fi';
 import { VscNewFile } from 'react-icons/vsc';
-import { version } from '../../../../package.json';
 import { cn } from '../../../utils/cn';
+import { VersionInfo } from './VersionInfo';
 import { SyncStatusButton, SyncStatusModal } from './sync-status';
 
 interface NavCollection {
@@ -220,9 +220,7 @@ export const Nav = ({
             className='text-lg py-2 first:pt-3 last:pb-3 whitespace-nowrap flex items-center opacity-80 text-gray-600 hover:text-blue-400'
             cms={cms}
           />
-          <span className='font-sans font-light text-xs mb-3 mt-4 text-gray-500'>
-            TinaCMS v{version}
-          </span>
+          <VersionInfo />
         </div>
       </div>
 


### PR DESCRIPTION
This pull request introduces a feature to display the latest version information for TinaCMS in the sidebar, enhancing user awareness of updates. The main changes include adding a new API method to fetch version data, creating a `VersionInfo` component for the UI, and integrating it into the sidebar navigation.

Closes #5735

### Backend Changes:
* Added a `getLatestVersion` method in the `internalClient` to fetch the latest version information from the production content API. This method handles API requests and error management. (`packages/tinacms/src/internalClient/index.ts`, [packages/tinacms/src/internalClient/index.tsR571-R591](diffhunk://#diff-e02e8af8c0fef23bc974a290d85cd5e497cc4169cebb545ddac9b9499da4f352R571-R591))
* Introduced new TypeScript types: `PackageVersionInfo` and `LatestVersionResponse`, to structure the version data. (`packages/tinacms/src/internalClient/index.ts`, [packages/tinacms/src/internalClient/index.tsR729-R735](diffhunk://#diff-e02e8af8c0fef23bc974a290d85cd5e497cc4169cebb545ddac9b9499da4f352R729-R735))

### Frontend Changes:
* Created a `VersionInfo` component to display the current and latest version of TinaCMS, including a status indicator for version updates. It uses `date-fns` for formatting timestamps and integrates icons for visual feedback. (`packages/tinacms/src/toolkit/react-sidebar/components/VersionInfo.tsx`, [packages/tinacms/src/toolkit/react-sidebar/components/VersionInfo.tsxR1-R66](diffhunk://#diff-19ed88cdfd179443ecbbdfd48d66a4da3636050f6d2f636840f30d4fb78834b7R1-R66))
* Replaced the static version display in the sidebar navigation with the new `VersionInfo` component, ensuring dynamic and up-to-date version information. (`packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx`, [[1]](diffhunk://#diff-133a0e784833b22fc4b2056592039e23e58183b79f935584f7ac258dbd6f5596L11-R12) [[2]](diffhunk://#diff-133a0e784833b22fc4b2056592039e23e58183b79f935584f7ac258dbd6f5596L223-R223)

![CleanShot 2025-06-24 at 11 15 16](https://github.com/user-attachments/assets/e4e25cee-3677-44ab-ba6f-021b355929f3)
**Figure: when user is using latest version**

![CleanShot 2025-06-24 at 16 59 15@2x](https://github.com/user-attachments/assets/ee229462-273e-4d5b-996c-13ac10745c03)
**Figure: when user is not using latest version**
