### PR TITLE
Update main.yml for OIDC trusted publishing support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,7 @@ jobs:
           - macOS-latest
     runs-on: ${{ matrix.os }}
     permissions:
-      contents: write
       id-token: write  # Required for OIDC authentication with npm
-      pull-requests: write
     timeout-minutes: 15
     env:
       TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}


### PR DESCRIPTION
## Summary

Updating workflows for OIDC trusted publishing support as the long life tokens have been deprecated by NPM
