### PR TITLE
fix(tinacms): trim whitespace from search input before querying

### DIFF
--- a/.changeset/fix-search-input-trim.md
+++ b/.changeset/fix-search-input-trim.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+fix(tinacms): trim whitespace from search input before querying

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -1236,7 +1236,7 @@ const SearchInput = ({
     if (e.key === 'Enter') {
       e.preventDefault();
       if (searchInput.trim()) {
-        setSearch(searchInput);
+        setSearch(searchInput.trim());
         setSearchLoaded(false);
       }
     }
@@ -1245,9 +1245,9 @@ const SearchInput = ({
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (searchInput.trim()) {
-      setSearch(searchInput);
+      setSearch(searchInput.trim());
       captureEvent(CollectionListPageSearchEvent, {
-        searchQuery: searchInput,
+        searchQuery: searchInput.trim(),
       });
       setSearchLoaded(false);
     }


### PR DESCRIPTION
## Summary
- Trims leading/trailing whitespace from the collection search input before passing it to the query
- Also trims the value sent to PostHog analytics for consistency

Closes #4499

## Changes
`packages/tinacms/src/admin/pages/CollectionListPage.tsx` — both `handleKeyDown` and `handleSubmit` now call `setSearch(searchInput.trim())` instead of `setSearch(searchInput)`

## Test plan
- [x] `pnpm build` passes
- [ ] Search for `" keyword "` (with spaces) — should return same results as `"keyword"`
- [ ] Search for `"  "` (only spaces) — should not trigger a search

🤖 Generated with [Claude Code](https://claude.com/claude-code)