### PR TITLE
chore(deps): upgrade react-router-dom 6.3.0 → ^6.30.3 (fix GHSA-9jcx-v3wj-wh4m)

### DIFF
--- a/.changeset/upgrade-react-router-dom.md
+++ b/.changeset/upgrade-react-router-dom.md
@@ -1,0 +1,6 @@
+---
+"tinacms": patch
+"@tinacms/app": patch
+---
+
+chore(deps): upgrade react-router-dom from 6.3.0 to ^6.30.3 to resolve GHSA-9jcx-v3wj-wh4m (unexpected external redirect via untrusted paths)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -565,8 +565,8 @@ catalogs:
       specifier: ^6.5.9
       version: 6.5.9
     react-router-dom:
-      specifier: 6.3.0
-      version: 6.3.0
+      specifier: ^6.30.3
+      version: 6.30.3
     react-use:
       specifier: ^17.6.0
       version: 17.6.0
@@ -1219,7 +1219,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       react-router-dom:
         specifier: 'catalog:'
-        version: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tinacms:
         specifier: workspace:*
         version: link:../../tinacms
@@ -2425,7 +2425,7 @@ importers:
         version: 5.5.0(react@18.3.1)
       react-router-dom:
         specifier: 'catalog:'
-        version: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-use:
         specifier: 'catalog:'
         version: 17.6.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10632,9 +10632,6 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  history@5.3.0:
-    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
-
   hoist-non-react-statics@3.3.2:
     resolution: {integrity: sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==}
 
@@ -13486,23 +13483,12 @@ packages:
       '@types/react':
         optional: true
 
-  react-router-dom@6.3.0:
-    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
-    peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
-
   react-router-dom@6.30.3:
     resolution: {integrity: sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       react: '>=16.8'
       react-dom: '>=16.8'
-
-  react-router@6.3.0:
-    resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}
-    peerDependencies:
-      react: '>=16.8'
 
   react-router@6.30.3:
     resolution: {integrity: sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==}
@@ -25688,10 +25674,6 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  history@5.3.0:
-    dependencies:
-      '@babel/runtime': 7.28.4
-
   hoist-non-react-statics@3.3.2:
     dependencies:
       react-is: 16.13.1
@@ -29789,24 +29771,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
-  react-router-dom@6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      history: 5.3.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-router: 6.3.0(react@18.3.1)
-
   react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.2
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.3(react@18.3.1)
-
-  react-router@6.3.0(react@18.3.1):
-    dependencies:
-      history: 5.3.0
-      react: 18.3.1
 
   react-router@6.30.3(react@18.3.1):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -205,7 +205,7 @@ catalog:
     react-dnd-html5-backend: ^16.0.1
     react-dropzone: 14.2.3
     react-final-form: ^6.5.9
-    react-router-dom: 6.3.0
+    react-router-dom: ^6.30.3
     react-use: ^17.6.0
     readable-stream: ^4.7.0
     remark: 14.0.2


### PR DESCRIPTION
## Summary
- Upgrades `react-router-dom` from pinned `6.3.0` to `^6.30.3` in the pnpm workspace catalog
- Resolves [GHSA-9jcx-v3wj-wh4m](https://github.com/advisories/GHSA-9jcx-v3wj-wh4m) — unexpected external redirect via untrusted paths
- All 22 packages build successfully, all 54 test tasks pass

Closes #6627

## Notes
The codebase only uses stable react-router-dom v6 APIs (`HashRouter`, `Routes`, `Route`, `useNavigate`, `useParams`, `useLocation`, `useSearchParams`, `NavLink`, `Link`) — none of which have breaking changes between 6.3 and 6.30.

The mermaid vulnerability mentioned in #6627 was already resolved in #6410 (bumped to `^11.12.2`).

## Test plan
- [x] `pnpm build` — all 22 package builds pass
- [x] `pnpm test` — all 54 test tasks pass (549+ tests)
- [x] Smoke test admin panel routing (hash-based navigation, collection CRUD, screen pages)
- [x] Verify search params handling in GraphQL explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)