### PR TITLE
fix(media): sanitize and NFC-normalize uploaded filenames

### DIFF
--- a/packages/next-tinacms-azure/src/azure-media-store.ts
+++ b/packages/next-tinacms-azure/src/azure-media-store.ts
@@ -5,7 +5,7 @@ import type {
   MediaStore,
   MediaUploadOptions,
 } from 'tinacms';
-import { DEFAULT_MEDIA_UPLOAD_TYPES } from 'tinacms';
+import { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from 'tinacms';
 import { E_UNAUTHORIZED, E_BAD_ROUTE, interpretErrorMessage } from './errors';
 
 export type AzureMediaStoreOptions = {
@@ -27,10 +27,13 @@ export class AzureMediaStore implements MediaStore {
 
     for (const item of media) {
       const { file, directory } = item;
+      // Normalize/sanitize so the name sent to Azure matches the value later
+      // persisted into content fields.
+      const safeName = sanitizeFilename(file.name);
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append('file', file, safeName);
       formData.append('directory', directory);
-      formData.append('filename', file.name);
+      formData.append('filename', safeName);
 
       const res = await this.fetchFunction(this.baseUrl, {
         method: 'POST',

--- a/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
+++ b/packages/next-tinacms-cloudinary/src/cloudinary-media-store.ts
@@ -5,7 +5,7 @@ import type {
   MediaStore,
   MediaUploadOptions,
 } from 'tinacms';
-import { DEFAULT_MEDIA_UPLOAD_TYPES } from 'tinacms';
+import { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from 'tinacms';
 import { E_UNAUTHORIZED, E_BAD_ROUTE, interpretErrorMessage } from './errors';
 
 export type CloudinaryMediaStoreOptions = {
@@ -27,10 +27,13 @@ export class CloudinaryMediaStore implements MediaStore {
 
     for (const item of media) {
       const { file, directory } = item;
+      // Normalize/sanitize so the name sent to Cloudinary matches the value
+      // later persisted into content fields.
+      const safeName = sanitizeFilename(file.name);
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append('file', file, safeName);
       formData.append('directory', directory);
-      formData.append('filename', file.name);
+      formData.append('filename', safeName);
 
       const res = await this.fetchFunction(this.baseUrl, {
         method: 'POST',

--- a/packages/next-tinacms-dos/src/dos-media-store.ts
+++ b/packages/next-tinacms-dos/src/dos-media-store.ts
@@ -5,7 +5,7 @@ import type {
   MediaStore,
   MediaUploadOptions,
 } from 'tinacms';
-import { DEFAULT_MEDIA_UPLOAD_TYPES } from 'tinacms';
+import { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from 'tinacms';
 
 import { E_UNAUTHORIZED, E_BAD_ROUTE, interpretErrorMessage } from './errors';
 
@@ -20,10 +20,13 @@ export class DOSMediaStore implements MediaStore {
 
     for (const item of media) {
       const { file, directory } = item;
+      // Normalize/sanitize so the name sent to DigitalOcean Spaces matches
+      // the value later persisted into content fields.
+      const safeName = sanitizeFilename(file.name);
       const formData = new FormData();
-      formData.append('file', file);
+      formData.append('file', file, safeName);
       formData.append('directory', directory);
-      formData.append('filename', file.name);
+      formData.append('filename', safeName);
 
       const res = await this.fetchFunction(`/api/dos/media`, {
         method: 'POST',

--- a/packages/next-tinacms-s3/src/s3-media-store.ts
+++ b/packages/next-tinacms-s3/src/s3-media-store.ts
@@ -43,9 +43,7 @@ export class S3MediaStore implements MediaStore {
       // value persisted into content all agree.
       const safeName = sanitizeFilename(item.file.name);
       const path = `${
-        directory && directory !== '/'
-          ? `${directory}/${safeName}`
-          : safeName
+        directory && directory !== '/' ? `${directory}/${safeName}` : safeName
       }`;
 
       const res = await this.fetchWithBasePath(

--- a/packages/next-tinacms-s3/src/s3-media-store.ts
+++ b/packages/next-tinacms-s3/src/s3-media-store.ts
@@ -9,7 +9,7 @@ import type {
   MediaStore,
   MediaUploadOptions,
 } from 'tinacms';
-import { DEFAULT_MEDIA_UPLOAD_TYPES } from 'tinacms';
+import { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from 'tinacms';
 const s3ErrorRegex = /<Error>.*<Code>(.+)<\/Code>.*<Message>(.+)<\/Message>.*/;
 
 import { E_UNAUTHORIZED, E_BAD_ROUTE, interpretErrorMessage } from './errors';
@@ -39,10 +39,13 @@ export class S3MediaStore implements MediaStore {
       if (directory?.endsWith('/')) {
         directory = directory.substr(0, directory.length - 1);
       }
+      // Normalize/sanitize once so the upload key, the saved object, and the
+      // value persisted into content all agree.
+      const safeName = sanitizeFilename(item.file.name);
       const path = `${
         directory && directory !== '/'
-          ? `${directory}/${item.file.name}`
-          : item.file.name
+          ? `${directory}/${safeName}`
+          : safeName
       }`;
 
       const res = await this.fetchWithBasePath(
@@ -95,8 +98,8 @@ export class S3MediaStore implements MediaStore {
 
       newFiles.push({
         directory: item.directory,
-        filename: item.file.name,
-        id: item.file.name,
+        filename: safeName,
+        id: safeName,
         type: 'file',
         thumbnails: {
           '75x75': src,

--- a/packages/tinacms/src/toolkit/components/media/index.ts
+++ b/packages/tinacms/src/toolkit/components/media/index.ts
@@ -3,4 +3,4 @@ export { ListMediaItem, GridMediaItem } from './media-item';
 export { Breadcrumb } from './breadcrumb';
 export { CursorPaginator } from './pagination';
 export type { MediaPaginatorProps } from './pagination';
-export { DEFAULT_MEDIA_UPLOAD_TYPES } from './utils';
+export { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from './utils';

--- a/packages/tinacms/src/toolkit/components/media/utils.test.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeFilename } from './utils';
+
+describe('sanitizeFilename', () => {
+  it('returns simple ASCII names unchanged', () => {
+    expect(sanitizeFilename('photo.jpg')).toBe('photo.jpg');
+    expect(sanitizeFilename('My-File_01.PNG')).toBe('My-File_01.PNG');
+  });
+
+  it('NFC-normalizes decomposed Unicode', () => {
+    const decomposed = 'image-a\u0308.jpg';
+    const result = sanitizeFilename(decomposed);
+    expect(result).toBe('image-ä.jpg');
+    expect(result.normalize('NFC')).toBe(result);
+    expect(result).not.toContain('\u0308');
+  });
+
+  it('strips directory components, keeping only the filename', () => {
+    expect(sanitizeFilename('a/b/c.txt')).toBe('c.txt');
+    expect(sanitizeFilename('a\\b\\c.txt')).toBe('c.txt');
+  });
+
+  it('removes control characters', () => {
+    expect(sanitizeFilename('he\u0000llo\u0007.txt')).toBe('hello.txt');
+  });
+
+  it('replaces Windows-reserved characters with hyphens', () => {
+    expect(sanitizeFilename('a<b>c:d"e|f?g*.txt')).toBe('a-b-c-d-e-f-g.txt');
+  });
+
+  it('collapses whitespace runs into a single hyphen', () => {
+    expect(sanitizeFilename('hello   world\tagain.txt')).toBe(
+      'hello-world-again.txt'
+    );
+  });
+
+  it('trims leading and trailing dots/hyphens/whitespace from the base', () => {
+    expect(sanitizeFilename('   ...weird---.jpg')).toBe('weird.jpg');
+  });
+
+  it('keeps the final extension after the last dot', () => {
+    expect(sanitizeFilename('archive.tar.gz')).toBe('archive.tar.gz');
+  });
+
+  it('falls back to "file" when the base would otherwise be empty', () => {
+    expect(sanitizeFilename('....jpg')).toBe('file.jpg');
+    expect(sanitizeFilename('')).toBe('file');
+  });
+
+  it('handles names without an extension', () => {
+    expect(sanitizeFilename('README')).toBe('README');
+    expect(sanitizeFilename('  hello world  ')).toBe('hello-world');
+  });
+
+  it('NFC-normalizes a decomposed name from a macOS-style upload', () => {
+    // macOS exposes filenames in NFD form (e.g. "a" + combining diaeresis).
+    const decomposed = 'Aufforstungsfläche.jpg'.normalize('NFD');
+    const result = sanitizeFilename(decomposed);
+    expect(result).toBe('Aufforstungsfläche.jpg'.normalize('NFC'));
+    expect(result.normalize('NFC')).toBe(result);
+  });
+
+  it('replaces URL-breaking characters with hyphens', () => {
+    expect(sanitizeFilename('a#b%c&d.jpg')).toBe('a-b-c-d.jpg');
+  });
+
+  it('collapses runs of generated separators into one hyphen', () => {
+    expect(sanitizeFilename('a<>b.jpg')).toBe('a-b.jpg');
+  });
+
+  it('caps the base length while preserving the extension', () => {
+    const result = sanitizeFilename(`${'a'.repeat(500)}.jpg`);
+    expect(result.endsWith('.jpg')).toBe(true);
+    expect(result.length).toBeLessThanOrEqual(204);
+  });
+});

--- a/packages/tinacms/src/toolkit/components/media/utils.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.ts
@@ -44,3 +44,49 @@ export const absoluteImgURL = (str: string) => {
   if (str.startsWith('http')) return str;
   return `${window.location.origin}${str}`;
 };
+
+// Longest base name (excluding extension) we keep. Stays well under the
+// common 255-byte filesystem limit and the 1024-char S3 key limit even after
+// a directory prefix is prepended.
+const MAX_BASENAME_LENGTH = 200;
+
+/**
+ * Normalizes filenames to NFC and replaces characters that are unsafe for
+ * URLs or common filesystems with a hyphen, while preserving the extension.
+ *
+ * Example: `image-a\u0308.jpg` becomes `image-ä.jpg`,
+ * so URLs use `%C3%A4` instead of the decomposed `%CC%88` sequence.
+ */
+export const sanitizeFilename = (filename: string): string => {
+  if (!filename) return 'file';
+
+  const normalized = filename.normalize('NFC');
+  const justName = normalized.split(/[\\/]/).pop() || '';
+
+  const lastDot = justName.lastIndexOf('.');
+  const hasExt = lastDot > 0 && lastDot < justName.length - 1;
+  const rawBase = hasExt ? justName.slice(0, lastDot) : justName;
+  const rawExt = hasExt ? justName.slice(lastDot) : '';
+
+  const clean = (input: string) =>
+    input
+      .replace(/\s+/g, '-')
+      // strip control characters
+      .replace(/[\x00-\x1F\x7F]/g, '')
+      // replace characters that break URLs (#, %, &) or are reserved on
+      // common filesystems (< > : " | ? *) with a hyphen
+      .replace(/[<>:"|?*#%&]/g, '-')
+      // collapse the separator runs the steps above can introduce
+      .replace(/-+/g, '-');
+
+  let base = clean(rawBase).replace(/^[.\-]+|[.\-]+$/g, '');
+  const ext = clean(rawExt);
+
+  if (!base) base = 'file';
+
+  if (base.length > MAX_BASENAME_LENGTH) {
+    base = base.slice(0, MAX_BASENAME_LENGTH).replace(/[.\-]+$/, '') || 'file';
+  }
+
+  return `${base}${ext}`;
+};

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -1,4 +1,7 @@
-import { DEFAULT_MEDIA_UPLOAD_TYPES } from '@toolkit/components/media/utils';
+import {
+  DEFAULT_MEDIA_UPLOAD_TYPES,
+  sanitizeFilename,
+} from '@toolkit/components/media/utils';
 import type { Client } from '../../internalClient';
 import { CMS } from './cms';
 import {
@@ -16,12 +19,15 @@ const s3ErrorRegex = /<Error>.*<Code>(.+)<\/Code>.*<Message>(.+)<\/Message>.*/;
 export class DummyMediaStore implements MediaStore {
   accept = '*';
   async persist(files: MediaUploadOptions[]): Promise<Media[]> {
-    return files.map(({ directory, file }) => ({
-      id: file.name,
-      type: 'file',
-      directory,
-      filename: file.name,
-    }));
+    return files.map(({ directory, file }) => {
+      const filename = sanitizeFilename(file.name);
+      return {
+        id: filename,
+        type: 'file',
+        directory,
+        filename,
+      };
+    });
   }
   async list(): Promise<MediaList> {
     const items: Media[] = [];
@@ -142,10 +148,15 @@ export class TinaMediaStore implements MediaStore {
       if (directory?.endsWith('/')) {
         directory = directory.substr(0, directory.length - 1);
       }
+      // Normalize/sanitize once so the upload URL, the saved asset, and the
+      // value persisted into content all agree. macOS exposes filenames in
+      // NFD form; leaving them as-is leaks sequences like
+      // `Aufforstungsfla%CC%88che.jpg` into content fields.
+      const safeName = sanitizeFilename(item.file.name);
       const path = `${
         directory && directory !== '/'
-          ? `${directory}/${item.file.name}`
-          : item.file.name
+          ? `${directory}/${safeName}`
+          : safeName
       }`;
       const res = await this.api.authProvider.fetchWithToken(
         `${this.url}/upload_url/${path}${branchQuery}`,
@@ -258,7 +269,9 @@ export class TinaMediaStore implements MediaStore {
         }
       }
       for (const item of items) {
-        const entry = found.get(item.file.name);
+        // The server stores the file under the sanitized name we sent at
+        // upload time, so match the canonical listing on the same value.
+        const entry = found.get(sanitizeFilename(item.file.name));
         if (entry) results.push(entry);
       }
     }
@@ -290,6 +303,10 @@ export class TinaMediaStore implements MediaStore {
 
     for (const item of media) {
       const { file, directory } = item;
+      // Normalize/sanitize once and reuse for the FormData filename, the
+      // upload URL, the on-disk path, and the value persisted into content,
+      // so every layer agrees on the same bytes.
+      const safeName = sanitizeFilename(file.name);
       // Stripped directory does not have leading or trailing slashes
       let strippedDirectory = directory;
       if (strippedDirectory.startsWith('/')) {
@@ -301,20 +318,22 @@ export class TinaMediaStore implements MediaStore {
       }
 
       const formData = new FormData();
-      formData.append('file', file);
+      // The third arg of FormData#append overrides the part filename — pass
+      // the sanitized name so the server reads what the client expects.
+      formData.append('file', file, safeName);
       formData.append('directory', directory);
-      formData.append('filename', file.name);
+      formData.append('filename', safeName);
 
       let uploadPath = `${
-        strippedDirectory ? `${strippedDirectory}/${file.name}` : file.name
+        strippedDirectory ? `${strippedDirectory}/${safeName}` : safeName
       }`;
       if (uploadPath.startsWith('/')) {
         uploadPath = uploadPath.substr(1);
       }
       const filePath = `${
         strippedDirectory
-          ? `${folder}${strippedDirectory}/${file.name}`
-          : folder + file.name
+          ? `${folder}${strippedDirectory}/${safeName}`
+          : folder + safeName
       }`;
       const res = await this.fetchFunction(`${this.url}/upload/${uploadPath}`, {
         method: 'POST',
@@ -330,8 +349,8 @@ export class TinaMediaStore implements MediaStore {
       if (fileRes?.success) {
         const parsedRes: Media = {
           type: 'file',
-          id: file.name,
-          filename: file.name,
+          id: safeName,
+          filename: safeName,
           directory,
           src: filePath,
           thumbnails: {

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -154,9 +154,7 @@ export class TinaMediaStore implements MediaStore {
       // `Aufforstungsfla%CC%88che.jpg` into content fields.
       const safeName = sanitizeFilename(item.file.name);
       const path = `${
-        directory && directory !== '/'
-          ? `${directory}/${safeName}`
-          : safeName
+        directory && directory !== '/' ? `${directory}/${safeName}` : safeName
       }`;
       const res = await this.api.authProvider.fetchWithToken(
         `${this.url}/upload_url/${path}${branchQuery}`,

--- a/packages/tinacms/src/toolkit/index.ts
+++ b/packages/tinacms/src/toolkit/index.ts
@@ -67,4 +67,4 @@ export type { TinaUIProps } from './components/tina-ui';
 
 export { useLocalStorage } from './hooks/use-local-storage';
 export { CursorPaginator } from './components/media/pagination';
-export { DEFAULT_MEDIA_UPLOAD_TYPES } from './components/media';
+export { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from './components/media';

--- a/packages/tinacms/src/toolkit/index.ts
+++ b/packages/tinacms/src/toolkit/index.ts
@@ -67,4 +67,7 @@ export type { TinaUIProps } from './components/tina-ui';
 
 export { useLocalStorage } from './hooks/use-local-storage';
 export { CursorPaginator } from './components/media/pagination';
-export { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from './components/media';
+export {
+  DEFAULT_MEDIA_UPLOAD_TYPES,
+  sanitizeFilename,
+} from './components/media';


### PR DESCRIPTION
## What

Sanitize and normalize uploaded media filenames so they stay consistent across operating systems, git, and the URLs that end up in content.

Closes #6359

## Why

Filenames were passed through to the media stores verbatim. This caused two problems:

- Names exposed in decomposed (NFD) form — common on macOS — were percent-encoded into content fields as multi-codepoint sequences, producing image URLs that didn't resolve on the frontend.
- Special characters and inconsistent casing could break URLs or be recognized differently across filesystems and git.

## What changed

- Added a shared `sanitizeFilename` helper (`packages/tinacms/src/toolkit/components/media/utils.ts`) that:
  - normalizes to NFC so a single codepoint is encoded in URLs
  - replaces URL-breaking (`# % &`) and filesystem-reserved (`< > : " | ? *`) characters with hyphens, collapsing the resulting runs
  - strips control characters and any path components
  - caps the base-name length while preserving the extension
- Applied it in the default, S3, Azure, Cloudinary, and DigitalOcean Spaces media stores, so the upload key, the stored asset, and the value persisted into content all agree.
- Exported the helper from `tinacms` and added unit tests.

## Testing

- `vitest run` on the new `utils.test.ts` — 14/14 passing (covers NFC normalization, macOS-style NFD input, URL/filesystem-unsafe characters, separator collapsing, length cap, and fallbacks).

## Notes

Sanitization is applied client-side at upload time. Editors who have already uploaded files with affected names will need to re-upload them to pick up the normalized name.
