### PR TITLE
🧹 Derive supported Node versions from a single source of truth

### DIFF
--- a/.changeset/node-version-ssot.md
+++ b/.changeset/node-version-ssot.md
@@ -1,0 +1,5 @@
+---
+"create-tina-app": patch
+---
+
+Derive supported Node versions from `engines.node` instead of a hardcoded list.

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -14,39 +14,14 @@ on:
         default: ''
         type: string
   schedule:
-    # Daily at 09:00 UTC. The workflow's full matrix (7 templates × 3 PMs ×
-    # the supported Node majors, derived from root engines.node) is the broader
-    # safety net for starter-template drift — daily cadence keeps worst-case
-    # detection latency under ~1 day, so a regression that lands today gets
-    # caught tomorrow, not next week.
+    # Daily at 09:00 UTC. The workflow's full matrix (7 templates × 3 PMs × 2
+    # Node versions = 42 jobs) is the broader safety net for starter-template
+    # drift — daily cadence keeps worst-case detection latency under ~1 day,
+    # so a regression that lands today gets caught tomorrow, not next week.
     - cron: '0 9 * * *'
 
 jobs:
-  # Single source of truth for supported Node versions is the root package.json
-  # `engines.node` (e.g. "22.x || 24.x"). Parse it into the build matrix here so
-  # the matrix can never drift from what we declare, and fail fast if
-  # create-tina-app's own engines (which ships to npm and drives the CLI's
-  # runtime check) has diverged from root.
-  resolve-node:
-    runs-on: ubuntu-latest
-    outputs:
-      majors: ${{ steps.versions.outputs.majors }}
-    steps:
-      - uses: actions/checkout@v4
-      - id: versions
-        run: |
-          ROOT=$(node -e "process.stdout.write(require('./package.json').engines.node)")
-          CTA=$(node -e "process.stdout.write(require('./packages/create-tina-app/package.json').engines.node)")
-          if [ "$ROOT" != "$CTA" ]; then
-            echo "::error::engines.node drift — root='$ROOT' create-tina-app='$CTA'. Keep them in sync."
-            exit 1
-          fi
-          MAJORS=$(node -e "console.log(JSON.stringify([...process.argv[1].matchAll(/(\d+)\.x/g)].map(m=>+m[1])))" "$ROOT")
-          echo "Supported Node majors: $MAJORS"
-          echo "majors=$MAJORS" >> "$GITHUB_OUTPUT"
-
   build-templates:
-    needs: resolve-node
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -60,7 +35,7 @@ jobs:
           - tina-docs
           - tinasaurus
           - basic
-        node-version: ${{ fromJSON(needs.resolve-node.outputs.majors) }}
+        node-version: [22, 24]
     outputs:
       failed: ${{ steps.report-errors.outputs.failed }}
 

--- a/.github/workflows/build-starter-templates.yml
+++ b/.github/workflows/build-starter-templates.yml
@@ -14,14 +14,39 @@ on:
         default: ''
         type: string
   schedule:
-    # Daily at 09:00 UTC. The workflow's full matrix (7 templates × 3 PMs × 3
-    # Node versions = 63 jobs) is the broader safety net for starter-template
-    # drift — daily cadence keeps worst-case detection latency under ~1 day,
-    # so a regression that lands today gets caught tomorrow, not next week.
+    # Daily at 09:00 UTC. The workflow's full matrix (7 templates × 3 PMs ×
+    # the supported Node majors, derived from root engines.node) is the broader
+    # safety net for starter-template drift — daily cadence keeps worst-case
+    # detection latency under ~1 day, so a regression that lands today gets
+    # caught tomorrow, not next week.
     - cron: '0 9 * * *'
 
 jobs:
+  # Single source of truth for supported Node versions is the root package.json
+  # `engines.node` (e.g. "22.x || 24.x"). Parse it into the build matrix here so
+  # the matrix can never drift from what we declare, and fail fast if
+  # create-tina-app's own engines (which ships to npm and drives the CLI's
+  # runtime check) has diverged from root.
+  resolve-node:
+    runs-on: ubuntu-latest
+    outputs:
+      majors: ${{ steps.versions.outputs.majors }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: versions
+        run: |
+          ROOT=$(node -e "process.stdout.write(require('./package.json').engines.node)")
+          CTA=$(node -e "process.stdout.write(require('./packages/create-tina-app/package.json').engines.node)")
+          if [ "$ROOT" != "$CTA" ]; then
+            echo "::error::engines.node drift — root='$ROOT' create-tina-app='$CTA'. Keep them in sync."
+            exit 1
+          fi
+          MAJORS=$(node -e "console.log(JSON.stringify([...process.argv[1].matchAll(/(\d+)\.x/g)].map(m=>+m[1])))" "$ROOT")
+          echo "Supported Node majors: $MAJORS"
+          echo "majors=$MAJORS" >> "$GITHUB_OUTPUT"
+
   build-templates:
+    needs: resolve-node
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -35,7 +60,7 @@ jobs:
           - tina-docs
           - tinasaurus
           - basic
-        node-version: [22, 24, 25]
+        node-version: ${{ fromJSON(needs.resolve-node.outputs.majors) }}
     outputs:
       failed: ${{ steps.report-errors.outputs.failed }}
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
 		"examples/*/*",
 		"packages/[^@]*"
 	],
+	"engines": {
+		"node": "22.x || 24.x"
+	},
 	"scripts": {
 		"dev": "pnpm watch",
 		"watch": "pnpm run build && pnpm --filter=\"./packages/@tinacms/scripts\" run watch",

--- a/packages/create-tina-app/package.json
+++ b/packages/create-tina-app/package.json
@@ -20,7 +20,7 @@
         ]
     },
     "engines": {
-        "node": ">=18.18.0"
+        "node": "22.x || 24.x"
     },
     "scripts": {
         "types": "pnpm tsc",

--- a/packages/create-tina-app/src/util/preRunChecks.ts
+++ b/packages/create-tina-app/src/util/preRunChecks.ts
@@ -8,20 +8,19 @@ import { Ora } from 'ora';
 // must declare its own supported versions — the repo root isn't available at
 // runtime.
 function getSupportedMajors(): number[] {
+  // The published CLI runs from the bundled dist/index.js, so ../package.json
+  // resolves to this package's own package.json.
   const here = dirname(fileURLToPath(import.meta.url));
-  // bundled: dist/index.js -> ../package.json ; source: src/util -> ../../package.json
-  for (const rel of ['../package.json', '../../package.json']) {
-    try {
-      const { engines } = JSON.parse(readFileSync(join(here, rel), 'utf8'));
-      const majors = [...String(engines?.node ?? '').matchAll(/(\d+)\.x/g)].map(
-        (m) => Number(m[1])
-      );
-      if (majors.length) return majors;
-    } catch {
-      // try the next candidate path
-    }
+  try {
+    const { engines } = JSON.parse(
+      readFileSync(join(here, '../package.json'), 'utf8')
+    );
+    return [...String(engines?.node ?? '').matchAll(/(\d+)\.x/g)].map((m) =>
+      Number(m[1])
+    );
+  } catch {
+    return [];
   }
-  return [];
 }
 
 export function preRunChecks(spinner: Ora) {

--- a/packages/create-tina-app/src/util/preRunChecks.ts
+++ b/packages/create-tina-app/src/util/preRunChecks.ts
@@ -1,20 +1,44 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Ora } from 'ora';
 
-const SUPPORTED_NODE_VERSION_BOUNDS = { oldest: 20, latest: 22 };
-const SUPPORTED_NODE_VERSION_RANGE: number[] = [
-  ...Array(SUPPORTED_NODE_VERSION_BOUNDS.latest).keys(),
-].map((i) => i + SUPPORTED_NODE_VERSION_BOUNDS.oldest);
-const isSupported = SUPPORTED_NODE_VERSION_RANGE.some((version) =>
-  process.version.startsWith(`v${version}`)
-);
+// Supported Node majors are derived from this package's own `engines.node`
+// (e.g. "22.x || 24.x"), which is the single source of truth kept in sync with
+// the repo root package.json. We can't read the root at runtime — only this
+// package's files ship in the npm tarball — so the value is mirrored here and a
+// CI drift-check guards the two from diverging.
+function getSupportedMajors(): number[] {
+  const here = dirname(fileURLToPath(import.meta.url));
+  // bundled: dist/index.js -> ../package.json ; source: src/util -> ../../package.json
+  for (const rel of ['../package.json', '../../package.json']) {
+    try {
+      const { engines } = JSON.parse(readFileSync(join(here, rel), 'utf8'));
+      const majors = [...String(engines?.node ?? '').matchAll(/(\d+)\.x/g)].map(
+        (m) => Number(m[1])
+      );
+      if (majors.length) return majors;
+    } catch {
+      // try the next candidate path
+    }
+  }
+  return [];
+}
 
 export function preRunChecks(spinner: Ora) {
   spinner.start('Running pre-run checks...');
 
+  const supported = getSupportedMajors();
+  const currentMajor = Number(process.versions.node.split('.')[0]);
+  const isSupported = supported.includes(currentMajor);
+
   if (!isSupported) {
+    const range = supported.length
+      ? supported.map((v) => `v${v}`).join(' or ')
+      : 'a supported LTS version';
     spinner.warn(
       `Node ${process.version} is not supported by create-tina-app. ` +
-        `Please update to be within v${SUPPORTED_NODE_VERSION_BOUNDS.oldest}-v${SUPPORTED_NODE_VERSION_BOUNDS.latest}. ` +
+        `Please use ${range}. ` +
         `See https://nodejs.org/en/download/ for more details.`
     );
   } else {

--- a/packages/create-tina-app/src/util/preRunChecks.ts
+++ b/packages/create-tina-app/src/util/preRunChecks.ts
@@ -4,10 +4,9 @@ import { fileURLToPath } from 'node:url';
 import { Ora } from 'ora';
 
 // Supported Node majors are derived from this package's own `engines.node`
-// (e.g. "22.x || 24.x"), which is the single source of truth kept in sync with
-// the repo root package.json. We can't read the root at runtime — only this
-// package's files ship in the npm tarball — so the value is mirrored here and a
-// CI drift-check guards the two from diverging.
+// (e.g. "22.x || 24.x"). This package is published and run standalone, so it
+// must declare its own supported versions — the repo root isn't available at
+// runtime.
 function getSupportedMajors(): number[] {
   const here = dirname(fileURLToPath(import.meta.url));
   // bundled: dist/index.js -> ../package.json ; source: src/util -> ../../package.json


### PR DESCRIPTION
## TL;DR

`create-tina-app` hardcoded its supported Node versions in a bounds constant that, due to an off-by-design bug, accepted v20–v41 instead of the intended v20–v22. This makes `engines.node` the source of truth for the CLI's runtime check instead.

## Why

Per #4822, supported versions were hardcoded and had drifted — `engines` said `>=18.18.0` (Node 18 is EOL) while the CLI bounds said 20–22, and the bounds math was wrong on top of that.

## How

- `create-tina-app`'s `engines.node` (`22.x || 24.x`) is the source of truth for the CLI.
- `preRunChecks` reads that `engines` value at runtime and parses the supported majors, replacing the buggy bounds constant.
- Root `package.json` gains the same `engines.node` for the dev environment.
- The starter-template CI matrix is set to `[22, 24]`.

## Reviewer notes

- **LTS-only.** Node 18 (EOL) and odd/non-LTS lines are no longer accepted; the CLI now allows 22 and 24.

## Follow-up

The supported versions are still edited by hand. A scheduled job that bumps `engines.node` when Node's LTS set changes (e.g. when 26 promotes to LTS) would make it fully dynamic — out of scope here.

## Links

- Closes #4822