### PR TITLE
🐛 Skip filesystem cache on edge runtimes to prevent client hang

### DIFF
--- a/.changeset/astro-cloudflare-import-meta-url.md
+++ b/.changeset/astro-cloudflare-import-meta-url.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/astro": patch
+---
+
+Make the experimental island route work under the `@astrojs/cloudflare` adapter by supplying a valid `import.meta.url` to server bundles only. Adds a `cloudflareWorkers` option to force the workaround on or off.

--- a/.changeset/edge-cache-skip.md
+++ b/.changeset/edge-cache-skip.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Skip the filesystem-backed response cache on edge runtimes (Cloudflare Workers, Vercel Edge) where Node's `fs` API is present but unusable, which could otherwise hang concurrent identical queries. Adds a `cache` option to `createClient` to force-disable the cache.

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -176,9 +176,9 @@ describe('tina() integration — cloudflare import.meta.url plugin', () => {
     expect(runConfigEnvironment(plugin, 'ssr')).toBeUndefined();
     // The same plugin instance picks up the adapter once config:done runs.
     runConfigDone(integration, '@astrojs/cloudflare');
-    expect(runConfigEnvironment(plugin, 'ssr')?.define?.['import.meta.url']).toBe(
-      EXPECTED
-    );
+    expect(
+      runConfigEnvironment(plugin, 'ssr')?.define?.['import.meta.url']
+    ).toBe(EXPECTED);
   });
 
   it('honours the cloudflareWorkers option override', () => {
@@ -194,7 +194,9 @@ describe('tina() integration — cloudflare import.meta.url plugin', () => {
     // Force off, even with the Cloudflare adapter.
     const forcedOff = runConfigSetup({ cloudflareWorkers: false });
     runConfigDone(forcedOff.integration, '@astrojs/cloudflare');
-    expect(runConfigEnvironment(cfPlugin(forcedOff.plugins), 'ssr')).toBeUndefined();
+    expect(
+      runConfigEnvironment(cfPlugin(forcedOff.plugins), 'ssr')
+    ).toBeUndefined();
   });
 });
 

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -12,11 +12,11 @@ type ConfigSetupArg = Parameters<NonNullable<Hooks['astro:config:setup']>>[0];
 type ConfigDoneArg = Parameters<NonNullable<Hooks['astro:config:done']>>[0];
 type BuildDoneArg = Parameters<NonNullable<Hooks['astro:build:done']>>[0];
 
-function runConfigSetup() {
+function runConfigSetup(options?: Parameters<typeof tina>[0]) {
   const addMiddleware = vi.fn();
   const updateConfig = vi.fn();
   const logger = { warn: vi.fn(), info: vi.fn() };
-  const integration = tina();
+  const integration = tina(options);
   (
     integration.hooks['astro:config:setup'] as NonNullable<
       Hooks['astro:config:setup']
@@ -26,6 +26,34 @@ function runConfigSetup() {
   const plugins: VitePlugin[] =
     updateConfig.mock.calls[0]?.[0]?.vite?.plugins ?? [];
   return { integration, addMiddleware, updateConfig, logger, plugins };
+}
+
+// Drive the astro:config:done hook with a chosen adapter so the integration can
+// resolve whether the Cloudflare workaround should apply.
+function runConfigDone(integration: AstroIntegration, adapterName?: string) {
+  (
+    integration.hooks['astro:config:done'] as NonNullable<
+      Hooks['astro:config:done']
+    >
+  )({
+    config: {
+      build: { client: pathToFileURL('/tmp/tina-client/') },
+      adapter: adapterName ? { name: adapterName, hooks: {} } : undefined,
+    },
+  } as unknown as ConfigDoneArg);
+}
+
+const cfPlugin = (plugins: VitePlugin[]) =>
+  plugins.find(
+    (p) => p.name === '@tinacms/astro:cloudflare-import-meta-url'
+  ) as VitePlugin;
+
+// Invoke a plugin's `configEnvironment` hook (a function in our plugin) without
+// a real Vite environment — it only branches on the environment name.
+function runConfigEnvironment(plugin: VitePlugin, name: string) {
+  const hook = plugin.configEnvironment as any;
+  const fn = typeof hook === 'function' ? hook : hook?.handler;
+  return fn?.call({}, name, {}, {});
 }
 
 // Drive a Vite plugin's `configureServer` and capture the request handler it
@@ -93,6 +121,80 @@ describe('tina() integration — bridge dev plugin', () => {
 
     expect(next).toHaveBeenCalledOnce();
     expect(res.body).toBeUndefined();
+  });
+});
+
+describe('tina() integration — cloudflare import.meta.url plugin', () => {
+  const EXPECTED = JSON.stringify('file:///worker.mjs');
+
+  it('injects a valid import.meta.url define for the workerd server envs under the cloudflare adapter', () => {
+    const { integration, plugins } = runConfigSetup();
+    runConfigDone(integration, '@astrojs/cloudflare');
+    const plugin = cfPlugin(plugins);
+    expect(plugin).toBeDefined();
+
+    for (const env of ['ssr', 'astro']) {
+      const result = runConfigEnvironment(plugin, env);
+      expect(result?.define?.['import.meta.url']).toBe(EXPECTED);
+      // The placeholder must itself be a valid absolute URL.
+      expect(
+        () => new URL(JSON.parse(result.define['import.meta.url']))
+      ).not.toThrow();
+    }
+  });
+
+  it('never injects the define into the client or prerender envs', () => {
+    const { integration, plugins } = runConfigSetup();
+    runConfigDone(integration, '@astrojs/cloudflare');
+    const plugin = cfPlugin(plugins);
+    // `client` keeps the real import.meta.url; `prerender` may run in Node.
+    expect(runConfigEnvironment(plugin, 'client')).toBeUndefined();
+    expect(runConfigEnvironment(plugin, 'prerender')).toBeUndefined();
+  });
+
+  it('does not inject the define for non-cloudflare adapters', () => {
+    for (const adapter of ['@astrojs/node', '@astrojs/vercel']) {
+      const { integration, plugins } = runConfigSetup();
+      runConfigDone(integration, adapter);
+      const plugin = cfPlugin(plugins);
+      for (const env of ['ssr', 'prerender', 'astro', 'client']) {
+        expect(runConfigEnvironment(plugin, env)).toBeUndefined();
+      }
+    }
+  });
+
+  it('does not inject the define when no adapter is configured', () => {
+    const { integration, plugins } = runConfigSetup();
+    runConfigDone(integration);
+    expect(runConfigEnvironment(cfPlugin(plugins), 'ssr')).toBeUndefined();
+  });
+
+  it('reads the adapter flag lazily, after config:done', () => {
+    const { integration, plugins } = runConfigSetup();
+    const plugin = cfPlugin(plugins);
+    // Before config:done the flag is false, so the plugin is inert.
+    expect(runConfigEnvironment(plugin, 'ssr')).toBeUndefined();
+    // The same plugin instance picks up the adapter once config:done runs.
+    runConfigDone(integration, '@astrojs/cloudflare');
+    expect(runConfigEnvironment(plugin, 'ssr')?.define?.['import.meta.url']).toBe(
+      EXPECTED
+    );
+  });
+
+  it('honours the cloudflareWorkers option override', () => {
+    // Force on, even with a Node adapter.
+    const forcedOn = runConfigSetup({ cloudflareWorkers: true });
+    runConfigDone(forcedOn.integration, '@astrojs/node');
+    expect(
+      runConfigEnvironment(cfPlugin(forcedOn.plugins), 'ssr')?.define?.[
+        'import.meta.url'
+      ]
+    ).toBe(EXPECTED);
+
+    // Force off, even with the Cloudflare adapter.
+    const forcedOff = runConfigSetup({ cloudflareWorkers: false });
+    runConfigDone(forcedOff.integration, '@astrojs/cloudflare');
+    expect(runConfigEnvironment(cfPlugin(forcedOff.plugins), 'ssr')).toBeUndefined();
   });
 });
 

--- a/packages/@tinacms/astro/src/integration.ts
+++ b/packages/@tinacms/astro/src/integration.ts
@@ -7,10 +7,31 @@ import type { Plugin as VitePlugin } from 'vite';
 
 export interface TinaIntegrationOptions {
   middlewareOrder?: 'pre' | 'post';
+  /**
+   * Force the Cloudflare Workers (workerd) `import.meta.url` workaround on or
+   * off. When omitted, it is applied automatically whenever the
+   * `@astrojs/cloudflare` adapter is detected. Set `false` to opt out, or
+   * `true` to force it for a custom Cloudflare setup.
+   */
+  cloudflareWorkers?: boolean;
 }
 
 /** Where the injected bridge bootstrap imports the bridge bundle from. */
 const BRIDGE_ROUTE = '/admin/bridge.js';
+
+const CLOUDFLARE_ADAPTER_NAME = '@astrojs/cloudflare';
+/** A valid absolute URL that stands in for `import.meta.url` in server bundles. */
+const WORKERD_IMPORT_META_URL = JSON.stringify('file:///worker.mjs');
+/**
+ * The Vite environments that run on workerd under `@astrojs/cloudflare` and
+ * therefore need the placeholder: `ssr` (the on-demand server build) and `astro`
+ * (the dev SSR runtime). The `client` bundle is excluded so the browser keeps
+ * the real `import.meta.url`, and `prerender` is excluded because it runs in
+ * real Node when `prerenderEnvironment: 'node'` (faking the URL there would
+ * break genuine file resolution) — and the island route is `prerender: false`,
+ * so it never renders during prerendering anyway.
+ */
+const SERVER_ENVIRONMENTS = new Set(['ssr', 'astro']);
 
 export default function tina(
   options: TinaIntegrationOptions = {}
@@ -19,6 +40,10 @@ export default function tina(
   // Resolved client output dir, captured at config:done and consumed at
   // build:done (only then is the final output location known).
   let clientDir: URL | undefined;
+  // Whether the Cloudflare adapter is in use, resolved at config:done. The
+  // injected Vite plugin reads it lazily (via a thunk) because the plugin is
+  // constructed at config:setup, before the adapter is known.
+  let isCloudflareAdapter = false;
 
   return {
     name: '@tinacms/astro',
@@ -32,10 +57,23 @@ export default function tina(
         // it into the user's source tree — config-time writes churn
         // public/admin on every `astro dev`/`astro build`, break on read-only
         // or sandboxed filesystems, and can race `tinacms build`.
-        updateConfig({ vite: { plugins: [bridgeDevPlugin()] } });
+        updateConfig({
+          vite: {
+            plugins: [
+              bridgeDevPlugin(),
+              cloudflareImportMetaUrlPlugin(() => isCloudflareAdapter),
+            ],
+          },
+        });
       },
       'astro:config:done': ({ config }) => {
         clientDir = config.build.client;
+        // config:done runs before Vite is created and after every integration
+        // (including a late-registered adapter) has resolved, so config.adapter
+        // is reliable here.
+        isCloudflareAdapter =
+          options.cloudflareWorkers ??
+          config.adapter?.name === CLOUDFLARE_ADAPTER_NAME;
       },
       'astro:build:done': ({ logger }) => {
         // Build: emit the bridge next to the admin SPA in the *output* tree.
@@ -78,6 +116,36 @@ function bridgeDevPlugin(): VitePlugin {
           res.end(`/* @tinacms/astro: bridge unavailable: ${error} */`);
         }
       });
+    },
+  };
+}
+
+/**
+ * Cloudflare Workers (workerd) runs the server bundle in a runtime where the
+ * bundled `import.meta.url` is not a valid absolute URL. Astro's experimental
+ * Container API — used by the on-demand island route — calls
+ * `new URL(import.meta.url)` while building its manifest, which throws
+ * "Invalid URL string" and 500s the island render in production. The paths it
+ * seeds from that URL are never dereferenced for an in-memory render, so a
+ * valid placeholder is harmless. We inject it as a Vite `define`, but only in
+ * the server environments (never the client bundle, which needs the real value)
+ * and only under the Cloudflare adapter (faking it on a Node server would break
+ * real file resolution).
+ *
+ * TODO: remove once Astro guards the unconditional `new URL(import.meta.url)` in
+ * createManifest (tracked upstream in withastro/astro).
+ */
+function cloudflareImportMetaUrlPlugin(
+  isCloudflare: () => boolean
+): VitePlugin {
+  const define = { 'import.meta.url': WORKERD_IMPORT_META_URL };
+  return {
+    name: '@tinacms/astro:cloudflare-import-meta-url',
+    // No `apply`: the define is needed in both the build (ssr) and dev envs.
+    configEnvironment(name) {
+      if (!isCloudflare()) return;
+      if (!SERVER_ENVIRONMENTS.has(name)) return;
+      return { define };
     },
   };
 }

--- a/packages/tinacms/src/unifiedClient/index.test.ts
+++ b/packages/tinacms/src/unifiedClient/index.test.ts
@@ -123,8 +123,7 @@ describe('TinaClient concurrent requests on edge', () => {
     // fs cache disabled there is no per-key lock, so both proceed; the test
     // passing within the default timeout is the no-deadlock assertion.
     const fetchMock = vi.fn(
-      () =>
-        new Promise((resolve) => setTimeout(() => resolve(okResponse()), 5))
+      () => new Promise((resolve) => setTimeout(() => resolve(okResponse()), 5))
     );
     vi.stubGlobal('fetch', fetchMock);
 

--- a/packages/tinacms/src/unifiedClient/index.test.ts
+++ b/packages/tinacms/src/unifiedClient/index.test.ts
@@ -1,0 +1,139 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The fs-backed cache is loaded via a dynamic `import('../cache/node-cache.js')`.
+// Mock it so the cache path can be exercised without touching the real
+// filesystem, and so we can assert whether the client even tried to load it.
+const { nodeCacheMock } = vi.hoisted(() => ({ nodeCacheMock: vi.fn() }));
+vi.mock('../cache/node-cache.js', () => ({ NodeCache: nodeCacheMock }));
+
+import { createClient } from './index';
+
+const CACHE_DIR = '/tmp/tina-cache/abc';
+
+// requestFromServer only reads ok/status/statusText/json(), so a plain object
+// stands in for a real Response and avoids depending on the test env's globals.
+const okResponse = () => ({
+  ok: true,
+  status: 200,
+  statusText: 'OK',
+  json: async () => ({ data: { ok: true }, errors: null }),
+});
+
+const makeClient = (args: Record<string, unknown> = {}) =>
+  createClient({
+    url: 'https://content.tinajs.io/content/abc/github/main',
+    queries: () => ({}),
+    cacheDir: CACHE_DIR,
+    ...args,
+  });
+
+// The vitest env is happy-dom, so `window`/`navigator` exist by default; every
+// test stubs the globals it cares about and restores them afterwards.
+const asEdge = (userAgent = 'Cloudflare-Workers') => {
+  vi.stubGlobal('window', undefined);
+  vi.stubGlobal('navigator', { userAgent });
+};
+
+const asNode = () => {
+  vi.stubGlobal('window', undefined);
+  vi.stubGlobal('navigator', undefined);
+};
+
+beforeEach(() => {
+  nodeCacheMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('TinaClient cache initialization', () => {
+  it('skips the fs cache on the Cloudflare Workers runtime', async () => {
+    asEdge();
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    await client.init();
+
+    expect(nodeCacheMock).not.toHaveBeenCalled();
+    expect(client.cache).toBeFalsy();
+    expect(client.cacheLock).toBeUndefined();
+
+    await client.request({ query: 'query { x }' }, {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the fs cache on the Vercel Edge runtime', async () => {
+    vi.stubGlobal('window', undefined);
+    vi.stubGlobal('navigator', undefined);
+    vi.stubGlobal('EdgeRuntime', 'edge-runtime');
+
+    const client = makeClient();
+    await client.init();
+
+    expect(nodeCacheMock).not.toHaveBeenCalled();
+    expect(client.cache).toBeFalsy();
+    expect(client.cacheLock).toBeUndefined();
+  });
+
+  it('enables the fs cache in a Node runtime', async () => {
+    asNode();
+    const cacheStub = {
+      makeKey: vi.fn(() => 'k'),
+      get: vi.fn().mockResolvedValue(undefined),
+      set: vi.fn().mockResolvedValue(undefined),
+    };
+    nodeCacheMock.mockResolvedValue(cacheStub);
+
+    const client = makeClient();
+    await client.init();
+
+    expect(nodeCacheMock).toHaveBeenCalledWith(CACHE_DIR);
+    expect(client.cache).toBe(cacheStub);
+    expect(client.cacheLock).toBeDefined();
+  });
+
+  it('respects cache: false even when a cacheDir is provided', async () => {
+    asNode();
+    nodeCacheMock.mockResolvedValue({
+      makeKey: () => 'k',
+      get: vi.fn(),
+      set: vi.fn(),
+    });
+    const fetchMock = vi.fn().mockResolvedValue(okResponse());
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient({ cache: false });
+    await client.init();
+
+    expect(nodeCacheMock).not.toHaveBeenCalled();
+    expect(client.cache).toBeFalsy();
+    expect(client.cacheLock).toBeUndefined();
+
+    await client.request({ query: 'query { x }' }, {});
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('TinaClient concurrent requests on edge', () => {
+  it('resolves concurrent identical requests without deadlocking', async () => {
+    asEdge();
+    // A slow resolve makes two same-key requests overlap in flight. With the
+    // fs cache disabled there is no per-key lock, so both proceed; the test
+    // passing within the default timeout is the no-deadlock assertion.
+    const fetchMock = vi.fn(
+      () =>
+        new Promise((resolve) => setTimeout(() => resolve(okResponse()), 5))
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = makeClient();
+    const query = { query: 'query { same }' };
+
+    await expect(
+      Promise.all([client.request(query, {}), client.request(query, {})])
+    ).resolves.toHaveLength(2);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/tinacms/src/unifiedClient/index.ts
+++ b/packages/tinacms/src/unifiedClient/index.ts
@@ -10,6 +10,13 @@ export interface TinaClientArgs<GenQueries = Record<string, unknown>> {
   queries: (client: TinaClient<GenQueries>) => GenQueries;
   errorPolicy?: Config['client']['errorPolicy'];
   cacheDir?: string;
+  /**
+   * Set to `false` to force-disable the filesystem-backed response cache, even
+   * when a `cacheDir` is provided. Useful as an escape hatch on runtimes where
+   * the cache shouldn't run (e.g. an edge runtime not auto-detected). Defaults
+   * to enabled when a `cacheDir` is set.
+   */
+  cache?: boolean;
 }
 export type TinaClientRequestArgs = {
   variables?: Record<string, any>;
@@ -40,6 +47,32 @@ function replaceGithubPathSplit(url: string, replacement: string) {
   }
 }
 
+/**
+ * Detects edge runtimes that expose a Node `fs` shim where the filesystem is not
+ * actually usable for the response cache. On Cloudflare Workers (workerd) the
+ * `node:fs` calls don't throw — they hang — which would never release the
+ * per-key cache lock and deadlock concurrent same-key requests. On these
+ * runtimes the client must skip the filesystem-backed cache entirely and take
+ * the lock-free request path instead. Every global is probed defensively so
+ * this never throws under a normal Node build.
+ */
+function isEdgeRuntimeWithoutFs(): boolean {
+  // Cloudflare Workers (workerd) reports this exact navigator.userAgent.
+  if (
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent === 'Cloudflare-Workers'
+  ) {
+    return true;
+  }
+  // Vercel Edge runtime exposes a global `EdgeRuntime`.
+  if (
+    typeof (globalThis as { EdgeRuntime?: unknown }).EdgeRuntime !== 'undefined'
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export class TinaClient<GenQueries> {
   public apiUrl: string;
   public readonlyToken?: string;
@@ -49,6 +82,7 @@ export class TinaClient<GenQueries> {
   cacheLock: AsyncLock | undefined;
   cacheDir: string;
   cache: Cache | null;
+  cacheEnabled: boolean;
 
   constructor({
     token,
@@ -56,12 +90,14 @@ export class TinaClient<GenQueries> {
     queries,
     errorPolicy,
     cacheDir,
+    cache,
   }: TinaClientArgs<GenQueries>) {
     this.apiUrl = url;
     this.readonlyToken = token?.trim();
     this.queries = queries(this);
     this.errorPolicy = errorPolicy || 'throw';
     this.cacheDir = cacheDir || '';
+    this.cacheEnabled = cache !== false;
   }
 
   async init() {
@@ -69,7 +105,12 @@ export class TinaClient<GenQueries> {
       return;
     }
     try {
-      if (this.cacheDir && typeof window === 'undefined') {
+      if (
+        this.cacheEnabled &&
+        this.cacheDir &&
+        typeof window === 'undefined' &&
+        !isEdgeRuntimeWithoutFs()
+      ) {
         const { NodeCache } = await import('../cache/node-cache.js');
         this.cache = await NodeCache(this.cacheDir);
         if (this.cache) {


### PR DESCRIPTION
✅ Tested and working!! https://astro.jack-082.workers.dev/

The generated Tina client enables an fs-backed NodeCache whenever a cacheDir is set and `window` is undefined. On Cloudflare Workers (workerd) the Node fs shim is present but read/write calls hang, so the per-key cache lock never releases and concurrent identical queries deadlock. Detect edge runtimes (Cloudflare Workers, Vercel Edge) in init() and skip the cache so requests take the lock-free path. Also add a `cache` client option to force-disable the cache.