### PR TITLE
fix: Upgrade npm to support OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Upgrade npm for OIDC support
+        run: npm install -g npm@latest
+
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         id: pnpm-install


### PR DESCRIPTION
## Summary
Upgrades npm to version 11.5.1+ in the publish workflow to enable OIDC trusted publishing support.

## Related
- Part of OIDC trusted publishing implementation (#6246)