### PR TITLE
feat: configurable typography for rich text editor

### DIFF
--- a/.changeset/editor-typography-config.md
+++ b/.changeset/editor-typography-config.md
@@ -1,0 +1,7 @@
+---
+"@tinacms/schema-tools": minor
+"@tinacms/app": minor
+"tinacms": minor
+---
+
+Add configurable typography for the rich text editor. Users can now set `overrides.typography.fontFamily` and `overrides.typography.headingFontFamily` on rich-text fields, and `admin.fontUrl` at the config level to load custom fonts. Editor headings default to Inter sans-serif instead of Libre Baskerville serif.

--- a/packages/@tinacms/app/src/global.css
+++ b/packages/@tinacms/app/src/global.css
@@ -45,6 +45,9 @@
   --tina-font-weight-regular: 400;
   --tina-font-weight-bold: 600;
 
+  --tina-editor-font-family: "Inter", sans-serif;
+  --tina-editor-heading-font-family: var(--tina-editor-font-family);
+
   --tina-shadow-big: 0px 2px 3px rgba(0, 0, 0, 0.05), 0 4px 12px
     rgba(0, 0, 0, 0.1);
   --tina-shadow-small: 0px 2px 3px rgba(0, 0, 0, 0.12);

--- a/packages/@tinacms/app/src/index.css
+++ b/packages/@tinacms/app/src/index.css
@@ -13,10 +13,6 @@
   fill: currentColor;
 }
 
-.font-libre-baskerville {
-  font-family: "Libre Baskerville", serif;
-}
-
 body {
   margin: 0;
   padding: 0;
@@ -46,6 +42,15 @@ div.graphiql-explorer-root > div:last-child {
   padding-bottom: 0.5em;
   /* Outline is placed on the parent element for styling consistency with other elements */
   outline: none;
+  font-family: var(--tina-editor-font-family);
+}
+.tina-prose [data-slate-editor="true"] h1,
+.tina-prose [data-slate-editor="true"] h2,
+.tina-prose [data-slate-editor="true"] h3,
+.tina-prose [data-slate-editor="true"] h4,
+.tina-prose [data-slate-editor="true"] h5,
+.tina-prose [data-slate-editor="true"] h6 {
+  font-family: var(--tina-editor-heading-font-family);
 }
 /* prose adds backticks, which look like they should be editable */
 .tina-prose [data-slate-editor="true"] .slate-code::before {

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -382,6 +382,18 @@ export type RichTextField<WithNamespace extends boolean = false> = (
       toolbar?: ToolbarOverrideType[];
       /**Default set to true */
       showFloatingToolbar?: boolean;
+      /**
+       * Configure typography for the rich text editor to match your frontend.
+       * Styles are applied via CSS custom properties on the editor wrapper.
+       */
+      typography?: {
+        /** CSS font-family for the editor body. E.g. "'Inter', sans-serif" */
+        fontFamily?: string;
+        /** CSS font-family for headings. Falls back to fontFamily if not set */
+        headingFontFamily?: string;
+        /** URL to load the font from (e.g. Google Fonts URL) */
+        fontUrl?: string;
+      };
     };
     /**
      * By default, Tina parses markdown with MDX, this is a more strict parser
@@ -641,6 +653,11 @@ export interface Config<
      * Hook functions that can be used to run logic when certain events happen
      */
     authHooks?: AuthHooks;
+    /**
+     * URL to load a custom font for the rich text editor (e.g. a Google Fonts URL).
+     * The font will be loaded alongside the default Inter font.
+     */
+    fontUrl?: string;
   };
   /**
    * The Schema is used to define the shape of the content.

--- a/packages/tinacms/src/tina-cms.tsx
+++ b/packages/tinacms/src/tina-cms.tsx
@@ -197,7 +197,7 @@ export const TinaCMSProvider2 = ({
         tinaGraphQLVersion={props.tinaGraphQLVersion}
       >
         {/* <style>{styles}</style> */}
-        <FontLoader />
+        <FontLoader fontUrl={schema?.config?.admin?.fontUrl} />
         <ErrorBoundary>{props.children}</ErrorBoundary>
       </TinaCloudProvider>
     </>

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/index.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/index.tsx
@@ -13,6 +13,21 @@ import type {
 } from './plate/toolbar/toolbar-overrides';
 import type { MdxTemplate } from './plate/types';
 
+function buildTypographyStyle(overrides?: {
+  typography?: {
+    fontFamily?: string;
+    headingFontFamily?: string;
+  };
+}): React.CSSProperties | undefined {
+  const tp = overrides?.typography;
+  if (!tp?.fontFamily && !tp?.headingFontFamily) return undefined;
+  return {
+    '--tina-editor-font-family': tp.fontFamily ?? "'Inter', sans-serif",
+    '--tina-editor-heading-font-family':
+      tp.headingFontFamily ?? tp.fontFamily ?? "'Inter', sans-serif",
+  } as React.CSSProperties;
+}
+
 export type RichTextType = React.PropsWithChildren<
   InputFieldType<
     InputProps,
@@ -65,6 +80,7 @@ export const MdxFieldPlugin = {
           className={
             'min-h-[100px] max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded pt-0 py-2'
           }
+          style={buildTypographyStyle(props.field.overrides)}
         >
           <RichEditor {...props} />
         </div>
@@ -124,6 +140,7 @@ export const MdxFieldPluginExtendible = {
           className={
             'min-h-[100px] max-w-full tina-prose relative shadow-inner focus-within:shadow-outline focus-within:border-blue-500 block w-full bg-white border border-gray-200 text-gray-600 focus-within:text-gray-900 rounded pt-0 py-2'
           }
+          style={buildTypographyStyle(props.field.overrides)}
         >
           {props.rawMode ? props.rawEditor : <RichEditor {...props} />}
         </div>

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/ui/components.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/ui/components.tsx
@@ -180,7 +180,10 @@ export const Components = () => {
           className,
           'text-lg mb-4 last:mb-0 mt-6 first:mt-0'
         )}
-        style={{ fontFamily: 'var(--tina-editor-heading-font-family)', fontWeight: '400' }}
+        style={{
+          fontFamily: 'var(--tina-editor-heading-font-family)',
+          fontWeight: '400',
+        }}
       />
     ),
     [HEADING_KEYS.h6]: ({
@@ -199,7 +202,10 @@ export const Components = () => {
           className,
           'text-base mb-4 last:mb-0 mt-6 first:mt-0'
         )}
-        style={{ fontFamily: 'var(--tina-editor-heading-font-family)', fontWeight: '400' }}
+        style={{
+          fontFamily: 'var(--tina-editor-heading-font-family)',
+          fontWeight: '400',
+        }}
       />
     ),
     [ParagraphPlugin.key]: ParagraphElement,

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/ui/components.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/ui/components.tsx
@@ -105,7 +105,7 @@ export const Components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-4xl mb-4 last:mb-0 mt-6 first:mt-0 font-libre-baskerville'
+          'text-4xl mb-4 last:mb-0 mt-6 first:mt-0'
         )}
       />
     ),
@@ -123,7 +123,7 @@ export const Components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-3xl mb-4 last:mb-0 mt-6 first:mt-0 font-libre-baskerville'
+          'text-3xl mb-4 last:mb-0 mt-6 first:mt-0'
         )}
       />
     ),
@@ -141,7 +141,7 @@ export const Components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-2xl mb-4 last:mb-0 mt-6 first:mt-0 font-libre-baskerville'
+          'text-2xl mb-4 last:mb-0 mt-6 first:mt-0'
         )}
       />
     ),
@@ -159,7 +159,7 @@ export const Components = () => {
           headerClasses,
           blockClasses,
           className,
-          'text-xl mb-4 last:mb-0 mt-6 first:mt-0 font-libre-baskerville'
+          'text-xl mb-4 last:mb-0 mt-6 first:mt-0'
         )}
       />
     ),
@@ -180,7 +180,7 @@ export const Components = () => {
           className,
           'text-lg mb-4 last:mb-0 mt-6 first:mt-0'
         )}
-        style={{ fontFamily: "'Libre Baskerville', serif", fontWeight: '400' }}
+        style={{ fontFamily: 'var(--tina-editor-heading-font-family)', fontWeight: '400' }}
       />
     ),
     [HEADING_KEYS.h6]: ({
@@ -199,7 +199,7 @@ export const Components = () => {
           className,
           'text-base mb-4 last:mb-0 mt-6 first:mt-0'
         )}
-        style={{ fontFamily: "'Libre Baskerville', serif", fontWeight: '400' }}
+        style={{ fontFamily: 'var(--tina-editor-heading-font-family)', fontWeight: '400' }}
       />
     ),
     [ParagraphPlugin.key]: ParagraphElement,

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-overrides.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-overrides.tsx
@@ -13,4 +13,9 @@ export const HEADING_LABEL = 'Headings';
 export type ToolbarOverrides = {
   toolbar?: ToolbarOverrideType[];
   showFloatingToolbar?: boolean;
+  typography?: {
+    fontFamily?: string;
+    headingFontFamily?: string;
+    fontUrl?: string;
+  };
 };

--- a/packages/tinacms/src/toolkit/styles/font-loader.tsx
+++ b/packages/tinacms/src/toolkit/styles/font-loader.tsx
@@ -1,19 +1,26 @@
 import * as React from 'react';
 
-export function FontLoader() {
+export function FontLoader({ fontUrl }: { fontUrl?: string } = {}) {
   React.useEffect(() => {
-    // Create link element for Google Fonts
     const link = document.createElement('link');
     link.href =
       'https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Libre+Baskerville:wght@400;500;600;700&display=swap';
     link.rel = 'stylesheet';
     document.head.appendChild(link);
 
-    // For cleanup
+    let customLink: HTMLLinkElement | null = null;
+    if (fontUrl) {
+      customLink = document.createElement('link');
+      customLink.href = fontUrl;
+      customLink.rel = 'stylesheet';
+      document.head.appendChild(customLink);
+    }
+
     return () => {
       document.head.removeChild(link);
+      if (customLink) document.head.removeChild(customLink);
     };
-  }, []);
+  }, [fontUrl]);
 
   return null;
 }


### PR DESCRIPTION
## Summary

- Remove hardcoded Libre Baskerville serif font from editor headings — defaults to Inter sans-serif now
- Add CSS custom properties (`--tina-editor-font-family`, `--tina-editor-heading-font-family`) for editor typography
- Add `overrides.typography` config on rich-text fields to set font families per-field
- Add `admin.fontUrl` config to load custom fonts (e.g. Google Fonts) into the admin panel

## Problem

The rich text editor hardcoded Libre Baskerville (serif) for headings, creating a mismatch with modern sites that use sans-serif fonts like Inter. There was no way to customize editor typography.

## Usage

```typescript
// tina/config.tsx
export default defineConfig({
  admin: {
    fontUrl: 'https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap',
  },
  schema: {
    collections: [{
      fields: [{
        type: 'rich-text',
        name: '_body',
        overrides: {
          typography: {
            fontFamily: "'Inter', sans-serif",
            headingFontFamily: "'Playfair Display', serif",
          },
        },
      }],
    }],
  },
});
```

## Files Changed

- `packages/@tinacms/app/src/global.css` — CSS custom properties for editor typography
- `packages/@tinacms/app/src/index.css` — Removed `.font-libre-baskerville`, added CSS rules using variables
- `packages/@tinacms/schema-tools/src/types/index.ts` — `typography` type on rich-text overrides, `fontUrl` on admin config
- `packages/tinacms/src/tina-cms.tsx` — Pass fontUrl to FontLoader
- `packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/index.tsx` — Apply CSS variables from typography config
- `packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/ui/components.tsx` — Removed hardcoded font classes
- `packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-overrides.tsx` — Typography type
- `packages/tinacms/src/toolkit/styles/font-loader.tsx` — Accept optional custom font URL