### PR TITLE
🚧 WIP - 🧑‍💻 DX - Cease overriding error stacks

### DIFF
--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -674,7 +674,6 @@ export class Database {
         originalError: error,
         file: filepath,
         collection: collectionName,
-        stack: error.stack,
       });
     }
   };
@@ -1191,7 +1190,6 @@ export class Database {
                 originalError: error,
                 file: path,
                 collection: collection.name,
-                stack: error.stack,
               });
             }
             // I dont think this should ever happen

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1750,7 +1750,6 @@ const _indexContent = async ({
         originalError: error,
         file: filepath,
         collection: collection?.name,
-        stack: error.stack,
       });
     }
   });

--- a/packages/@tinacms/graphql/src/resolver/error.ts
+++ b/packages/@tinacms/graphql/src/resolver/error.ts
@@ -39,19 +39,19 @@ export type TypeFetchErrorArgs = {
 };
 
 export class TinaFetchError extends Error {
-  public stack?: string;
   public collection?: string;
   public file?: string;
   originalError: Error;
+
   constructor(message: string, args: TypeFetchErrorArgs) {
     super(message);
     this.name = 'TinaFetchError';
     this.collection = args.collection;
-    this.stack = args.stack;
     this.file = args.file;
     this.originalError = args.originalError;
   }
 }
+
 export class TinaQueryError extends TinaFetchError {
   public stack?: string;
   public collection?: string;
@@ -68,10 +68,10 @@ export class TinaQueryError extends TinaFetchError {
 }
 
 export class TinaParseDocumentError extends TinaFetchError {
-  public stack?: string;
   public collection?: string;
   public file?: string;
   originalError: Error;
+
   constructor(args: TypeFetchErrorArgs) {
     super(
       `Error parsing file ${args.file} from collection ${
@@ -80,6 +80,7 @@ export class TinaParseDocumentError extends TinaFetchError {
       args
     );
   }
+
   toString() {
     return (
       super.toString() + '\n OriginalError: \n' + this.originalError.toString()

--- a/packages/@tinacms/graphql/src/resolver/error.ts
+++ b/packages/@tinacms/graphql/src/resolver/error.ts
@@ -31,6 +31,7 @@ export class TinaGraphQLError extends Error implements GraphQLError {
 }
 
 export type TypeFetchErrorArgs = {
+  /** @deprecated */
   stack?: string;
   file?: string;
   includeAuditMessage?: boolean;

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -236,7 +236,6 @@ export const transformDocumentIntoPayload = async (
         collection: collection.name,
         includeAuditMessage: !isAudit,
         file: relativePath,
-        stack: e.stack,
       });
     }
 


### PR DESCRIPTION
In the following sub-classes of Error, the stack member is overridden:

- `TinaFetchError`
- `TinaQueryError`

As a result, the normal stack trace produced by the error unwinding the stack becomes inaccessible, making bug hunting within Tina difficult.

This PR is WIP until a proper testing plan can be devised.

![image](https://github.com/user-attachments/assets/9bc65496-954b-4fd4-96c7-fc7eba305b10)
**Figure: Error output as seen in the TinaCloud logs - not only is this a duplicate of the `originalError.stack` value, it is not clear how the error was processed within Tina**