### PR TITLE
Added schema tools to changeset

### DIFF
--- a/.changeset/three-mice-tie.md
+++ b/.changeset/three-mice-tie.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/schema-tools": minor
+---
+
+Updated type definition for schema tools to include filename.parse


### PR DESCRIPTION
In a recent PR I updated the `filename.ui` field. However, because `@tinacms/schema-tools` wasn't part of the changeset the type definition was not included.

This PR adds a changeset so that the latest schema tools version will be included in the release. 

https://github.com/tinacms/tinacms/pull/6374