### PR TITLE
fix: CLI ora import

### DIFF
--- a/.changeset/lucky-cups-give.md
+++ b/.changeset/lucky-cups-give.md
@@ -1,0 +1,5 @@
+---
+"create-tina-app": patch
+---
+
+fix: cli compatibility with CommonJS

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -15,7 +15,6 @@ import { preRunChecks } from './util/preRunChecks';
 import { checkPackageExists } from './util/checkPkgManagers';
 import { TextStyles } from './util/textstyles';
 import { exit } from 'node:process';
-import ora from 'ora';
 import { extractOptions } from './util/options';
 import { PackageManager, PKG_MANAGERS } from './util/packageManagers';
 import validate from 'validate-npm-package-name';
@@ -23,6 +22,9 @@ import * as ascii from './util/asciiArt';
 import { THEMES } from './themes';
 
 export async function run() {
+  // Dynamic import for ora to handle ES module compatibility
+  const ora = (await import('ora')).default;
+
   if (process.stdout.columns >= 60) {
     console.log(TextStyles.tinaOrange(`${ascii.llama}`));
     console.log(TextStyles.tinaOrange(`${ascii.tinaCms}`));
@@ -229,4 +231,7 @@ export async function run() {
   );
 }
 
-run();
+run().catch((error) => {
+  console.error('Error running create-tina-app:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
This pull request addresses compatibility issues with the CLI for `create-tina-app`, specifically improving support for CommonJS environments. 

* Changed the import of `ora` in `packages/create-tina-app/src/index.ts` to use a dynamic import, ensuring compatibility with both CommonJS and ES modules

Fixes: #5938

Can be run with `npx create-tina-app@0.0.0-d795c47-20250806022207`

