### PR TITLE
🐛 Bug - Popover panel hidden under other content

### DIFF
--- a/.changeset/forty-boats-smile.md
+++ b/.changeset/forty-boats-smile.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+🐛 fix Popover on rich-text fields from being hidden under other content

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/create-mdx-plugins/component.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/create-mdx-plugins/component.tsx
@@ -219,7 +219,7 @@ const DotMenu = ({ onOpen, onRemove }) => {
         leaveFrom='transform opacity-100 scale-100'
         leaveTo='transform opacity-0 scale-95'
       >
-        <PopoverPanel className='z-30 absolute origin-top-right right-0'>
+        <PopoverPanel className='z-30 fixed origin-top-right right-0'>
           <div className='mt-2 -mr-1 rounded shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none'>
             <div className='py-1'>
               <span


### PR DESCRIPTION
As per #6760

Similar to how the `data-radix-popper-content-wrapper` uses fixed in order to remain on top of content hierarchically, i've updated the same to the `PopOverPanel` 

<img width="786" height="323" alt="Screenshot 2026-04-29 at 5 23 36 pm" src="https://github.com/user-attachments/assets/faf777ac-bd9a-495b-a537-e46a17157638" />

**Figure: data-radix-popper-content-wrapper uses `fixed`**

<img width="524" height="260" alt="Screenshot 2026-04-29 at 5 23 31 pm" src="https://github.com/user-attachments/assets/cccbf1e4-e62b-4962-a9e1-ac4ef9a111d9" />

**Figure: ✅ Using `fixed` to ensure its showing**