### PR TITLE
Fix typos: notifiySubscribers → notifySubscribers, Error occured → occurred

### DIFF
--- a/.changeset/fix-typos-notify-subscribers-error-occurred.md
+++ b/.changeset/fix-typos-notify-subscribers-error-occurred.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/cli": patch
+"tinacms": patch
+---
+
+Fix typos: rename misspelled `notifiySubscribers` to `notifySubscribers` and correct "Error occured" to "Error occurred" in CLI error messages

--- a/packages/@tinacms/cli/src/next/commands/audit-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/audit-command/index.ts
@@ -35,7 +35,7 @@ export class AuditCommand extends Command {
   });
 
   async catch(error: any): Promise<void> {
-    logger.error('Error occured during tinacms audit');
+    logger.error('Error occurred during tinacms audit');
     if (this.verbose) {
       console.error(error);
     }

--- a/packages/@tinacms/cli/src/next/commands/codemod-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/codemod-command/index.ts
@@ -19,7 +19,7 @@ export class CodemodCommand extends Command {
 
   async catch(error: any): Promise<void> {
     console.log(error);
-    // logger.error('Error occured during tinacms codemod')
+    // logger.error('Error occurred during tinacms codemod')
     // process.exit(1)
   }
 

--- a/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/index.ts
@@ -45,7 +45,7 @@ export class DevCommand extends BaseCommand {
   });
 
   async catch(error: any): Promise<void> {
-    logger.error('Error occured during tinacms dev');
+    logger.error('Error occurred during tinacms dev');
     console.error(error);
     process.exit(1);
   }

--- a/packages/@tinacms/cli/src/next/commands/init-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/init-command/index.ts
@@ -27,7 +27,7 @@ export class InitCommand extends Command {
   });
 
   async catch(error: any): Promise<void> {
-    logger.error('Error occured during tinacms init');
+    logger.error('Error occurred during tinacms init');
     console.error(error);
     process.exit(1);
   }

--- a/packages/@tinacms/cli/src/next/commands/searchindex-command/index.ts
+++ b/packages/@tinacms/cli/src/next/commands/searchindex-command/index.ts
@@ -25,7 +25,7 @@ export class SearchIndexCommand extends Command {
   });
 
   async catch(error: any): Promise<void> {
-    logger.error('Error occured during tinacms search-index');
+    logger.error('Error occurred during tinacms search-index');
     console.error(error);
     process.exit(1);
   }

--- a/packages/tinacms/src/toolkit/core/subscribable.test.ts
+++ b/packages/tinacms/src/toolkit/core/subscribable.test.ts
@@ -3,7 +3,7 @@ import { describe, it, test, expect, beforeEach, vi } from 'vitest';
 
 class Example extends Subscribable {
   notify() {
-    this.notifiySubscribers();
+    this.notifySubscribers();
   }
 }
 

--- a/packages/tinacms/src/toolkit/core/subscribable.ts
+++ b/packages/tinacms/src/toolkit/core/subscribable.ts
@@ -43,7 +43,7 @@ export class Subscribable {
   /**
    * Removes the given listener from the `Subscribable` object.
    *
-   * @param listener The functioni to be removed.
+   * @param listener The function to be removed.
    */
   unsubscribe(listener: Function) {
     const index = this.__subscribers.indexOf(listener);
@@ -79,7 +79,7 @@ export class Subscribable {
    * cup.empty() // Logs: false
    * ```
    */
-  protected notifiySubscribers() {
+  protected notifySubscribers() {
     // TODO: Catch and log errors.
     this.__subscribers.forEach((cb) => cb());
   }


### PR DESCRIPTION
## Summary

- Rename misspelled protected method `notifiySubscribers` to `notifySubscribers` in `Subscribable` class (`packages/tinacms/src/toolkit/core/subscribable.ts`) and its test file. The JSDoc usage examples already showed the correct spelling.
- Fix JSDoc `@param` description typo: "functioni" → "function" in the same file.
- Correct "Error occured" to "Error occurred" in five CLI command error messages: `audit`, `dev`, `init`, `search-index`, and `codemod`.

All 7 existing `Subscribable` unit tests pass with the renamed method.

## Test plan

- [x] Ran `vitest run src/toolkit/core/subscribable.test.ts` — all 7 tests pass
- [x] Verified no other callers of the old `notifiySubscribers` name remain in the codebase