### PR TITLE
🐛 Bug - Fix Media Manager Image Display for Grid Items

### DIFF
--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -83,7 +83,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
   const thumbnail = (item.thumbnails || {})['400x400'];
   const itemIsImage = isImage(thumbnail);
   return (
-    <li className='block overflow-hidden flex justify-center shrink-0 w-full transition duration-150 ease-out'>
+    <li className='block flex justify-center shrink-0 w-full transition duration-150 ease-out'>
       <button
         className={cn(
           'relative flex flex-col items-center justify-center w-full',


### PR DESCRIPTION
As per #6007, remove `overflow-hidden` on grid items 

<img width="1037" height="903" alt="Screenshot 2025-09-26 at 9 21 39 am" src="https://github.com/user-attachments/assets/83b95718-90ad-44a2-890c-e59bc73f2322" />

**Figure: Before - all images squashed**

<img width="996" height="995" alt="Screenshot 2025-09-26 at 9 40 24 am" src="https://github.com/user-attachments/assets/a2381cd3-7927-4ec9-a700-b01398356198" />

**Figure: After - all images fixed**