### PR TITLE
fix(tinacms): hide highlight for markdown rich text fields

### DIFF
--- a/.changeset/hide-highlight-markdown.md
+++ b/.changeset/hide-highlight-markdown.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Hide the highlight toolbar item for Markdown rich-text fields.

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/fixed-toolbar-buttons.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/fixed-toolbar-buttons.tsx
@@ -143,7 +143,7 @@ const toolbarItems: { [key in ToolbarOverrideType]: ToolbarItem } = {
 export default function FixedToolbarButtons() {
   const toolbarRef = React.useRef(null);
   const [itemsShown, setItemsShown] = React.useState(11);
-  const { overrides, templates, field } = useToolbarContext();
+  const { overrides, templates, parserType } = useToolbarContext();
   const showEmbedButton = templates.length > 0;
 
   let items = [];
@@ -168,7 +168,7 @@ export default function FixedToolbarButtons() {
     items = items.filter((item) => item.label !== toolbarItems.embed.label);
   }
 
-  if (field?.parser?.type === 'markdown') {
+  if (parserType === 'markdown') {
     items = items.filter((item) => item.label !== toolbarItems.highlight.label);
   }
 

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/fixed-toolbar-buttons.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/fixed-toolbar-buttons.tsx
@@ -143,7 +143,7 @@ const toolbarItems: { [key in ToolbarOverrideType]: ToolbarItem } = {
 export default function FixedToolbarButtons() {
   const toolbarRef = React.useRef(null);
   const [itemsShown, setItemsShown] = React.useState(11);
-  const { overrides, templates } = useToolbarContext();
+  const { overrides, templates, field } = useToolbarContext();
   const showEmbedButton = templates.length > 0;
 
   let items = [];
@@ -166,6 +166,10 @@ export default function FixedToolbarButtons() {
 
   if (!showEmbedButton) {
     items = items.filter((item) => item.label !== toolbarItems.embed.label);
+  }
+
+  if (field?.parser?.type === 'markdown') {
+    items = items.filter((item) => item.label !== toolbarItems.highlight.label);
   }
 
   const editorState = useEditorState();

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/index.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/index.tsx
@@ -77,6 +77,7 @@ export const RichEditor = ({ input, tinaForm, field }: RichTextType) => {
               overrides={
                 field?.toolbarOverride ? field.toolbarOverride : field.overrides
               }
+              field={field}
             >
               <FixedToolbar>
                 <FixedToolbarButtons />

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/index.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/index.tsx
@@ -77,7 +77,7 @@ export const RichEditor = ({ input, tinaForm, field }: RichTextType) => {
               overrides={
                 field?.toolbarOverride ? field.toolbarOverride : field.overrides
               }
-              field={field}
+              parserType={field.parser?.type}
             >
               <FixedToolbar>
                 <FixedToolbarButtons />

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-provider.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-provider.tsx
@@ -12,7 +12,7 @@ interface ToolbarContextProps {
   tinaForm: Form;
   templates: MdxTemplate[];
   overrides: ToolbarOverrideType[] | ToolbarOverrides;
-  field?: any;
+  parserType?: string;
 }
 
 interface ToolbarProviderProps extends ToolbarContextProps {
@@ -27,11 +27,13 @@ export const ToolbarProvider: React.FC<ToolbarProviderProps> = ({
   tinaForm,
   templates,
   overrides,
-  field,
+  parserType,
   children,
 }) => {
   return (
-    <ToolbarContext.Provider value={{ tinaForm, templates, overrides, field }}>
+    <ToolbarContext.Provider
+      value={{ tinaForm, templates, overrides, parserType }}
+    >
       {children}
     </ToolbarContext.Provider>
   );

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-provider.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/toolbar/toolbar-provider.tsx
@@ -12,6 +12,7 @@ interface ToolbarContextProps {
   tinaForm: Form;
   templates: MdxTemplate[];
   overrides: ToolbarOverrideType[] | ToolbarOverrides;
+  field?: any;
 }
 
 interface ToolbarProviderProps extends ToolbarContextProps {
@@ -26,10 +27,11 @@ export const ToolbarProvider: React.FC<ToolbarProviderProps> = ({
   tinaForm,
   templates,
   overrides,
+  field,
   children,
 }) => {
   return (
-    <ToolbarContext.Provider value={{ tinaForm, templates, overrides }}>
+    <ToolbarContext.Provider value={{ tinaForm, templates, overrides, field }}>
       {children}
     </ToolbarContext.Provider>
   );


### PR DESCRIPTION
Fixes #6903

## Summary

This PR hides the `highlight` toolbar item when a rich-text field uses the Markdown parser.

Highlight serializes to JSX markup, which does not safely round-trip through the Markdown parser and can result in broken `.md` output.

## Changes

- Pass the parser type into the toolbar context.
- Hide the `highlight` toolbar item when `parserType === 'markdown'`.
- Keep highlight available for non-Markdown rich-text fields.

## Notes

This PR intentionally keeps the scope small and does not change embed/shortcode behavior.