### PR TITLE
Fix sidebar file tree: consolidate roots, chevron shrink, bottom padding

### DIFF
--- a/.changeset/fix-sidebar-file-tree-ui.md
+++ b/.changeset/fix-sidebar-file-tree-ui.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Fix sidebar file tree: consolidate duplicate roots from multiple useTina() calls, prevent chevron shrinking on long filenames, add bottom padding for last item visibility

--- a/packages/tinacms/src/toolkit/react-sidebar/components/form-list.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/form-list.tsx
@@ -363,7 +363,7 @@ const TreeNodeComponent = ({
         {/* Expand/collapse arrow for folders */}
         {node.children.length > 0 && (
           <BiChevronRight
-            className={`w-4 h-4 text-gray-500 transition-transform duration-150 -ml-1 ${
+            className={`w-4 h-4 flex-none text-gray-500 transition-transform duration-150 -ml-1 ${
               isExpanded ? 'rotate-90' : ''
             }`}
           />
@@ -514,19 +514,19 @@ export const FormLists = (props: { lastActiveFormId: string | null }) => {
       </div>
 
       {/* Scrollable content area */}
-      <div className='flex-1 overflow-x-auto overflow-y-auto min-h-0'>
-        {cms.state.formLists.map((formList, index) => (
-          <div key={`${formList.id}-${index}`}>
-            {/* TODO: add labels for each list */}
-            <FormList
-              setActiveFormId={(id) => {
-                cms.dispatch({ type: 'forms:set-active-form-id', value: id });
-              }}
-              formList={formList}
-              showReferences={showReferences}
-            />
-          </div>
-        ))}
+      <div className='flex-1 overflow-x-auto overflow-y-auto min-h-0 pb-16'>
+        <FormList
+          setActiveFormId={(id) => {
+            cms.dispatch({ type: 'forms:set-active-form-id', value: id });
+          }}
+          formList={{
+            id: 'merged',
+            label: 'All',
+            items: cms.state.formLists.flatMap((fl) => fl.items),
+            formIds: cms.state.formLists.flatMap((fl) => fl.formIds),
+          }}
+          showReferences={showReferences}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Three fixes for the sidebar "Referenced Files" file tree:

- **Consolidate duplicate roots:** When multiple `useTina()` calls register forms (e.g. homepage + two connection queries), each created a separate tree. Now all formList items are merged into a single tree — `buildTreeFromPaths` already deduplicates shared path segments.
- **Chevron shrink on long filenames:** Added `flex-none` to the expand/collapse chevron so long folder names don't compress it.
- **Last item not reachable:** Added `pb-16` to the scrollable content area so the final tree item isn't clipped.

Closes #6690
Closes #6691

## Test plan

- [x] Page with multiple `useTina()` calls shows a single consolidated file tree (no duplicate roots)
- [x] Long folder/file names truncate without squishing the chevron icon
- [x] Can scroll to and click the last item in a long file tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)