### PR TITLE
🧪 GraphQL Test - Boolean filtering queries

### DIFF
--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/index.test.ts
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/index.test.ts
@@ -1,0 +1,31 @@
+import { it, expect } from 'vitest';
+import config from './tina/config';
+import { setup, format } from '../util';
+
+it('filters movies by boolean archived operations', async () => {
+  const { get } = await setup(__dirname, config);
+  const result = await get({
+    query: `query {
+      archivedTrue: movieConnection(filter: { archived: { eq: true } }, sort: "title") {
+        edges {
+          node {
+            id
+            title
+            archived
+          }
+        }
+      },
+      archivedFalse: movieConnection(filter: { archived: { eq: false } }, sort: "title") {
+        edges {
+          node {
+            id
+            title
+            archived
+          }
+        }
+      }
+    }`,
+    variables: {},
+  });
+  expect(format(result)).toMatchFileSnapshot('node.json');
+});

--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-alpha.md
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-alpha.md
@@ -1,0 +1,4 @@
+---
+title: Movie Alpha
+archived: false
+---

--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-beta.md
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-beta.md
@@ -1,0 +1,4 @@
+---
+title: Movie Beta
+archived: true
+---

--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-delta.md
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-delta.md
@@ -1,0 +1,4 @@
+---
+title: Movie Delta
+archived: true
+---

--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-gamma.md
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/movies/movie-gamma.md
@@ -1,0 +1,4 @@
+---
+title: Movie Gamma
+archived: false
+---

--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/node.json
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/node.json
@@ -1,0 +1,40 @@
+{
+  "data": {
+    "archivedTrue": {
+      "edges": [
+        {
+          "node": {
+            "id": "movies/movie-beta.md",
+            "title": "Movie Beta",
+            "archived": true
+          }
+        },
+        {
+          "node": {
+            "id": "movies/movie-delta.md",
+            "title": "Movie Delta",
+            "archived": true
+          }
+        }
+      ]
+    },
+    "archivedFalse": {
+      "edges": [
+        {
+          "node": {
+            "id": "movies/movie-alpha.md",
+            "title": "Movie Alpha",
+            "archived": false
+          }
+        },
+        {
+          "node": {
+            "id": "movies/movie-gamma.md",
+            "title": "Movie Gamma",
+            "archived": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/@tinacms/graphql/tests/boolean-filtering-query/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/boolean-filtering-query/tina/config.ts
@@ -1,0 +1,26 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Movie',
+      name: 'movie',
+      path: 'movies',
+      fields: [
+        {
+          name: 'title',
+          label: 'Title',
+          required: true,
+          type: 'string',
+        },
+        {
+          name: 'archived',
+          label: 'Archived',
+          type: 'boolean',
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };

--- a/packages/@tinacms/graphql/tests/util.ts
+++ b/packages/@tinacms/graphql/tests/util.ts
@@ -37,10 +37,9 @@ export const setup = async (dir: string, config: any) => {
     tinaDirectory: 'tina',
   });
   await database.indexContent(await buildSchema(config));
-  const get = async <T extends z.ZodSchema = typeof dataSchema>(options?: {
+  const get = async (options?: {
     query: string;
     variables: Record<string, unknown>;
-    schema: T;
   }) => {
     const result = await resolve({
       database,


### PR DESCRIPTION
This change:

- Adds an automated test for filtering on boolean types
- Removes an unused parameter from the test utility function used to execute queries.