### PR TITLE
Allow pnpm template builds to run dependency scripts

### DIFF
--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -78,6 +78,9 @@ jobs:
         id: build
         run: |
           cd template-repo
+          if [[ "${{ matrix.package-manager }}" == "pnpm" ]]; then
+            pnpm config set dangerouslyAllowAllBuilds true
+          fi
           ${{ matrix.package-manager }} install && ${{ matrix.package-manager }} run build
 
       - name: Report errors


### PR DESCRIPTION
The pnpm template jobs are failing because pnpm ignores dependency build scripts by default, which leaves native packages unavailable for the subsequent build. This sets pnpm's build-script approval config before the install step in the starter-template workflow while leaving the yarn and npm paths unchanged. Closes #6873.