### PR TITLE
feat: simplify errors shown to users

### DIFF
--- a/.changeset/mean-houses-sip.md
+++ b/.changeset/mean-houses-sip.md
@@ -1,0 +1,6 @@
+---
+"tinacms": patch
+"@tinacms/app": patch
+---
+
+feat: simplify errors shown to users

--- a/packages/@tinacms/app/src/lib/errors.tsx
+++ b/packages/@tinacms/app/src/lib/errors.tsx
@@ -10,7 +10,7 @@ const ErrorModalContent = (props: { title: string; message: string }) => {
       <div>{title}</div>
       <p>{message}</p>
       <a href={TROUBLESHOOTING_URL} target='_blank' rel='noopener noreferrer'>
-        Learn more
+        Try these troubleshooting tips
       </a>
     </>
   );

--- a/packages/@tinacms/app/src/lib/errors.tsx
+++ b/packages/@tinacms/app/src/lib/errors.tsx
@@ -1,24 +1,27 @@
 import React from 'react';
 import { TinaCMS } from 'tinacms';
 
-const ErrorModalContent = (props: { title: string; errors: string[] }) => {
-  const { title, errors } = props;
+const TROUBLESHOOTING_URL = 'https://tina.io/docs/tinacloud/troubleshooting';
+
+const ErrorModalContent = (props: { title: string; message: string }) => {
+  const { title, message } = props;
   return (
     <>
       <div>{title}</div>
-      <ul>
-        {errors.map((error, i) => (
-          <li key={i}>{error}</li>
-        ))}
-      </ul>
+      <p>{message}</p>
+      <a href={TROUBLESHOOTING_URL} target='_blank' rel='noopener noreferrer'>
+        Learn more
+      </a>
     </>
   );
 };
 
 export const showErrorModal = (
   title: string,
-  errors: string[],
+  message: string,
   cms: TinaCMS
 ) => {
-  cms.alerts.error(() => <ErrorModalContent title={title} errors={errors} />);
+  if (cms.alerts.all.some((a: { level: string }) => a.level === 'error'))
+    return;
+  cms.alerts.error(() => <ErrorModalContent title={title} message={message} />);
 };

--- a/packages/@tinacms/app/src/lib/graphql-reducer.ts
+++ b/packages/@tinacms/app/src/lib/graphql-reducer.ts
@@ -613,7 +613,12 @@ export const useGraphQLReducer = (
 
   React.useEffect(() => {
     if (requestErrors.length) {
-      showErrorModal('Unexpected error querying content', requestErrors, cms);
+      console.error('Unexpected error querying content:', requestErrors);
+      showErrorModal(
+        'Unexpected Error',
+        'We ran into an unexpected error while fetching your content. If after refreshing the issue persists, reach out to us on Discord.',
+        cms
+      );
     }
   }, [requestErrors]);
 };

--- a/packages/tinacms/src/admin/index.tsx
+++ b/packages/tinacms/src/admin/index.tsx
@@ -40,6 +40,26 @@ import pkg from '../../package.json';
 
 type AuthType = 'tinacloud' | 'self-hosted' | 'local' | 'other';
 
+const TROUBLESHOOTING_URL = 'https://tina.io/docs/tinacloud/troubleshooting';
+
+const ErrorModalContent = (props: { title: string; message: string }) => {
+  const { title, message } = props;
+  return (
+    <>
+      <div>{title}</div>
+      <p>{message}</p>
+      <a href={TROUBLESHOOTING_URL} target='_blank' rel='noopener noreferrer'>
+        Learn more
+      </a>
+    </>
+  );
+};
+
+const showErrorModal = (title: string, message: string, cms: TinaCMS) => {
+  if (cms.alerts.all.some((a) => a.level === 'error')) return;
+  cms.alerts.error(() => <ErrorModalContent title={title} message={message} />);
+};
+
 const getBackendType = (client: Client | undefined): AuthType => {
   if (!client) return 'other';
 
@@ -198,14 +218,10 @@ const CheckSchema = ({
         })
         .then((isSchemaMatchedToCloud) => {
           if (isSchemaMatchedToCloud === false) {
-            cms.alerts.error(
-              `GraphQL Schema Mismatch - Editing may not work. 
-              
-              If you just switched branches, try going back to the previous branch.
-              
-              If you just pushed changes to the branch, try pulling the latest changes.
-              
-              For more information, please see https://tina.io/docs/r/troubleshooting`
+            showErrorModal(
+              'GraphQL Schema Mismatch',
+              'Editing may not work. If you just switched branches, try going back to the previous branch. If you just pushed changes, try pulling the latest.',
+              cms
             );
           }
         })
@@ -214,7 +230,12 @@ const CheckSchema = ({
           if (error.message.includes('has not been indexed by TinaCloud')) {
             setSchemaMissingError(true);
           } else {
-            cms.alerts.error(`Unexpected error checking schema: ${error}`);
+            console.error('Unexpected error checking schema:', error);
+            showErrorModal(
+              'Unexpected Error',
+              'An unexpected error occurred while validating your Tina schema. If after refreshing the issue persists, reach out to us on Discord.',
+              cms
+            );
             throw error;
           }
         });


### PR DESCRIPTION
While the work done in this PR and #6678 won't solve the underlying issue of #6660, it aims to make the error message less scary to the user and gives them a way forward as after a refresh the issue should resolve itself. An investigation into the underlying issue will be conducted with the work required for TinaV4

<img width="985" height="473" alt="image" src="https://github.com/user-attachments/assets/c7b59da4-ba98-4397-a533-633a49d36772" />
