### PR TITLE
Fix dropdown options hidden behind fields

### DIFF
--- a/.changeset/sharp-shrimps-pump.md
+++ b/.changeset/sharp-shrimps-pump.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Fix dropdown options being hidden behind other fields.

--- a/packages/tinacms/src/toolkit/fields/plugins/list-field-meta.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/list-field-meta.tsx
@@ -50,7 +50,7 @@ export const ListFieldMeta = ({
       margin={margin}
       {...hoverEvents}
       onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
-      style={{ zIndex: index !== undefined ? 1000 - index : undefined }}
+      style={{ zIndex: index != null ? 1000 - index : undefined }}
       {...props}
     >
       <ListHeader>

--- a/packages/tinacms/src/toolkit/fields/plugins/list-field-meta.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/list-field-meta.tsx
@@ -50,7 +50,7 @@ export const ListFieldMeta = ({
       margin={margin}
       {...hoverEvents}
       onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
-      style={{ zIndex: index ? 1000 - index : undefined }}
+      style={{ zIndex: index !== undefined ? 1000 - index : undefined }}
       {...props}
     >
       <ListHeader>

--- a/packages/tinacms/src/toolkit/fields/plugins/wrap-field-with-meta.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/wrap-field-with-meta.tsx
@@ -116,7 +116,7 @@ export const FieldMeta = ({
       onMouseOver={() => setHoveredField({ id: tinaForm.id, fieldName: name })}
       onMouseOut={() => setHoveredField({ id: null, fieldName: null })}
       onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
-      style={{ zIndex: index !== undefined ? 1000 - index : undefined }}
+      style={{ zIndex: index != null ? 1000 - index : undefined }}
       {...props}
     >
       {(label !== false || description) && (

--- a/packages/tinacms/src/toolkit/fields/plugins/wrap-field-with-meta.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/wrap-field-with-meta.tsx
@@ -116,7 +116,7 @@ export const FieldMeta = ({
       onMouseOver={() => setHoveredField({ id: tinaForm.id, fieldName: name })}
       onMouseOut={() => setHoveredField({ id: null, fieldName: null })}
       onClick={() => setFocusedField({ id: tinaForm.id, fieldName: name })}
-      style={{ zIndex: index ? 1000 - index : undefined }}
+      style={{ zIndex: index !== undefined ? 1000 - index : undefined }}
       {...props}
     >
       {(label !== false || description) && (


### PR DESCRIPTION
<!--

Thank you for contributing to TinaCMS!

Several things must happen for your PR to be merged:

1. It must successfully build, test, and lint your branch
1. It must pass the dangerjs script
2. It must be up-to-date with master
3. It must be approved by at least 1 tinacms core member
4. It must have conventional-commits that clearly explain what has been changed


Small is beautiful! 

PRs should be small. They should be made up of many small commits, with clear 
commit messages explaining _what_ has been changed and _why_. The tests should
be short and specific, with single assertions. 

-->

Relates to #5684 

This pull request addresses a UI bug where dropdown options in fields were being hidden behind other elements in the `tinacms` package. The main fix involves improving how the `zIndex` style is applied to field components, ensuring dropdowns display correctly.

**Bug Fixes (Dropdown Visibility):**

* Updated the `style` prop in both `ListFieldMeta` (`list-field-meta.tsx`) and `FieldMeta` (`wrap-field-with-meta.tsx`) components to set `zIndex` only when `index` is defined, preventing dropdowns from being hidden behind other fields.


**Before:**
<img width="1245" height="1070" alt="image" src="https://github.com/user-attachments/assets/ff0897ba-dd1e-4951-96a3-8a9a2b173e7f" />


**After:**
<img width="1373" height="991" alt="image" src="https://github.com/user-attachments/assets/7738ef7b-06f5-4642-b3f9-50577f66c308" />
