### PR TITLE
Improve build starter templates action

### DIFF
--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -2,8 +2,19 @@ name: Build TinaCMS Starter Templates
 
 on:
   workflow_dispatch:
+    inputs:
+      tina_version:
+        description: 'Version applied to any Tina package not listed in published_packages (semver, dist-tag, or snapshot tag, e.g. 2.5.0, latest, or my-branch). Defaults to latest.'
+        required: false
+        default: 'latest'
+        type: string
+      published_packages:
+        description: 'JSON array [{name, version}] of per-package versions to test. Use when packages carry different versions — e.g. a partial tagged release or a prod publish where only some packages changed. Packages omitted here fall back to tina_version.'
+        required: false
+        default: ''
+        type: string
   schedule:
-    - cron: '0 9 * * 1-5'
+    - cron: '0 9 * * 1'
 
 jobs:
   build-templates:
@@ -33,7 +44,7 @@ jobs:
       - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: latest
+          version: '10'
         if: ${{ matrix.package-manager == 'pnpm' }}
 
       - name: Setup Hugo
@@ -74,11 +85,52 @@ jobs:
         id: create-tina-app
         run: npx create-tina-app@latest template-repo --pkg-manager ${{ matrix.package-manager }} --template ${{ matrix.template }} --noTelemetry ${{ matrix.template == 'tina-docs' && '--theme default' || '' }}
 
+      - name: Install and pin Tina packages
+        id: install
+        env:
+          PUBLISHED_PACKAGES: ${{ inputs.published_packages }}
+          TINA_VERSION: ${{ inputs.tina_version || 'latest' }}
+        run: |
+          cd template-repo
+          PKG_MANAGER="${{ matrix.package-manager }}"
+
+          # For each tinacms/@tinacms/* package found in this starter's package.json:
+          #   - Use the exact version from published_packages if it was part of this release.
+          #   - Fall back to TINA_VERSION (default: "latest") for packages not in the release,
+          #     e.g. when only a subset of Tina packages changed.
+          # published_packages is a JSON array [{name, version}] passed by the publish workflow,
+          # or an empty array for cron/manual runs.
+          TINA_PKGS=$(jq -r --arg fallback "$TINA_VERSION" \
+            --argjson published "${PUBLISHED_PACKAGES:-[]}" '
+            [(.dependencies // {}), (.devDependencies // {})] |
+            add // {} |
+            to_entries[] |
+            select(.key == "tinacms" or (.key | startswith("@tinacms/"))) |
+            . as {key: $pkg} |
+            # Look up this package in the published list; fall back to $fallback if not found.
+            (($published | map(select(.name == $pkg)) | first | .version) // $fallback) as $ver |
+            $pkg + "@" + $ver
+          ' package.json | tr '\n' ' ')
+
+          if [ -n "$TINA_PKGS" ]; then
+            echo "Pinning Tina packages: $TINA_PKGS"
+            # Using "add"/"install" rather than a plain install so that only the Tina packages
+            # are re-resolved, leaving the rest of the lock file intact for other dependencies.
+            case "$PKG_MANAGER" in
+              pnpm) pnpm add $TINA_PKGS ;;
+              yarn) yarn add $TINA_PKGS ;;
+              npm)  npm install $TINA_PKGS ;;
+            esac
+          else
+            echo "No Tina packages found in package.json, running standard install"
+            $PKG_MANAGER install
+          fi
+
       - name: Run build
         id: build
         run: |
           cd template-repo
-          ${{ matrix.package-manager }} install && ${{ matrix.package-manager }} run build
+          ${{ matrix.package-manager }} run build
 
       - name: Report errors
         continue-on-error: false
@@ -87,6 +139,8 @@ jobs:
         run: |
           if [[ "${{ steps.create-tina-app.outcome }}" == "failure" ]]; then
             ERROR_STEP="create-tina-app"
+          elif [[ "${{ steps.install.outcome }}" == "failure" ]]; then
+            ERROR_STEP="install"
           else
             ERROR_STEP="build"
           fi

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -85,8 +85,14 @@ jobs:
         id: create-tina-app
         run: npx create-tina-app@latest template-repo --pkg-manager ${{ matrix.package-manager }} --template ${{ matrix.template }} --noTelemetry ${{ matrix.template == 'tina-docs' && '--theme default' || '' }}
 
-      - name: Install and pin Tina packages
+      - name: Install dependencies
         id: install
+        run: |
+          cd template-repo
+          ${{ matrix.package-manager }} install
+
+      - name: Update Tina packages to target version
+        id: update-tina
         env:
           PUBLISHED_PACKAGES: ${{ inputs.published_packages }}
           TINA_VERSION: ${{ inputs.tina_version || 'latest' }}
@@ -94,7 +100,7 @@ jobs:
           cd template-repo
           PKG_MANAGER="${{ matrix.package-manager }}"
 
-          # For each tinacms/@tinacms/* package found in this starter's package.json:
+          # For each tinacms/@tinacms/* package in this starter's package.json:
           #   - Use the exact version from published_packages if it was part of this release.
           #   - Fall back to TINA_VERSION (default: "latest") for packages not in the release,
           #     e.g. when only a subset of Tina packages changed.
@@ -112,19 +118,36 @@ jobs:
             $pkg + "@" + $ver
           ' package.json | tr '\n' ' ')
 
-          if [ -n "$TINA_PKGS" ]; then
-            echo "Pinning Tina packages: $TINA_PKGS"
-            # Using "add"/"install" rather than a plain install so that only the Tina packages
-            # are re-resolved, leaving the rest of the lock file intact for other dependencies.
-            case "$PKG_MANAGER" in
-              pnpm) pnpm add $TINA_PKGS ;;
-              yarn) yarn add $TINA_PKGS ;;
-              npm)  npm install $TINA_PKGS ;;
-            esac
-          else
-            echo "No Tina packages found in package.json, running standard install"
-            $PKG_MANAGER install
-          fi
+          # Bypass the minimum release age gate for Tina packages only.
+          # The install step above ran with the gate fully active for all other dependencies.
+          # npm has no per-package exclusion (npm#8994); disable the gate for this project.
+          # .npmrc is ini-style so appending always wins (last value takes precedence).
+          echo "min-release-age=0" >> .npmrc
+          case "$PKG_MANAGER" in
+            pnpm)
+              # pnpm 11+ defaults to a 1440-minute gate. Whitelist Tina packages specifically
+              # rather than disabling the gate entirely. yq merges into any existing list
+              # and deduplicates, safe whether or not the file or key already exists.
+              touch pnpm-workspace.yaml
+              yq -i '.minimumReleaseAgeExclude += ["tinacms", "@tinacms/*"] | .minimumReleaseAgeExclude |= unique' pnpm-workspace.yaml
+              ;;
+            yarn)
+              # yarn berry 4.10+ supports npmPreapprovedPackages with glob patterns.
+              # yarn 1.x (bundled with Node) predates this feature — no-op if detected.
+              YARN_MAJOR=$(yarn --version 2>/dev/null | cut -d. -f1)
+              if [ "${YARN_MAJOR:-0}" -ge 4 ] 2>/dev/null; then
+                touch .yarnrc.yml
+                yq -i '.npmPreapprovedPackages += ["tinacms", "@tinacms/*"] | .npmPreapprovedPackages |= unique' .yarnrc.yml
+              fi
+              ;;
+          esac
+
+          echo "Updating Tina packages: $TINA_PKGS"
+          case "$PKG_MANAGER" in
+            pnpm) pnpm add $TINA_PKGS ;;
+            yarn) yarn add $TINA_PKGS ;;
+            npm)  npm install $TINA_PKGS ;;
+          esac
 
       - name: Run build
         id: build
@@ -141,6 +164,8 @@ jobs:
             ERROR_STEP="create-tina-app"
           elif [[ "${{ steps.install.outcome }}" == "failure" ]]; then
             ERROR_STEP="install"
+          elif [[ "${{ steps.update-tina.outcome }}" == "failure" ]]; then
+            ERROR_STEP="update-tina"
           else
             ERROR_STEP="build"
           fi

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -100,27 +100,29 @@ jobs:
           cd template-repo
           PKG_MANAGER="${{ matrix.package-manager }}"
 
-          # For each tinacms/@tinacms/* package in this starter's package.json:
+          # Resolve versioned package specs for direct and dev dependencies separately
+          # so the add command preserves their original category in package.json.
+          # For each matching package:
           #   - Use the exact version from published_packages if it was part of this release.
-          #   - Fall back to TINA_VERSION (default: "latest") for packages not in the release,
-          #     e.g. when only a subset of Tina packages changed.
-          # published_packages is a JSON array [{name, version}] passed by the publish workflow,
-          # or an empty array for cron/manual runs.
-          TINA_PKGS=$(jq -r --arg fallback "$TINA_VERSION" \
-            --argjson published "${PUBLISHED_PACKAGES:-[]}" '
-            [(.dependencies // {}), (.devDependencies // {})] |
-            add // {} |
-            to_entries[] |
-            select(
-              .key == "tinacms" or
-              (.key | startswith("@tinacms/")) or
-              (.key | startswith("tinacms-")) or
-              (.key | startswith("next-tinacms-"))
-            ) |
-            . as {key: $pkg} |
-            # Look up this package in the published list; fall back to $fallback if not found.
-            (($published | map(select(.name == $pkg)) | first | .version) // $fallback) as $ver |
-            $pkg + "@" + $ver
+          #   - Fall back to TINA_VERSION (default: "latest") for packages not in the release.
+          TINA_FILTER='
+            def is_tina: contains("tinacms");
+            def resolve($published; $fallback):
+              . as $pkg | (($published | map(select(.name == $pkg)) | first | .version) // $fallback);
+          '
+          TINA_DEPS=$(jq -r --arg fallback "$TINA_VERSION" \
+            --argjson published "${PUBLISHED_PACKAGES:-[]}" \
+            "${TINA_FILTER}"'
+            (.dependencies // {}) | to_entries[] |
+            select(.key | is_tina) |
+            .key + "@" + (.key | resolve($published; $fallback))
+          ' package.json | tr '\n' ' ')
+          TINA_DEV_DEPS=$(jq -r --arg fallback "$TINA_VERSION" \
+            --argjson published "${PUBLISHED_PACKAGES:-[]}" \
+            "${TINA_FILTER}"'
+            (.devDependencies // {}) | to_entries[] |
+            select(.key | is_tina) |
+            .key + "@" + (.key | resolve($published; $fallback))
           ' package.json | tr '\n' ' ')
 
           # Bypass the minimum release age gate for Tina packages only.
@@ -147,11 +149,16 @@ jobs:
               ;;
           esac
 
-          echo "Updating Tina packages: $TINA_PKGS"
-          case "$PKG_MANAGER" in
-            pnpm) pnpm add $TINA_PKGS ;;
-            yarn) yarn add $TINA_PKGS ;;
-            npm)  npm install $TINA_PKGS ;;
+          echo "Updating Tina packages — deps: $TINA_DEPS dev deps: $TINA_DEV_DEPS"
+          [ -n "$TINA_DEPS" ] && case "$PKG_MANAGER" in
+            pnpm) pnpm add $TINA_DEPS ;;
+            yarn) yarn add $TINA_DEPS ;;
+            npm)  npm install $TINA_DEPS ;;
+          esac
+          [ -n "$TINA_DEV_DEPS" ] && case "$PKG_MANAGER" in
+            pnpm) pnpm add -D $TINA_DEV_DEPS ;;
+            yarn) yarn add -D $TINA_DEV_DEPS ;;
+            npm)  npm install --save-dev $TINA_DEV_DEPS ;;
           esac
 
       - name: Run build

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -111,7 +111,12 @@ jobs:
             [(.dependencies // {}), (.devDependencies // {})] |
             add // {} |
             to_entries[] |
-            select(.key == "tinacms" or (.key | startswith("@tinacms/"))) |
+            select(
+              .key == "tinacms" or
+              (.key | startswith("@tinacms/")) or
+              (.key | startswith("tinacms-")) or
+              (.key | startswith("next-tinacms-"))
+            ) |
             . as {key: $pkg} |
             # Look up this package in the published list; fall back to $fallback if not found.
             (($published | map(select(.name == $pkg)) | first | .version) // $fallback) as $ver |

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           version: '10'

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -106,7 +106,7 @@ jobs:
           #   - Use the exact version from published_packages if it was part of this release.
           #   - Fall back to TINA_VERSION (default: "latest") for packages not in the release.
           TINA_FILTER='
-            def is_tina: contains("tinacms");
+            def is_tina: . == "tinacms" or startswith("@tinacms/") or startswith("tinacms-") or startswith("next-tinacms-");
             def resolve($published; $fallback):
               . as $pkg | (($published | map(select(.name == $pkg)) | first | .version) // $fallback);
           '
@@ -150,16 +150,20 @@ jobs:
           esac
 
           echo "Updating Tina packages — deps: $TINA_DEPS dev deps: $TINA_DEV_DEPS"
-          [ -n "$TINA_DEPS" ] && case "$PKG_MANAGER" in
-            pnpm) pnpm add $TINA_DEPS ;;
-            yarn) yarn add $TINA_DEPS ;;
-            npm)  npm install $TINA_DEPS ;;
-          esac
-          [ -n "$TINA_DEV_DEPS" ] && case "$PKG_MANAGER" in
-            pnpm) pnpm add -D $TINA_DEV_DEPS ;;
-            yarn) yarn add -D $TINA_DEV_DEPS ;;
-            npm)  npm install --save-dev $TINA_DEV_DEPS ;;
-          esac
+          if [ -n "$TINA_DEPS" ]; then
+            case "$PKG_MANAGER" in
+              pnpm) pnpm add $TINA_DEPS ;;
+              yarn) yarn add $TINA_DEPS ;;
+              npm)  npm install $TINA_DEPS ;;
+            esac
+          fi
+          if [ -n "$TINA_DEV_DEPS" ]; then
+            case "$PKG_MANAGER" in
+              pnpm) pnpm add -D $TINA_DEV_DEPS ;;
+              yarn) yarn add -D $TINA_DEV_DEPS ;;
+              npm)  npm install --save-dev $TINA_DEV_DEPS ;;
+            esac
+          fi
 
       - name: Run build
         id: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,7 +41,7 @@ jobs:
           fetch-depth: 2
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"
@@ -229,7 +229,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version-file: ".nvmrc"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:
@@ -237,7 +237,7 @@ jobs:
       - name: Upgrade npm for OIDC support
         run: npm install -g npm@latest
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         id: pnpm-install
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -325,6 +325,25 @@ jobs:
             }
           token: ${{ steps.generate-token.outputs.token }}
 
+      - name: Trigger starter template builds
+        if: steps.changesets.outputs.published == 'true'
+        uses: actions/github-script@v7
+        env:
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}
+        with:
+          github-token: ${{ steps.generate-token.outputs.token }}
+          script: |
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'build-starter-templates.yml',
+              ref: 'main',
+              inputs: {
+                published_packages: process.env.PUBLISHED_PACKAGES || '[]'
+              }
+            });
+            console.log('Triggered starter template builds with published packages');
+
       - name: Generate token for tinacloud
         if: steps.changesets.outputs.published == 'true'
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Previously ran on a weekday cron with no version control over tina packages. Now triggers automatically after each publish, pins each tina package to its exact published version (packages carry different version numbers), and falls back to latest for packages not in the release. Lock files for non-tina dependencies are preserved. Manual dispatch supports both a flat version and a JSON package map for testing tagged/candidate builds.

Note: pnpm is pinned to version 10 for now. Version 11 required explicitly specifying which packages are allowed to run scripts, which requires an update to all starter templates. After that's done - we can bump it.
