### PR TITLE
Media manager - improve handling of transparent images

### DIFF
--- a/.changeset/twenty-yaks-sell.md
+++ b/.changeset/twenty-yaks-sell.md
@@ -1,0 +1,6 @@
+---
+"tinacms": patch
+---
+
+Media manager - improved display of transparent images
+Media manager - grid view now displays filenames

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,8 +16,9 @@
         "**/.hg": true,
         "**/CVS": true,
         "**/.DS_Store": true,
+        "**/.turbo": true,
         "**/Thumbs.db": true,
-        "node_modules": true
+        "**/node_modules": true
     },
     "files.watcherExclude": {
         "**/.git/objects/**": true,
@@ -25,5 +26,6 @@
         "**/node_modules/*/**": true,
         "**/.turbo/**": true,
         "**/.next/**": true,
-    }
+    },
+    "search.followSymlinks": false
 }

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -1,4 +1,3 @@
-import AsyncLock from 'async-lock';
 import type { Plugin } from 'vite';
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import type { Config } from '@svgr/core';

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -1,3 +1,4 @@
+import AsyncLock from 'async-lock';
 import type { Plugin } from 'vite';
 import { createFilter, FilterPattern } from '@rollup/pluginutils';
 import type { Config } from '@svgr/core';

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -13,8 +13,15 @@ interface MediaItemProps {
 export const checkerboardStyle = {
   backgroundImage:
     'linear-gradient(45deg, #eee 25%, transparent 25%), linear-gradient(-45deg, #eee 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #eee 75%), linear-gradient(-45deg, transparent 75%, #eee 75%)',
-  backgroundSize: '24px 24px',
-  backgroundPosition: '0 0, 0 12px, 12px -12px, -12px 0px',
+  backgroundSize: '12px 12px',
+  backgroundPosition: '0 0, 0 6px, 6px -6px, -6px 0px',
+};
+
+export const smallCheckerboardStyle = {
+  backgroundImage:
+    'linear-gradient(45deg, #eee 25%, transparent 25%), linear-gradient(-45deg, #eee 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #eee 75%), linear-gradient(-45deg, transparent 75%, #eee 75%)',
+  backgroundSize: '6px 6px',
+  backgroundPosition: '0 0, 0 3px, 3px -3px, -3px 0px',
 };
 
 export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
@@ -49,7 +56,7 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
         {isImage(thumbnail) ? (
           <img
             className='block overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
-            style={checkerboardStyle}
+            style={smallCheckerboardStyle}
             src={thumbnail}
             alt={item.filename}
           />
@@ -78,8 +85,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
   return (
     <li className='block overflow-hidden flex justify-center shrink-0 w-full transition duration-150 ease-out'>
       <button
-        className={cn('relative flex items-center justify-center', {
-          // 'primary-outline': active,
+        className={cn('relative flex flex-col items-center justify-center', {
           'shadow hover:shadow-md hover:scale-103 hover:border-gray-150':
             !active,
           'cursor-pointer': item.type === 'dir',
@@ -98,24 +104,37 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
             NEW
           </span>
         )}
-        {itemIsImage ? (
-          <img
-            className={cn(
-              'block overflow-hidden object-center object-contain max-w-full max-h-[16rem] m-auto shadow',
-              { 'border border-blue-500': active }
-            )}
-            style={checkerboardStyle}
-            src={thumbnail}
-            alt={item.filename}
-          />
-        ) : (
-          <div className='p-4 w-full h-full flex flex-col gap-4 items-center justify-center'>
-            <FileIcon className='w-[30%] h-auto fill-gray-300' />
-            <span className='block text-base text-gray-600 w-full break-words truncate'>
-              {item.filename}
-            </span>
-          </div>
-        )}
+        <div className='relative w-full flex items-center justify-center'>
+          {itemIsImage ? (
+            <>
+              <img
+                className={cn(
+                  'block overflow-hidden object-center object-contain max-w-full max-h-[16rem] m-auto shadow',
+                  { 'border border-blue-500': active }
+                )}
+                style={checkerboardStyle}
+                src={thumbnail}
+                alt={item.filename}
+              />
+              <span
+                className={cn(
+                  'absolute bottom-0 left-0 w-full text-xs text-white px-2 py-1 truncate z-10',
+                  active ? 'bg-blue-500/60' : 'bg-black/60'
+                )}
+                style={{ pointerEvents: 'none' }}
+              >
+                {item.filename}
+              </span>
+            </>
+          ) : (
+            <div className='p-4 w-full h-full flex flex-col gap-4 items-center justify-center'>
+              <FileIcon className='w-[30%] h-auto fill-gray-300' />
+              <span className='block text-base text-gray-600 w-full break-words truncate'>
+                {item.filename}
+              </span>
+            </div>
+          )}
+        </div>
       </button>
     </li>
   );

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -44,10 +44,10 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
           NEW
         </span>
       )}
-      <div className='w-16 h-16 bg-gray-50 border-r border-gray-150 overflow-hidden flex justify-center flex-shrink-0'>
+      <div className='w-16 h-16 bg-gray-50 overflow-hidden flex justify-center flex-shrink-0'>
         {isImage(thumbnail) ? (
           <img
-            className='object-contain object-center w-full h-full'
+            className='block overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
             style={checkerboardStyle}
             src={thumbnail}
             alt={item.filename}
@@ -98,7 +98,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
       >
         {isImage(thumbnail) ? (
           <img
-            className='object-contain object-center w-full h-full'
+            className='block overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
             style={checkerboardStyle}
             src={thumbnail}
             alt={item.filename}

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -9,6 +9,13 @@ interface MediaItemProps {
   active: boolean;
 }
 
+export const checkerboardStyle = {
+  backgroundImage:
+    'linear-gradient(45deg, #eee 25%, transparent 25%), linear-gradient(-45deg, #eee 25%, transparent 25%), linear-gradient(45deg, transparent 75%, #eee 75%), linear-gradient(-45deg, transparent 75%, #eee 75%)',
+  backgroundSize: '24px 24px',
+  backgroundPosition: '0 0, 0 12px, 12px -12px, -12px 0px',
+};
+
 export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
   let FileIcon = BiFile;
   if (item.type === 'dir') {
@@ -40,7 +47,8 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
       <div className='w-16 h-16 bg-gray-50 border-r border-gray-150 overflow-hidden flex justify-center flex-shrink-0'>
         {isImage(thumbnail) ? (
           <img
-            className='object-contain object-center w-full h-full origin-center transition-all duration-150 ease-out group-hover:scale-110'
+            className='object-contain object-center w-full h-full'
+            style={checkerboardStyle}
             src={thumbnail}
             alt={item.filename}
           />
@@ -91,6 +99,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
         {isImage(thumbnail) ? (
           <img
             className='object-contain object-center w-full h-full'
+            style={checkerboardStyle}
             src={thumbnail}
             alt={item.filename}
           />

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -41,11 +41,11 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
       }}
     >
       {item.new && (
-        <span className='absolute top-1.5 left-1.5 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide	 font-bold text-green-600 px-1.5 py-0.5 z-10'>
+        <span className='absolute top-1 right-1 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide	 font-bold text-green-600 px-1.5 py-0.5 z-10'>
           NEW
         </span>
       )}
-      <div className='w-16 h-16 bg-gray-50 overflow-hidden flex justify-center flex-shrink-0'>
+      <div className='w-16 h-16 overflow-hidden flex justify-center flex-shrink-0'>
         {isImage(thumbnail) ? (
           <img
             className='block overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
@@ -77,13 +77,8 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
   const itemIsImage = isImage(thumbnail);
   return (
     <li className='block overflow-hidden flex justify-center shrink-0 w-full transition duration-150 ease-out'>
-      {item.new && (
-        <span className='absolute top-1.5 left-1.5 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide font-bold text-green-600 px-1.5 py-0.5 z-10'>
-          NEW
-        </span>
-      )}
       <button
-        className={cn('flex items-center justify-center', {
+        className={cn('relative flex items-center justify-center', {
           // 'primary-outline': active,
           'shadow hover:shadow-md hover:scale-103 hover:border-gray-150':
             !active,
@@ -98,6 +93,11 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
           }
         }}
       >
+        {item.new && (
+          <span className='absolute top-1 right-1 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide font-bold text-green-600 px-1.5 py-0.5 z-10'>
+            NEW
+          </span>
+        )}
         {itemIsImage ? (
           <img
             className={cn(

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -2,6 +2,7 @@ import { Media } from '@toolkit/core';
 import React from 'react';
 import { BiFile, BiFolder, BiMovie } from 'react-icons/bi';
 import { isImage, isVideo } from './utils';
+import { cn } from '../../../utils/cn';
 
 interface MediaItemProps {
   item: Media & { new?: boolean };
@@ -73,21 +74,22 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
     FileIcon = BiMovie;
   }
   const thumbnail = (item.thumbnails || {})['400x400'];
+  const itemIsImage = isImage(thumbnail);
   return (
-    <li
-      className={`relative pb-[100%] h-0 block border border-gray-100 rounded overflow-hidden flex justify-center shrink-0 w-full transition duration-150 ease-out ${
-        active
-          ? 'shadow-outline'
-          : 'shadow hover:shadow-md hover:scale-103 hover:border-gray-150'
-      } ${item.type === 'dir' ? 'cursor-pointer' : ''}`}
-    >
+    <li className='block overflow-hidden flex justify-center shrink-0 w-full transition duration-150 ease-out'>
       {item.new && (
-        <span className='absolute top-1.5 left-1.5 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide	 font-bold text-green-600 px-1.5 py-0.5 z-10'>
+        <span className='absolute top-1.5 left-1.5 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide font-bold text-green-600 px-1.5 py-0.5 z-10'>
           NEW
         </span>
       )}
       <button
-        className='absolute w-full h-full flex items-center justify-center bg-white'
+        className={cn('flex items-center justify-center', {
+          // 'primary-outline': active,
+          'shadow hover:shadow-md hover:scale-103 hover:border-gray-150':
+            !active,
+          'cursor-pointer': item.type === 'dir',
+          'w-full': !itemIsImage,
+        })}
         onClick={() => {
           if (!active) {
             onClick(item);
@@ -96,15 +98,18 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
           }
         }}
       >
-        {isImage(thumbnail) ? (
+        {itemIsImage ? (
           <img
-            className='block overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
+            className={cn(
+              'block overflow-hidden object-center object-contain max-w-full max-h-[16rem] m-auto shadow',
+              { 'border border-blue-500': active }
+            )}
             style={checkerboardStyle}
             src={thumbnail}
             alt={item.filename}
           />
         ) : (
-          <div className='p-4 w-full flex flex-col gap-4 items-center justify-center'>
+          <div className='p-4 w-full h-full flex flex-col gap-4 items-center justify-center'>
             <FileIcon className='w-[30%] h-auto fill-gray-300' />
             <span className='block text-base text-gray-600 w-full break-words truncate'>
               {item.filename}

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -85,12 +85,14 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
   return (
     <li className='block overflow-hidden flex justify-center shrink-0 w-full transition duration-150 ease-out'>
       <button
-        className={cn('relative flex flex-col items-center justify-center', {
-          'shadow hover:shadow-md hover:scale-103 hover:border-gray-150':
-            !active,
-          'cursor-pointer': item.type === 'dir',
-          'w-full': !itemIsImage,
-        })}
+        className={cn(
+          'relative flex flex-col items-center justify-center w-full',
+          {
+            'shadow hover:shadow-md hover:scale-103 hover:border-gray-150':
+              !active,
+            'cursor-pointer': item.type === 'dir',
+          }
+        )}
         onClick={() => {
           if (!active) {
             onClick(item);
@@ -127,7 +129,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
               </span>
             </>
           ) : (
-            <div className='p-4 w-full h-full flex flex-col gap-4 items-center justify-center'>
+            <div className='p-4 w-full flex flex-col gap-4 items-center justify-center'>
               <FileIcon className='w-[30%] h-auto fill-gray-300' />
               <span className='block text-base text-gray-600 w-full break-words truncate'>
                 {item.filename}

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -578,22 +578,20 @@ const ActiveItemPreview = ({
                 <Button
                   size='medium'
                   variant='primary'
-                  className='grow'
                   onClick={() => selectMediaItem(activeItem)}
                 >
                   Insert
-                  <BiArrowToBottom className='ml-1 -mr-0.5 w-6 h-auto text-white opacity-70' />
+                  <BiArrowToBottom className='ml-1 -mr-0.5 w-6 h-auto opacity-70' />
                 </Button>
               )}
               {allowDelete && (
                 <Button
-                  variant='white'
+                  variant='danger'
                   size='medium'
-                  className='grow max-w-[40%]'
                   onClick={deleteMediaItem}
                 >
                   Delete
-                  <TrashIcon className='ml-1 -mr-0.5 w-6 h-auto text-red-500 opacity-70' />
+                  <TrashIcon className='ml-1 -mr-0.5 w-6 h-auto opacity-70' />
                 </Button>
               )}
             </div>

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -27,7 +27,7 @@ import { BiFile } from 'react-icons/bi';
 import { IoMdRefresh } from 'react-icons/io';
 import { Breadcrumb } from './breadcrumb';
 import { CopyField } from './copy-field';
-import { GridMediaItem, ListMediaItem } from './media-item';
+import { checkerboardStyle, GridMediaItem, ListMediaItem } from './media-item';
 import { DeleteModal, NewFolderModal } from './modal';
 import {
   DEFAULT_MEDIA_UPLOAD_TYPES,
@@ -560,6 +560,7 @@ const ActiveItemPreview = ({
             <div className='w-full max-h-[75%]'>
               <img
                 className='block border border-gray-100 rounded overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
+                style={checkerboardStyle}
                 src={thumbnail}
                 alt={activeItem.filename}
               />

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -559,7 +559,7 @@ const ActiveItemPreview = ({
           {isImage(thumbnail) ? (
             <div className='w-full max-h-[75%]'>
               <img
-                className='block border border-gray-100 rounded overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
+                className='block border border-gray-100 bg-gray-50/50 rounded overflow-hidden object-center object-contain max-w-full max-h-full m-auto shadow'
                 style={checkerboardStyle}
                 src={thumbnail}
                 alt={activeItem.filename}


### PR DESCRIPTION
This pull request improves the media manager in the `tinacms` package, focusing on better handling and display of images—especially those with transparency—and enhancing the user experience in grid view. It also includes minor configuration updates for development tooling.

closes #5930

**Media Manager UI Improvements:**

* Transparent images are now displayed with a checkerboard background in both grid and preview views, making them easier to identify visually. (`media-item.tsx`, `media-manager.tsx`) [[1]](diffhunk://#diff-e656e9a630ce8ab182c9708cd34fbb8d2b2bfaf5f31b7d20e42469795642795dL36-R59) [[2]](diffhunk://#diff-e656e9a630ce8ab182c9708cd34fbb8d2b2bfaf5f31b7d20e42469795642795dL91-R137) [[3]](diffhunk://#diff-78421bfdaed7860cfed1b864d9d38c17242919f6376dd9fcc54a01a7e7679654L562-R563)
* Grid view now shows filenames directly on image thumbnails and improves the layout for non-image files, providing clearer identification of media items. (`media-item.tsx`)
* "NEW" badge positioning is standardized to the top-right corner in both list and grid views for consistency. (`media-item.tsx`) [[1]](diffhunk://#diff-e656e9a630ce8ab182c9708cd34fbb8d2b2bfaf5f31b7d20e42469795642795dL36-R59) [[2]](diffhunk://#diff-e656e9a630ce8ab182c9708cd34fbb8d2b2bfaf5f31b7d20e42469795642795dL91-R137)
* The delete button in the media manager now uses a "danger" variant for clearer intent, and some minor styling adjustments were made for action buttons. (`media-manager.tsx`)

**Development Tooling:**

* `.vscode/settings.json` now excludes additional folders and disables symlink following in search, improving editor performance

<img width="1434" height="828" alt="CleanShot 2025-08-07 at 15 48 51" src="https://github.com/user-attachments/assets/48421cbf-d7f0-45db-9984-1f9aedcc598f" />

