### PR TITLE
chore(@tinacms/graphql): remove duplicate atob/btoa from database/util.ts

### DIFF
--- a/.changeset/loud-rice-drive.md
+++ b/.changeset/loud-rice-drive.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+chore(@tinacms/graphql): remove duplicate atob/btoa from database/util.ts

--- a/packages/@tinacms/graphql/src/database/util.ts
+++ b/packages/@tinacms/graphql/src/database/util.ts
@@ -195,14 +195,6 @@ export const parseFile = <T extends object>(
   throw new Error(`Must specify a valid format, got ${format}`);
 };
 
-export const atob = (b64Encoded: string) => {
-  return Buffer.from(b64Encoded, 'base64').toString();
-};
-
-export const btoa = (string: string) => {
-  return Buffer.from(string).toString('base64');
-};
-
 export const scanAllContent = async (
   tinaSchema: TinaSchema,
   bridge: Bridge,


### PR DESCRIPTION
Both `atob` and `btoa` are defined identically in src/util.ts and
src/database/util.ts — exact same 2-line Buffer-based implementations.

Cross-repo grep confirms every consumer imports them from src/util.ts
(via `from '../util'`), not from src/database/util.ts:
- database/index.ts (lines 1044, 1046, 1185, 1208, 1209)
- database/database.test.ts (lines 309, 310, 320)

Deleting the duplicates in database/util.ts has no runtime effect.

Fallow baseline: -1 duplicate export pair (fewer barrel ambiguity risks).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>