### PR TITLE
Fix Local Mode banner for absolute contentApiUrlOverride

### DIFF
--- a/.changeset/hot-rice-pull.md
+++ b/.changeset/hot-rice-pull.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/schema-tools": patch
+"tinacms": patch
+---
+
+Fix Local Mode banner for absolute contentApiUrlOverride

--- a/packages/@tinacms/schema-tools/src/types/index.ts
+++ b/packages/@tinacms/schema-tools/src/types/index.ts
@@ -654,6 +654,14 @@ export interface Config<
   Store = undefined,
   SearchClient = undefined,
 > {
+  /**
+   * Points the admin UI at a custom/self-hosted content API instead of TinaCloud.
+   *
+   * Can be a relative URL, such as `/api/tina/gql`, or an absolute URL, such as
+   * `https://example.com/api/content`. When set, the admin UI will not show the
+   * Local Mode banner; Local Mode is only detected when this option is unset and
+   * the content API resolves to `localhost`.
+   */
   contentApiUrlOverride?: string;
   authProvider?: AuthProvider;
   admin?: {

--- a/packages/@tinacms/schema-tools/src/util/parseURL.spec.ts
+++ b/packages/@tinacms/schema-tools/src/util/parseURL.spec.ts
@@ -38,4 +38,18 @@ describe('parseUrl', () => {
       parseURL(wrongURL);
     }).toThrow();
   });
+  it('treats a relative contentApiUrlOverride as not local', () => {
+    const { isLocalClient, host } = parseURL('/api/tina/gql');
+    expect(isLocalClient).toBe(false);
+    expect(host).toBe(null);
+  });
+  it('treats an absolute (self-hosted) contentApiUrlOverride as not local', () => {
+    const { branch, clientId, isLocalClient, host } = parseURL(
+      'https://example.com/api/content'
+    );
+    expect(isLocalClient).toBe(false);
+    expect(host).toBe('example.com');
+    expect(branch).toBe(null);
+    expect(clientId).toBe(null);
+  });
 });

--- a/packages/@tinacms/schema-tools/src/util/parseURL.ts
+++ b/packages/@tinacms/schema-tools/src/util/parseURL.ts
@@ -33,16 +33,19 @@ export const parseURL = (
 
   const params = new URL(url);
 
-  // This is a self-hosted URL
   const isTinaCloud =
     params.host.includes('tinajs.dev') ||
     params.host.includes('tina.io') ||
     params.host.includes('tinajs.io');
 
+  // This is a self-hosted URL (e.g. an absolute `contentApiUrlOverride`).
+  // It points at a custom/self-hosted content API, not the local dev server,
+  // so it must not be treated as local mode. The genuine local server URL
+  // contains `localhost` and is handled by the check above.
   if (!isTinaCloud) {
     return {
       branch: null,
-      isLocalClient: true,
+      isLocalClient: false,
       clientId: null,
       host: params.host,
     };

--- a/packages/tinacms/src/utils/index.test.ts
+++ b/packages/tinacms/src/utils/index.test.ts
@@ -1,0 +1,65 @@
+import { Client, LocalClient, LocalAuthProvider } from '../internalClient';
+import { createClient } from './index';
+
+/**
+ * `createClient` turns the `isLocalClient` flag (derived from the resolved
+ * content API URL, see `parseURL`) into the client used by the admin UI. The
+ * Local Mode banner (`LocalWarning`) shows only when `client.isLocalMode` is
+ * true, so these tests assert the banner-driving signal directly.
+ */
+describe('createClient — Local Mode routing', () => {
+  it('does not enter Local Mode for a relative contentApiUrlOverride', () => {
+    // A relative `contentApiUrlOverride` resolves to isLocalClient === false.
+    const client = createClient({
+      isLocalClient: false,
+      apiUrl: '/api/tina/gql',
+      tinaGraphQLVersion: '1.1',
+    });
+
+    expect(client).toBeInstanceOf(Client);
+    expect(client).not.toBeInstanceOf(LocalClient);
+    expect(client.isLocalMode).toBe(false);
+  });
+
+  it('does not enter Local Mode for an absolute (self-hosted) contentApiUrlOverride', () => {
+    // An absolute `contentApiUrlOverride` also resolves to isLocalClient === false.
+    const client = createClient({
+      isLocalClient: false,
+      apiUrl: 'https://example.com/api/content',
+      tinaGraphQLVersion: '1.1',
+    });
+
+    expect(client).toBeInstanceOf(Client);
+    expect(client).not.toBeInstanceOf(LocalClient);
+    expect(client.isLocalMode).toBe(false);
+  });
+
+  it('does not enter Local Mode when an auth provider is configured alongside an absolute contentApiUrlOverride', () => {
+    const client = createClient({
+      isLocalClient: false,
+      apiUrl: 'https://example.com/api/content',
+      tinaGraphQLVersion: '1.1',
+      schema: {
+        collections: [],
+        config: {
+          contentApiUrlOverride: 'https://example.com/api/content',
+          config: { authProvider: new LocalAuthProvider() },
+        },
+      } as any,
+    });
+
+    expect(client).toBeInstanceOf(Client);
+    expect(client).not.toBeInstanceOf(LocalClient);
+    expect(client.isLocalMode).toBe(false);
+  });
+
+  it('stays in Local Mode when there is no contentApiUrlOverride (true local mode)', () => {
+    const client = createClient({
+      isLocalClient: true,
+      tinaGraphQLVersion: '1.1',
+    });
+
+    expect(client).toBeInstanceOf(LocalClient);
+    expect(client.isLocalMode).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #5520

## PR Summary

**Root cause** — `parseURL` classified any non-TinaCloud absolute URL as `isLocalClient: true`. As a result, an absolute `contentApiUrlOverride` routed the admin UI to `LocalClient` (`isLocalMode === true`), causing the Local Mode banner to appear even when an auth provider was configured.

**Fix** — Updated the non-TinaCloud branch of `parseURL` to return `isLocalClient: false`. A non-TinaCloud absolute override represents a custom/self-hosted content API, not the local dev server. True local dev server URLs containing `localhost` are still handled by the earlier local branch, so existing Local Mode behavior is preserved.

**Tests** — Added/updated coverage for relative and absolute `contentApiUrlOverride` values, including the auth provider case. Also verified true local mode still returns `LocalClient` / `isLocalMode: true`.

**Docs** — Updated the `contentApiUrlOverride` JSDoc to clarify that it may be relative or absolute, and that setting it opts the admin UI out of Local Mode detection.

## Testing

* `pnpm --filter @tinacms/schema-tools test -- parseURL`
* `pnpm --filter tinacms test -- src/utils/index.test.ts src/internalClient/index.test.ts`
* `pnpm --filter @tinacms/schema-tools types`
