### PR TITLE
test(@tinacms/graphql): add integration tests for uncovered scenarios

### DIFF
--- a/packages/@tinacms/graphql/tests/basic-document-get/index.test.ts
+++ b/packages/@tinacms/graphql/tests/basic-document-get/index.test.ts
@@ -23,3 +23,19 @@ it('retrieves document using post field', async () => {
   const result = await get({ query: postQuery, variables: {} });
   expect(format(result)).toMatchFileSnapshot('post-query-node.json');
 });
+
+it('returns a graceful error when document does not exist', async () => {
+  const query = `query { document(collection: "post", relativePath: "non-existent.md") { ...on Document { _values, _sys { title } }} }`;
+
+  const { get } = await setup(__dirname, config);
+  const result = await get({ query, variables: {} });
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors).toHaveLength(1);
+  expect(result.errors![0].path).toEqual(['document']);
+  // Path separator is platform-dependent.
+  expect(result.errors![0].message).toMatch(
+    /Unable to find record post[/\\]non-existent\.md/
+  );
+  expect(result.data).toBeNull();
+});

--- a/packages/@tinacms/graphql/tests/bridge-failure-mid-batch/index.test.ts
+++ b/packages/@tinacms/graphql/tests/bridge-failure-mid-batch/index.test.ts
@@ -1,0 +1,74 @@
+import { it, expect } from 'vitest';
+import { MemoryLevel } from 'memory-level';
+import config from './tina/config';
+import {
+  buildSchema,
+  createDatabaseInternal,
+  FilesystemBridge,
+  resolve,
+} from '../../src';
+
+// Bridge that throws on every write — simulates storage layer unavailable.
+class FailingBridge extends FilesystemBridge {
+  private writeAttempts: string[] = [];
+  private deletes: string[] = [];
+
+  async get(filepath: string): Promise<string> {
+    return super.get(filepath);
+  }
+
+  async put(filepath: string, _data: string): Promise<void> {
+    this.writeAttempts.push(filepath);
+    throw new Error(`Simulated bridge.put failure for ${filepath}`);
+  }
+
+  async delete(filepath: string): Promise<void> {
+    this.deletes.push(filepath);
+  }
+
+  getWriteAttempts(): string[] {
+    return [...this.writeAttempts];
+  }
+
+  getDeletes(): string[] {
+    return [...this.deletes];
+  }
+}
+
+it('surfaces a structured error to the caller when bridge.put throws during a create mutation', async () => {
+  const bridge = new FailingBridge(__dirname);
+  const level = new MemoryLevel<string, Record<string, any>>();
+  const database = createDatabaseInternal({
+    bridge,
+    level,
+    tinaDirectory: 'tina',
+  });
+  await database.indexContent(await buildSchema(config));
+
+  let thrown: unknown = null;
+  let result: any = null;
+  try {
+    result = await resolve({
+      database,
+      query: `
+        mutation {
+          createDocument(
+            collection: "author"
+            relativePath: "alice.md"
+            params: { author: { name: "Alice" } }
+          ) {
+            __typename
+          }
+        }
+      `,
+      variables: {},
+    });
+  } catch (err) {
+    thrown = err;
+  }
+
+  const reported =
+    thrown !== null || (result && result.errors && result.errors.length > 0);
+  expect(reported).toBeTruthy();
+  expect(bridge.getWriteAttempts().length).toBeGreaterThan(0);
+});

--- a/packages/@tinacms/graphql/tests/bridge-failure-mid-batch/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/bridge-failure-mid-batch/tina/config.ts
@@ -1,0 +1,40 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Author',
+      name: 'author',
+      path: 'authors',
+      fields: [
+        {
+          name: 'name',
+          label: 'Name',
+          type: 'string',
+          required: true,
+        },
+      ],
+    },
+    {
+      label: 'Post',
+      name: 'post',
+      path: 'posts',
+      fields: [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'string',
+          required: true,
+        },
+        {
+          name: 'author',
+          label: 'Author',
+          type: 'reference',
+          collections: ['author'],
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };

--- a/packages/@tinacms/graphql/tests/collection-list-query/index.test.ts
+++ b/packages/@tinacms/graphql/tests/collection-list-query/index.test.ts
@@ -23,3 +23,33 @@ it('retrieves collection document list', async () => {
   });
   expect(format(result)).toMatchFileSnapshot('node.json');
 });
+
+it('returns empty edges and zero totalCount for an empty collection', async () => {
+  const { get } = await setup(__dirname, config);
+  const result = await get({
+    query: `query {
+      screenwritersConnection {
+        totalCount
+        edges {
+          node {
+            id
+            name
+          }
+        }
+        pageInfo {
+          hasNextPage
+          hasPreviousPage
+        }
+      }
+    }`,
+    variables: {},
+  });
+
+  expect(result.errors).toBeUndefined();
+  expect(result.data?.screenwritersConnection.totalCount).toBe(0);
+  expect(result.data?.screenwritersConnection.edges).toEqual([]);
+  expect(result.data?.screenwritersConnection.pageInfo.hasNextPage).toBe(false);
+  expect(result.data?.screenwritersConnection.pageInfo.hasPreviousPage).toBe(
+    false
+  );
+});

--- a/packages/@tinacms/graphql/tests/collection-list-query/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/collection-list-query/tina/config.ts
@@ -29,6 +29,18 @@ export const schema: Schema = {
         },
       ],
     },
+    {
+      name: 'screenwriters',
+      label: 'Screenwriters',
+      path: 'screenwriters',
+      fields: [
+        {
+          type: 'string',
+          name: 'name',
+          label: 'Name',
+        },
+      ],
+    },
   ],
 };
 

--- a/packages/@tinacms/graphql/tests/concurrent-mutations/index.test.ts
+++ b/packages/@tinacms/graphql/tests/concurrent-mutations/index.test.ts
@@ -1,0 +1,78 @@
+import { it, expect } from 'vitest';
+import config from './tina/config';
+import { setupMutation } from '../util';
+
+const createMutation = (title: string) => `
+  mutation {
+    createDocument(
+      collection: "post"
+      relativePath: "race.md"
+      params: { post: { title: "${title}" } }
+    ) {
+      __typename
+    }
+  }
+`;
+
+const updateMutation = (title: string) => `
+  mutation {
+    updateDocument(
+      collection: "post"
+      relativePath: "race.md"
+      params: { post: { title: "${title}" } }
+    ) {
+      ...on Document { _values }
+    }
+  }
+`;
+
+it('handles parallel creates of the same relativePath without leaving inconsistent bridge state', async () => {
+  const { query, bridge } = await setupMutation(__dirname, config);
+
+  const [resultA, resultB] = await Promise.all([
+    query({ query: createMutation('Writer A'), variables: {} }),
+    query({ query: createMutation('Writer B'), variables: {} }),
+  ]);
+
+  for (const result of [resultA, resultB]) {
+    expect(result).toBeDefined();
+    expect(result.data === null || result.data !== undefined).toBe(true);
+  }
+
+  const finalWrite = bridge.getWrite('posts/race.md');
+  expect(finalWrite).toBeDefined();
+  expect(
+    finalWrite!.includes('Writer A') || finalWrite!.includes('Writer B')
+  ).toBe(true);
+});
+
+it('serializes parallel updates of the same document to a single final state', async () => {
+  const { query, bridge } = await setupMutation(__dirname, config);
+  await query({
+    query: `
+      mutation {
+        createDocument(
+          collection: "post"
+          relativePath: "race.md"
+          params: { post: { title: "Initial" } }
+        ) { __typename }
+      }
+    `,
+    variables: {},
+  });
+
+  const [resultA, resultB] = await Promise.all([
+    query({ query: updateMutation('Update A'), variables: {} }),
+    query({ query: updateMutation('Update B'), variables: {} }),
+  ]);
+
+  expect(resultA).toBeDefined();
+  expect(resultB).toBeDefined();
+
+  const finalWrite = bridge.getWrite('posts/race.md');
+  expect(finalWrite).toBeDefined();
+  expect(
+    finalWrite!.includes('Update A') || finalWrite!.includes('Update B')
+  ).toBe(true);
+  expect(finalWrite).not.toContain('Initial');
+});

--- a/packages/@tinacms/graphql/tests/concurrent-mutations/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/concurrent-mutations/tina/config.ts
@@ -1,0 +1,21 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Post',
+      name: 'post',
+      path: 'posts',
+      fields: [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'string',
+          required: true,
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };

--- a/packages/@tinacms/graphql/tests/large-document/index.test.ts
+++ b/packages/@tinacms/graphql/tests/large-document/index.test.ts
@@ -1,0 +1,51 @@
+import { it, expect } from 'vitest';
+import config from './tina/config';
+import { setupMutation } from '../util';
+
+it('round-trips a multi-hundred-kilobyte content field without truncation', async () => {
+  const { query, bridge } = await setupMutation(__dirname, config);
+
+  const largeContent = 'a'.repeat(200 * 1024);
+
+  const createResult = await query({
+    query: `
+      mutation {
+        createDocument(
+          collection: "article"
+          relativePath: "huge.md"
+          params: {
+            article: {
+              title: "Huge Article"
+              content: ${JSON.stringify(largeContent)}
+            }
+          }
+        ) {
+          __typename
+        }
+      }
+    `,
+    variables: {},
+  });
+
+  expect(createResult.errors).toBeUndefined();
+
+  const queryResult = await query({
+    query: `
+      query {
+        article(relativePath: "huge.md") {
+          title
+          content
+        }
+      }
+    `,
+    variables: {},
+  });
+
+  expect(queryResult.errors).toBeUndefined();
+  expect(queryResult.data?.article?.content?.length).toBe(largeContent.length);
+  expect(queryResult.data?.article?.content).toBe(largeContent);
+
+  const bridgeWrite = bridge.getWrite('articles/huge.md');
+  expect(bridgeWrite).toBeDefined();
+  expect(bridgeWrite!.length).toBeGreaterThan(largeContent.length);
+});

--- a/packages/@tinacms/graphql/tests/large-document/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/large-document/tina/config.ts
@@ -1,0 +1,26 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Article',
+      name: 'article',
+      path: 'articles',
+      fields: [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'string',
+          required: true,
+        },
+        {
+          name: 'content',
+          label: 'Content',
+          type: 'string',
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };

--- a/packages/@tinacms/graphql/tests/malformed-graphql-input/index.test.ts
+++ b/packages/@tinacms/graphql/tests/malformed-graphql-input/index.test.ts
@@ -1,0 +1,38 @@
+import { it, expect } from 'vitest';
+import config from './tina/config';
+import { setup } from '../util';
+
+const malformedCases: Array<{ name: string; query: string }> = [
+  {
+    name: 'filter referencing a field not declared on the collection',
+    query: `query {
+      movieConnection(filter: { ghostField: { eq: "anything" } }) {
+        edges { node { id } }
+      }
+    }`,
+  },
+  {
+    name: 'filter argument with the wrong scalar type for the field',
+    query: `query {
+      movieConnection(filter: { rating: { eq: "not-a-number" } }) {
+        edges { node { id } }
+      }
+    }`,
+  },
+  {
+    name: 'query against a collection that is not declared in the schema',
+    query: `query {
+      ghostCollectionConnection {
+        edges { node { id } }
+      }
+    }`,
+  },
+];
+
+it.each(malformedCases)('rejects $name', async ({ query }) => {
+  const { get } = await setup(__dirname, config);
+
+  const result = await get({ query, variables: {} });
+  expect(result.errors).toBeDefined();
+  expect(result.errors!.length).toBeGreaterThan(0);
+});

--- a/packages/@tinacms/graphql/tests/malformed-graphql-input/tina/config.ts
+++ b/packages/@tinacms/graphql/tests/malformed-graphql-input/tina/config.ts
@@ -1,0 +1,26 @@
+import { Schema } from '@tinacms/schema-tools';
+
+export const schema: Schema = {
+  collections: [
+    {
+      label: 'Movie',
+      name: 'movie',
+      path: 'movies',
+      fields: [
+        {
+          name: 'title',
+          label: 'Title',
+          type: 'string',
+          required: true,
+        },
+        {
+          name: 'rating',
+          label: 'Rating',
+          type: 'number',
+        },
+      ],
+    },
+  ],
+};
+
+export default { schema };

--- a/packages/@tinacms/graphql/tests/multi-field-sorting-query/index.test.ts
+++ b/packages/@tinacms/graphql/tests/multi-field-sorting-query/index.test.ts
@@ -21,3 +21,24 @@ it('handles multi-field sorting operations using index', async () => {
   });
   expect(format(result)).toMatchFileSnapshot('node.json');
 });
+
+it('surfaces a GraphQL error when sort key matches no defined index or field', async () => {
+  const { get } = await setup(__dirname, config);
+  const result = await get({
+    query: `query {
+      movieConnection(sort: "non-existent-index") {
+        edges {
+          node {
+            id
+            title
+          }
+        }
+      }
+    }`,
+    variables: {},
+  });
+
+  expect(result.errors).toBeDefined();
+  expect(result.errors!.length).toBeGreaterThan(0);
+  expect(result.errors![0].path).toContain('movieConnection');
+});

--- a/packages/@tinacms/graphql/tests/sorting-query/index.test.ts
+++ b/packages/@tinacms/graphql/tests/sorting-query/index.test.ts
@@ -41,3 +41,36 @@ it('handles single and multi-field sorting operations', async () => {
   });
   expect(format(result)).toMatchFileSnapshot('node.json');
 });
+
+it('combines sort with filter, returning sorted results from the filtered subset only', async () => {
+  const { get } = await setup(__dirname, config);
+  const result = await get({
+    query: `query {
+      movieConnection(
+        sort: "rating"
+        filter: { rating: { gte: 8.0 } }
+      ) {
+        edges {
+          node {
+            id
+            title
+            rating
+          }
+        }
+      }
+    }`,
+    variables: {},
+  });
+
+  expect(result.errors).toBeUndefined();
+  const edges = result.data!.movieConnection.edges;
+  expect(edges.length).toBeGreaterThan(0);
+  for (const edge of edges) {
+    expect(edge.node.rating).toBeGreaterThanOrEqual(8.0);
+  }
+  for (let i = 1; i < edges.length; i++) {
+    expect(edges[i].node.rating).toBeGreaterThanOrEqual(
+      edges[i - 1].node.rating
+    );
+  }
+});


### PR DESCRIPTION
## Summary

Adds 9 integration tests to `packages/@tinacms/graphql/tests/` covering scenarios that have no equivalent unit-test or integration-test coverage today. This PR closes #6472 (error path, filtering edge case, concurrent mutation, CI passing).

## Tests added

| File | Test Name | Test Area |
|---|---|---|
| `tests/basic-document-get/index.test.ts` | `returns a graceful error when document does not exist` | Resolver behaviour for valid path with no document on bridge |
| `tests/sorting-query/index.test.ts` | `combines sort with filter, returning sorted results from the filtered subset only` | Combined sort + filter wiring with explicit ordering assertion |
| `tests/collection-list-query/index.test.ts` | `returns empty edges and zero totalCount for an empty collection` | Connection-shape contract for empty result sets |
| `tests/multi-field-sorting-query/index.test.ts` | `surfaces a GraphQL error when sort key matches no defined index or field` | Resolver behaviour on unknown sort key |
| `tests/large-document/index.test.ts` (new) | `round-trips a multi-hundred-kilobyte content field without truncation` | 200KB content round-trip through the full GraphQL → resolver → bridge pipeline |
| `tests/concurrent-mutations/index.test.ts` (new) | `handles parallel creates of the same relativePath without leaving inconsistent bridge state` | Parallel create race condition |
| `tests/concurrent-mutations/index.test.ts` (new) | `serializes parallel updates of the same document to a single final state` | Parallel update race condition |
| `tests/malformed-graphql-input/index.test.ts` (new) | `rejects $name` (parameterised `it.each` with 3 cases) | Schema generator correctness — unknown filter field, wrong scalar type, undeclared collection |
| `tests/bridge-failure-mid-batch/index.test.ts` (new) | `surfaces a structured error to the caller when bridge.put throws during a create mutation` | Bridge-layer failure surfacing (custom `FailingBridge` that throws on every write) |