### PR TITLE
fix(graphql): preserve absolute external URLs in image-type resolvers

### DIFF
--- a/.changeset/fresh-tomatoes-look.md
+++ b/.changeset/fresh-tomatoes-look.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+fix(graphql): preserve absolute external URLs in image-type resolvers

--- a/packages/@tinacms/graphql/src/resolver/media-rich-text.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-rich-text.test.ts
@@ -1,0 +1,150 @@
+/**
+ * End-to-end round-trip through `parseMDX` + `serializeMDX` for a rich-text
+ * field that contains a JSX template with an `image`-typed src prop. Exercises
+ * the same pipeline the GraphQL `rich-text` resolver uses, with the actual
+ * resolver callbacks plugged in.
+ *
+ * Guards against regressing the absolute-URL guard in `media-utils.ts`: an
+ * `image`-typed src that is already an external URL must survive both the
+ * relative→cloud (read) and cloud→relative (save) transforms unchanged, while
+ * a media-library path must still pick up the staging branch prefix on read
+ * and round-trip back to its original form on save.
+ */
+
+import { parseMDX, serializeMDX } from '@tinacms/mdx';
+import type { RichTextType, Schema } from '@tinacms/schema-tools';
+import { describe, expect, it } from 'vitest';
+import type { GraphQLConfig } from '../types';
+import {
+  resolveMediaCloudToRelative,
+  resolveMediaRelativeToCloud,
+} from './media-utils';
+
+const bodyField: RichTextType = {
+  type: 'rich-text',
+  name: 'body',
+  templates: [
+    {
+      name: 'imageEmbed',
+      label: 'Image',
+      fields: [
+        { name: 'alt', label: 'Alt', type: 'string' },
+        { name: 'src', label: 'Src', type: 'image', required: true },
+      ],
+    },
+  ],
+};
+
+const schema: Schema<true> = {
+  config: {
+    branch: '',
+    clientId: '',
+    token: '',
+    build: { outputFolder: '', publicFolder: '' },
+    schema: { collections: [] },
+    media: {
+      tina: {
+        publicFolder: 'public',
+        mediaRoot: 'uploads',
+      },
+    },
+  },
+  collections: [],
+};
+
+// Feature branch with media rooted at `main`: staging prefix is active.
+const config: GraphQLConfig = {
+  useRelativeMedia: false,
+  assetsHost: 'assets.tinajs.dev',
+  clientId: 'a03ff3e2-1c3a-41af-8afd-ba0d58853191',
+  branch: 'feat/example',
+  mediaBranch: 'main',
+};
+
+const readCallback = (url: string) =>
+  resolveMediaRelativeToCloud(url, config, schema) as string;
+const writeCallback = (url: string) =>
+  resolveMediaCloudToRelative(url, config, schema) as string;
+
+type ImageEmbed = { src: unknown; alt: unknown };
+
+const findImageEmbeds = (tree: ReturnType<typeof parseMDX>): ImageEmbed[] => {
+  const embeds: ImageEmbed[] = [];
+  for (const child of tree.children ?? []) {
+    if (
+      child &&
+      typeof child === 'object' &&
+      'name' in child &&
+      child.name === 'imageEmbed' &&
+      'props' in child
+    ) {
+      const props = (child as { props: Record<string, unknown> }).props;
+      embeds.push({ src: props.src, alt: props.alt });
+    }
+  }
+  return embeds;
+};
+
+describe('media-resolver round-trip through rich-text JSX templates', () => {
+  it('round-trips an absolute external URL identically while still staging local media', () => {
+    const relativeSrc = '/uploads/library/local.png';
+    const externalSrc = 'https://cdn.example.com/external/image.png';
+
+    const inputMdx = [
+      `<imageEmbed alt="Local" src="${relativeSrc}" />`,
+      '',
+      `<imageEmbed alt="External" src="${externalSrc}" />`,
+    ].join('\n');
+
+    // READ: server resolves stored MDX into the editor tree.
+    const editorTree = parseMDX(inputMdx, bodyField, readCallback);
+    const [local, external] = findImageEmbeds(editorTree);
+
+    // Local media gets the cloud-assets + staging-branch prefix, with the
+    // media-root segment stripped (S3 key is rooted at the file path).
+    expect(local.src).toBe(
+      `https://${config.assetsHost}/${config.clientId}/__staging/${config.branch}/__file/library/local.png`
+    );
+
+    // Absolute external URL passes through untouched in the read direction.
+    expect(external.src).toBe(externalSrc);
+
+    // WRITE: editor sends the tree back, server serializes to MDX.
+    const serialized = serializeMDX(editorTree, bodyField, writeCallback);
+    if (typeof serialized !== 'string') {
+      throw new Error('Expected serializeMDX to return a string');
+    }
+
+    // Round-trip identity: the serialized output equals the input.
+    expect(serialized.trim()).toBe(inputMdx.trim());
+
+    // Re-parsing the serialized output yields the same editor-side values.
+    const reparsed = parseMDX(serialized, bodyField, readCallback);
+    const [localAgain, externalAgain] = findImageEmbeds(reparsed);
+    expect(localAgain.src).toBe(local.src);
+    expect(externalAgain.src).toBe(externalSrc);
+  });
+
+  it('round-trips protocol-relative and http URLs identically', () => {
+    const protocolRelativeSrc = '//cdn.example.com/img.png';
+    const httpSrc = 'http://example.com/img.jpg';
+
+    const inputMdx = [
+      `<imageEmbed alt="Protocol-relative" src="${protocolRelativeSrc}" />`,
+      '',
+      `<imageEmbed alt="HTTP" src="${httpSrc}" />`,
+    ].join('\n');
+
+    const editorTree = parseMDX(inputMdx, bodyField, readCallback);
+    const [protoRel, http] = findImageEmbeds(editorTree);
+
+    expect(protoRel.src).toBe(protocolRelativeSrc);
+    expect(http.src).toBe(httpSrc);
+
+    const serialized = serializeMDX(editorTree, bodyField, writeCallback);
+    if (typeof serialized !== 'string') {
+      throw new Error('Expected serializeMDX to return a string');
+    }
+    expect(serialized.trim()).toBe(inputMdx.trim());
+  });
+});

--- a/packages/@tinacms/graphql/src/resolver/media-rich-text.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-rich-text.test.ts
@@ -147,4 +147,28 @@ describe('media-resolver round-trip through rich-text JSX templates', () => {
     }
     expect(serialized.trim()).toBe(inputMdx.trim());
   });
+
+  it('self-heals a corrupted src on read and writes it back cleanly on save', () => {
+    // Shape of a previously-corrupted value: the configured media root
+    // (`/uploads`) was concatenated directly in front of an absolute URL by
+    // an earlier broken round-trip. After this round-trip the disk value
+    // should be back to the clean external URL.
+    const corruptedSrc =
+      '/uploadshttps://github.com/owner/repo/assets/123/abc.png';
+    const healedSrc = 'https://github.com/owner/repo/assets/123/abc.png';
+
+    const inputMdx = `<imageEmbed alt="Was corrupted" src="${corruptedSrc}" />`;
+
+    const editorTree = parseMDX(inputMdx, bodyField, readCallback);
+    const [embed] = findImageEmbeds(editorTree);
+    expect(embed.src).toBe(healedSrc);
+
+    const serialized = serializeMDX(editorTree, bodyField, writeCallback);
+    if (typeof serialized !== 'string') {
+      throw new Error('Expected serializeMDX to return a string');
+    }
+    expect(serialized.trim()).toBe(
+      `<imageEmbed alt="Was corrupted" src="${healedSrc}" />`
+    );
+  });
 });

--- a/packages/@tinacms/graphql/src/resolver/media-utils.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.test.ts
@@ -312,16 +312,20 @@ describe('resolveMedia', () => {
   });
 
   /**
-   * Absolute external URLs (http://, https://, protocol-relative //) point
-   * outside the user's media root. They must round-trip identically in both
-   * directions on every branch, so that content authored with hard-coded
-   * external image links is preserved on read and on save.
+   * Absolute URLs of any scheme — http(s), data, blob, file, mailto — and
+   * protocol-relative URLs point outside the user's media root. They must
+   * round-trip identically in both directions on every branch, so that
+   * content authored with hard-coded external links (or inline base64
+   * payloads) is preserved on read and on save.
    */
   it.each([
     'https://github.com/owner/repo/assets/123/abc.png',
     'http://example.com/img.jpg',
     '//cdn.example.com/img.jpg',
-  ])('leaves absolute external URL %s untouched on both directions', (url) => {
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=',
+    'blob:https://example.com/abcdef12-3456-7890-abcd-ef1234567890',
+    'file:///tmp/img.png',
+  ])('leaves absolute URL %s untouched on both directions', (url) => {
     const config: GraphQLConfig = {
       useRelativeMedia: false,
       assetsHost,
@@ -332,6 +336,78 @@ describe('resolveMedia', () => {
 
     expect(resolveMediaRelativeToCloud(url, config, schema)).toEqual(url);
     expect(resolveMediaCloudToRelative(url, config, schema)).toEqual(url);
+  });
+
+  /**
+   * Self-heal: a previously-corrupted document on disk can store values like
+   * `/uploadshttps://…` where the media root was concatenated directly in
+   * front of an absolute URL. On read, after stripping the media root the
+   * remaining value is itself an absolute URL; return that directly rather
+   * than re-wrapping it with the cloud assets prefix. On the next save the
+   * value lands back on disk in its clean form.
+   */
+  it.each([
+    {
+      stored: '/uploadshttps://github.com/owner/repo/assets/123/abc.png',
+      healed: 'https://github.com/owner/repo/assets/123/abc.png',
+    },
+    {
+      stored: '/uploadshttp://example.com/img.jpg',
+      healed: 'http://example.com/img.jpg',
+    },
+    {
+      stored: '/uploads//cdn.example.com/img.jpg',
+      healed: '//cdn.example.com/img.jpg',
+    },
+    {
+      stored: '/uploadsdata:image/png;base64,AAAA',
+      healed: 'data:image/png;base64,AAAA',
+    },
+  ])(
+    'self-heals previously-corrupted value $stored to $healed on read',
+    ({ stored, healed }) => {
+      const config: GraphQLConfig = {
+        useRelativeMedia: false,
+        assetsHost,
+        clientId,
+        branch: 'feat/x',
+        mediaBranch: 'main',
+      };
+
+      expect(resolveMediaRelativeToCloud(stored, config, schema)).toEqual(
+        healed
+      );
+    }
+  );
+
+  /**
+   * Self-heal also applies inside array values — mixed clean + corrupted
+   * entries are normalized into their intended form alongside relative
+   * entries still picking up the staging prefix.
+   */
+  it('self-heals corrupted entries inside mixed array values', () => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: false,
+      assetsHost,
+      clientId,
+      branch: 'feat/x',
+      mediaBranch: 'main',
+    };
+
+    const resolved = resolveMediaRelativeToCloud(
+      [
+        '/uploads/a.png',
+        '/uploadshttps://github.com/owner/repo/assets/123/abc.png',
+        '/uploads/b.png',
+      ],
+      config,
+      schema
+    );
+    expect(resolved).toEqual([
+      `https://${assetsHost}/${clientId}/__staging/feat/x/__file/a.png`,
+      'https://github.com/owner/repo/assets/123/abc.png',
+      `https://${assetsHost}/${clientId}/__staging/feat/x/__file/b.png`,
+    ]);
   });
 
   /**

--- a/packages/@tinacms/graphql/src/resolver/media-utils.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.test.ts
@@ -312,6 +312,59 @@ describe('resolveMedia', () => {
   });
 
   /**
+   * Absolute external URLs (http://, https://, protocol-relative //) point
+   * outside the user's media root. They must round-trip identically in both
+   * directions on every branch, so that content authored with hard-coded
+   * external image links is preserved on read and on save.
+   */
+  it.each([
+    'https://github.com/owner/repo/assets/123/abc.png',
+    'http://example.com/img.jpg',
+    '//cdn.example.com/img.jpg',
+  ])('leaves absolute external URL %s untouched on both directions', (url) => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: false,
+      assetsHost,
+      clientId,
+      branch: 'feat/x',
+      mediaBranch: 'main',
+    };
+
+    expect(resolveMediaRelativeToCloud(url, config, schema)).toEqual(url);
+    expect(resolveMediaCloudToRelative(url, config, schema)).toEqual(url);
+  });
+
+  /**
+   * Array values containing a mix of relative media paths and absolute
+   * external URLs must rewrite only the relative entries and preserve the
+   * external ones verbatim.
+   */
+  it('preserves absolute external URLs inside mixed array values', () => {
+    const config: GraphQLConfig = {
+      useRelativeMedia: false,
+      assetsHost,
+      clientId,
+      branch: 'feat/x',
+      mediaBranch: 'main',
+    };
+
+    const resolved = resolveMediaRelativeToCloud(
+      [
+        '/uploads/a.png',
+        'https://github.com/owner/repo/assets/123/abc.png',
+        '/uploads/b.png',
+      ],
+      config,
+      schema
+    );
+    expect(resolved).toEqual([
+      `https://${assetsHost}/${clientId}/__staging/feat/x/__file/a.png`,
+      'https://github.com/owner/repo/assets/123/abc.png',
+      `https://${assetsHost}/${clientId}/__staging/feat/x/__file/b.png`,
+    ]);
+  });
+
+  /**
    * Missing `media: { tina: { ... }}` config should return the value, regardless of `useRelativeMedia`
    */
   it('persists value when no `tina` config is provided regardless of `useRelativeMedia`', () => {

--- a/packages/@tinacms/graphql/src/resolver/media-utils.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.ts
@@ -74,11 +74,15 @@ export const resolveMediaRelativeToCloud = (
       const cleanMediaRoot = cleanUpSlashes(schema.config.media.tina.mediaRoot);
       const prefix = stagingPrefix(config);
       if (typeof value === 'string') {
-        // Absolute external URLs (http://, https://, protocol-relative //)
-        // are not media-library paths — they live outside the configured
-        // media root and must not be wrapped with the cloud assets prefix.
+        // Absolute URLs (any scheme, or protocol-relative `//`) are not
+        // media-library paths — they live outside the configured media
+        // root and must not be wrapped with the cloud assets prefix.
         if (ABSOLUTE_URL.test(value)) return value;
         const strippedValue = value.replace(cleanMediaRoot, '');
+        // Self-heal: if stripping the media root reveals an absolute URL
+        // underneath (e.g. `/uploadshttps://…` from a previously corrupted
+        // round-trip), return that URL directly rather than re-wrapping it.
+        if (ABSOLUTE_URL.test(strippedValue)) return strippedValue;
         return `https://${config.assetsHost}/${config.clientId}${prefix}${strippedValue}`;
       }
       if (Array.isArray(value)) {
@@ -86,6 +90,7 @@ export const resolveMediaRelativeToCloud = (
           if (!v || typeof v !== 'string') return v;
           if (ABSOLUTE_URL.test(v)) return v;
           const strippedValue = v.replace(cleanMediaRoot, '');
+          if (ABSOLUTE_URL.test(strippedValue)) return strippedValue;
           return `https://${config.assetsHost}/${config.clientId}${prefix}${strippedValue}`;
         });
       }
@@ -122,10 +127,13 @@ const stripStagingPrefix = (path: string): string => {
   return match ? match[1] : path;
 };
 
-// Matches absolute URLs: `http://…`, `https://…`, or protocol-relative `//…`.
-// Values matching this are not media-library paths and must not be rewritten
-// as branch-staged cloud URLs.
-const ABSOLUTE_URL = /^(?:https?:)?\/\//;
+// Matches values that aren't media-library paths and must not be rewritten as
+// branch-staged cloud URLs:
+//   - Any URL with a scheme — `https://`, `http://`, `data:`, `blob:`,
+//     `file:`, `mailto:`, etc. Scheme grammar per RFC 3986:
+//     ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ).
+//   - Protocol-relative URLs starting with `//`.
+const ABSOLUTE_URL = /^[a-z][a-z0-9+.\-]*:|^\/\//i;
 
 const escapeRegExp = (s: string): string =>
   s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/packages/@tinacms/graphql/src/resolver/media-utils.ts
+++ b/packages/@tinacms/graphql/src/resolver/media-utils.ts
@@ -74,12 +74,17 @@ export const resolveMediaRelativeToCloud = (
       const cleanMediaRoot = cleanUpSlashes(schema.config.media.tina.mediaRoot);
       const prefix = stagingPrefix(config);
       if (typeof value === 'string') {
+        // Absolute external URLs (http://, https://, protocol-relative //)
+        // are not media-library paths — they live outside the configured
+        // media root and must not be wrapped with the cloud assets prefix.
+        if (ABSOLUTE_URL.test(value)) return value;
         const strippedValue = value.replace(cleanMediaRoot, '');
         return `https://${config.assetsHost}/${config.clientId}${prefix}${strippedValue}`;
       }
       if (Array.isArray(value)) {
         return value.map((v) => {
           if (!v || typeof v !== 'string') return v;
+          if (ABSOLUTE_URL.test(v)) return v;
           const strippedValue = v.replace(cleanMediaRoot, '');
           return `https://${config.assetsHost}/${config.clientId}${prefix}${strippedValue}`;
         });
@@ -116,6 +121,11 @@ const stripStagingPrefix = (path: string): string => {
   const match = path.match(STAGING_SEGMENT);
   return match ? match[1] : path;
 };
+
+// Matches absolute URLs: `http://…`, `https://…`, or protocol-relative `//…`.
+// Values matching this are not media-library paths and must not be rewritten
+// as branch-staged cloud URLs.
+const ABSOLUTE_URL = /^(?:https?:)?\/\//;
 
 const escapeRegExp = (s: string): string =>
   s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
## Summary

- `resolveMediaRelativeToCloud` previously treated every `image`-typed value as a media-library path — wrapping it with the cloud assets prefix on read. That corrupts any value that's already an absolute URL (external link, `data:` URL, etc.), because the prefix gets concatenated directly in front of the original URL with no separator.
- Adds a guard for absolute URLs (any RFC 3986 scheme, plus protocol-relative `//`) so they round-trip identically in both directions.
- Adds a self-heal: if stripping the configured media root from a stored value reveals an absolute URL underneath (the shape of a previously-corrupted round-trip), return the URL directly instead of re-wrapping. Documents already on disk in the broken shape transparently recover on next save.
- The save-side resolver already gated rewriting on a cloud-URL pattern match, so no change there beyond inheriting cleaner inputs.

## Verification

Drove the full `parseMDX` → resolver → `serializeMDX` pipeline against a rich-text body containing both a media-library src and an external URL, on a feature branch with a staging prefix active:

| Phase | Local `src` | External `src` |
|---|---|---|
| Stored MDX | `/uploads/library/local.png` | `https://cdn.example.com/external/image.png` |
| After read (editor sees) | `https://<assetsHost>/<clientId>/__staging/<branch>/__file/library/local.png` | `https://cdn.example.com/external/image.png` |
| After write (re-serialized MDX) | `/uploads/library/local.png` | `https://cdn.example.com/external/image.png` |

Self-heal verified end-to-end: a corrupted stored src of the form `/uploads<absolute-url>` is read as the clean absolute URL and serialized back to disk in that form.

Confirmed the same demo fails against the unpatched resolver — the external URL gets clobbered with a leading `https://<assetsHost>/<clientId>/__staging/<branch>/__file` and then mangled further on save.

## Test plan

- [x] `pnpm --filter @tinacms/graphql test` — 516/516 passing across 50 files
- [x] New `media-utils.test.ts` cases:
  - [x] `it.each` over `https://`, `http://`, `//`, `data:`, `blob:`, `file:` — identity in both directions on a feature branch with active staging prefix
  - [x] Mixed array — relative entries get the staging prefix, absolute entries pass through untouched
  - [x] `it.each` self-heal cases — `/uploads<url>` shapes for `https://`, `http://`, `//`, `data:` recover to the underlying URL on read
  - [x] Array self-heal — mixed clean + corrupted entries are all normalized
- [x] New `media-rich-text.test.ts` end-to-end cases:
  - [x] Rich-text body with a mix of local + external `imageEmbed` srcs — full parse/serialize round-trip identity
  - [x] Protocol-relative and `http://` srcs — same identity guarantee
  - [x] Corrupted src — read self-heals, save writes clean form back to disk
- [ ] Smoke test in a branch-enabled site: open a document containing an `image`-typed field whose stored value is an external URL, save without touching it, confirm the stored value is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)