### PR TITLE
Show content file path on breadcrumb hover

### DIFF
--- a/.changeset/ten-clouds-act.md
+++ b/.changeset/ten-clouds-act.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+feat(tinacms): show content file path on breadcrumb hover

--- a/packages/tinacms/src/toolkit/react-sidebar/components/sidebar-body.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/sidebar-body.tsx
@@ -202,7 +202,10 @@ export const FormHeader = ({
 
   return (
     <div className='px-4 pt-2 pb-4 flex flex-row flex-nowrap justify-between items-center gap-2 bg-gradient-to-t from-white to-gray-50 border-b border-gray-100'>
-      <FormBreadcrumbs className='w-[calc(100%-3rem)]' contentPath={activeForm.tinaForm.path} />
+      <FormBreadcrumbs
+        className='w-[calc(100%-3rem)]'
+        contentPath={activeForm.tinaForm.path}
+      />
       <FileHistoryProvider
         defaultBranchName={repoProvider?.defaultBranchName}
         historyUrl={repoProvider?.historyUrl}
@@ -358,7 +361,11 @@ export const FormBreadcrumbs = ({
               </span>
             </TooltipTrigger>
             {contentPath && (
-              <TooltipContent side='bottom' align='start' className='shadow-md max-w-xs break-all'>
+              <TooltipContent
+                side='bottom'
+                align='start'
+                className='shadow-md max-w-xs break-all'
+              >
                 {contentPath}
               </TooltipContent>
             )}

--- a/packages/tinacms/src/toolkit/react-sidebar/components/sidebar-body.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/sidebar-body.tsx
@@ -202,7 +202,7 @@ export const FormHeader = ({
 
   return (
     <div className='px-4 pt-2 pb-4 flex flex-row flex-nowrap justify-between items-center gap-2 bg-gradient-to-t from-white to-gray-50 border-b border-gray-100'>
-      <FormBreadcrumbs className='w-[calc(100%-3rem)]' />
+      <FormBreadcrumbs className='w-[calc(100%-3rem)]' contentPath={activeForm.tinaForm.path} />
       <FileHistoryProvider
         defaultBranchName={repoProvider?.defaultBranchName}
         historyUrl={repoProvider?.historyUrl}
@@ -295,7 +295,7 @@ const BreadcrumbItemLink = ({
 const FinalBreadcrumbItem = ({ breadcrumb }: { breadcrumb: string }) => {
   return (
     <BreadcrumbItem className='shrink truncate'>
-      <BreadcrumbPage className='text-gray-700 font-medium'>
+      <BreadcrumbPage className='text-gray-700 font-medium cursor-default'>
         {breadcrumb}
       </BreadcrumbPage>
     </BreadcrumbItem>
@@ -304,9 +304,11 @@ const FinalBreadcrumbItem = ({ breadcrumb }: { breadcrumb: string }) => {
 
 export const FormBreadcrumbs = ({
   rootBreadcrumbName,
+  contentPath,
   ...props
 }: {
   rootBreadcrumbName?: string;
+  contentPath?: string;
 } & React.HTMLAttributes<HTMLDivElement>) => {
   const cms = useCMS();
   const breadcrumbs = cms.state.breadcrumbs;
@@ -337,18 +339,31 @@ export const FormBreadcrumbs = ({
     <Breadcrumb {...props}>
       <BreadcrumbList className='flex-nowrap text-nowrap'>
         {/* First breadcrumb */}
-        {breadcrumbs.length > 1 ? (
-          <BreadcrumbItemLink
-            breadcrumb={rootBreadcrumbName || firstBreadcrumb.label}
-            onClick={() =>
-              goBack(firstBreadcrumb.formId, firstBreadcrumb.formName)
-            }
-          />
-        ) : (
-          <FinalBreadcrumbItem
-            breadcrumb={rootBreadcrumbName || firstBreadcrumb.label}
-          />
-        )}
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span>
+                {breadcrumbs.length > 1 ? (
+                  <BreadcrumbItemLink
+                    breadcrumb={rootBreadcrumbName || firstBreadcrumb.label}
+                    onClick={() =>
+                      goBack(firstBreadcrumb.formId, firstBreadcrumb.formName)
+                    }
+                  />
+                ) : (
+                  <FinalBreadcrumbItem
+                    breadcrumb={rootBreadcrumbName || firstBreadcrumb.label}
+                  />
+                )}
+              </span>
+            </TooltipTrigger>
+            {contentPath && (
+              <TooltipContent side='bottom' align='start' className='shadow-md max-w-xs break-all'>
+                {contentPath}
+              </TooltipContent>
+            )}
+          </Tooltip>
+        </TooltipProvider>
 
         {/* Dropdown for middle breadcrumbs */}
         {dropdownBreadcrumbs.length > 0 && (


### PR DESCRIPTION
## Summary
- The first (non-URL) breadcrumb in the sidebar now displays a tooltip on hover showing the content file path (e.g. `content/posts/my-post.mdx`), making it easy to identify which file is being edited
- Fixes cursor on non-clickable breadcrumbs from text cursor to default pointer
- Tooltip is constrained to `max-w-xs` with `break-all` for long file paths

<img width="729" height="1079" alt="Screenshot 2026-04-29 at 2 45 52 pm" src="https://github.com/user-attachments/assets/679bb677-f32c-44d1-a8a5-b0e19d231ec2" />


## Context
Adam's request — editors want a quick way to see the filename they're editing without navigating away.

## Test plan
- [x] Open any content file in the TinaCMS sidebar
- [x] Hover over the first breadcrumb (collection name) — tooltip should show the file path
- [x] Verify tooltip doesn't overflow on long filenames
- [x] Verify non-clickable breadcrumbs show default cursor, not text cursor
- [x] Verify clickable breadcrumbs still navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)