### PR TITLE
🔧 fix: Trim whitespace in query before splitting for search index

### DIFF
--- a/packages/@tinacms/search/src/index-client.ts
+++ b/packages/@tinacms/search/src/index-client.ts
@@ -7,7 +7,7 @@ export const queryToSearchIndexQuery = (
   stopwordLanguages?: string[]
 ) => {
   let q;
-  const parts = query.split(' ');
+  const parts = query.trim().split(' ');
   const stopwords = lookupStopwords(stopwordLanguages);
   if (parts.length === 1) {
     q = { AND: [parts[0]] };


### PR DESCRIPTION
There has been some issues around JSON parsing on search queries with whitespace, so quick solution is to trim the white space.
