### PR TITLE
feat(create-tina-app): make Astro the default starter

### DIFF
--- a/.changeset/create-tina-app-default-astro-starter.md
+++ b/.changeset/create-tina-app-default-astro-starter.md
@@ -1,0 +1,5 @@
+---
+"create-tina-app": minor
+---
+
+Make Astro the default starter. The interactive `What starter code would you like to use?` prompt now pre-selects `Astro Starter` (moved to the top of the list), and when `create-tina-app` is invoked in a non-interactive context (no TTY) without a `--template` flag, the Astro starter is selected automatically instead of the prompt receiving empty input and exiting as `user cancelled`.

--- a/.changeset/create-tina-app-default-astro-starter.md
+++ b/.changeset/create-tina-app-default-astro-starter.md
@@ -2,4 +2,6 @@
 "create-tina-app": minor
 ---
 
-Make Astro the default starter. The interactive `What starter code would you like to use?` prompt now pre-selects `Astro Starter` (moved to the top of the list), and when `create-tina-app` is invoked in a non-interactive context (no TTY) without a `--template` flag, the Astro starter is selected automatically instead of the prompt receiving empty input and exiting as `user cancelled`.
+Make Astro the default starter. The interactive `What starter code would you like to use?` prompt now pre-selects `Astro Starter` (moved to the top of the list). When `create-tina-app` runs without a TTY and without a `--template` flag, the Astro starter is now selected automatically instead of the prompt receiving empty input and exiting as `user cancelled`.
+
+Note that a fully non-interactive run still needs `--pkg-manager` and a project name. Those two prompts have no non-TTY fallback yet, so a bare `create-tina-app` in CI still stops at the package manager question.

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -11,7 +11,12 @@ import {
 } from './util/fileUtil';
 import { install } from './util/install';
 import { initializeGit, makeFirstCommit } from './util/git';
-import { TEMPLATES, Template, downloadTemplate } from './templates';
+import {
+  DEFAULT_TEMPLATE_VALUE,
+  TEMPLATES,
+  Template,
+  downloadTemplate,
+} from './templates';
 import { preRunChecks } from './util/preRunChecks';
 import { checkPackageExists } from './util/checkPkgManagers';
 import { TextStyles, TextStylesBold, box } from './util/textstyles';
@@ -302,30 +307,44 @@ export async function run() {
   }
 
   if (!template) {
-    const res = await prompts({
-      name: 'template',
-      type: 'select',
-      message: 'What starter code would you like to use?',
-      choices: TEMPLATES.map(formatTemplateChoice),
-    });
-    if (!Object.hasOwn(res, 'template')) {
-      postHogCaptureError(
-        posthogClient,
-        userId,
-        sessionId,
-        new Error('User cancelled template selection'),
-        {
-          errorCode: ERROR_CODES.ERR_CANCEL_TEMPLATE_PROMPT,
-          errorCategory: 'user-cancellation',
-          step: TRACKING_STEPS.TEMPLATE_SELECT,
-          fatal: true,
-          additionalProperties: telemetryData,
-        }
+    const defaultTemplate = TEMPLATES.find(
+      (t) => t.value === DEFAULT_TEMPLATE_VALUE
+    );
+    const defaultTemplateIndex = defaultTemplate
+      ? TEMPLATES.indexOf(defaultTemplate)
+      : 0;
+
+    if (!process.stdin.isTTY && defaultTemplate) {
+      template = defaultTemplate;
+    } else {
+      const res = await prompts({
+        name: 'template',
+        type: 'select',
+        message: 'What starter code would you like to use?',
+        choices: TEMPLATES.map(formatTemplateChoice),
+        initial: defaultTemplateIndex,
+      });
+      if (!Object.hasOwn(res, 'template')) {
+        postHogCaptureError(
+          posthogClient,
+          userId,
+          sessionId,
+          new Error('User cancelled template selection'),
+          {
+            errorCode: ERROR_CODES.ERR_CANCEL_TEMPLATE_PROMPT,
+            errorCategory: 'user-cancellation',
+            step: TRACKING_STEPS.TEMPLATE_SELECT,
+            fatal: true,
+            additionalProperties: telemetryData,
+          }
+        );
+        if (posthogClient) await posthogClient.shutdown();
+        exit(1);
+      }
+      template = TEMPLATES.find(
+        (_template) => _template.value === res.template
       );
-      if (posthogClient) await posthogClient.shutdown();
-      exit(1);
     }
-    template = TEMPLATES.find((_template) => _template.value === res.template);
   }
   telemetryData['template'] = template.value;
 

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -307,12 +307,12 @@ export async function run() {
   }
 
   if (!template) {
-    const defaultTemplate = TEMPLATES.find(
+    const foundDefaultIndex = TEMPLATES.findIndex(
       (t) => t.value === DEFAULT_TEMPLATE_VALUE
     );
-    const defaultTemplateIndex = defaultTemplate
-      ? TEMPLATES.indexOf(defaultTemplate)
-      : 0;
+    const defaultTemplate =
+      foundDefaultIndex >= 0 ? TEMPLATES[foundDefaultIndex] : undefined;
+    const defaultTemplateIndex = foundDefaultIndex >= 0 ? foundDefaultIndex : 0;
 
     if (!process.stdin.isTTY && defaultTemplate) {
       template = defaultTemplate;

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { install } from './util/install';
 import { initializeGit, makeFirstCommit } from './util/git';
 import {
-  DEFAULT_TEMPLATE_VALUE,
+  DEFAULT_TEMPLATE,
   TEMPLATES,
   Template,
   downloadTemplate,
@@ -307,22 +307,15 @@ export async function run() {
   }
 
   if (!template) {
-    const foundDefaultIndex = TEMPLATES.findIndex(
-      (t) => t.value === DEFAULT_TEMPLATE_VALUE
-    );
-    const defaultTemplate =
-      foundDefaultIndex >= 0 ? TEMPLATES[foundDefaultIndex] : undefined;
-    const defaultTemplateIndex = foundDefaultIndex >= 0 ? foundDefaultIndex : 0;
-
-    if (!process.stdin.isTTY && defaultTemplate) {
-      template = defaultTemplate;
+    if (!process.stdin.isTTY) {
+      template = DEFAULT_TEMPLATE;
     } else {
       const res = await prompts({
         name: 'template',
         type: 'select',
         message: 'What starter code would you like to use?',
         choices: TEMPLATES.map(formatTemplateChoice),
-        initial: defaultTemplateIndex,
+        initial: TEMPLATES.indexOf(DEFAULT_TEMPLATE),
       });
       if (!Object.hasOwn(res, 'template')) {
         postHogCaptureError(

--- a/packages/create-tina-app/src/templates.ts
+++ b/packages/create-tina-app/src/templates.ts
@@ -27,11 +27,33 @@ export type ExternalTemplate = BaseExample & {
 };
 export type Template = InternalTemplate | ExternalTemplate;
 
+export const DEFAULT_TEMPLATE_VALUE = 'tina-astro-starter';
+
 export const TEMPLATES: Template[] = [
   {
-    title: '⭐ NextJS starter',
+    title: '⭐ Astro Starter',
     description:
-      'Kickstart your project with Next.js – our top recommendation for a seamless, performant, and versatile web experience.',
+      'Get started with Astro - a modern static site generator designed for fast, lightweight, and flexible web projects.',
+    value: 'tina-astro-starter',
+    isInternal: false,
+    features: [
+      {
+        name: 'Visual Editing',
+        description: '✅',
+      },
+      {
+        name: 'SSG',
+        description: '✅',
+      },
+    ],
+    gitURL: 'https://github.com/tinacms/tina-astro-starter',
+    branch: 'main',
+    devUrl: 'http://localhost:4321',
+  },
+  {
+    title: 'NextJS starter',
+    description:
+      'Kickstart your project with Next.js – a seamless, performant, and versatile web experience.',
     value: 'tina-nextjs-starter',
     isInternal: false,
     features: [
@@ -53,7 +75,7 @@ export const TEMPLATES: Template[] = [
     devUrl: 'http://localhost:3000',
   },
   {
-    title: '⭐️ TinaDocs',
+    title: 'TinaDocs',
     description:
       'Get your documentation site up and running with TinaCMS and Next.js in minutes.',
     value: 'tina-docs',
@@ -75,26 +97,6 @@ export const TEMPLATES: Template[] = [
     gitURL: 'https://github.com/tinacms/tina-docs',
     branch: 'main',
     devUrl: 'http://localhost:3000',
-  },
-  {
-    title: 'Astro Starter',
-    description:
-      'Get started with Astro - a modern static site generator designed for fast, lightweight, and flexible web projects.',
-    value: 'tina-astro-starter',
-    isInternal: false,
-    features: [
-      {
-        name: 'Visual Editing',
-        description: '✅',
-      },
-      {
-        name: 'SSG',
-        description: '✅',
-      },
-    ],
-    gitURL: 'https://github.com/tinacms/tina-astro-starter',
-    branch: 'main',
-    devUrl: 'http://localhost:4321',
   },
   {
     title: 'Hugo Starter',

--- a/packages/create-tina-app/src/templates.ts
+++ b/packages/create-tina-app/src/templates.ts
@@ -27,8 +27,6 @@ export type ExternalTemplate = BaseExample & {
 };
 export type Template = InternalTemplate | ExternalTemplate;
 
-export const DEFAULT_TEMPLATE_VALUE = 'tina-astro-starter';
-
 export const TEMPLATES: Template[] = [
   {
     title: '⭐ Astro Starter',
@@ -199,6 +197,16 @@ export const TEMPLATES: Template[] = [
     devUrl: 'http://localhost:3000',
   },
 ];
+
+const defaultTemplate = TEMPLATES.find(
+  (template) => template.value === 'tina-astro-starter'
+);
+if (!defaultTemplate) {
+  throw new Error(
+    'DEFAULT_TEMPLATE: no template in TEMPLATES has the value "tina-astro-starter"'
+  );
+}
+export const DEFAULT_TEMPLATE = defaultTemplate;
 
 export async function downloadTemplate(
   template: Template,

--- a/packages/create-tina-app/src/templates.ts
+++ b/packages/create-tina-app/src/templates.ts
@@ -33,13 +33,17 @@ export const TEMPLATES: Template[] = [
   {
     title: '⭐ Astro Starter',
     description:
-      'Get started with Astro - a modern static site generator designed for fast, lightweight, and flexible web projects.',
+      'Kickstart your project with Astro, our top recommendation for a fast, lightweight, and flexible web experience.',
     value: 'tina-astro-starter',
     isInternal: false,
     features: [
       {
         name: 'Visual Editing',
         description: '✅',
+      },
+      {
+        name: 'ISR',
+        description: '❌',
       },
       {
         name: 'SSG',
@@ -51,9 +55,9 @@ export const TEMPLATES: Template[] = [
     devUrl: 'http://localhost:4321',
   },
   {
-    title: 'NextJS starter',
+    title: 'Next.js Starter',
     description:
-      'Kickstart your project with Next.js – a seamless, performant, and versatile web experience.',
+      'Kickstart your project with Next.js, a seamless, performant, and versatile web experience.',
     value: 'tina-nextjs-starter',
     isInternal: false,
     features: [


### PR DESCRIPTION
## Summary

- Astro is now the pre-selected option in the interactive `What starter code would you like to use?` prompt (moved to the top of `TEMPLATES`, and the ⭐ "recommended" marker is shifted from `NextJS starter` / `TinaDocs` onto `⭐ Astro Starter`).
- Introduces a resolved `DEFAULT_TEMPLATE` export in `templates.ts` so the default lives in one place. The prompt's `initial` index is derived from it, so any future reordering won't desync the visual cursor, and a bad value throws at import instead of degrading silently.
- When `create-tina-app` is invoked **without a TTY** (e.g. piped, CI, scripted) and no `--template` flag is given, Astro is selected directly instead of falling into the prompt and exiting as `user cancelled`. Existing interactive behavior is unchanged for TTY users beyond the new default.

## Behavioural diff

| Invocation | Before | After |
|---|---|---|
| Interactive, no `--template` | Prompt opens on `⭐ NextJS starter` | Prompt opens on `⭐ Astro Starter` |
| `--template tina-nextjs-starter` (or any other) | Unchanged | Unchanged |
| Non-TTY **with `--pkg-manager` and a project name**, no `--template` | Prompt fires, gets empty input, exits with `ERR_CANCEL_TEMPLATE_PROMPT` | Astro selected, scaffolding proceeds |
| Non-TTY, bare (no `--pkg-manager`, no project name) | Stops at the package manager prompt | Unchanged, still stops there |
| Non-TTY (e.g. `< /dev/null`), with `--template foo` | Unchanged | Unchanged |

**Scope note:** this PR only gives the *template* prompt a non-TTY fallback. The package manager prompt (`index.ts:226-271`) and the project name prompt (`index.ts:274-307`) are still ungated, so a bare `npx create-tina-app` in CI exits 0 without scaffolding, same as before. Covering all three prompts behind an explicit `--yes` is tracked separately.

The existing `ERR_CANCEL_TEMPLATE_PROMPT` telemetry event now only fires when an interactive user dismisses the prompt, which is what its `errorCategory: 'user-cancellation'` already claimed. Non-TTY runs still record `telemetryData.template = 'tina-astro-starter'` via the existing line below the `if (!template)` block, so PostHog analytics still capture the choice.

## Test plan

- [x] `pnpm tsc` in `packages/create-tina-app` — passes
- [x] `pnpm format` (CI command) — no diff
- [x] `pnpm build` — produces dist/index.js containing the resolved default and the `!process.stdin.isTTY` branch
- [x] Non-TTY smoke test: `node bin/create-tina-app my-test-app --pkg-manager npm --noTelemetry < /dev/null` — output includes `✔ Downloading files from repo tinacms/tina-astro-starter` and `dev server http://localhost:4321`; resulting `package.json` has `"astro": "^6.4.4"`
- [x] Bare non-TTY: `node bin/create-tina-app my-test-app --noTelemetry < /dev/null` — stops at the package manager prompt, nothing scaffolded (documented above, not fixed here)
- [ ] Reviewer smoke (manual, requires a real terminal): run `node packages/create-tina-app/bin/create-tina-app` interactively and confirm the cursor lands on `⭐ Astro Starter`
