### PR TITLE
ci(starter-templates): run nightly (daily) instead of weekly

### DIFF
--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -14,7 +14,11 @@ on:
         default: ''
         type: string
   schedule:
-    - cron: '0 9 * * 1'
+    # Daily at 09:00 UTC. The workflow's full matrix (7 templates × 3 PMs × 3
+    # Node versions = 63 jobs) is the broader safety net for starter-template
+    # drift — daily cadence keeps worst-case detection latency under ~1 day,
+    # so a regression that lands today gets caught tomorrow, not next week.
+    - cron: '0 9 * * *'
 
 jobs:
   build-templates:


### PR DESCRIPTION
## Summary

```diff
  schedule:
-   - cron: '0 9 * * 1'   # Mondays — weekly
+   - cron: '0 9 * * *'   # Daily
```

## Why

The workflow is colloquially called "nightly" — and the original issue framing (#6789) assumes daily cadence ("could ship to main and only be discovered the next morning"). But the cron has been `0 9 * * 1` (Mondays only), meaning regressions could go undetected for up to ~7 days. A regression that landed on Tuesday and got published mid-week wouldn't surface until the following Monday.

Today's [hugo-starter peer-dep failure](https://github.com/tinacms/tinacms/actions/runs/26395938910/job/77696501901) actually surfaced relatively fast (4 days from the underlying PR), but only because the merge happened to land on a Thursday. Worst case under the old cadence was significantly longer.

## Cost

| | Weekly | Daily |
| --- | --- | --- |
| Jobs / week | 63 (7 templates × 3 PMs × 3 Node versions) | 441 |
| Worst-case latency from regression-publish to detection | ~7 days | ~1 day |

For this public repo on GitHub-hosted runners, the CI-minutes increase is negligible. `continue-on-error: true` + the existing title-based dedup in the "Report errors" step keeps recurring failures from spamming the issue tracker.

## Test plan

- [ ] After merge: confirm a scheduled run fires daily at 09:00 UTC (not just Mondays)
- [ ] If a regression is in flight: it should now get caught within a day of its publish, not within a week
- [ ] Nightly behavior is otherwise unchanged — same matrix, same secrets, same auto-issue-filing

🤖 Generated with [Claude Code](https://claude.com/claude-code)