### PR TITLE
fix(create-tina-app): surface real error when package install fails

### DIFF
--- a/packages/create-tina-app/src/util/install.ts
+++ b/packages/create-tina-app/src/util/install.ts
@@ -12,13 +12,33 @@ export function install(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(packageManager, ['install'], {
-      stdio: verboseOutput ? 'inherit' : 'ignore',
+      stdio: verboseOutput ? 'inherit' : ['ignore', 'ignore', 'pipe'],
       env: { ...process.env, ADBLOCK: '1', DISABLE_OPENCOLLECTIVE: '1' },
+    });
+
+    let stderr = '';
+    if (!verboseOutput && child.stderr) {
+      child.stderr.setEncoding('utf8');
+      child.stderr.on('data', (chunk: string) => {
+        stderr += chunk;
+      });
+    }
+
+    child.on('error', (err) => {
+      reject(
+        new Error(`Could not run \`${packageManager} install\`: ${err.message}`)
+      );
     });
 
     child.on('close', (code) => {
       if (code !== 0) {
-        reject({ command: `${packageManager} install` });
+        const tail = stderr.trim().split('\n').slice(-30).join('\n');
+        const detail = tail ? `\n${tail}` : '';
+        reject(
+          new Error(
+            `\`${packageManager} install\` exited with code ${code}.${detail}`
+          )
+        );
         return;
       }
       resolve();


### PR DESCRIPTION
## Summary

When `create-tina-app` runs the install step and the package manager exits non-zero, the spinner reports:

```
✖ Failed to install packages: undefined
```

…which is useless for the user, especially in CI / scripted runs where they can't just re-run with `--verbose`.

Root cause in [`packages/create-tina-app/src/util/install.ts`](https://github.com/tinacms/tinacms/blob/main/packages/create-tina-app/src/util/install.ts):

- `reject({ command: ... })` rejected with a plain object that has no `.message`, so `error.message` in the catch block at `src/index.ts:468` was `undefined`.
- `stdio: 'ignore'` swallowed stderr entirely, so even if the message were populated there'd be nothing useful in it.
- No `'error'` handler on the child — a spawn failure (e.g. `ENOENT` on the package-manager binary) would have left the promise hanging forever.

This PR:

- Pipes stderr in non-verbose mode (stdout still ignored so the spinner stays clean) and buffers it.
- Rejects with a real `Error` whose message includes the exit code and the tail (last 30 lines) of stderr — enough to cover a full npm/pnpm/yarn error block while still capping unbounded output.
- Adds an `'error'` handler so spawn failures reject cleanly.

Before:

```
✖ Failed to install packages: undefined
```

After (real example — npm ERESOLVE in a scaffolded Astro starter):

```
✖ Failed to install packages: `npm install` exited with code 1.
npm error code ERESOLVE
npm error ERESOLVE unable to resolve dependency tree
npm error
npm error While resolving: my-test-app@0.0.1
npm error Found: astro@6.3.7
...
```

## Test plan

- [ ] `pnpm --filter create-tina-app build` succeeds
- [ ] `node packages/create-tina-app/bin/create-tina-app my-app --pkg-manager npm --noTelemetry < /dev/null` in a fresh dir surfaces the real npm error (when install fails) instead of `undefined`
- [ ] Happy-path scaffold (where install succeeds) still works end-to-end
- [ ] `--verbose` still streams install output to the terminal (stdio: 'inherit' path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)