### PR TITLE
Fix - removing sample examples from changeset

### DIFF
--- a/.changeset/eighty-forks-cough.md
+++ b/.changeset/eighty-forks-cough.md
@@ -1,5 +1,0 @@
----
-"tinacms": patch
----
-
-Fix slugify function making file name editable


### PR DESCRIPTION
The example sample projects have been included in the changesets, causing the release pipeline to break. This PR manually removes them.