### PR TITLE
🚧 WIP - Add navigation lock modal for unsaved changes

### DIFF
--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -217,110 +217,112 @@ export const TinaAdmin = ({
             <>
               <CheckSchema schemaJson={schemaJson}>
                 <Router>
-                  {/* @ts-ignore */}
-                  <SetPreviewFlag preview={preview} cms={cms} />
-                  <Routes>
-                    {preview && (
+                  <NavigationLockProvider>
+                    {/* @ts-ignore */}
+                    <SetPreviewFlag preview={preview} cms={cms} />
+                    <Routes>
+                      {preview && (
+                        <Route
+                          path='/~/*'
+                          element={
+                            <PreviewInner config={config} preview={preview} />
+                          }
+                        />
+                      )}
                       <Route
-                        path='/~/*'
+                        path='graphql'
                         element={
-                          <PreviewInner config={config} preview={preview} />
+                          <PlainLayout>
+                            <Playground />
+                          </PlainLayout>
                         }
                       />
-                    )}
-                    <Route
-                      path='graphql'
-                      element={
-                        <PlainLayout>
-                          <Playground />
-                        </PlainLayout>
-                      }
-                    />
-                    <Route
-                      path='collections/new/:collectionName'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionCreatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/duplicate/:collectionName/~/*'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionDuplicatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/duplicate/:collectionName/*'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionDuplicatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/new/:collectionName/:templateName'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionCreatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/new/:collectionName/:templateName/~/*'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionCreatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/new/:collectionName/~/*'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionCreatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/edit/:collectionName/*'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionUpdatePage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='collections/:collectionName/*'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <CollectionListPage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='screens/:screenName'
-                      element={
-                        <DefaultWrapper cms={cms}>
-                          <ScreenPage />
-                        </DefaultWrapper>
-                      }
-                    />
-                    <Route
-                      path='/'
-                      element={
-                        <MaybeRedirectToPreview
-                          redirect={!!preview && hasRouter}
-                        >
+                      <Route
+                        path='collections/new/:collectionName'
+                        element={
                           <DefaultWrapper cms={cms}>
-                            <DashboardPage />
+                            <CollectionCreatePage />
                           </DefaultWrapper>
-                        </MaybeRedirectToPreview>
-                      }
-                    />
-                  </Routes>
+                        }
+                      />
+                      <Route
+                        path='collections/duplicate/:collectionName/~/*'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionDuplicatePage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='collections/duplicate/:collectionName/*'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionDuplicatePage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='collections/new/:collectionName/:templateName'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionCreatePage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='collections/new/:collectionName/:templateName/~/*'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionCreatePage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='collections/new/:collectionName/~/*'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionCreatePage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='collections/edit/:collectionName/*'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionUpdatePage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='collections/:collectionName/*'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <CollectionListPage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='screens/:screenName'
+                        element={
+                          <DefaultWrapper cms={cms}>
+                            <ScreenPage />
+                          </DefaultWrapper>
+                        }
+                      />
+                      <Route
+                        path='/'
+                        element={
+                          <MaybeRedirectToPreview
+                            redirect={!!preview && hasRouter}
+                          >
+                            <DefaultWrapper cms={cms}>
+                              <DashboardPage />
+                            </DefaultWrapper>
+                          </MaybeRedirectToPreview>
+                        }
+                      />
+                    </Routes>
+                  </NavigationLockProvider>
                 </Router>
               </CheckSchema>
             </>
@@ -350,14 +352,12 @@ const DefaultWrapper = ({
 }) => {
   return (
     <Layout>
-      <NavigationLockProvider>
-        <NavProvider defaultOpen={false}>
-          <div className='flex items-stretch h-dvh overflow-hidden'>
-            <Sidebar cms={cms} />
-            <div className='w-full relative'>{children}</div>
-          </div>
-        </NavProvider>
-      </NavigationLockProvider>
+      <NavProvider defaultOpen={false}>
+        <div className='flex items-stretch h-dvh overflow-hidden'>
+          <Sidebar cms={cms} />
+          <div className='w-full relative'>{children}</div>
+        </div>
+      </NavProvider>
     </Layout>
   );
 };

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -4,6 +4,7 @@ import {
   ModalActions,
   ModalBody,
   ModalHeader,
+  NavigationLockProvider,
   NavProvider,
   PopupModal,
   TinaCMS,
@@ -349,12 +350,14 @@ const DefaultWrapper = ({
 }) => {
   return (
     <Layout>
-      <NavProvider defaultOpen={false}>
-        <div className='flex items-stretch h-dvh overflow-hidden'>
-          <Sidebar cms={cms} />
-          <div className='w-full relative'>{children}</div>
-        </div>
-      </NavProvider>
+      <NavigationLockProvider>
+        <NavProvider defaultOpen={false}>
+          <div className='flex items-stretch h-dvh overflow-hidden'>
+            <Sidebar cms={cms} />
+            <div className='w-full relative'>{children}</div>
+          </div>
+        </NavProvider>
+      </NavigationLockProvider>
     </Layout>
   );
 };

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -10,7 +10,9 @@ import {
   Form,
   FormBuilder,
   FormStatus,
+  NavigationLockModal,
   TinaForm,
+  useNavigationLock,
   wrapFieldsWithMeta,
 } from '@tinacms/toolkit';
 import React, { useMemo, useState } from 'react';
@@ -151,6 +153,7 @@ export const RenderForm = ({
 }) => {
   const navigate = useNavigate();
   const [formIsPristine, setFormIsPristine] = useState(true);
+  const navigationLock = useNavigationLock(!formIsPristine);
   const schema: TinaSchema | undefined = cms.api.tina.schema;
 
   // the schema is being passed in from the frontend so we can use that
@@ -354,6 +357,12 @@ export const RenderForm = ({
   return (
     <PageWrapper headerClassName='bg-white'>
       <>
+        {navigationLock.isBlocked && (
+          <NavigationLockModal
+            onStay={navigationLock.reset}
+            onLeave={navigationLock.proceed}
+          />
+        )}
         <div
           className={`py-4 px-6 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center`}
         >

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -10,9 +10,8 @@ import {
   Form,
   FormBuilder,
   FormStatus,
-  NavigationLockModal,
   TinaForm,
-  useNavigationLock,
+  useNavigationBlocker,
   wrapFieldsWithMeta,
 } from '@tinacms/toolkit';
 import React, { useMemo, useState } from 'react';
@@ -153,7 +152,7 @@ export const RenderForm = ({
 }) => {
   const navigate = useNavigate();
   const [formIsPristine, setFormIsPristine] = useState(true);
-  const navigationLock = useNavigationLock(!formIsPristine);
+  useNavigationBlocker(!formIsPristine);
   const schema: TinaSchema | undefined = cms.api.tina.schema;
 
   // the schema is being passed in from the frontend so we can use that
@@ -357,12 +356,6 @@ export const RenderForm = ({
   return (
     <PageWrapper headerClassName='bg-white'>
       <>
-        {navigationLock.isBlocked && (
-          <NavigationLockModal
-            onStay={navigationLock.reset}
-            onLeave={navigationLock.proceed}
-          />
-        )}
         <div
           className={`py-4 px-6 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center`}
         >

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -8,8 +8,7 @@ import {
   Form,
   FormBuilder,
   FormStatus,
-  NavigationLockModal,
-  useNavigationLock,
+  useNavigationBlocker,
 } from '@tinacms/toolkit';
 import type { TinaCMS } from '@tinacms/toolkit';
 import {
@@ -110,7 +109,7 @@ const RenderForm = ({
   mutationInfo;
 }) => {
   const [formIsPristine, setFormIsPristine] = useState(true);
-  const navigationLock = useNavigationLock(!formIsPristine);
+  useNavigationBlocker(!formIsPristine);
   const schema: TinaSchema | undefined = cms.api.tina.schema;
 
   // the schema is being passed in from the frontend so we can use that
@@ -178,12 +177,6 @@ const RenderForm = ({
 
   return (
     <>
-      {navigationLock.isBlocked && (
-        <NavigationLockModal
-          onStay={navigationLock.reset}
-          onLeave={navigationLock.proceed}
-        />
-      )}
       <div
         className={`py-4 px-6 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center`}
       >

--- a/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionUpdatePage.tsx
@@ -4,7 +4,13 @@ import {
   canonicalPath,
   resolveForm,
 } from '@tinacms/schema-tools';
-import { Form, FormBuilder, FormStatus } from '@tinacms/toolkit';
+import {
+  Form,
+  FormBuilder,
+  FormStatus,
+  NavigationLockModal,
+  useNavigationLock,
+} from '@tinacms/toolkit';
 import type { TinaCMS } from '@tinacms/toolkit';
 import {
   FormBreadcrumbs,
@@ -104,6 +110,7 @@ const RenderForm = ({
   mutationInfo;
 }) => {
   const [formIsPristine, setFormIsPristine] = useState(true);
+  const navigationLock = useNavigationLock(!formIsPristine);
   const schema: TinaSchema | undefined = cms.api.tina.schema;
 
   // the schema is being passed in from the frontend so we can use that
@@ -171,6 +178,12 @@ const RenderForm = ({
 
   return (
     <>
+      {navigationLock.isBlocked && (
+        <NavigationLockModal
+          onStay={navigationLock.reset}
+          onLeave={navigationLock.proceed}
+        />
+      )}
       <div
         className={`py-4 px-6 border-b border-gray-200 bg-white w-full grow-0 shrink basis-0 flex justify-center`}
       >

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -126,10 +126,10 @@ export const FormBuilder: FC<FormBuilderProps> = ({
    * Prevent navigation away from the window when the form is dirty
    */
   React.useEffect(() => {
-    // const onBeforeUnload = (event) => {
-    //   event.preventDefault()
-    //   event.returnValue = ''
-    // }
+    const onBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = '';
+    };
 
     const unsubscribe = finalForm.subscribe(
       ({ pristine }) => {
@@ -137,16 +137,16 @@ export const FormBuilder: FC<FormBuilderProps> = ({
           onPristineChange(pristine);
         }
 
-        // if (!pristine) {
-        //   window.addEventListener('beforeunload', onBeforeUnload)
-        // } else {
-        //   window.removeEventListener('beforeunload', onBeforeUnload)
-        // }
+        if (!pristine) {
+          window.addEventListener('beforeunload', onBeforeUnload);
+        } else {
+          window.removeEventListener('beforeunload', onBeforeUnload);
+        }
       },
       { pristine: true }
     );
     return () => {
-      // window.removeEventListener('beforeunload', onBeforeUnload)
+      window.removeEventListener('beforeunload', onBeforeUnload);
       unsubscribe();
     };
   }, [finalForm]);

--- a/packages/tinacms/src/toolkit/form-builder/index.ts
+++ b/packages/tinacms/src/toolkit/form-builder/index.ts
@@ -10,4 +10,5 @@ export * from './form-actions';
 export * from './create-branch-modal';
 export * from './navigation-lock-modal';
 export * from './use-navigation-lock';
+export * from './navigation-lock-context';
 export type { FieldRenderProps } from 'react-final-form';

--- a/packages/tinacms/src/toolkit/form-builder/index.ts
+++ b/packages/tinacms/src/toolkit/form-builder/index.ts
@@ -8,4 +8,6 @@ export * from './loading-dots';
 export * from './reset-form';
 export * from './form-actions';
 export * from './create-branch-modal';
+export * from './navigation-lock-modal';
+export * from './use-navigation-lock';
 export type { FieldRenderProps } from 'react-final-form';

--- a/packages/tinacms/src/toolkit/form-builder/navigation-lock-context.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/navigation-lock-context.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { createContext, useCallback, useContext, useState } from 'react';
+import { useNavigationLock } from './use-navigation-lock';
+import { NavigationLockModal } from './navigation-lock-modal';
+
+interface NavigationLockContextValue {
+  /**
+   * Set whether navigation should be blocked (e.g., when form has unsaved changes)
+   */
+  setShouldBlock: (shouldBlock: boolean) => void;
+}
+
+const NavigationLockContext = createContext<NavigationLockContextValue | null>(
+  null
+);
+
+/**
+ * Provider component that manages navigation blocking state at a high level
+ * in the component tree. This prevents the issue where the navigation lock
+ * hook gets unmounted when the user navigates away.
+ */
+export const NavigationLockProvider: React.FC<{
+  children: React.ReactNode;
+}> = ({ children }) => {
+  const [shouldBlock, setShouldBlockState] = useState(false);
+  const navigationLock = useNavigationLock(shouldBlock);
+
+  const setShouldBlock = useCallback((value: boolean) => {
+    setShouldBlockState(value);
+  }, []);
+
+  return (
+    <NavigationLockContext.Provider value={{ setShouldBlock }}>
+      {navigationLock.isBlocked && (
+        <NavigationLockModal
+          onStay={navigationLock.reset}
+          onLeave={navigationLock.proceed}
+        />
+      )}
+      {children}
+    </NavigationLockContext.Provider>
+  );
+};
+
+/**
+ * Hook to register a component as having unsaved changes that should
+ * block navigation. Call with `true` when form is dirty, `false` when pristine.
+ */
+export function useNavigationBlocker(shouldBlock: boolean): void {
+  const context = useContext(NavigationLockContext);
+
+  React.useEffect(() => {
+    if (context) {
+      context.setShouldBlock(shouldBlock);
+    }
+
+    // Reset when component unmounts
+    return () => {
+      if (context) {
+        context.setShouldBlock(false);
+      }
+    };
+  }, [shouldBlock, context]);
+}

--- a/packages/tinacms/src/toolkit/form-builder/navigation-lock-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/navigation-lock-modal.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { BiError } from 'react-icons/bi';
+import { Button } from '@toolkit/styles';
+import {
+  Modal,
+  ModalActions,
+  ModalBody,
+  ModalHeader,
+  PopupModal,
+} from '../react-modals';
+
+export interface NavigationLockModalProps {
+  /**
+   * Called when the user chooses to stay on the page
+   */
+  onStay: () => void;
+  /**
+   * Called when the user chooses to leave the page (discard changes)
+   */
+  onLeave: () => void;
+}
+
+/**
+ * Modal displayed when user tries to navigate away with unsaved changes.
+ * Provides options to stay on the page or leave (discarding changes).
+ */
+export const NavigationLockModal: React.FC<NavigationLockModalProps> = ({
+  onStay,
+  onLeave,
+}) => {
+  return (
+    <Modal>
+      <PopupModal>
+        <ModalHeader close={onStay}>Unsaved Changes</ModalHeader>
+        <ModalBody padded={true}>
+          <div className='flex items-start gap-3'>
+            <BiError className='w-6 h-6 text-yellow-500 flex-shrink-0 mt-0.5' />
+            <div>
+              <p className='text-gray-700 mb-2'>
+                You have unsaved changes that will be lost if you leave this
+                page.
+              </p>
+              <p className='text-gray-500 text-sm'>
+                Would you like to stay on this page and save your changes, or
+                leave without saving?
+              </p>
+            </div>
+          </div>
+        </ModalBody>
+        <ModalActions align='end'>
+          <Button variant='secondary' onClick={onLeave}>
+            Leave without saving
+          </Button>
+          <Button variant='primary' onClick={onStay}>
+            Stay on page
+          </Button>
+        </ModalActions>
+      </PopupModal>
+    </Modal>
+  );
+};

--- a/packages/tinacms/src/toolkit/form-builder/use-navigation-lock.ts
+++ b/packages/tinacms/src/toolkit/form-builder/use-navigation-lock.ts
@@ -1,0 +1,110 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface NavigationLockState {
+  isBlocked: boolean;
+  blockedUrl: string | null;
+  proceed: () => void;
+  reset: () => void;
+}
+
+/**
+ * Hook to block navigation when there are unsaved changes.
+ * Works with HashRouter by intercepting hash changes and popstate events.
+ *
+ * @param shouldBlock - Whether navigation should be blocked
+ * @returns NavigationLockState object with isBlocked, blockedUrl, proceed, and reset
+ */
+export function useNavigationLock(shouldBlock: boolean): NavigationLockState {
+  const [isBlocked, setIsBlocked] = useState(false);
+  const [blockedUrl, setBlockedUrl] = useState<string | null>(null);
+  const shouldBlockRef = useRef(shouldBlock);
+  const currentHashRef = useRef(window.location.hash);
+  const isRestoringRef = useRef(false);
+
+  // Keep ref in sync with prop
+  useEffect(() => {
+    shouldBlockRef.current = shouldBlock;
+    currentHashRef.current = window.location.hash;
+  }, [shouldBlock]);
+
+  const proceed = useCallback(() => {
+    if (blockedUrl) {
+      isRestoringRef.current = true;
+      window.location.hash = blockedUrl;
+      setIsBlocked(false);
+      setBlockedUrl(null);
+    }
+  }, [blockedUrl]);
+
+  const reset = useCallback(() => {
+    setIsBlocked(false);
+    setBlockedUrl(null);
+  }, []);
+
+  useEffect(() => {
+    if (!shouldBlock) {
+      return;
+    }
+
+    const handleHashChange = (event: HashChangeEvent) => {
+      // Skip if we're restoring to the blocked URL
+      if (isRestoringRef.current) {
+        isRestoringRef.current = false;
+        currentHashRef.current = window.location.hash;
+        return;
+      }
+
+      // Block the navigation
+      if (shouldBlockRef.current && !isBlocked) {
+        event.preventDefault();
+        const newHash = window.location.hash;
+
+        // Restore the previous hash
+        window.history.replaceState(null, '', currentHashRef.current);
+
+        // Store the blocked URL and show modal
+        setBlockedUrl(newHash);
+        setIsBlocked(true);
+      }
+    };
+
+    const handlePopState = (event: PopStateEvent) => {
+      // Skip if we're restoring to the blocked URL
+      if (isRestoringRef.current) {
+        isRestoringRef.current = false;
+        currentHashRef.current = window.location.hash;
+        return;
+      }
+
+      // Block browser back/forward navigation
+      if (shouldBlockRef.current && !isBlocked) {
+        const newHash = window.location.hash;
+
+        // Push the current state back to prevent navigation
+        window.history.pushState(null, '', currentHashRef.current);
+
+        // Store the blocked URL and show modal
+        setBlockedUrl(newHash);
+        setIsBlocked(true);
+      }
+    };
+
+    // Add a history entry to catch back button presses
+    window.history.pushState(null, '', window.location.href);
+
+    window.addEventListener('hashchange', handleHashChange);
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange);
+      window.removeEventListener('popstate', handlePopState);
+    };
+  }, [shouldBlock, isBlocked]);
+
+  return {
+    isBlocked,
+    blockedUrl,
+    proceed,
+    reset,
+  };
+}


### PR DESCRIPTION
## Description

This PR adds a navigation lock feature to prevent users from accidentally losing unsaved changes when navigating away from collection create/update pages.

## Changes

### New Components & Hooks
- **`NavigationLockModal`**: A modal component that displays when users attempt to navigate away with unsaved changes. Provides options to stay on the page or leave without saving.
- **`useNavigationLock`**: A custom hook that intercepts navigation attempts (hash changes and popstate events) when `shouldBlock` is true. Works with HashRouter by preventing navigation and displaying the modal instead.

### Updated Pages
- **`CollectionCreatePage`**: Integrated `useNavigationLock` hook and `NavigationLockModal` component to block navigation when form has unsaved changes.
- **`CollectionUpdatePage`**: Integrated `useNavigationLock` hook and `NavigationLockModal` component to block navigation when form has unsaved changes.

### Re-enabled Browser Protection
- **`FormBuilder`**: Re-enabled the `beforeunload` event listener that was previously commented out. This provides a fallback protection when users try to close the browser tab/window with unsaved changes.

### Exports
- Updated `form-builder/index.ts` to export the new `NavigationLockModal` and `useNavigationLock` for use throughout the application.

## Why

Users can now be protected from accidentally losing their work when navigating away from forms with unsaved changes. The solution provides:
1. **Modal confirmation** for in-app navigation (via React Router hash changes)
2. **Browser warning** for tab/window close attempts
3. **Clear user feedback** about unsaved changes with actionable options

## Testing

The implementation handles:
- Hash-based routing navigation
- Browser back/forward button presses
- Browser tab/window close attempts
- Proper state cleanup and restoration

https://claude.ai/code/session_01QnrKjL5rvUasuStC6oXbDF