### PR TITLE
Fix modal title not wrapping on mobile

### DIFF
--- a/packages/tinacms/src/toolkit/react-modals/modal/modal-header.tsx
+++ b/packages/tinacms/src/toolkit/react-modals/modal/modal-header.tsx
@@ -24,9 +24,5 @@ export const ModalHeader = ({ children, close }: ModalHeaderProps) => {
 };
 
 const ModalTitle = ({ children }) => {
-  return (
-    <h2 className='font-medium flex items-center'>
-      {children}
-    </h2>
-  );
+  return <h2 className='font-medium flex items-center'>{children}</h2>;
 };


### PR DESCRIPTION
Make the modal header title wrap on narrow devices.

<img width="320" height="256" alt="tina io_admin (2)" src="https://github.com/user-attachments/assets/7c1f3085-09a7-4c4f-9a3e-01862b4e9c8a" />

**Figure: Before - Modal title not wrapping and getting cut off on small viewport width**

<img width="320" height="256" alt="tina io_admin (1)" src="https://github.com/user-attachments/assets/28b9b995-ff06-4254-be4f-4ca6e4e606c6" />

**Figure: After - Modal title wraps** 