### PR TITLE
Improve position of title overlay

### DIFF
--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -127,15 +127,6 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
                 src={thumbnail}
                 alt={item.filename}
               />
-              {/* <span
-                className={cn(
-                  'absolute bottom-0 left-0 w-full text-xs text-white px-2 py-1 truncate z-10',
-                  active ? 'bg-blue-500/60' : 'bg-black/60'
-                )}
-                style={{ pointerEvents: 'none' }}
-              >
-                {item.filename}
-              </span> */}
             </>
           ) : (
             <div className='p-4 w-full flex flex-col gap-4 items-center justify-center'>

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -101,6 +101,15 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
           }
         }}
       >
+        <span
+          className={cn(
+            'absolute bottom-0 left-0 w-full text-xs text-white px-2 py-1 truncate z-10',
+            active ? 'bg-blue-500/60' : 'bg-black/60'
+          )}
+          style={{ pointerEvents: 'none' }}
+        >
+          {item.filename}
+        </span>
         {item.new && (
           <span className='absolute top-1 right-1 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide font-bold text-green-600 px-1.5 py-0.5 z-10'>
             NEW
@@ -118,7 +127,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
                 src={thumbnail}
                 alt={item.filename}
               />
-              <span
+              {/* <span
                 className={cn(
                   'absolute bottom-0 left-0 w-full text-xs text-white px-2 py-1 truncate z-10',
                   active ? 'bg-blue-500/60' : 'bg-black/60'
@@ -126,7 +135,7 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
                 style={{ pointerEvents: 'none' }}
               >
                 {item.filename}
-              </span>
+              </span> */}
             </>
           ) : (
             <div className='p-4 w-full flex flex-col gap-4 items-center justify-center'>


### PR DESCRIPTION
Overlay position was a child of the image, so it looked weird 

<img width="1163" height="918" alt="Screenshot 2025-09-29 at 12 46 25 pm" src="https://github.com/user-attachments/assets/f994d2ad-40a2-4c49-9650-19a2030336fa" />


**Figure: Before**


<img width="1083" height="667" alt="Screenshot 2025-09-29 at 12 50 51 pm" src="https://github.com/user-attachments/assets/0ddf43ab-1aca-4ef2-a861-b281e1814aff" />


**Figure: After**