### PR TITLE
🧪 GraphQL Test - addPendingDocument mutation with template

### DIFF
--- a/packages/@tinacms/graphql/tests/pending-document-with-template/addPendingDocument-article-response.json
+++ b/packages/@tinacms/graphql/tests/pending-document-with-template/addPendingDocument-article-response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "addPendingDocument": {
+      "__typename": "PageArticle"
+    }
+  }
+}

--- a/packages/@tinacms/graphql/tests/pending-document-with-template/addPendingDocument-product-response.json
+++ b/packages/@tinacms/graphql/tests/pending-document-with-template/addPendingDocument-product-response.json
@@ -1,0 +1,7 @@
+{
+  "data": {
+    "addPendingDocument": {
+      "__typename": "PageProduct"
+    }
+  }
+}

--- a/packages/@tinacms/graphql/tests/pending-document-with-template/index.test.ts
+++ b/packages/@tinacms/graphql/tests/pending-document-with-template/index.test.ts
@@ -1,0 +1,53 @@
+import { it, expect } from 'vitest';
+import config from './tina/config';
+import { setupMutation, format } from '../util';
+
+const createArticleMutation = `
+  mutation {
+    addPendingDocument(
+      collection: "page"
+      relativePath: "new-article.md"
+      template: "article"
+    ) {
+      __typename
+    }
+  }
+`;
+
+const createProductMutation = `
+  mutation {
+    addPendingDocument(
+      collection: "page"
+      relativePath: "new-product.md"
+      template: "product"
+    ) {
+      __typename
+    }
+  }
+`;
+
+it('creates pending document with article template and validates bridge writes', async () => {
+  const { query, bridge } = await setupMutation(__dirname, config);
+
+  const result = await query({ query: createArticleMutation, variables: {} });
+  expect(format(result)).toMatchFileSnapshot(
+    'addPendingDocument-article-response.json'
+  );
+
+  const newDocWrite = bridge.getWrite('pages/new-article.md');
+  expect(newDocWrite).toBeDefined();
+  expect(newDocWrite).toMatchFileSnapshot('new-article-content.md');
+});
+
+it('creates pending document with product template and validates bridge writes', async () => {
+  const { query, bridge } = await setupMutation(__dirname, config);
+
+  const result = await query({ query: createProductMutation, variables: {} });
+  expect(format(result)).toMatchFileSnapshot(
+    'addPendingDocument-product-response.json'
+  );
+
+  const newDocWrite = bridge.getWrite('pages/new-product.md');
+  expect(newDocWrite).toBeDefined();
+  expect(newDocWrite).toMatchFileSnapshot('new-product-content.md');
+});

--- a/packages/@tinacms/graphql/tests/pending-document-with-template/new-article-content.md
+++ b/packages/@tinacms/graphql/tests/pending-document-with-template/new-article-content.md
@@ -1,0 +1,4 @@
+---
+_template: article
+---
+

--- a/packages/@tinacms/graphql/tests/pending-document-with-template/new-product-content.md
+++ b/packages/@tinacms/graphql/tests/pending-document-with-template/new-product-content.md
@@ -1,0 +1,4 @@
+---
+_template: product
+---
+

--- a/packages/@tinacms/graphql/tests/pending-document-with-template/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/pending-document-with-template/tina/config.ts
@@ -1,0 +1,37 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Page',
+      name: 'page',
+      path: 'pages',
+      templates: [
+        {
+          label: 'Article',
+          name: 'article',
+          fields: [
+            {
+              type: 'string',
+              label: 'Title',
+              name: 'title',
+            },
+          ],
+        },
+        {
+          label: 'Product',
+          name: 'product',
+          fields: [
+            {
+              type: 'string',
+              label: 'Name',
+              name: 'name',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };


### PR DESCRIPTION
This change adds a basic automated test to ensure that `addPendingDocument` can be successfully called with a template selection.