### PR TITLE
💄 UI: add new color variants for 'tina-orange'

### DIFF
--- a/packages/@tinacms/cli/src/next/vite/tailwind.ts
+++ b/packages/@tinacms/cli/src/next/vite/tailwind.ts
@@ -210,6 +210,8 @@ export const tinaTailwind = (
                 600: '#DC4419',
               },
               'tina-orange': '#EC4815',
+              'tina-orange-dark': '#C2410C',
+              'tina-orange-light': '#FFF7ED',
               background: '#FFFFFF',
               foreground: '#0A0A0A',
               muted: '#F5F5F5',


### PR DESCRIPTION
## Summary
- Added `tina-orange-dark` color variant (#C2410C)
- Added `tina-orange-light` color variant (#FFF7ED)

## Changes
This PR extends the TinaCMS Tailwind color palette by adding dark and light variants of the existing `tina-orange` color. These additional color variants provide more flexibility for theming and design consistency across the TinaCMS interface.

### Color Values
- `tina-orange-dark`: #C2410C
- `tina-orange-light`: #FFF7ED

## Test plan
- [ ] Verify new color variants are available in Tailwind classes
- [ ] Test color variants render correctly in the UI
- [ ] Confirm color palette changes don't break existing styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)