### PR TITLE
feat(@tinacms/cli): warn when project uses legacy .tina/ folder

### DIFF
--- a/.changeset/warn-legacy-tina-folder.md
+++ b/.changeset/warn-legacy-tina-folder.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": patch
+---
+
+Warn when a project still uses the legacy `.tina/` config folder. `tina-lock.json` is only generated for the new `tina/` layout, and TinaCloud requires it to index the schema, so projects on the legacy layout were silently failing the Project Setup Checklist. The warning fires once per CLI run from `dev`, `build`, and any other command that loads the config.

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -11,6 +11,7 @@ import chalk from 'chalk';
 import { logger } from '../logger';
 import { createRequire } from 'module';
 import { stripNativeTrailingSlash } from '../utils/path';
+import { warnText } from '../utils/theme';
 import { resolveContentRootPath } from './resolve-content-root';
 
 export const TINA_FOLDER = 'tina';
@@ -26,6 +27,7 @@ export class ConfigManager {
   rootPath: string;
   tinaFolderPath: string;
   isUsingLegacyFolder: boolean;
+  private hasWarnedLegacyFolder = false;
   tinaConfigFilePath: string;
   tinaSpaPackagePath: string;
   contentRootPath?: string;
@@ -99,6 +101,18 @@ export class ConfigManager {
   async processConfig() {
     const require = createRequire(import.meta.url);
     this.tinaFolderPath = await this.getTinaFolderPath(this.rootPath);
+
+    if (this.isUsingLegacyFolder && !this.hasWarnedLegacyFolder) {
+      this.hasWarnedLegacyFolder = true;
+      logger.warn(
+        warnText(
+          'WARN: Detected legacy `.tina/` config folder. `tina-lock.json` is only ' +
+            'generated for the new `tina/` layout, and TinaCloud requires it to ' +
+            'index your schema. Migrate by renaming `.tina/` to `tina/` (the ' +
+            'contents stay the same). See https://tina.io/docs/tina-folder/overview/.'
+        )
+      );
+    }
 
     // TODO - .env should potentially be configurable
     this.envFilePath = path.resolve(


### PR DESCRIPTION
## Summary

- A user reported on Discord that `tina-lock.json` was never generated for their new TinaCloud project, blocking the Project Setup Checklist. Root cause: their config still lived in the legacy `.tina/` folder, and `tina-lock.json` is only written when `ConfigManager.isUsingLegacyFolder` is `false` (see [`dev-command/index.ts:105`](https://github.com/tinacms/tinacms/blob/main/packages/%40tinacms/cli/src/next/commands/dev-command/index.ts#L105)).
- Today the CLI runs cleanly and silently in this state — the user has no way to know they're on an unsupported layout.
- This PR adds a one-shot yellow warning emitted from `ConfigManager.processConfig()` so it fires once per CLI run from `dev`, `build`, `audit`, or any other command that loads the config. The message names the problem, points at the rename, and links to the `tina/` folder docs.
- A `hasWarnedLegacyFolder` guard prevents the warning from spamming on every config-change reload during `tinacms dev`.

## What the user sees

When `.tina/` is present and `tina/` is not:

```
WARN: Detected legacy `.tina/` config folder. `tina-lock.json` is only generated
for the new `tina/` layout, and TinaCloud requires it to index your schema.
Migrate by renaming `.tina/` to `tina/` (the contents stay the same).
See https://tina.io/docs/tina-folder/overview/.
```

Projects on the modern `tina/` layout see no change.

## Test plan

- [ ] Manual: run `npx tinacms dev` in a project with a `.tina/` folder — warning prints once at startup, not on every config-change reload.
- [ ] Manual: run `npx tinacms build` in the same project — warning prints once.
- [ ] Manual: run `npx tinacms dev` in a project with a `tina/` folder — no warning.
- [ ] CLI build (`pnpm build --filter='@tinacms/cli...'`) passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)