### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,5 @@ dist/**
 **/.env
 
 .cursor/rules/*
+CLAUDE.md
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,3 @@ dist/**
 
 .cursor/rules/*
 CLAUDE.md
-CLAUDE.md


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` to `.gitignore` to allow developers to maintain local AI assistant context files without affecting other contributors.

## Changes

- Added `CLAUDE.md` to `.gitignore`

## Why

`CLAUDE.md` files can be used by AI assistants (like Claude Code) to store project-specific development notes, testing procedures, and context. These files are useful for individual developers but shouldn't be tracked in version control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)