### PR TITLE
🐖 PostHog - Cloud Nav Items

### DIFF
--- a/.changeset/gorgeous-items-admire.md
+++ b/.changeset/gorgeous-items-admire.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+🐖 Telemetry - Seeing how many users interact with nav bar buttons (Project Config, User management, support)

--- a/packages/tinacms/src/lib/posthog/posthog.ts
+++ b/packages/tinacms/src/lib/posthog/posthog.ts
@@ -85,7 +85,8 @@ export type CollectionListPageSearchPayload = {
   searchQuery: string;
 };
 
-export const CloudConfigNavComponentClickedEvent: string = 'cloud-config-nav-component-clicked';
+export const CloudConfigNavComponentClickedEvent: string =
+  'cloud-config-nav-component-clicked';
 export type CloudConfigNavComponentClickedPayload = {
   itemType: 'Project Config' | 'User Management' | 'Support';
-}
+};

--- a/packages/tinacms/src/toolkit/react-sidebar/components/nav-components.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/nav-components.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import type { CloudConfigPlugin } from '@toolkit/react-cloud-config';
-import { captureEvent, CloudConfigNavComponentClickedEvent } from '../../../lib/posthog';
+import {
+  captureEvent,
+  CloudConfigNavComponentClickedEvent,
+} from '../../../lib/posthog';
 
 interface NavCloudLinkProps {
   config: CloudConfigPlugin;
@@ -18,7 +21,11 @@ export const NavCloudLink: React.FC<NavCloudLinkProps> = ({ config }) => {
         <a
           target='_blank'
           className='ml-1 text-blue-600 hover:opacity-60'
-          onClick={() => captureEvent(CloudConfigNavComponentClickedEvent, { itemType: config.link.text })}
+          onClick={() =>
+            captureEvent(CloudConfigNavComponentClickedEvent, {
+              itemType: config.link.text,
+            })
+          }
           href={config.link.href}
         >
           {config.link.text}
@@ -29,7 +36,15 @@ export const NavCloudLink: React.FC<NavCloudLinkProps> = ({ config }) => {
   return (
     <span className='text-base tracking-wide text-gray-500 hover:text-blue-600 flex items-center opacity-90 hover:opacity-100'>
       <config.Icon className='mr-2 h-6 opacity-80 w-auto' />
-      <a target='_blank' href={config.link.href} onClick={() => captureEvent(CloudConfigNavComponentClickedEvent, { itemType: config.link.text })}>
+      <a
+        target='_blank'
+        href={config.link.href}
+        onClick={() =>
+          captureEvent(CloudConfigNavComponentClickedEvent, {
+            itemType: config.link.text,
+          })
+        }
+      >
         {config.link.text}
       </a>
     </span>


### PR DESCRIPTION
As per https://github.com/tinacms/tinacms/issues/6425

Originally this PBI was scoped to just the user management button, but we might as well look at all the cloud nav items. 

The reason I chose to create one event and then specify the buttons name in the payload is because of the way we use the nav plugins and create a shared component for rendering cloud configuration links. 

This shared component is shared across both admin and sidebar nav

<img width="1369" height="194" alt="Screenshot 2026-03-06 at 12 41 05 pm" src="https://github.com/user-attachments/assets/450d217f-b3d8-47ac-ae30-238a7ec426f3" />

**Figure: Tested on a tagged branch, clicked each of the three buttons**

<img width="787" height="74" alt="Screenshot 2026-03-06 at 12 41 12 pm" src="https://github.com/user-attachments/assets/d94968f0-99a4-41d2-a4ca-d4befa830584" />

**Figure: Payload button name showing up correctly**



