### PR TITLE
fix: Add repository field to package.json for provenance validation

### DIFF
--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -28,5 +28,9 @@
 		"tinacms": "workspace:*",
 		"typescript": "^5.7.3",
 		"zod": "catalog:"
+	},
+	"repository": {
+		"url": "https://github.com/tinacms/tinacms.git",
+		"directory": "packages/@tinacms/app"
 	}
 }

--- a/packages/@tinacms/scripts/package.json
+++ b/packages/@tinacms/scripts/package.json
@@ -34,5 +34,9 @@
         "@types/fs-extra": "^11.0.4",
         "@types/json-diff": "^1.0.3",
         "jest": "^30.1.3"
+    },
+    "repository": {
+        "url": "https://github.com/tinacms/tinacms.git",
+        "directory": "packages/@tinacms/scripts"
     }
 }


### PR DESCRIPTION
## Summary
Adds missing `repository` field to `@tinacms/app` and `@tinacms/scripts` package.json files to enable npm provenance attestation.

## Problem
When publishing packages with provenance enabled (`NPM_CONFIG_PROVENANCE: true`), npm validates that the `repository.url` in package.json matches the GitHub repository from the provenance attestation.

## Related
- Part of OIDC trusted publishing implementation (#6246, #6249)
- Required for provenance validation when `NPM_CONFIG_PROVENANCE: true` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)