### PR TITLE
fix(@tinacms/cli): add .js extension to ./types import in generated client (fix #6062)

### DIFF
--- a/.changeset/fix-generated-client-esm-extension.md
+++ b/.changeset/fix-generated-client-esm-extension.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": patch
+---
+
+Fix missing .js extension on ./types import in generated client.ts and databaseClient.ts

--- a/packages/@tinacms/cli/src/next/codegen/index.test.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.test.ts
@@ -19,6 +19,58 @@ jest.mock('esbuild', () => ({
 import * as stripModule from './stripSearchTokenFromConfig';
 import { Codegen } from './index';
 
+describe('Codegen.genClient', () => {
+  function makeInstance(isTs: boolean): Codegen {
+    const instance = Object.create(Codegen.prototype) as Codegen;
+    instance.apiURL = 'https://example.com/graphql';
+    instance.localContentBuild = false;
+    instance.noClientBuildCache = true;
+    instance.configManager = {
+      config: { token: 'tok' },
+      generatedCachePath: '/fake/cache',
+      isUsingTs: () => isTs,
+    } as any;
+    return instance;
+  }
+
+  it('emits ./types.ts import for TypeScript projects', async () => {
+    const { clientString } = await makeInstance(true).genClient();
+    expect(clientString).toContain('from "./types.ts"');
+    expect(clientString).not.toMatch(/from ["']\.\/types["']/);
+  });
+
+  it('emits ./types.js import for non-TypeScript projects', async () => {
+    const { clientString } = await makeInstance(false).genClient();
+    expect(clientString).toContain('from "./types.js"');
+    expect(clientString).not.toMatch(/from ["']\.\/types["']/);
+  });
+});
+
+describe('Codegen.genDatabaseClient', () => {
+  function makeInstance(isTs: boolean): Codegen {
+    const instance = Object.create(Codegen.prototype) as Codegen;
+    instance.configManager = {
+      isUsingTs: () => isTs,
+    } as any;
+    instance.tinaSchema = {
+      getCollections: () => [],
+    } as any;
+    return instance;
+  }
+
+  it('emits ./types.ts import for TypeScript projects', async () => {
+    const result = await makeInstance(true).genDatabaseClient();
+    expect(result).toContain('from "./types.ts"');
+    expect(result).not.toMatch(/from ["']\.\/types["']/);
+  });
+
+  it('emits ./types.js import for non-TypeScript projects', async () => {
+    const result = await makeInstance(false).genDatabaseClient();
+    expect(result).toContain('from "./types.js"');
+    expect(result).not.toMatch(/from ["']\.\/types["']/);
+  });
+});
+
 describe('Codegen.execute integration', () => {
   let spy: jest.SpyInstance;
   const SAFE_RESULT = { branch: 'main', token: 'tok' };

--- a/packages/@tinacms/cli/src/next/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/index.ts
@@ -297,7 +297,7 @@ export class Codegen {
 import { resolve } from "@tinacms/datalayer";
 import type { TinaClient } from "tinacms/dist/client";
 
-import { queries } from "./types";
+import { queries } from "${this.configManager.isUsingTs() ? './types.ts' : './types.js'}";
 import database from "../database";
 
 export async function databaseRequest({ query, variables, user }) {
@@ -365,7 +365,7 @@ export default databaseClient;
     const apiURL = this.getApiURL();
 
     const clientString = `import { createClient } from "tinacms/dist/client";
-import { queries } from "./types";
+import { queries } from "${this.configManager.isUsingTs() ? './types.ts' : './types.js'}";
 export const client = createClient({ ${
       this.noClientBuildCache === false
         ? `cacheDir: '${normalizePath(


### PR DESCRIPTION
#6062 while looking at the generated `tina/__generated__/client.ts`. The generator writes `import { queries } from "./types"` with no file extension, which breaks Node.js ESM resolution.

The fix is extension-aware rather than a flat `.js` addition — for TypeScript projects `genClient()` and `genDatabaseClient()` now emit `./types.ts`, and for non-TypeScript projects they emit `./types.js`. This matters because on the TS path, `types.js` is explicitly deleted after generation, so a flat `.js` extension would break `--experimental-strip-types` users. On the non-TS path, esbuild compiles everything to JS so `.js` is correct.

Added two tests in `index.test.ts` covering both branches via a shared helper, one asserting `./types.ts` for TS projects, one asserting `./types.js` for non-TS projects. All 6 tests pass.