### PR TITLE
Harden Forestry migration code generation against untrusted input

### DIFF
--- a/.changeset/perky-ears-serve.md
+++ b/.changeset/perky-ears-serve.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": patch
+---
+
+Harden Forestry migration code generation against untrusted input

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/index.ts
@@ -18,6 +18,7 @@ import {
   makeTemplateFile,
   makeFieldsWithInternalCode,
 } from './util/codeTransformer';
+import { stringifyLabel, stringifyLabelWithField } from './util/naming';
 
 const BODY_FIELD = {
   // This is the body field
@@ -28,13 +29,7 @@ const BODY_FIELD = {
   isBody: true,
 };
 
-export const stringifyLabel = (label: string) => {
-  return label.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
-};
-export const stringifyLabelWithField = (label: string) => {
-  const labelString = stringifyLabel(label);
-  return `${labelString}Fields`;
-};
+export { stringifyLabel, stringifyLabelWithField };
 const transformForestryMatchToTinaMatch = (match: string) => {
   const newMatch = match
     // remove white space

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/codeTransformer.test.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/codeTransformer.test.ts
@@ -1,0 +1,111 @@
+import type { TinaField } from '@tinacms/schema-tools';
+import {
+  addVariablesToCode,
+  makeFieldsWithInternalCode,
+  makeTemplateFile,
+} from './codeTransformer';
+
+// Characterization + regression tests for the Forestry-migration code
+// generator. The generator round-trips generated code expressions through a
+// `JSON.stringify` pass using an internal marker, then un-quotes the marked
+// values back into raw source. User-authored Forestry YAML (labels, names,
+// etc.) flows through the *same* `JSON.stringify` call, so the marker must not
+// be forgeable from user data.
+
+describe('addVariablesToCode (internal marker round-trip)', () => {
+  it('un-quotes an internally generated spread marker into raw code', () => {
+    const marker = makeFieldsWithInternalCode({
+      hasBody: false,
+      field: 'myTemplateFields',
+      spread: true,
+    }) as string;
+
+    const { code } = addVariablesToCode(JSON.stringify([marker]));
+
+    // The marker is emitted as a bare spread call, no longer a quoted string.
+    expect(code).toContain('...myTemplateFields()');
+    expect(code).not.toContain('"...myTemplateFields()"');
+  });
+
+  it('un-quotes an internally generated (non-spread) marker into raw code', () => {
+    const marker = makeFieldsWithInternalCode({
+      hasBody: false,
+      field: 'myTemplateFields',
+    }) as string;
+
+    const { code } = addVariablesToCode(JSON.stringify([marker]));
+
+    expect(code).toContain('myTemplateFields()');
+    expect(code).not.toContain('"myTemplateFields()"');
+  });
+
+  it('leaves ordinary JSON string values untouched', () => {
+    const fields = [{ type: 'string', name: 'title', label: 'Title' }];
+
+    const { code } = addVariablesToCode(JSON.stringify(fields, null, 2));
+
+    expect(code).toContain('"label": "Title"');
+  });
+});
+
+describe('makeTemplateFile (legitimate generation)', () => {
+  it('emits a fields function whose body is the stringified field array', async () => {
+    const fields = [
+      { type: 'string', name: 'title', label: 'Title' },
+    ] as TinaField[];
+    const templateMap = new Map([
+      ['post', { fields, templateObj: { label: 'Post' } }],
+    ]);
+
+    const { importStatements, templateCodeText } = await makeTemplateFile({
+      templateMap,
+      usingTypescript: true,
+    });
+
+    expect(importStatements).toEqual([
+      `import { postFields } from './templates'`,
+    ]);
+    expect(templateCodeText).toContain('export function postFields()');
+    expect(templateCodeText).toContain('name: "title"');
+    expect(templateCodeText).toContain('label: "Title"');
+  });
+});
+
+describe('addVariablesToCode (code-injection hardening)', () => {
+  // Regression test: a user-controlled label/name carrying the marker sentinel
+  // must stay inert data and never be emitted as a bare (executable) identifier.
+  it('does not un-quote a user-controlled label wearing the marker sentinel', () => {
+    const userControlledLabel = '__TINA_INTERNAL__:::INJECTED_TOKEN:::';
+    const fields = [
+      { type: 'string', name: 'title', label: userControlledLabel },
+    ];
+
+    const { code } = addVariablesToCode(JSON.stringify(fields, null, 2));
+
+    // Must remain a quoted string (preserved, not silently dropped)...
+    expect(code).toContain(`"${userControlledLabel}"`);
+    // ...and must NOT become a bare identifier assigned to the label key.
+    expect(code).not.toMatch(/"label":\s*INJECTED_TOKEN/);
+  });
+});
+
+describe('makeTemplateFile (code-injection hardening)', () => {
+  it('keeps a user-controlled label wearing the marker sentinel as a string', async () => {
+    const userControlledLabel = '__TINA_INTERNAL__:::INJECTED_TOKEN:::';
+    const fields = [
+      { type: 'string', name: 'title', label: userControlledLabel },
+    ] as unknown as TinaField[];
+    const templateMap = new Map([
+      ['post', { fields, templateObj: { label: 'Post' } }],
+    ]);
+
+    const { templateCodeText } = await makeTemplateFile({
+      templateMap,
+      usingTypescript: true,
+    });
+
+    expect(templateCodeText).toContain(userControlledLabel);
+    // Prettier emits unquoted keys, so an injection would read `label: INJECTED_TOKEN`.
+    expect(templateCodeText).not.toMatch(/label:\s*INJECTED_TOKEN/);
+  });
+});

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/codeTransformer.test.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/codeTransformer.test.ts
@@ -4,6 +4,7 @@ import {
   makeFieldsWithInternalCode,
   makeTemplateFile,
 } from './codeTransformer';
+import { isForestrySafeString } from './naming';
 
 // Characterization + regression tests for the Forestry-migration code
 // generator. The generator round-trips generated code expressions through a
@@ -86,6 +87,49 @@ describe('addVariablesToCode (code-injection hardening)', () => {
     expect(code).toContain(`"${userControlledLabel}"`);
     // ...and must NOT become a bare identifier assigned to the label key.
     expect(code).not.toMatch(/"label":\s*INJECTED_TOKEN/);
+  });
+});
+
+describe('addVariablesToCode (mixed trusted + untrusted in one pass)', () => {
+  // Mirrors the real `apply.ts` collections path: a single JSON.stringify pass
+  // carries both a generator-produced marker (which must be un-quoted into code)
+  // and a user-controlled label wearing the public sentinel (which must not).
+  it('un-quotes the generator marker but never the user-supplied sentinel', () => {
+    const legitMarker = makeFieldsWithInternalCode({
+      hasBody: false,
+      field: 'heroFields',
+      spread: true,
+    }) as string;
+    const userControlledLabel = '__TINA_INTERNAL__:::INJECTED_TOKEN:::';
+
+    const payload = [
+      legitMarker,
+      { type: 'string', name: 'title', label: userControlledLabel },
+    ];
+
+    const { code } = addVariablesToCode(JSON.stringify(payload, null, 2));
+
+    // Trusted marker becomes bare code...
+    expect(code).toContain('...heroFields()');
+    expect(code).not.toContain('"...heroFields()"');
+    // ...while the untrusted look-alike stays an inert quoted string.
+    expect(code).toContain(`"${userControlledLabel}"`);
+    expect(code).not.toMatch(/"label":\s*INJECTED_TOKEN/);
+  });
+});
+
+describe('isForestrySafeString (defence-in-depth input guard)', () => {
+  it('accepts ordinary single-line names and labels', () => {
+    expect(isForestrySafeString('Title')).toBe(true);
+    expect(isForestrySafeString('Hero Block')).toBe(true);
+    expect(isForestrySafeString('field_name-1')).toBe(true);
+    expect(isForestrySafeString('')).toBe(true);
+  });
+
+  it('rejects NUL bytes and newlines that never occur in real Forestry config', () => {
+    expect(isForestrySafeString('a\x00b')).toBe(false);
+    expect(isForestrySafeString('line1\nline2')).toBe(false);
+    expect(isForestrySafeString('line1\r\nline2')).toBe(false);
   });
 });
 

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/codeTransformer.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/codeTransformer.ts
@@ -1,23 +1,43 @@
+import crypto from 'crypto';
 import path from 'path';
 import fs from 'fs-extra';
 import { TinaField } from '@tinacms/schema-tools';
 import { format } from 'prettier';
 import TsParser from 'prettier/parser-typescript.js';
-import { stringifyLabelWithField } from '..';
+import { stringifyLabelWithField } from './naming';
+
+/**
+ * Internal marker used to smuggle generated code expressions through the
+ * `JSON.stringify` pass and back out as un-quoted source.
+ *
+ * The delimiters embed a per-process random nonce. Field arrays passed to
+ * `addVariablesToCode` mix internally generated markers with user-authored
+ * Forestry content (labels, names, option values, ...) that flows through the
+ * same `JSON.stringify` call. Without the nonce, a user-supplied string could
+ * reproduce the marker and have its contents emitted as executable code. The
+ * nonce is unguessable, so only the generator can produce a marker the
+ * un-quoter will act on.
+ *
+ * Hex contains no JSON- or RegExp-special characters, so the marker survives
+ * `JSON.stringify` byte-for-byte and needs no escaping when built into the
+ * RegExp. It only has to be stable within a single migration run (markers are
+ * stripped before the file is written), so a per-process value is sufficient.
+ */
+const INTERNAL_NONCE = crypto.randomBytes(16).toString('hex');
+const MARKER_OPEN = `__TINA_INTERNAL_${INTERNAL_NONCE}__:::`;
+const MARKER_CLOSE = `:::__TINA_INTERNAL_${INTERNAL_NONCE}__`;
+const MARKER_REGEX = new RegExp(`"${MARKER_OPEN}(.*?)${MARKER_CLOSE}"`, 'g');
 
 /**
  * This function is used to replace the internal code with the actual code
  *
  * EX:
- *  __TINA_INTERNAL__:::...fields::: => ...fields
+ *  <marker>...fields()<marker> => ...fields()
  *
- * or __TINA_INTERNAL__:::fields::: => fields
+ * or <marker>fields()<marker> => fields()
  */
 export const addVariablesToCode = (codeWithTinaPrefix: string) => {
-  const code = codeWithTinaPrefix.replace(
-    /"__TINA_INTERNAL__:::(.*?):::"/g,
-    '$1'
-  );
+  const code = codeWithTinaPrefix.replace(MARKER_REGEX, '$1');
   return { code };
 };
 
@@ -46,10 +66,10 @@ export const makeFieldsWithInternalCode = ({
       bodyField: unknown;
     }) => {
   if (hasBody) {
-    return [bodyField, `__TINA_INTERNAL__:::...${field}():::`];
+    return [bodyField, `${MARKER_OPEN}...${field}()${MARKER_CLOSE}`];
   } else {
-    if (spread) return `__TINA_INTERNAL__:::...${field}():::`;
-    return `__TINA_INTERNAL__:::${field}():::`;
+    if (spread) return `${MARKER_OPEN}...${field}()${MARKER_CLOSE}`;
+    return `${MARKER_OPEN}${field}()${MARKER_CLOSE}`;
   }
 };
 

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/index.ts
@@ -6,7 +6,7 @@ import type { TinaField, Template } from '@tinacms/schema-tools';
 import { logger } from '../../../logger';
 import { warnText } from '../../../utils/theme';
 import { ErrorSingleton } from './errorSingleton';
-import { stringifyLabelWithField } from './naming';
+import { isForestrySafeString, stringifyLabelWithField } from './naming';
 import { makeFieldsWithInternalCode } from './codeTransformer';
 
 const errorSingletonInstance = ErrorSingleton.getInstance();
@@ -39,6 +39,14 @@ export const stringifyTemplateName = (name: string, template: string) => {
     return newName;
   }
 };
+// Reject control characters in names/labels at parse time. This is a
+// defence-in-depth guard layered on top of the un-forgeable code-generation
+// marker — it fails the migration closed rather than carrying unexpected
+// bytes into the generated source.
+const forestrySafeString = z.string().refine(isForestrySafeString, {
+  message: 'Forestry name/label contains an unexpected control character',
+});
+
 // A zod schema for the information we need from the .forestry/settings.yml file
 const forestryConfigSchema = z.object({
   sections: z.array(
@@ -84,8 +92,8 @@ const forestryFieldWithoutField = z.object({
     z.literal('color'),
   ]),
   template_types: z.array(z.string()).optional().nullable(),
-  name: z.string(),
-  label: z.string(),
+  name: forestrySafeString,
+  label: forestrySafeString,
   default: z.any().optional(),
   template: z.string().optional(),
   config: z
@@ -130,7 +138,7 @@ const forestryField: z.ZodType<ForestryFieldType> = z.lazy(() =>
 );
 
 const FrontmatterTemplateSchema = z.object({
-  label: z.string(),
+  label: forestrySafeString,
   hide_body: z.boolean().optional(),
   fields: z.array(forestryField).optional(),
 });

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/index.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/index.ts
@@ -6,7 +6,7 @@ import type { TinaField, Template } from '@tinacms/schema-tools';
 import { logger } from '../../../logger';
 import { warnText } from '../../../utils/theme';
 import { ErrorSingleton } from './errorSingleton';
-import { stringifyLabelWithField } from '..';
+import { stringifyLabelWithField } from './naming';
 import { makeFieldsWithInternalCode } from './codeTransformer';
 
 const errorSingletonInstance = ErrorSingleton.getInstance();

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/naming.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/naming.ts
@@ -13,3 +13,10 @@ export const stringifyLabelWithField = (label: string) => {
   const labelString = stringifyLabel(label);
   return `${labelString}Fields`;
 };
+
+// Forestry field/template names and labels are single-line plain text.
+// Control characters (NUL, carriage return, newline) never appear in
+// legitimate Forestry config, so callers reject them at parse time as a
+// defence-in-depth guard on the generated source.
+export const isForestrySafeString = (value: string) =>
+  !/[\x00\r\n]/.test(value);

--- a/packages/@tinacms/cli/src/cmds/forestry-migrate/util/naming.ts
+++ b/packages/@tinacms/cli/src/cmds/forestry-migrate/util/naming.ts
@@ -1,0 +1,15 @@
+// Pure naming helpers shared by the Forestry migration code generator.
+//
+// These live in a dependency-free leaf module so that `codeTransformer.ts`
+// (and `util/index.ts`) can use them without importing the package's heavy
+// `forestry-migrate/index.ts` graph (`@tinacms/graphql`, `chalk`, etc.), which
+// previously created a circular import.
+
+export const stringifyLabel = (label: string) => {
+  return label.replace(/[^a-zA-Z0-9]/g, '_').toLowerCase();
+};
+
+export const stringifyLabelWithField = (label: string) => {
+  const labelString = stringifyLabel(label);
+  return `${labelString}Fields`;
+};


### PR DESCRIPTION
This closes [#3593](https://github.com/tinacms/tinacloud/issues/3598)

The Forestry migrator serializes field definitions and un-quotes generator-produced expressions via an internal marker. Make that marker unforgeable with a per-process random nonce so values originating from migration input cannot be emitted as executable code in the generated template file.

Also extract the pure naming helpers (stringifyLabel, stringifyLabelWithField) into a dependency-free util/naming module, breaking a circular import so the code generator is unit-testable in isolation. Adds regression tests for the marker round-trip and the hardening.
