### PR TITLE
Restrict publish workflow to non-forked PRs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,7 @@ jobs:
   publish-tagged-pr:
     if: >
       github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.fork == false &&
       contains(github.event.pull_request.labels.*.name, 'tagged') &&
       github.event.pull_request.title != 'Version Packages'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Adds a condition to prevent the publish workflow from running on forked PRs
- This ensures that the `tagged` label publish only triggers for PRs from the main repository, not from forks
- This is because our NPM OIDC policy does not allow publishes from forked repositories