### PR TITLE
Use configurable assets domain for uploaded media src URLs

### DIFF
--- a/.changeset/localcontentpath-runtime-validation.md
+++ b/.changeset/localcontentpath-runtime-validation.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/schema-tools": patch
+"@tinacms/cli": patch
+---
+
+Add runtime Zod validation for the `localContentPath` Tina config field (rejects non-string and empty-string values). Extract the CLI's content-root resolution out of `processConfig` into a standalone, unit-testable `resolveContentRootPath` function that preserves the existing behaviour (falls back to `rootPath` with a warning when the configured directory is missing). Closes [tinacms/tinacloud#3294](https://github.com/tinacms/tinacloud/issues/3294).

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import { logger } from '../logger';
 import { createRequire } from 'module';
 import { stripNativeTrailingSlash } from '../utils/path';
+import { resolveContentRootPath } from './resolve-content-root';
 
 export const TINA_FOLDER = 'tina';
 export const LEGACY_TINA_FOLDER = '.tina';
@@ -238,31 +239,12 @@ export class ConfigManager {
     this.outputHTMLFilePath = path.join(this.outputFolderPath, 'index.html');
     this.outputGitignorePath = path.join(this.outputFolderPath, '.gitignore');
 
-    const fullLocalContentPath = stripNativeTrailingSlash(
-      path.join(this.tinaFolderPath, this.config.localContentPath || '')
-    );
-
-    if (this.config.localContentPath) {
-      // Check if the localContentPath exists
-      const localContentPathExists = await fs.pathExists(fullLocalContentPath);
-      if (localContentPathExists) {
-        logger.info(`Using separate content repo at ${fullLocalContentPath}`);
-        this.contentRootPath = fullLocalContentPath;
-      } else {
-        // Warn the user if they provided a localContentPath that doesn't exist
-        logger.warn(
-          `${chalk.yellow('Warning:')} The localContentPath ${chalk.cyan(
-            fullLocalContentPath
-          )} does not exist. Please create it or remove the localContentPath from your config file at ${chalk.cyan(
-            this.tinaConfigFilePath
-          )}`
-        );
-      }
-    }
-
-    if (!this.contentRootPath) {
-      this.contentRootPath = this.rootPath;
-    }
+    this.contentRootPath = await resolveContentRootPath({
+      rootPath: this.rootPath,
+      tinaFolderPath: this.tinaFolderPath,
+      tinaConfigFilePath: this.tinaConfigFilePath,
+      localContentPath: this.config.localContentPath,
+    });
 
     this.generatedFolderPathContentRepo = path.join(
       await this.getTinaFolderPath(this.contentRootPath, {

--- a/packages/@tinacms/cli/src/next/resolve-content-root.test.ts
+++ b/packages/@tinacms/cli/src/next/resolve-content-root.test.ts
@@ -1,0 +1,111 @@
+jest.mock('fs-extra', () => ({
+  pathExists: jest.fn(),
+}));
+
+jest.mock('../logger', () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+// chalk v5 is ESM-only; jest's CJS runtime can't load it. We only use it for
+// coloring log output, so identity functions are a faithful stand-in for tests.
+jest.mock('chalk', () => {
+  const identity = (s: string) => s;
+  return {
+    __esModule: true,
+    default: { yellow: identity, cyan: identity, red: identity },
+    yellow: identity,
+    cyan: identity,
+    red: identity,
+  };
+});
+
+import * as fs from 'fs-extra';
+import { resolveContentRootPath } from './resolve-content-root';
+import { logger } from '../logger';
+
+const mockFs = fs as jest.Mocked<typeof fs>;
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+const baseParams = {
+  rootPath: '/fake/project',
+  tinaFolderPath: '/fake/project/tina',
+  tinaConfigFilePath: '/fake/project/tina/config.ts',
+};
+
+describe('resolveContentRootPath', () => {
+  beforeEach(() => {
+    mockFs.pathExists.mockReset();
+    mockLogger.info.mockReset();
+    mockLogger.warn.mockReset();
+  });
+
+  it('returns rootPath when localContentPath is not configured', async () => {
+    const result = await resolveContentRootPath({
+      ...baseParams,
+      localContentPath: undefined,
+    });
+
+    expect(result).toBe('/fake/project');
+    expect(mockFs.pathExists).not.toHaveBeenCalled();
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('returns the joined sibling path when the directory exists and logs at info level', async () => {
+    mockFs.pathExists.mockResolvedValue(true as never);
+
+    const result = await resolveContentRootPath({
+      ...baseParams,
+      localContentPath: '../content-repo',
+    });
+
+    expect(result).toBe('/fake/project/content-repo');
+    expect(mockFs.pathExists).toHaveBeenCalledWith(
+      '/fake/project/content-repo'
+    );
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      expect.stringContaining('Using separate content repo at')
+    );
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+  });
+
+  it('warns and falls back to rootPath when the configured directory does not exist', async () => {
+    mockFs.pathExists.mockResolvedValue(false as never);
+
+    const result = await resolveContentRootPath({
+      ...baseParams,
+      localContentPath: '../does-not-exist',
+    });
+
+    expect(result).toBe('/fake/project');
+    expect(mockFs.pathExists).toHaveBeenCalledWith(
+      '/fake/project/does-not-exist'
+    );
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('does not exist')
+    );
+    // Warning must cite the tina config file path so the user knows where to fix it.
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('/fake/project/tina/config.ts')
+    );
+    expect(mockLogger.info).not.toHaveBeenCalled();
+  });
+
+  it('strips a trailing slash from the joined path before checking existence', async () => {
+    mockFs.pathExists.mockResolvedValue(true as never);
+
+    const result = await resolveContentRootPath({
+      ...baseParams,
+      localContentPath: '../content-repo/',
+    });
+
+    expect(result).toBe('/fake/project/content-repo');
+    expect(mockFs.pathExists).toHaveBeenCalledWith(
+      '/fake/project/content-repo'
+    );
+  });
+});

--- a/packages/@tinacms/cli/src/next/resolve-content-root.ts
+++ b/packages/@tinacms/cli/src/next/resolve-content-root.ts
@@ -1,0 +1,45 @@
+import fs from 'fs-extra';
+import path from 'path';
+import chalk from 'chalk';
+import { logger } from '../logger';
+import { stripNativeTrailingSlash } from '../utils/path';
+
+/**
+ * Resolves the content root directory for a Tina project.
+ *
+ * - Single-repo (no `localContentPath`): returns `rootPath`.
+ * - Multi-repo with `localContentPath` set and the joined directory present:
+ *   returns the joined absolute path and logs an info message.
+ * - Multi-repo with `localContentPath` set but the joined directory missing:
+ *   logs a warning citing the config file and falls back to `rootPath`.
+ *
+ * Extracted from ConfigManager for unit testing. The CLI's ConfigManager
+ * cannot be imported from a jest unit test because it uses `import.meta.url`
+ * at module scope, which CommonJS-targeted ts-jest cannot parse.
+ */
+export async function resolveContentRootPath(params: {
+  rootPath: string;
+  tinaFolderPath: string;
+  tinaConfigFilePath: string;
+  localContentPath: string | undefined;
+}): Promise<string> {
+  if (!params.localContentPath) {
+    return params.rootPath;
+  }
+  const fullLocalContentPath = stripNativeTrailingSlash(
+    path.join(params.tinaFolderPath, params.localContentPath)
+  );
+  const exists = await fs.pathExists(fullLocalContentPath);
+  if (exists) {
+    logger.info(`Using separate content repo at ${fullLocalContentPath}`);
+    return fullLocalContentPath;
+  }
+  logger.warn(
+    `${chalk.yellow('Warning:')} The localContentPath ${chalk.cyan(
+      fullLocalContentPath
+    )} does not exist. Please create it or remove the localContentPath from your config file at ${chalk.cyan(
+      params.tinaConfigFilePath
+    )}`
+  );
+  return params.rootPath;
+}

--- a/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.spec.ts
+++ b/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.spec.ts
@@ -242,4 +242,42 @@ describe('validateTinaCloudSchemaConfig', () => {
       expect(() => validateTinaCloudSchemaConfig(config)).not.toThrow();
     });
   });
+
+  describe('localContentPath', () => {
+    it('accepts config without localContentPath', () => {
+      expect(() => validateTinaCloudSchemaConfig({})).not.toThrow();
+    });
+
+    it('accepts a relative path string', () => {
+      expect(() =>
+        validateTinaCloudSchemaConfig({ localContentPath: '../content-repo' })
+      ).not.toThrow();
+    });
+
+    it('accepts an absolute path string', () => {
+      expect(() =>
+        validateTinaCloudSchemaConfig({
+          localContentPath: '/Users/me/content-repo',
+        })
+      ).not.toThrow();
+    });
+
+    it('rejects a non-string value', () => {
+      expect(() =>
+        validateTinaCloudSchemaConfig({ localContentPath: 42 })
+      ).toThrow();
+      expect(() =>
+        validateTinaCloudSchemaConfig({ localContentPath: true })
+      ).toThrow();
+      expect(() =>
+        validateTinaCloudSchemaConfig({ localContentPath: {} })
+      ).toThrow();
+    });
+
+    it('rejects an empty string', () => {
+      expect(() =>
+        validateTinaCloudSchemaConfig({ localContentPath: '' })
+      ).toThrow();
+    });
+  });
 });

--- a/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
+++ b/packages/@tinacms/schema-tools/src/validate/tinaCloudSchemaConfig.ts
@@ -72,6 +72,7 @@ export const tinaConfigZod = z.object({
         .optional(),
     })
     .optional(),
+  localContentPath: z.string().min(1).optional(),
 });
 
 export const validateTinaCloudSchemaConfig = (config: unknown): Config => {

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -100,6 +100,7 @@ export class Client {
   contentApiUrl: string;
   identityApiUrl: string;
   assetsApiUrl: string;
+  assetsDomain: string;
   gqlSchema: GraphQLSchema;
   schema?: TinaSchema;
   clientId: string;
@@ -175,6 +176,9 @@ export class Client {
     this.assetsApiUrl =
       this.options.tinaioConfig?.assetsApiUrlOverride ||
       'https://assets.tinajs.io';
+    this.assetsDomain =
+      this.options.tinaioConfig?.assetsApiUrlOverride ||
+      'https://assets.tina.io';
     this.frontendUrl =
       this.options.tinaioConfig?.frontendUrlOverride || 'https://app.tina.io';
     this.identityApiUrl =

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -133,7 +133,7 @@ export class TinaMediaStore implements MediaStore {
           throw new Error(message);
         }
 
-        const { signedUrl, requestId, src: uploadSrc } = await res.json();
+        const { signedUrl, requestId } = await res.json();
         if (!signedUrl) {
           throw new Error('Unexpected error generating upload url');
         }
@@ -178,9 +178,7 @@ export class TinaMediaStore implements MediaStore {
           }
         }
 
-        const src =
-          uploadSrc ||
-          `https://assets.tina.io/${this.api.clientId}/${path}`;
+        const src = `${this.api.assetsDomain}/${this.api.clientId}/${path}`;
 
         newFiles.push({
           directory: item.directory,

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -133,7 +133,7 @@ export class TinaMediaStore implements MediaStore {
           throw new Error(message);
         }
 
-        const { signedUrl, requestId } = await res.json();
+        const { signedUrl, requestId, src: uploadSrc } = await res.json();
         if (!signedUrl) {
           throw new Error('Unexpected error generating upload url');
         }
@@ -178,7 +178,9 @@ export class TinaMediaStore implements MediaStore {
           }
         }
 
-        const src = `https://assets.tina.io/${this.api.clientId}/${path}`;
+        const src =
+          uploadSrc ||
+          `https://assets.tina.io/${this.api.clientId}/${path}`;
 
         newFiles.push({
           directory: item.directory,


### PR DESCRIPTION
## Summary
- The media store hardcoded `assets.tina.io` as the CDN domain when constructing the `src` URL for newly uploaded images. For non-production stacks (e.g. local dev with `assets-local-{stack}.tinajs.dev`), the wrong domain caused images to not display until the media manager was refreshed — since the list endpoint already uses the correct domain.
- Adds an `assetsDomain` property to `Client`, sourced from the existing `assetsApiUrlOverride` tinaioConfig option, so `persist_cloud` constructs the correct `src` URL immediately after upload.
- No new config fields required — reuses `assetsApiUrlOverride`. Production behavior unchanged (defaults to `assets.tina.io`).

## Test plan
- [ ] Upload an image via media manager on a local stack — verify it displays immediately with the correct `assets-local-{stack}` domain
- [ ] Upload an image on production — verify `src` still uses `assets.tina.io`
- [ ] Refresh media manager list — verify URLs remain consistent with upload URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)