### PR TITLE
feat(admin): v4 UI/UX overhaul – orange accent, sticky header, improved dashboard

### DIFF
--- a/packages/tinacms/src/admin/components/AdminNav.tsx
+++ b/packages/tinacms/src/admin/components/AdminNav.tsx
@@ -83,14 +83,16 @@ const SidebarLink = (props: {
   return (
     <NavLink
       className={({ isActive }) => {
-        return `text-base tracking-wide ${
-          isActive ? 'text-blue-600' : 'text-gray-500'
-        } hover:text-blue-600 flex items-center opacity-90 hover:opacity-100`;
+        return `text-base tracking-wide rounded-md px-2 py-1 -mx-2 ${
+          isActive
+            ? 'text-orange-600 font-semibold bg-orange-50'
+            : 'text-gray-500 hover:bg-gray-50'
+        } hover:text-orange-500 flex items-center transition-colors duration-150 ease-out`;
       }}
       onClick={props.onClick ? props.onClick : () => {}}
       to={to}
     >
-      <Icon className='mr-2 h-6 opacity-80 w-auto' /> {label}
+      <Icon className='mr-2 h-6 opacity-80 w-auto flex-shrink-0' /> {label}
     </NavLink>
   );
 };

--- a/packages/tinacms/src/admin/components/Page.tsx
+++ b/packages/tinacms/src/admin/components/Page.tsx
@@ -17,17 +17,20 @@ export const PageWrapper = ({
 }) => {
   return (
     <div className='relative left-0 w-full h-full bg-gradient-to-b from-gray-50/50 to-gray-50 overflow-y-auto transition-opacity duration-300 ease-out flex flex-col opacity-100'>
-      <div className={`py-2 w-full ${headerClassName}`}>
+      <header className={`sticky top-0 z-20 bg-white border-b border-gray-200 shadow-sm py-0 w-full ${headerClassName ?? ''}`}>
         <BillingWarning />
-        <div className='flex items-center gap-4'>
-          <NavMenuTrigger className='ml-2' />
-          <TinaIcon className='self-center h-10 min-w-10 w-auto text-orange-500' />
+        <div className='flex items-center gap-3 px-2 py-2 min-h-[52px]'>
+          <NavMenuTrigger className='ml-0 flex-shrink-0' />
+          <TinaIcon className='self-center h-8 min-w-8 w-auto text-orange-500 flex-shrink-0' />
+          <div className='flex-1 min-w-0' />
           <LocalWarning />
           <BranchButton />
           <BranchPreviewButton />
         </div>
+      </header>
+      <div className='flex-1 flex flex-col'>
+        {children}
       </div>
-      {children}
     </div>
   );
 };
@@ -38,12 +41,12 @@ export const PageHeader = ({
   children: React.ReactNode;
 }) => {
   return (
-    <div className='pt-4 pb-2 px-6'>
+    <div className='pt-5 pb-3 px-6 border-b border-gray-100'>
       <div className='w-full flex justify-between items-end'>{children}</div>
     </div>
   );
 };
 
 export const PageBody = ({ children }: { children: React.ReactNode }) => (
-  <div className='py-4 px-6'>{children}</div>
+  <div className='py-5 px-6'>{children}</div>
 );

--- a/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionCreatePage.tsx
@@ -108,7 +108,7 @@ const FilenameInput = (props) => {
     >
       <input
         type='text'
-        className={`shadow-inner focus:shadow-outline focus:border-blue-500 focus:outline-none block text-base pr-3 truncate py-2 w-full border transition-all ease-out duration-150 focus:text-gray-900 rounded ${
+        className={`shadow-inner focus:shadow-outline focus:border-orange-500 focus:outline-none block text-base pr-3 truncate py-2 w-full border transition-all ease-out duration-150 focus:text-gray-900 rounded ${
           props.readonly || !filenameTouched
             ? 'bg-gray-50 text-gray-300  border-gray-150 pointer-events-none pl-8 group-hover:bg-white group-hover:text-gray-600  group-hover:border-gray-200'
             : 'bg-white text-gray-600  border-gray-200 pl-3'
@@ -124,7 +124,7 @@ const FilenameInput = (props) => {
         }`}
       />
       <FaUnlock
-        className={`text-blue-500 absolute top-1/2 left-2 -translate-y-1/2 pointer-events-none h-5 w-auto transition-opacity duration-150 ease-out ${
+        className={`text-orange-500 absolute top-1/2 left-2 -translate-y-1/2 pointer-events-none h-5 w-auto transition-opacity duration-150 ease-out ${
           !filenameTouched && !props.readonly
             ? 'opacity-0 group-hover:opacity-80 group-active:opacity-80'
             : 'opacity-0'

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -126,7 +126,7 @@ const TemplateMenu = ({
                         // to={`${template.name}/new`}
                         className={`w-full text-md px-4 py-2 tracking-wide flex items-center transition ease-out duration-100 ${
                           focus
-                            ? 'text-blue-600 opacity-100 bg-gray-50'
+                            ? 'text-orange-600 opacity-100 bg-gray-50'
                             : 'opacity-80 text-gray-600'
                         }`}
                       >
@@ -664,7 +664,7 @@ const CollectionListPage = () => {
                                     <a
                                       href='https://tina.io/docs/r/content-search'
                                       target='_blank'
-                                      className='underline hover:text-blue-700 transition-all duration-150'
+                                      className='underline hover:text-orange-700 transition-all duration-150'
                                     >
                                       Read the docs
                                     </a>
@@ -700,7 +700,7 @@ const CollectionListPage = () => {
                                           }}
                                           to='/collections/new-folder'
                                           className={cn(
-                                            'icon-parent inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-gray-500 bg-white hover:bg-gray-50 border border-gray-100 focus:ring-white focus:ring-blue-500 w-full md:w-auto text-sm h-10 px-6 mr-4',
+                                            'icon-parent inline-flex items-center font-medium focus:outline-none focus:ring-2 focus:shadow-outline text-center rounded justify-center transition-all duration-150 ease-out whitespace-nowrap shadow text-gray-500 bg-white hover:bg-gray-50 border border-gray-100 focus:ring-white focus:ring-orange-500 w-full md:w-auto text-sm h-10 px-6 mr-4',
                                             (collection.templates ||
                                               !allowCreateFolder) &&
                                               'opacity-50 pointer-events-none cursor-not-allowed'
@@ -737,7 +737,7 @@ const CollectionListPage = () => {
                                                   href='https://tina.io/docs/r/content-modelling-templates'
                                                   target='_blank'
                                                   rel='noopener noreferrer'
-                                                  className='underline text-blue-500'
+                                                  className='underline text-orange-500'
                                                 >
                                                   https://tina.io/docs/r/content-modelling-templates
                                                 </a>
@@ -890,7 +890,7 @@ const CollectionListPage = () => {
                                               >
                                                 <td className='pl-5 pr-3 py-3'>
                                                   <a
-                                                    className='text-blue-600 flex items-center gap-3 cursor-pointer truncate'
+                                                    className='text-orange-600 flex items-center gap-3 cursor-pointer truncate'
                                                     onClick={() => {
                                                       captureEvent(
                                                         CollectionListPageItemClickedEvent,
@@ -966,7 +966,7 @@ const CollectionListPage = () => {
                                                 colSpan={hasTitle ? 1 : 2}
                                               >
                                                 <a
-                                                  className='text-blue-600 flex items-center gap-3 cursor-pointer truncate'
+                                                  className='text-orange-600 flex items-center gap-3 cursor-pointer truncate'
                                                   onClick={() => {
                                                     captureEvent(
                                                       CollectionListPageItemClickedEvent,
@@ -1270,7 +1270,7 @@ const SearchInput = ({
             value={searchInput}
             onChange={(e) => setSearchInput(e.target.value)}
             onKeyDown={handleKeyDown}
-            className='shadow appearance-none bg-white block pl-10 pr-10 py-2 truncate w-full text-base border border-gray-200 focus:outline-none focus:shadow-outline focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded placeholder:text-gray-300 text-gray-600 focus:text-gray-900'
+            className='shadow appearance-none bg-white block pl-10 pr-10 py-2 truncate w-full text-base border border-gray-200 focus:outline-none focus:shadow-outline focus:ring-orange-500 focus:border-orange-500 sm:text-sm rounded placeholder:text-gray-300 text-gray-600 focus:text-gray-900'
             autoComplete='off'
           />
           {search && searchLoaded && (
@@ -1315,7 +1315,7 @@ const Breadcrumb = ({ folder, navigate, collectionName }) => {
             { replace: true }
           );
         }}
-        className='px-3 py-2 bg-white hover:bg-gray-50/50 transition ease-out duration-100 border-r border-gray-100 text-blue-500 hover:text-blue-600'
+        className='px-3 py-2 bg-white hover:bg-gray-50/50 transition ease-out duration-100 border-r border-gray-100 text-orange-500 hover:text-orange-600'
       >
         <BiArrowBack className='w-6 h-full opacity-70' />
       </button>
@@ -1326,7 +1326,7 @@ const Breadcrumb = ({ folder, navigate, collectionName }) => {
               replace: true,
             });
           }}
-          className='shrink-0 bg-transparent p-0 border-0 text-blue-400 hover:text-blue-500 transition-all ease-out duration-100 opacity-70 hover:opacity-100'
+          className='shrink-0 bg-transparent p-0 border-0 text-orange-400 hover:text-orange-500 transition-all ease-out duration-100 opacity-70 hover:opacity-100'
         >
           <RiHome2Line className='w-5 h-auto' />
         </button>
@@ -1336,7 +1336,7 @@ const Breadcrumb = ({ folder, navigate, collectionName }) => {
               <span className='text-gray-200 shrink-0'>/</span>
               {index < folderArray.length - 1 ? (
                 <button
-                  className='bg-transparent whitespace-nowrap truncate p-0 border-0 text-blue-500 hover:text-blue-600 transition-all ease-out duration-100 underline underline-offset-2 decoration-1	decoration-blue-200 hover:decoration-blue-400'
+                  className='bg-transparent whitespace-nowrap truncate p-0 border-0 text-orange-500 hover:text-orange-600 transition-all ease-out duration-100 underline underline-offset-2 decoration-1 decoration-orange-200 hover:decoration-orange-400'
                   onClick={() => {
                     const folders = folder.fullyQualifiedName.split('/');
                     navigate(

--- a/packages/tinacms/src/admin/pages/DashboardPage.tsx
+++ b/packages/tinacms/src/admin/pages/DashboardPage.tsx
@@ -1,8 +1,95 @@
 import type { TinaCMS } from '@tinacms/toolkit';
 import React from 'react';
+import { BiFile, BiFolder, BiEdit } from 'react-icons/bi';
+import { ImFilesEmpty } from 'react-icons/im';
+import { NavLink } from 'react-router-dom';
 
 import GetCMS from '../components/GetCMS';
 import { PageBody, PageHeader, PageWrapper } from '../components/Page';
+import { useGetCollections } from '../components/GetCollections';
+
+const CollectionCard = ({
+  collection,
+}: {
+  collection: { name: string; label?: string };
+}) => {
+  return (
+    <NavLink
+      to={`/collections/${collection.name}/~`}
+      className='group flex items-center gap-3 p-4 rounded-lg border border-gray-200 bg-white hover:border-orange-300 hover:shadow-md transition-all duration-150 ease-out'
+    >
+      <div className='flex-shrink-0 w-10 h-10 rounded-md bg-orange-50 flex items-center justify-center group-hover:bg-orange-100 transition-colors duration-150'>
+        <ImFilesEmpty className='w-5 h-5 text-orange-500' />
+      </div>
+      <div className='flex-1 min-w-0'>
+        <p className='text-sm font-medium text-gray-800 truncate'>
+          {collection.label || collection.name}
+        </p>
+        <p className='text-xs text-gray-400 mt-0.5'>Browse &amp; edit content</p>
+      </div>
+      <BiEdit className='w-4 h-4 text-gray-300 group-hover:text-orange-400 transition-colors duration-150 flex-shrink-0' />
+    </NavLink>
+  );
+};
+
+const QuickStartCard = ({
+  icon: Icon,
+  title,
+  description,
+  href,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+  href: string;
+}) => (
+  <a
+    href={href}
+    target='_blank'
+    rel='noopener noreferrer'
+    className='flex items-start gap-3 p-4 rounded-lg border border-gray-100 bg-gray-50 hover:border-orange-200 hover:bg-orange-50/30 transition-all duration-150 ease-out'
+  >
+    <div className='flex-shrink-0 w-8 h-8 rounded-md bg-white border border-gray-200 flex items-center justify-center mt-0.5'>
+      <Icon className='w-4 h-4 text-orange-500' />
+    </div>
+    <div>
+      <p className='text-sm font-medium text-gray-700'>{title}</p>
+      <p className='text-xs text-gray-400 mt-0.5 leading-relaxed'>{description}</p>
+    </div>
+  </a>
+);
+
+const CollectionsList = ({ cms }: { cms: TinaCMS }) => {
+  const collectionsInfo = useGetCollections(cms);
+  const collections = collectionsInfo.collections.filter(
+    (c) => !c.isAuthCollection
+  );
+
+  if (collections.length === 0) {
+    return (
+      <div className='flex flex-col items-center justify-center py-10 text-center rounded-lg border border-dashed border-gray-200 bg-gray-50/50'>
+        <BiFolder className='w-10 h-10 text-gray-300 mb-2' />
+        <p className='text-sm text-gray-400'>No collections configured yet.</p>
+        <a
+          href='https://tina.io/docs/r/content-modelling-collections'
+          target='_blank'
+          rel='noopener noreferrer'
+          className='text-xs text-orange-500 underline mt-1 hover:text-orange-600'
+        >
+          Learn how to add collections
+        </a>
+      </div>
+    );
+  }
+
+  return (
+    <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'>
+      {collections.map((collection) => (
+        <CollectionCard key={collection.name} collection={collection} />
+      ))}
+    </div>
+  );
+};
 
 const DashboardPage = () => {
   return (
@@ -11,13 +98,50 @@ const DashboardPage = () => {
         <PageWrapper>
           <>
             <PageHeader>
-              <h3 className='text-2xl font-sans text-gray-700'>
-                Welcome to Tina!
-              </h3>
+              <div>
+                <h3 className='text-2xl font-sans font-semibold text-gray-800'>
+                  Dashboard
+                </h3>
+                <p className='text-sm text-gray-400 mt-1'>
+                  Select a collection to browse and edit your content.
+                </p>
+              </div>
             </PageHeader>
             <PageBody>
-              This is your dashboard for editing or creating content. Select a
-              collection on the left to begin.
+              <div className='w-full mx-auto max-w-screen-xl space-y-8'>
+                <section>
+                  <h4 className='text-xs font-bold uppercase tracking-wider text-gray-500 mb-3'>
+                    Collections
+                  </h4>
+                  <CollectionsList cms={cms} />
+                </section>
+
+                <section>
+                  <h4 className='text-xs font-bold uppercase tracking-wider text-gray-500 mb-3'>
+                    Resources
+                  </h4>
+                  <div className='grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3'>
+                    <QuickStartCard
+                      icon={BiFile}
+                      title='Documentation'
+                      description='Read the TinaCMS docs to learn about collections, fields, and more.'
+                      href='https://tina.io/docs'
+                    />
+                    <QuickStartCard
+                      icon={BiFolder}
+                      title='Content Modelling'
+                      description='Learn how to structure your content with collections and templates.'
+                      href='https://tina.io/docs/r/content-modelling-collections'
+                    />
+                    <QuickStartCard
+                      icon={BiEdit}
+                      title='Media Management'
+                      description='Upload and manage images, videos, and other media assets.'
+                      href='https://tina.io/docs/r/media'
+                    />
+                  </div>
+                </section>
+              </div>
             </PageBody>
           </>
         </PageWrapper>

--- a/packages/tinacms/src/toolkit/react-sidebar/components/form-list.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/form-list.tsx
@@ -199,7 +199,7 @@ const CollectionGroup = ({
       >
         {/* Global badge for global collections */}
         {isGlobalCollection && (
-          <span className='px-2 pb-0.5 text-xs bg-gray-100 text-blue-700 rounded-full'>
+          <span className='px-2 pb-0.5 text-xs bg-orange-50 text-orange-700 rounded-full'>
             global
           </span>
         )}
@@ -334,7 +334,7 @@ const TreeNodeComponent = ({
       >
         {/* Global badge for global collections */}
         {node.isGlobal && (
-          <span className='px-2 py-0.5 text-xs bg-blue-100 text-blue-700 rounded-full flex-none'>
+          <span className='px-2 py-0.5 text-xs bg-orange-100 text-orange-700 rounded-full flex-none'>
             global
           </span>
         )}

--- a/packages/tinacms/src/toolkit/react-sidebar/components/local-warning.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/local-warning.tsx
@@ -60,7 +60,7 @@ export const BillingWarning = () => {
         </span>
       </span>
       <a
-        className='text-xs text-blue-600 underline decoration-blue-200 hover:text-blue-500 hover:decoration-blue-500 transition-all ease-out duration-150 flex items-center gap-1 self-end'
+        className='text-xs text-orange-600 underline decoration-orange-200 hover:text-orange-500 hover:decoration-orange-500 transition-all ease-out duration-150 flex items-center gap-1 self-end'
         href={`https://app.tina.io/projects/${billingState.clientId}/billing`}
         target='_blank'
       >

--- a/packages/tinacms/src/toolkit/react-sidebar/components/nav-components.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/nav-components.tsx
@@ -20,7 +20,7 @@ export const NavCloudLink: React.FC<NavCloudLinkProps> = ({ config }) => {
         {config.text}{' '}
         <a
           target='_blank'
-          className='ml-1 text-blue-600 hover:opacity-60'
+          className='ml-1 text-orange-600 hover:opacity-60'
           onClick={() =>
             captureEvent(CloudConfigNavComponentClickedEvent, {
               itemType: config.link.text,
@@ -34,7 +34,7 @@ export const NavCloudLink: React.FC<NavCloudLinkProps> = ({ config }) => {
     );
   }
   return (
-    <span className='text-base tracking-wide text-gray-500 hover:text-blue-600 flex items-center opacity-90 hover:opacity-100'>
+    <span className='text-base tracking-wide text-gray-500 hover:text-orange-500 flex items-center opacity-90 hover:opacity-100'>
       <config.Icon className='mr-2 h-6 opacity-80 w-auto' />
       <a
         target='_blank'

--- a/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
+++ b/packages/tinacms/src/toolkit/react-sidebar/components/nav.tsx
@@ -238,12 +238,12 @@ export const Nav = ({
           <div className='grow my-4 border-b border-gray-200'></div>
 
           <SyncStatusButton
-            className='text-lg py-2 first:pt-3 last:pb-3 whitespace-nowrap flex items-center opacity-80 text-gray-600 hover:text-blue-400'
+            className='text-lg py-2 first:pt-3 last:pb-3 whitespace-nowrap flex items-center opacity-80 text-gray-600 hover:text-orange-500'
             cms={cms}
             setEventsOpen={setEventsOpen}
           />
           <Logout
-            className='text-lg py-2 first:pt-3 last:pb-3 whitespace-nowrap flex items-center opacity-80 text-gray-600 hover:text-blue-400'
+            className='text-lg py-2 first:pt-3 last:pb-3 whitespace-nowrap flex items-center opacity-80 text-gray-600 hover:text-orange-500'
             cms={cms}
           />
           <VersionInfo />
@@ -291,7 +291,7 @@ const CreateContentNavItem = ({ plugin }) => {
   return (
     <li key={plugin.name}>
       <button
-        className='text-base tracking-wide text-gray-500 hover:text-blue-600 flex items-center opacity-90 hover:opacity-100'
+        className='text-base tracking-wide text-gray-500 hover:text-orange-500 flex items-center opacity-90 hover:opacity-100'
         onClick={() => {
           setOpen(true);
         }}


### PR DESCRIPTION
## Summary

Partial implementation toward the v4 admin panel overhaul described in #6898. This PR addresses the most clearly specified acceptance criteria — consistent branding, navigation clarity, and editor-state visibility — without making speculative structural changes that should be driven by the reviewed design prototype.

### Changes

#### 1. Orange accent applied consistently across the admin panel
TinaCMS's brand colour is orange, but the admin UI had blue (`text-blue-600`, `ring-blue-500`, etc.) scattered across interactive elements. This PR replaces all blue accent colours with orange across:

- **`AdminNav.tsx`** – sidebar nav links: active state now uses `text-orange-600 bg-orange-50` with a hover-highlight, making the current collection clearly visible
- **`nav.tsx`** – sidebar footer (SyncStatus / Log Out) hover; `CreateContentNavItem` button hover
- **`nav-components.tsx`** – cloud-config nav links
- **`local-warning.tsx`** – billing page link
- **`form-list.tsx`** – "global" collection badge (was `bg-blue-100 text-blue-700`, now orange)
- **`CollectionCreatePage.tsx`** – filename input focus border + unlock icon
- **`CollectionListPage.tsx`** – folder/document row links, breadcrumb navigation buttons, search input focus ring, Add Folder button focus ring, template dropdown focus state

#### 2. Sticky header with consistent editor-state visibility
- **`Page.tsx`** – The top bar is now `sticky top-0` with a white background, `border-b` separator and subtle `shadow-sm`. This ensures the TinaCMS logo, hamburger trigger, branch switcher, and billing/local warnings remain visible as content scrolls — addressing the "active branch and operation status have consistent visible treatment" acceptance criterion.

#### 3. Improved dashboard page
- **`DashboardPage.tsx`** – Replaced the placeholder "Welcome to Tina!" text with a functional landing page:
  - **Collections grid** – clickable cards for every content collection (direct navigation, no sidebar required)
  - **Resources section** – links to Docs, Content Modelling, and Media Management
  - Empty state with a prompt when no collections are configured

## Acceptance criteria addressed

| Criterion | Status |
|-----------|--------|
| TinaCMS logo, orange accent, typography applied consistently | ✅ All blue interactive accents replaced with orange |
| Active branch visible across admin views | ✅ Header is now sticky — branch button always on screen |
| Operation status (Event Log) reachable | ✅ SyncStatus button hover updated; still accessible from sidebar footer |
| Existing core editor workflows remain reachable | ✅ No routing or structural changes made |
| Navigation between collections is clearer | ✅ Dashboard now shows collection cards for direct one-click access |

## Not in this PR

- Full layout restructuring (waiting on reviewed v4 prototype/screenshots referenced in the issue)
- Hamburger/overlay vs. persistent sidebar decision (design-dependent)
- Responsive breakpoint adjustments beyond what Tailwind's existing utilities handle
- Tests / visual regression checks (can be added once the full design direction is confirmed)

## Test plan

- [ ] Open the admin panel — header should be white with a border, logo and branch button visible
- [ ] Scroll a long collection list — confirm header stays sticky
- [ ] Visit the dashboard (`/`) — collection cards appear; clicking one navigates to the collection list
- [ ] Open the sidebar hamburger — active nav item should be orange with a light background highlight
- [ ] Hover over sidebar footer items (Event Log, Log Out) — should turn orange, not blue
- [ ] Open a collection with folders — breadcrumb and back-button should be orange
- [ ] Create a new document — filename input focus ring should be orange
- [ ] Check "global" badge in the form sidebar — should be orange, not blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)