### PR TITLE
fix: allow folder creation in collections with match.exclude configured

### DIFF
--- a/.changeset/fix-folder-creation-match-exclude.md
+++ b/.changeset/fix-folder-creation-match-exclude.md
@@ -1,0 +1,10 @@
+---
+"@tinacms/graphql": patch
+"@tinacms/schema-tools": patch
+---
+
+Fix folder creation failing when a collection has `match.exclude` configured.
+
+`TinaSchema.getCollectionByFullPath` was applying the `match.exclude` glob check to `.gitkeep.*` folder placeholder files, causing the collection lookup to return no results. This made `database.put()` throw during `resolveCreateFolder`, blocking folder creation entirely in any collection with `match.exclude` set.
+
+The fix skips the `match.include`/`match.exclude` check for `.gitkeep.*` placeholders in both `TinaSchema` and `Database.put`, mirroring the existing extension-check special-case that already handled these files.

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -531,7 +531,8 @@ export class Database {
 
         // If a collection match is specified, make sure the file matches the glob.
         // TODO: Maybe we should service this error better in the frontend?
-        if (collection.match?.exclude || collection.match?.include) {
+        const isFolderPlaceholder = filepath.includes('.gitkeep.')
+        if (!isFolderPlaceholder && (collection.match?.exclude || collection.match?.include)) {
           const matches = this.tinaSchema.getMatches({ collection });
 
           const match = micromatch.isMatch(filepath, matches);

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -531,8 +531,11 @@ export class Database {
 
         // If a collection match is specified, make sure the file matches the glob.
         // TODO: Maybe we should service this error better in the frontend?
-        const isFolderPlaceholder = filepath.includes('.gitkeep.')
-        if (!isFolderPlaceholder && (collection.match?.exclude || collection.match?.include)) {
+        const isFolderPlaceholder = filepath.includes('.gitkeep.');
+        if (
+          !isFolderPlaceholder &&
+          (collection.match?.exclude || collection.match?.include)
+        ) {
           const matches = this.tinaSchema.getMatches({ collection });
 
           const match = micromatch.isMatch(filepath, matches);

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -531,7 +531,9 @@ export class Database {
 
         // If a collection match is specified, make sure the file matches the glob.
         // TODO: Maybe we should service this error better in the frontend?
-        const isFolderPlaceholder = filepath.includes('.gitkeep.');
+        const isFolderPlaceholder = filepath.endsWith(
+          `.gitkeep.${collection.format || 'md'}`
+        );
         if (
           !isFolderPlaceholder &&
           (collection.match?.exclude || collection.match?.include)

--- a/packages/@tinacms/graphql/tests/folder-creation-mutation/index.test.ts
+++ b/packages/@tinacms/graphql/tests/folder-creation-mutation/index.test.ts
@@ -1,6 +1,7 @@
 import { it, expect } from 'vitest';
 import config from './tina/config';
 import { setupMutation, format } from '../util';
+import type { Schema } from '@tinacms/schema-tools';
 
 const createFolderMutation = `
   mutation {
@@ -46,6 +47,40 @@ it('prevents creating duplicate folder', async () => {
 
   expect(result.errors).toBeDefined();
   expect(result.errors![0].message).toContain('already exists');
+});
+
+it('creates folder when collection has match.exclude configured', async () => {
+  const schemaWithExclude: Schema = {
+    collections: [
+      {
+        label: 'Post',
+        name: 'post',
+        path: 'posts',
+        match: {
+          exclude: 'drafts/**',
+        },
+        fields: [
+          { name: 'title', label: 'Title', type: 'string', required: true },
+          { name: 'content', label: 'Content', type: 'string' },
+        ],
+      },
+    ],
+  };
+
+  const { query, bridge } = await setupMutation(__dirname, {
+    schema: schemaWithExclude,
+  });
+
+  const result = await query({
+    query: createFolderMutation,
+    variables: {},
+  });
+
+  expect(result.errors).toBeUndefined();
+  const folderWrite = bridge.getWrite(
+    'posts/northwind/company-updates/.gitkeep.md'
+  );
+  expect(folderWrite).toBeDefined();
 });
 
 it('creates nested folder structure', async () => {

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -137,7 +137,10 @@ export class TinaSchema {
       ) {
         return false;
       }
-      if (collection?.match?.include || collection?.match?.exclude) {
+      const isFolderPlaceholder = canonicalFilepath.endsWith(
+        `.gitkeep.${collection.format || 'md'}`
+      );
+      if (!isFolderPlaceholder && (collection?.match?.include || collection?.match?.exclude)) {
         // if the collection has a match or exclude, we need to check if the file matches
         const matches = this.getMatches({ collection });
         const match = picomatch.isMatch(canonicalFilepath, matches);

--- a/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
+++ b/packages/@tinacms/schema-tools/src/schema/TinaSchema.ts
@@ -140,7 +140,10 @@ export class TinaSchema {
       const isFolderPlaceholder = canonicalFilepath.endsWith(
         `.gitkeep.${collection.format || 'md'}`
       );
-      if (!isFolderPlaceholder && (collection?.match?.include || collection?.match?.exclude)) {
+      if (
+        !isFolderPlaceholder &&
+        (collection?.match?.include || collection?.match?.exclude)
+      ) {
         // if the collection has a match or exclude, we need to check if the file matches
         const matches = this.getMatches({ collection });
         const match = picomatch.isMatch(canonicalFilepath, matches);


### PR DESCRIPTION
## Summary

Fixes folder creation failing when a collection has `match.exclude` configured.

When a collection specifies `match.exclude`, `TinaSchema.getCollectionByFullPath` evaluates the exclude glob against the `.gitkeep.*` placeholder file path used internally for folder creation. Since the placeholder path typically doesn't match the exclude pattern's positive side (e.g. `!(posts/drafts/**/*.md)` requires an explicit positive path match), the collection lookup returns no results. This causes `database.put()` to throw `Unable to find collection for path …` inside `formatBodyOnPayload`, surfacing as a `TinaFetchError` to the caller.

**Changes:**

- `packages/@tinacms/schema-tools/src/schema/TinaSchema.ts` — Skip the `match.include`/`match.exclude` glob check in `getCollectionByFullPath` when the file path ends with `.gitkeep.{format}`. The existing extension-check already has this special-case; the match check now mirrors it.
- `packages/@tinacms/graphql/src/database/index.ts` — Same guard in `Database.put()` where the glob check is repeated for the file being written.
- `packages/@tinacms/graphql/tests/folder-creation-mutation/index.test.ts` — New regression test: creates a folder in a collection that has `match.exclude: 'drafts/**'` and asserts no errors and that the bridge write is present.

## Test plan

- [x] `pnpm --filter @tinacms/graphql test` — all `folder-creation-mutation` tests pass (4/4)
- [x] New test `creates folder when collection has match.exclude configured` exercises the fixed code path

Closes #5978

🤖 Generated with [Claude Code](https://claude.com/claude-code)