### PR TITLE
Fix broken cross-package posthog import in @tinacms/app

### DIFF
--- a/.changeset/fix-posthog-cross-package-import.md
+++ b/.changeset/fix-posthog-cross-package-import.md
@@ -1,0 +1,6 @@
+---
+'tinacms': patch
+'@tinacms/app': patch
+---
+
+Fix broken cross-package relative import for posthog in @tinacms/app that caused consumer build failures

--- a/packages/@tinacms/app/src/fields/rich-text/monaco/index.tsx
+++ b/packages/@tinacms/app/src/fields/rich-text/monaco/index.tsx
@@ -15,8 +15,7 @@ import {
   buildError,
 } from './error-message';
 import { useDebounce } from './use-debounce';
-import { RichTextEditorSwitchedEvent } from '../../../../../../tinacms/src/lib/posthog/posthog';
-import { captureEvent } from '../../../../../../tinacms/src/lib/posthog/posthogProvider';
+import { RichTextEditorSwitchedEvent, captureEvent } from 'tinacms';
 
 export const uuid = () => {
   // @ts-ignore

--- a/packages/tinacms/src/index.ts
+++ b/packages/tinacms/src/index.ts
@@ -100,3 +100,6 @@ export const defineStaticConfig = (
 export const defineConfig = defineStaticConfig;
 
 export { tinaTableTemplate } from './table';
+
+export { captureEvent } from './lib/posthog/posthogProvider';
+export { RichTextEditorSwitchedEvent } from './lib/posthog/posthog';


### PR DESCRIPTION
## Summary
- `@tinacms/app` used relative paths (`../../../../../../tinacms/src/lib/posthog/...`) to import posthog utilities, which breaks in consumer builds since those paths don't exist in `node_modules`
- Exported `captureEvent` and `RichTextEditorSwitchedEvent` from the `tinacms` public API
- Updated `@tinacms/app` to import from `'tinacms'` instead

## Test plan
- [ ] Verify consumer project builds succeed without the `UNRESOLVED_IMPORT` error
- [ ] Verify posthog event capture still works when switching between rich-text and markdown editors

🤖 Generated with [Claude Code](https://claude.com/claude-code)