### PR TITLE
fix(cli): improve error when content dir missing tina/ folder

### DIFF
--- a/.changeset/improve-localcontentpath-error.md
+++ b/.changeset/improve-localcontentpath-error.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Improve error message when content directory is missing a `tina/` folder. When using `localContentPath`, the error now explains that the content directory needs a `tina/` folder for generated files and provides the exact `mkdir` command to fix it, instead of the misleading suggestion to use `--rootPath`.

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -125,7 +125,8 @@ export class DevCommand extends BaseCommand {
 
           if (configManager.hasSeparateContentRoot()) {
             const rootPath = await configManager.getTinaFolderPath(
-              configManager.contentRootPath
+              configManager.contentRootPath,
+              { isContentRoot: true }
             );
             const filePath = path.join(rootPath, tinaLockFilename);
             await fs.ensureFile(filePath);

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -265,7 +265,9 @@ export class ConfigManager {
     }
 
     this.generatedFolderPathContentRepo = path.join(
-      await this.getTinaFolderPath(this.contentRootPath),
+      await this.getTinaFolderPath(this.contentRootPath, {
+        isContentRoot: this.hasSeparateContentRoot(),
+      }),
       GENERATED_FOLDER
     );
     this.spaMainPath = require.resolve('@tinacms/app');
@@ -274,7 +276,10 @@ export class ConfigManager {
     // End of paths that depend on the config file
   }
 
-  async getTinaFolderPath(rootPath) {
+  async getTinaFolderPath(
+    rootPath: string,
+    { isContentRoot }: { isContentRoot?: boolean } = {}
+  ) {
     const tinaFolderPath = path.join(rootPath, TINA_FOLDER);
     const tinaFolderExists = await fs.pathExists(tinaFolderPath);
     if (tinaFolderExists) {
@@ -286,6 +291,11 @@ export class ConfigManager {
     if (legacyFolderExists) {
       this.isUsingLegacyFolder = true;
       return legacyFolderPath;
+    }
+    if (isContentRoot) {
+      throw new Error(
+        `Unable to find a ${chalk.cyan('tina/')} folder in your content root at ${chalk.cyan(rootPath)}. When using localContentPath, the content directory must contain a ${chalk.cyan('tina/')} folder for generated files. Create one with: mkdir ${path.join(rootPath, TINA_FOLDER)}`
+      );
     }
     throw new Error(
       `Unable to find Tina folder, if you're working in folder outside of the Tina config be sure to specify --rootPath`


### PR DESCRIPTION
## Summary

When using `localContentPath` and the content directory doesn't have a `tina/` folder, the CLI currently shows:

```
Unable to find Tina folder, if you're working in folder outside of the Tina config be sure to specify --rootPath
```

This is misleading because `--rootPath` controls where the app config is found, not the content directory. Users follow the suggestion, it doesn't help, and they get stuck.

The new error for this specific case is:

```
Unable to find a tina/ folder in your content root at /path/to/content. When using localContentPath, the content directory must contain a tina/ folder for generated files. Create one with: mkdir /path/to/content/tina
```

### Changes

- Added optional `isContentRoot` parameter to `getTinaFolderPath()` in `config-manager.ts`
- When called for the content root (both in `processConfig` and `dev-command`), passes `isContentRoot: true` to get the improved error message
- The original error message for the app root case is unchanged

Closes #6433

Reported via https://github.com/tinacms/tinacms/discussions/6414