### PR TITLE
⚡ Performance - Improved query engine performance with slow databases, adds abort signal

### DIFF
--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1010,7 +1010,18 @@ export class Database {
     return true;
   };
 
-  public query = async (queryOptions: QueryOptions, hydrator) => {
+  public query = async <T>(
+    queryOptions: QueryOptions,
+    hydrator: (path: string, value?: Record<string, unknown>) => T
+  ): Promise<{
+    edges: { node: T; cursor: string }[];
+    pageInfo: {
+      hasPreviousPage: boolean;
+      hasNextPage: boolean;
+      startCursor: string;
+      endCursor: string;
+    };
+  }> => {
     await this.initLevel();
     const {
       first,

--- a/packages/@tinacms/graphql/tests/list-query-performance/index.test.ts
+++ b/packages/@tinacms/graphql/tests/list-query-performance/index.test.ts
@@ -5,10 +5,16 @@ import { setup, format, SlowMemoryLevel } from '../util';
 const TEST_TIMEOUT = 5000;
 const EACH_GET_DELAY = 1000;
 
-it('retrieves a 4 item list within 5 seconds', async () => {
-  const { get } = await setup(__dirname, config, new SlowMemoryLevel<string, Record<string, any>>(EACH_GET_DELAY));
-  const result = await get({
-    query: `query {
+it(
+  'retrieves a 4 item list within 5 seconds',
+  async () => {
+    const { get } = await setup(
+      __dirname,
+      config,
+      new SlowMemoryLevel<string, Record<string, any>>(EACH_GET_DELAY)
+    );
+    const result = await get({
+      query: `query {
       movieConnection {
         totalCount
         edges {
@@ -21,7 +27,9 @@ it('retrieves a 4 item list within 5 seconds', async () => {
         }
       }
     }`,
-    variables: {},
-  });
-  expect(format(result)).toMatchFileSnapshot('node.json');
-}, { timeout: TEST_TIMEOUT });
+      variables: {},
+    });
+    expect(format(result)).toMatchFileSnapshot('node.json');
+  },
+  { timeout: TEST_TIMEOUT }
+);

--- a/packages/@tinacms/graphql/tests/list-query-performance/index.test.ts
+++ b/packages/@tinacms/graphql/tests/list-query-performance/index.test.ts
@@ -1,0 +1,27 @@
+import { it, expect } from 'vitest';
+import config from './tina/config';
+import { setup, format, SlowMemoryLevel } from '../util';
+
+const TEST_TIMEOUT = 5000;
+const EACH_GET_DELAY = 1000;
+
+it('retrieves a 4 item list within 5 seconds', async () => {
+  const { get } = await setup(__dirname, config, new SlowMemoryLevel<string, Record<string, any>>(EACH_GET_DELAY));
+  const result = await get({
+    query: `query {
+      movieConnection {
+        totalCount
+        edges {
+          node {
+            id
+            title
+            releaseDate
+            rating
+          }
+        }
+      }
+    }`,
+    variables: {},
+  });
+  expect(format(result)).toMatchFileSnapshot('node.json');
+}, { timeout: TEST_TIMEOUT });

--- a/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-alpha.md
+++ b/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-alpha.md
@@ -1,0 +1,5 @@
+---
+title: 'Alpha Movie'
+releaseDate: '2020-01-01T00:00:00.000Z'
+rating: 8.5
+---

--- a/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-beta.md
+++ b/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-beta.md
@@ -1,0 +1,5 @@
+---
+title: 'Beta Movie'
+releaseDate: '2020-01-01T00:00:00.000Z'
+rating: 7.2
+---

--- a/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-delta.md
+++ b/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-delta.md
@@ -1,0 +1,5 @@
+---
+title: 'Delta Movie'
+releaseDate: '2019-01-01T00:00:00.000Z'
+rating: 6.8
+---

--- a/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-gamma.md
+++ b/packages/@tinacms/graphql/tests/list-query-performance/movies/movie-gamma.md
@@ -1,0 +1,5 @@
+---
+title: 'Gamma Movie'
+releaseDate: '2019-01-01T00:00:00.000Z'
+rating: 9.1
+---

--- a/packages/@tinacms/graphql/tests/list-query-performance/node.json
+++ b/packages/@tinacms/graphql/tests/list-query-performance/node.json
@@ -1,0 +1,41 @@
+{
+  "data": {
+    "movieConnection": {
+      "totalCount": 4,
+      "edges": [
+        {
+          "node": {
+            "id": "movies/movie-alpha.md",
+            "title": "Alpha Movie",
+            "releaseDate": "2020-01-01T00:00:00.000Z",
+            "rating": 8.5
+          }
+        },
+        {
+          "node": {
+            "id": "movies/movie-beta.md",
+            "title": "Beta Movie",
+            "releaseDate": "2020-01-01T00:00:00.000Z",
+            "rating": 7.2
+          }
+        },
+        {
+          "node": {
+            "id": "movies/movie-delta.md",
+            "title": "Delta Movie",
+            "releaseDate": "2019-01-01T00:00:00.000Z",
+            "rating": 6.8
+          }
+        },
+        {
+          "node": {
+            "id": "movies/movie-gamma.md",
+            "title": "Gamma Movie",
+            "releaseDate": "2019-01-01T00:00:00.000Z",
+            "rating": 9.1
+          }
+        }
+      ]
+    }
+  }
+}

--- a/packages/@tinacms/graphql/tests/list-query-performance/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/list-query-performance/tina/config.ts
@@ -1,0 +1,36 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Movie',
+      name: 'movie',
+      path: 'movies',
+      fields: [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'string',
+        },
+        {
+          name: 'releaseDate',
+          label: 'Release Date',
+          type: 'datetime',
+        },
+        {
+          name: 'rating',
+          label: 'Rating',
+          type: 'number',
+        },
+      ],
+      indexes: [
+        {
+          name: 'release-rating',
+          fields: [{ name: 'releaseDate' }, { name: 'rating' }],
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };

--- a/packages/@tinacms/graphql/tests/list-query-performance/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/list-query-performance/tina/config.ts
@@ -23,12 +23,6 @@ export const schema: Schema = {
           type: 'number',
         },
       ],
-      indexes: [
-        {
-          name: 'release-rating',
-          fields: [{ name: 'releaseDate' }, { name: 'rating' }],
-        },
-      ],
     },
   ],
 };

--- a/packages/@tinacms/graphql/tests/util.ts
+++ b/packages/@tinacms/graphql/tests/util.ts
@@ -24,7 +24,7 @@ const dataSchema = z.object({
 
 const defaultQuery = `query { document(collection: "post", relativePath: "in.md") { ...on Document { _values, _sys { title } }} }`;
 
-export class SlowMemoryLevel<K, V> extends MemoryLevel<K,V> {
+export class SlowMemoryLevel<K, V> extends MemoryLevel<K, V> {
   private delayMS: number;
 
   constructor(delayMS: number) {
@@ -33,7 +33,7 @@ export class SlowMemoryLevel<K, V> extends MemoryLevel<K,V> {
   }
 
   public async get(key: any, options?: any, callback?: any): Promise<any> {
-    await new Promise(r => setTimeout(r, this.delayMS));
+    await new Promise((r) => setTimeout(r, this.delayMS));
     if (typeof callback === 'function') {
       return super.get(key, options, callback);
     }


### PR DESCRIPTION
This change:

- **Modifies the query engine to execute the required "hydration" callbacks in parallel.** The hydration callback is used to read individual documents, which is sometimes done over a network as seen in TinaCloud. Network requests are slow, and do not require much involvement from the processor, so this is expected to improve TinaCloud query performance.

- **Adds the ability for the query engine to abort a query.** In future, this will be used to quicken queries that have already been shown to fail. The plumbing for the abort signal is included in this request as this change amends the type signature of `Database.query(...)` to explicitly list the arguments to be accepted by the hydrator.

- **Adds a performance test to ensure that requests are being executed in parallel.** This test consistently fails when executed with main, as the sequential document accesses (when the schema reading is included) total to a duration longer than the test timeout.





