### PR TITLE
feat: trigger tinacloud PR on @tinacms/graphql minor/major bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -370,11 +370,20 @@ jobs:
         env:
           publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
 
+      - name: Generate token for tinacloud
+        if: steps.graphqlVersion.outputs.published == 'true'
+        uses: actions/create-github-app-token@v1
+        id: tinacloud-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_SECRET }}
+          repositories: tinacloud
+
       - name: Create PR in tinacloud to update @tinacms/graphql
         if: steps.graphqlVersion.outputs.published == 'true'
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.TINACLOUD_REPO_PAT }}
+          github-token: ${{ steps.tinacloud-token.outputs.token }}
           script: |
             const version = '${{ steps.graphqlVersion.outputs.version }}';
             const bumpType = '${{ steps.graphqlVersion.outputs.bump_type }}';
@@ -433,10 +442,18 @@ jobs:
             echo "bump_type=patch" >> $GITHUB_OUTPUT
           fi
 
+      - name: Generate token for tinacloud
+        uses: actions/create-github-app-token@v1
+        id: tinacloud-token
+        with:
+          app-id: ${{ secrets.BOT_APP_ID }}
+          private-key: ${{ secrets.BOT_APP_SECRET }}
+          repositories: tinacloud
+
       - name: Trigger tinacloud update (test mode)
         uses: actions/github-script@v7
         with:
-          github-token: ${{ secrets.TINACLOUD_REPO_PAT }}
+          github-token: ${{ steps.tinacloud-token.outputs.token }}
           script: |
             const version = '${{ inputs.test_version }}';
             const bumpType = '${{ steps.bump.outputs.bump_type }}';


### PR DESCRIPTION
## Summary

- Adds workflow steps to detect when `@tinacms/graphql` has a minor or major version bump during publish
- Triggers a repository dispatch event to tinacloud to create an update PR automatically
- Adds a `workflow_dispatch` trigger for manual testing of the flow

## Changes

- Added version bump detection step that compares published version against npm
- Added step to send `tinacms-graphql-update` dispatch event to tinacloud repo
- Added `test-graphql-update` job for manual testing via workflow_dispatch

## Testing

1. Go to Actions → "Publish" workflow → "Run workflow"
2. Check "Test the @tinacms/graphql update flow to tinacloud"
3. Enter a test version (e.g., `2.2.0`)
4. This will trigger the tinacloud workflow to create an update PR

## Requirements

- `TINACLOUD_REPO_PAT` secret must be added to this repo with permissions to dispatch events to tinacloud

🤖 Generated with [Claude Code](https://claude.com/claude-code)