### PR TITLE
fix(@tinacms/astro): re-run getStaticPaths in dev on Tina content writes

### DIFF
--- a/.changeset/astro-dev-content-invalidation.md
+++ b/.changeset/astro-dev-content-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/astro": patch
+---
+
+Re-run `getStaticPaths` in dev when Tina writes or deletes a content file, so newly created entries no longer 404 until the dev server is restarted by hand.

--- a/.changeset/astro-dev-content-invalidation.md
+++ b/.changeset/astro-dev-content-invalidation.md
@@ -2,4 +2,4 @@
 "@tinacms/astro": patch
 ---
 
-Re-run `getStaticPaths` in dev when Tina writes or deletes a content file, so newly created entries no longer 404 until the dev server is restarted by hand.
+Re-run `getStaticPaths` in dev when Tina writes or deletes a content file, so newly created entries no longer 404 until the dev server is restarted by hand. Applies to Astro 6+, whose dev runtime handles the `astro:content-changed` signal; Astro 5 is left untouched.

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -18,7 +18,10 @@ type ConfigSetupArg = Parameters<NonNullable<Hooks['astro:config:setup']>>[0];
 type ConfigDoneArg = Parameters<NonNullable<Hooks['astro:config:done']>>[0];
 type BuildDoneArg = Parameters<NonNullable<Hooks['astro:build:done']>>[0];
 
-function runConfigSetup(options?: Parameters<typeof tina>[0]) {
+function runConfigSetup(
+  options?: Parameters<typeof tina>[0],
+  extra?: { command?: 'dev' | 'build' | 'preview' }
+) {
   const addMiddleware = vi.fn();
   const updateConfig = vi.fn();
   const logger = { warn: vi.fn(), info: vi.fn() };
@@ -27,7 +30,12 @@ function runConfigSetup(options?: Parameters<typeof tina>[0]) {
     integration.hooks['astro:config:setup'] as NonNullable<
       Hooks['astro:config:setup']
     >
-  )({ addMiddleware, updateConfig, logger } as unknown as ConfigSetupArg);
+  )({
+    addMiddleware,
+    updateConfig,
+    logger,
+    command: extra?.command ?? 'dev',
+  } as unknown as ConfigSetupArg);
 
   const plugins: VitePlugin[] =
     updateConfig.mock.calls[0]?.[0]?.vite?.plugins ?? [];
@@ -402,6 +410,38 @@ describe('tina() integration - dev content invalidation plugin', () => {
       expect(Object.keys(handlers)).toHaveLength(0);
       expect(ssrSend).not.toHaveBeenCalled();
       expect(clientSend).not.toHaveBeenCalled();
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it('warns in dev that live refresh needs Astro 6+ when on Astro 5', () => {
+    const parse = vi
+      .spyOn(JSON, 'parse')
+      .mockReturnValue({ version: '5.18.1' });
+    try {
+      const { logger } = runConfigSetup();
+      expect(logger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Astro 6 or newer')
+      );
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
+  it('does not warn on Astro 6, where live refresh works', () => {
+    // The installed Astro is 6.x, so the version gate passes and nothing warns.
+    const { logger } = runConfigSetup();
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn outside dev (e.g. build) even on Astro 5', () => {
+    const parse = vi
+      .spyOn(JSON, 'parse')
+      .mockReturnValue({ version: '5.18.1' });
+    try {
+      const { logger } = runConfigSetup(undefined, { command: 'build' });
+      expect(logger.warn).not.toHaveBeenCalled();
     } finally {
       parse.mockRestore();
     }

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -108,7 +108,7 @@ const invalidationPlugin = (plugins: VitePlugin[]) =>
     (p) => p.name === '@tinacms/astro:dev-content-invalidation'
   ) as VitePlugin;
 
-describe('tina() integration — astro:config:setup', () => {
+describe('tina() integration - astro:config:setup', () => {
   it('wires the middleware without writing to the source tree', () => {
     const { addMiddleware, plugins } = runConfigSetup();
 
@@ -123,7 +123,7 @@ describe('tina() integration — astro:config:setup', () => {
   });
 });
 
-describe('tina() integration — bridge dev plugin', () => {
+describe('tina() integration - bridge dev plugin', () => {
   it('serves the bridge bundle at /admin/bridge.js', () => {
     const { plugins } = runConfigSetup();
     const plugin = plugins.find((p) => p.name === '@tinacms/astro:bridge-dev')!;
@@ -152,7 +152,7 @@ describe('tina() integration — bridge dev plugin', () => {
   });
 });
 
-describe('tina() integration — cloudflare import.meta.url plugin', () => {
+describe('tina() integration - cloudflare import.meta.url plugin', () => {
   const EXPECTED = JSON.stringify('file:///worker.mjs');
 
   it('injects a valid import.meta.url define for the workerd server envs under the cloudflare adapter', () => {
@@ -228,7 +228,7 @@ describe('tina() integration — cloudflare import.meta.url plugin', () => {
   });
 });
 
-describe('tina() integration — dev content invalidation plugin', () => {
+describe('tina() integration - dev content invalidation plugin', () => {
   it('is a dev-only plugin', () => {
     const { plugins } = runConfigSetup();
     const plugin = invalidationPlugin(plugins);
@@ -363,7 +363,7 @@ describe('tina() integration — dev content invalidation plugin', () => {
   });
 });
 
-describe('tina() integration — astro:build:done', () => {
+describe('tina() integration - astro:build:done', () => {
   it('emits bridge.js into the client output dir', () => {
     const clientDir = mkdtempSync(join(tmpdir(), 'tina-client-'));
     const { integration } = runConfigSetup();

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -80,6 +80,34 @@ function makeRes() {
   };
 }
 
+// A minimal dev server exposing the Vite environment hot channels and a file
+// watcher, so we can drive the content-invalidation plugin and capture both the
+// HMR signals it sends and the watcher handlers it registers.
+function makeDevServer(opts: { environments?: boolean } = {}) {
+  const ssrSend = vi.fn();
+  const clientSend = vi.fn();
+  const handlers: Record<string, (file: string) => void> = {};
+  const watcher = {
+    on(event: string, cb: (file: string) => void) {
+      handlers[event] = cb;
+      return watcher;
+    },
+  };
+  const server: Record<string, unknown> = { watcher };
+  if (opts.environments !== false) {
+    server.environments = {
+      ssr: { hot: { send: ssrSend } },
+      client: { hot: { send: clientSend } },
+    };
+  }
+  return { server, ssrSend, clientSend, handlers };
+}
+
+const invalidationPlugin = (plugins: VitePlugin[]) =>
+  plugins.find(
+    (p) => p.name === '@tinacms/astro:dev-content-invalidation'
+  ) as VitePlugin;
+
 describe('tina() integration — astro:config:setup', () => {
   it('wires the middleware without writing to the source tree', () => {
     const { addMiddleware, plugins } = runConfigSetup();
@@ -197,6 +225,118 @@ describe('tina() integration — cloudflare import.meta.url plugin', () => {
     expect(
       runConfigEnvironment(cfPlugin(forcedOff.plugins), 'ssr')
     ).toBeUndefined();
+  });
+});
+
+describe('tina() integration — dev content invalidation plugin', () => {
+  it('is a dev-only plugin', () => {
+    const { plugins } = runConfigSetup();
+    const plugin = invalidationPlugin(plugins);
+    expect(plugin).toBeDefined();
+    expect(plugin.apply).toBe('serve');
+  });
+
+  it('clears the route cache and reloads when a content file is added', () => {
+    vi.useFakeTimers();
+    try {
+      const { plugins } = runConfigSetup();
+      const { server, ssrSend, clientSend, handlers } = makeDevServer();
+      (invalidationPlugin(plugins).configureServer as any)(server);
+
+      handlers.add('/project/src/content/blog/new-post.mdx');
+      // Debounced — nothing fires synchronously.
+      expect(ssrSend).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(50);
+      expect(ssrSend).toHaveBeenCalledWith('astro:content-changed', {});
+      expect(clientSend).toHaveBeenCalledWith({
+        type: 'full-reload',
+        path: '*',
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('also reacts to content files being removed', () => {
+    vi.useFakeTimers();
+    try {
+      const { plugins } = runConfigSetup();
+      const { server, ssrSend, handlers } = makeDevServer();
+      (invalidationPlugin(plugins).configureServer as any)(server);
+
+      handlers.unlink('/project/content/posts/gone.md');
+      vi.advanceTimersByTime(50);
+      expect(ssrSend).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('treats markdown as content anywhere, but structured data only inside a content dir', () => {
+    vi.useFakeTimers();
+    try {
+      const { plugins } = runConfigSetup();
+      const { server, ssrSend, handlers } = makeDevServer();
+      (invalidationPlugin(plugins).configureServer as any)(server);
+
+      // Reacts to: markdown anywhere, and json/yaml inside a content dir.
+      for (const file of [
+        '/project/src/pages/inline.mdx',
+        '/project/content/tags/tag.json',
+        '/project/content/global/site.yaml',
+      ]) {
+        handlers.add(file);
+        vi.advanceTimersByTime(50);
+        expect(ssrSend).toHaveBeenCalled();
+        ssrSend.mockClear();
+      }
+
+      // Ignores: config json outside a content dir, source code, and anything
+      // inside ignored directories.
+      for (const file of [
+        '/project/package.json',
+        '/project/tsconfig.json',
+        '/project/src/lib/data.ts',
+        '/project/node_modules/pkg/content/x.md',
+        '/project/dist/content/x.md',
+      ]) {
+        handlers.add(file);
+        vi.advanceTimersByTime(50);
+        expect(ssrSend).not.toHaveBeenCalled();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('coalesces a burst of changes into a single reload', () => {
+    vi.useFakeTimers();
+    try {
+      const { plugins } = runConfigSetup();
+      const { server, ssrSend, clientSend, handlers } = makeDevServer();
+      (invalidationPlugin(plugins).configureServer as any)(server);
+
+      handlers.add('/project/content/a.md');
+      handlers.add('/project/content/b.md');
+      handlers.unlink('/project/content/c.md');
+      vi.advanceTimersByTime(50);
+
+      expect(ssrSend).toHaveBeenCalledOnce();
+      expect(clientSend).toHaveBeenCalledOnce();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('no-ops without throwing when the environment API is unavailable', () => {
+    const { plugins } = runConfigSetup();
+    const { server, handlers } = makeDevServer({ environments: false });
+    expect(() =>
+      (invalidationPlugin(plugins).configureServer as any)(server)
+    ).not.toThrow();
+    // It registers no watcher handlers rather than guessing at the HMR channel.
+    expect(Object.keys(handlers)).toHaveLength(0);
   });
 });
 

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -244,7 +244,7 @@ describe('tina() integration — dev content invalidation plugin', () => {
       (invalidationPlugin(plugins).configureServer as any)(server);
 
       handlers.add('/project/src/content/blog/new-post.mdx');
-      // Debounced — nothing fires synchronously.
+      // Debounced, so nothing fires synchronously.
       expect(ssrSend).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(50);
@@ -329,13 +329,36 @@ describe('tina() integration — dev content invalidation plugin', () => {
     }
   });
 
+  it('does not arm on Astro 5, whose runtime has no astro:content-changed listener', () => {
+    // The integration reads the installed Astro major from `astro`'s
+    // package.json via JSON.parse; force it to 5.x for this call only. Astro 5
+    // ships Vite 6, so the environment API is present either way; the version
+    // gate, not an API sniff, is what keeps the plugin from arming here.
+    const parse = vi
+      .spyOn(JSON, 'parse')
+      .mockReturnValue({ version: '5.18.1' });
+    try {
+      const { plugins } = runConfigSetup();
+      const { server, ssrSend, clientSend, handlers } = makeDevServer();
+      (invalidationPlugin(plugins).configureServer as any)(server);
+
+      // Gate trips before any watcher is wired or HMR signal is sent.
+      expect(Object.keys(handlers)).toHaveLength(0);
+      expect(ssrSend).not.toHaveBeenCalled();
+      expect(clientSend).not.toHaveBeenCalled();
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
   it('no-ops without throwing when the environment API is unavailable', () => {
     const { plugins } = runConfigSetup();
     const { server, handlers } = makeDevServer({ environments: false });
     expect(() =>
       (invalidationPlugin(plugins).configureServer as any)(server)
     ).not.toThrow();
-    // It registers no watcher handlers rather than guessing at the HMR channel.
+    // Defensive secondary guard: past the version check but with the hot
+    // channels absent, register no handlers rather than guess at the channel.
     expect(Object.keys(handlers)).toHaveLength(0);
   });
 });

--- a/packages/@tinacms/astro/src/__tests__/integration.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/integration.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
@@ -83,7 +89,7 @@ function makeRes() {
 // A minimal dev server exposing the Vite environment hot channels and a file
 // watcher, so we can drive the content-invalidation plugin and capture both the
 // HMR signals it sends and the watcher handlers it registers.
-function makeDevServer(opts: { environments?: boolean } = {}) {
+function makeDevServer(opts: { environments?: boolean; root?: string } = {}) {
   const ssrSend = vi.fn();
   const clientSend = vi.fn();
   const handlers: Record<string, (file: string) => void> = {};
@@ -94,6 +100,9 @@ function makeDevServer(opts: { environments?: boolean } = {}) {
     },
   };
   const server: Record<string, unknown> = { watcher };
+  if (opts.root !== undefined) {
+    server.config = { root: opts.root };
+  }
   if (opts.environments !== false) {
     server.environments = {
       ssr: { hot: { send: ssrSend } },
@@ -273,10 +282,11 @@ describe('tina() integration - dev content invalidation plugin', () => {
     }
   });
 
-  it('treats markdown as content anywhere, but structured data only inside a content dir', () => {
+  it('falls back to a heuristic without a schema: markdown anywhere, structured data only inside a content dir', () => {
     vi.useFakeTimers();
     try {
       const { plugins } = runConfigSetup();
+      // No `root`, so no schema is read and detection uses the heuristic.
       const { server, ssrSend, handlers } = makeDevServer();
       (invalidationPlugin(plugins).configureServer as any)(server);
 
@@ -300,6 +310,52 @@ describe('tina() integration - dev content invalidation plugin', () => {
         '/project/src/lib/data.ts',
         '/project/node_modules/pkg/content/x.md',
         '/project/dist/content/x.md',
+      ]) {
+        handlers.add(file);
+        vi.advanceTimersByTime(50);
+        expect(ssrSend).not.toHaveBeenCalled();
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('watches collection roots from the schema, so content outside a content dir still reloads', () => {
+    const root = mkdtempSync(join(tmpdir(), 'tina-astro-'));
+    mkdirSync(join(root, 'tina', '__generated__'), { recursive: true });
+    writeFileSync(
+      join(root, 'tina', '__generated__', '_schema.json'),
+      JSON.stringify({
+        collections: [
+          // A JSON collection that does NOT live under a `content` dir: the
+          // exact case the heuristic would miss.
+          { name: 'settings', path: 'data/settings', format: 'json' },
+          { name: 'post', path: 'src/posts', format: 'mdx' },
+        ],
+      })
+    );
+
+    vi.useFakeTimers();
+    try {
+      const { plugins } = runConfigSetup();
+      const { server, ssrSend, handlers } = makeDevServer({ root });
+      (invalidationPlugin(plugins).configureServer as any)(server);
+
+      // Reacts to content under any configured collection root.
+      for (const file of [
+        join(root, 'data/settings/site.json'),
+        join(root, 'src/posts/hello.mdx'),
+      ]) {
+        handlers.add(file);
+        vi.advanceTimersByTime(50);
+        expect(ssrSend).toHaveBeenCalled();
+        ssrSend.mockClear();
+      }
+
+      // Ignores files outside every root, and non-content files inside one.
+      for (const file of [
+        join(root, 'package.json'),
+        join(root, 'data/settings/README.txt'),
       ]) {
         handlers.add(file);
         vi.advanceTimersByTime(50);

--- a/packages/@tinacms/astro/src/integration.ts
+++ b/packages/@tinacms/astro/src/integration.ts
@@ -255,6 +255,12 @@ function devContentInvalidationPlugin(
         if (timer) clearTimeout(timer);
         timer = setTimeout(flush, 50);
       };
+      // Vite only watches files inside the Astro project root, so content kept
+      // in a separate repo (a `localContentPath` resolving outside the project)
+      // isn't seen here and won't auto-refresh the route cache in dev. That
+      // content is still indexed by `tinacms dev`'s own watcher; only this
+      // Astro-side refresh can't reach outside the project root, which matches
+      // the behaviour before this fix existed.
       server.watcher.on('add', onChange);
       server.watcher.on('unlink', onChange);
     },

--- a/packages/@tinacms/astro/src/integration.ts
+++ b/packages/@tinacms/astro/src/integration.ts
@@ -48,11 +48,25 @@ export default function tina(
   return {
     name: '@tinacms/astro',
     hooks: {
-      'astro:config:setup': ({ addMiddleware, updateConfig }) => {
+      'astro:config:setup': ({
+        addMiddleware,
+        updateConfig,
+        command,
+        logger,
+      }) => {
         addMiddleware({
           entrypoint: '@tinacms/astro/middleware',
           order: middlewareOrder,
         });
+        const astroMajor = astroMajorVersion();
+        // Live dev content refresh needs Astro 6+ (see
+        // devContentInvalidationPlugin). On Astro 5 nothing handles the signal,
+        // so let editors know new entries won't appear without a manual restart.
+        if (command === 'dev' && astroMajor !== undefined && astroMajor < 6) {
+          logger.warn(
+            'Live content refresh in dev requires Astro 6 or newer. On Astro 5, newly created entries will not appear on the dev site until you restart the dev server. See https://github.com/tinacms/tinacms/issues/5611.'
+          );
+        }
         // Dev: serve the bridge straight from the package rather than writing
         // it into the user's source tree — config-time writes churn
         // public/admin on every `astro dev`/`astro build`, break on read-only
@@ -61,7 +75,7 @@ export default function tina(
           vite: {
             plugins: [
               bridgeDevPlugin(),
-              devContentInvalidationPlugin(astroMajorVersion()),
+              devContentInvalidationPlugin(astroMajor),
               cloudflareImportMetaUrlPlugin(() => isCloudflareAdapter),
             ],
           },

--- a/packages/@tinacms/astro/src/integration.ts
+++ b/packages/@tinacms/astro/src/integration.ts
@@ -61,6 +61,7 @@ export default function tina(
           vite: {
             plugins: [
               bridgeDevPlugin(),
+              devContentInvalidationPlugin(),
               cloudflareImportMetaUrlPlugin(() => isCloudflareAdapter),
             ],
           },
@@ -116,6 +117,63 @@ function bridgeDevPlugin(): VitePlugin {
           res.end(`/* @tinacms/astro: bridge unavailable: ${error} */`);
         }
       });
+    },
+  };
+}
+
+/**
+ * Astro caches `getStaticPaths()` results in dev and only re-runs them for a
+ * change it recognises: a module in the graph, or a file in a watched
+ * content-layer collection. Content sourced through Tina's GraphQL client
+ * (a `getStaticPaths` that queries `client.queries.*`) is neither, so when the
+ * admin writes a new entry the route's path list stays stale and the
+ * freshly-created page 404s until the dev server is restarted by hand.
+ *
+ * This dev-only plugin watches for content files being added or removed and
+ * emits the same `astro:content-changed` signal Astro fires for its own content
+ * layer, which clears the route cache so `getStaticPaths()` re-runs and the new
+ * path resolves, then reloads the open tab so it picks up the change.
+ *
+ * See https://github.com/tinacms/tinacms/issues/5611.
+ */
+function devContentInvalidationPlugin(): VitePlugin {
+  // Markdown-family files are content wherever they live. Structured-data
+  // formats only count inside a `content` directory, so an unrelated
+  // `package.json` / `tsconfig.json` write doesn't trigger a reload.
+  const MARKDOWN = /\.(?:md|mdx|markdown|mdoc)$/i;
+  const STRUCTURED = /\.(?:json|ya?ml|toml)$/i;
+  const IGNORED =
+    /[\\/](?:node_modules|\.git|\.astro|dist|\.vercel|\.netlify|\.cache)[\\/]/;
+  const isContentFile = (file: string): boolean => {
+    if (IGNORED.test(file)) return false;
+    if (MARKDOWN.test(file)) return true;
+    return STRUCTURED.test(file) && /[\\/]content[\\/]/.test(file);
+  };
+
+  return {
+    name: '@tinacms/astro:dev-content-invalidation',
+    apply: 'serve',
+    configureServer(server) {
+      // Requires Vite's environment API (always present under Astro 6). If it
+      // is missing, no-op rather than guessing at the wrong HMR channel.
+      const ssr = server.environments?.ssr;
+      const client = server.environments?.client;
+      if (!ssr?.hot || !client?.hot) return;
+
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const flush = () => {
+        ssr.hot.send('astro:content-changed', {});
+        client.hot.send({ type: 'full-reload', path: '*' });
+      };
+      const onChange = (file: string) => {
+        if (!isContentFile(file)) return;
+        // Coalesce bursts — saving several documents fires many events — into a
+        // single reload.
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(flush, 50);
+      };
+      server.watcher.on('add', onChange);
+      server.watcher.on('unlink', onChange);
     },
   };
 }

--- a/packages/@tinacms/astro/src/integration.ts
+++ b/packages/@tinacms/astro/src/integration.ts
@@ -61,7 +61,7 @@ export default function tina(
           vite: {
             plugins: [
               bridgeDevPlugin(),
-              devContentInvalidationPlugin(),
+              devContentInvalidationPlugin(astroMajorVersion()),
               cloudflareImportMetaUrlPlugin(() => isCloudflareAdapter),
             ],
           },
@@ -91,6 +91,24 @@ export default function tina(
 
 function resolveBridge(): string {
   return createRequire(import.meta.url).resolve('@tinacms/bridge');
+}
+
+/**
+ * Major version of the consumer's installed `astro`, or `undefined` if it can't
+ * be resolved. Used to scope the dev content-invalidation plugin to Astro 6+,
+ * the only majors where the `astro:content-changed` signal it emits is handled.
+ */
+function astroMajorVersion(): number | undefined {
+  try {
+    const pkg = createRequire(import.meta.url).resolve('astro/package.json');
+    const major = Number.parseInt(
+      JSON.parse(readFileSync(pkg, 'utf8')).version,
+      10
+    );
+    return Number.isNaN(major) ? undefined : major;
+  } catch {
+    return undefined;
+  }
 }
 
 // Dev-only Vite plugin that answers `/admin/bridge.js` from the installed
@@ -134,9 +152,18 @@ function bridgeDevPlugin(): VitePlugin {
  * layer, which clears the route cache so `getStaticPaths()` re-runs and the new
  * path resolves, then reloads the open tab so it picks up the change.
  *
+ * Scoped to Astro 6+: the listener that turns `astro:content-changed` into a
+ * route-cache clear only exists from Astro 6 on. On Astro 5 nothing handles the
+ * signal, so it does nothing useful while the paired full-reload would still
+ * churn the open tab. Hence a version gate rather than sniffing Vite's
+ * environment API, which is present in both Astro 5 and 6 and so can't tell them
+ * apart.
+ *
  * See https://github.com/tinacms/tinacms/issues/5611.
  */
-function devContentInvalidationPlugin(): VitePlugin {
+function devContentInvalidationPlugin(
+  astroMajor: number | undefined
+): VitePlugin {
   // Markdown-family files are content wherever they live. Structured-data
   // formats only count inside a `content` directory, so an unrelated
   // `package.json` / `tsconfig.json` write doesn't trigger a reload.
@@ -154,8 +181,11 @@ function devContentInvalidationPlugin(): VitePlugin {
     name: '@tinacms/astro:dev-content-invalidation',
     apply: 'serve',
     configureServer(server) {
-      // Requires Vite's environment API (always present under Astro 6). If it
-      // is missing, no-op rather than guessing at the wrong HMR channel.
+      // The `astro:content-changed` signal below is only handled by Astro 6+.
+      // Bail on older (or unresolvable) majors so a no-op stays a no-op.
+      if (astroMajor === undefined || astroMajor < 6) return;
+      // Astro 6 routes HMR through Vite's per-environment hot channels.
+      // Defensive: if they're somehow absent, skip rather than guess.
       const ssr = server.environments?.ssr;
       const client = server.environments?.client;
       if (!ssr?.hot || !client?.hot) return;
@@ -167,7 +197,7 @@ function devContentInvalidationPlugin(): VitePlugin {
       };
       const onChange = (file: string) => {
         if (!isContentFile(file)) return;
-        // Coalesce bursts — saving several documents fires many events — into a
+        // Coalesce bursts (saving several documents fires many events) into a
         // single reload.
         if (timer) clearTimeout(timer);
         timer = setTimeout(flush, 50);

--- a/packages/@tinacms/astro/src/integration.ts
+++ b/packages/@tinacms/astro/src/integration.ts
@@ -111,6 +111,37 @@ function astroMajorVersion(): number | undefined {
   }
 }
 
+/** Normalise separators so path prefix matching works on Windows too. */
+const toPosix = (p: string): string => p.replace(/\\/g, '/');
+
+/**
+ * Absolute, posix-normalised paths of the configured Tina collection content
+ * roots, read from the generated schema. `tinacms dev` writes this before it
+ * spawns the framework dev server, so it is on disk by the time this plugin's
+ * `configureServer` runs. Returns an empty list when the schema can't be read
+ * (e.g. running `astro dev` on its own), signalling the caller to fall back to
+ * a path heuristic.
+ */
+function readTinaCollectionRoots(root: string | undefined): string[] {
+  if (!root) return [];
+  for (const rel of [
+    'tina/__generated__/_schema.json',
+    '.tina/__generated__/_schema.json',
+  ]) {
+    try {
+      const schema = JSON.parse(readFileSync(join(root, rel), 'utf8'));
+      const roots: string[] = (schema?.collections ?? [])
+        .map((c: { path?: unknown }) => c?.path)
+        .filter((p: unknown): p is string => typeof p === 'string' && p !== '')
+        .map((p: string) => toPosix(join(root, p)));
+      if (roots.length) return roots;
+    } catch {
+      // Not generated yet or unreadable: try the next location, then fall back.
+    }
+  }
+  return [];
+}
+
 // Dev-only Vite plugin that answers `/admin/bridge.js` from the installed
 // bridge package. The bridge never varies per request, so a single readFile
 // per request is fine and nothing is persisted to disk.
@@ -147,10 +178,12 @@ function bridgeDevPlugin(): VitePlugin {
  * admin writes a new entry the route's path list stays stale and the
  * freshly-created page 404s until the dev server is restarted by hand.
  *
- * This dev-only plugin watches for content files being added or removed and
- * emits the same `astro:content-changed` signal Astro fires for its own content
- * layer, which clears the route cache so `getStaticPaths()` re-runs and the new
- * path resolves, then reloads the open tab so it picks up the change.
+ * This dev-only plugin watches the configured Tina collection paths (read from
+ * the generated schema, so it tracks content wherever a collection's `path`
+ * points) for files being added or removed, and emits the same
+ * `astro:content-changed` signal Astro fires for its own content layer, which
+ * clears the route cache so `getStaticPaths()` re-runs and the new path
+ * resolves, then reloads the open tab so it picks up the change.
  *
  * Scoped to Astro 6+: the listener that turns `astro:content-changed` into a
  * route-cache clear only exists from Astro 6 on. On Astro 5 nothing handles the
@@ -164,15 +197,31 @@ function bridgeDevPlugin(): VitePlugin {
 function devContentInvalidationPlugin(
   astroMajor: number | undefined
 ): VitePlugin {
-  // Markdown-family files are content wherever they live. Structured-data
-  // formats only count inside a `content` directory, so an unrelated
-  // `package.json` / `tsconfig.json` write doesn't trigger a reload.
+  // Content extensions Tina writes. The precise watch list comes from the
+  // collection roots in the generated schema; these patterns drive the fallback
+  // used when the schema isn't readable yet.
+  const CONTENT_EXT = /\.(?:md|mdx|markdown|mdoc|json|ya?ml|toml)$/i;
   const MARKDOWN = /\.(?:md|mdx|markdown|mdoc)$/i;
   const STRUCTURED = /\.(?:json|ya?ml|toml)$/i;
   const IGNORED =
     /[\\/](?:node_modules|\.git|\.astro|dist|\.vercel|\.netlify|\.cache)[\\/]/;
-  const isContentFile = (file: string): boolean => {
+
+  const isWithin = (file: string, dir: string): boolean => {
+    const f = toPosix(file);
+    const d = toPosix(dir).replace(/\/$/, '');
+    return f === d || f.startsWith(`${d}/`);
+  };
+
+  const isContentFile = (file: string, roots: string[]): boolean => {
     if (IGNORED.test(file)) return false;
+    // Schema known: a content-formatted file under any configured collection
+    // root, regardless of whether that root is named `content`.
+    if (roots.length) {
+      return CONTENT_EXT.test(file) && roots.some((r) => isWithin(file, r));
+    }
+    // Fallback (schema not generated yet): markdown counts anywhere; structured
+    // data only inside a `content` dir, so a stray `package.json` / `tsconfig`
+    // write doesn't trigger a reload.
     if (MARKDOWN.test(file)) return true;
     return STRUCTURED.test(file) && /[\\/]content[\\/]/.test(file);
   };
@@ -190,13 +239,17 @@ function devContentInvalidationPlugin(
       const client = server.environments?.client;
       if (!ssr?.hot || !client?.hot) return;
 
+      // Exact content roots from the Tina schema; empty when it isn't on disk
+      // yet, in which case isContentFile() falls back to a path heuristic.
+      const roots = readTinaCollectionRoots(server.config?.root);
+
       let timer: ReturnType<typeof setTimeout> | undefined;
       const flush = () => {
         ssr.hot.send('astro:content-changed', {});
         client.hot.send({ type: 'full-reload', path: '*' });
       };
       const onChange = (file: string) => {
-        if (!isContentFile(file)) return;
+        if (!isContentFile(file, roots)) return;
         // Coalesce bursts (saving several documents fires many events) into a
         // single reload.
         if (timer) clearTimeout(timer);


### PR DESCRIPTION
## The problem

Creating a new entry in the admin leaves it unreachable: it shows in the collection list and on index pages, but visiting its own route 404s until you restart `tinacms dev` by hand. Reported in #5611 (and the same symptom blocked the Astro starter's create-content flow).

## Why

Astro caches `getStaticPaths()` in dev and only re-runs it for a change it recognises: a module in the graph, or a file in a watched content-layer collection. When content is sourced through Tina's GraphQL client rather than Astro's content layer, a newly written file is neither, so the route's path list stays stale and the new page is unreachable.

Confirmed by hand: touching the route file (forcing `getStaticPaths` to re-run) flips the new page from 404 to 200 with nothing else changed.

## The fix

A dev-only Vite plugin in the `tina()` integration watches the configured Tina collection paths and, when a content file is added or removed, emits the same `astro:content-changed` HMR signal Astro fires for its own content layer. Astro clears the route cache, `getStaticPaths` re-runs, the new path resolves, and the open tab reloads.

- Content paths come from the generated schema (`tina/__generated__/_schema.json`), the same source `tinacms dev`'s own watcher uses, so content is matched wherever a collection's `path` points, not just under `content/`. A path heuristic (markdown anywhere; structured data under a `content` dir) is used as a fallback when the schema isn't on disk yet.
- Bursts (a multi-file save) are debounced into a single reload.
- Scoped to Astro 6+ via the installed Astro major: only Astro 6's dev runtime listens for `astro:content-changed` and clears the route cache. Astro 5 has no listener, so it is left a genuine no-op. Gating on the env API would not do this, since Astro 5 ships Vite 6 and has that API too.
- Known limitation: content kept in a separate repo (a `localContentPath` resolving outside the Astro project) isn't watched by Vite, so its new entries still need a manual dev restart. `tinacms dev` indexes that content fine; only the Astro route-cache refresh can't reach outside the project root. This is unchanged from before this PR, not a regression.

## Before / after

Same URL (`/blog/Hello-Tina-Demo/`) in `tinacms dev`, created through the admin; only the fix differs.

![Before the fix: 404](https://raw.githubusercontent.com/kulesy/cc-uploads/main/img/57bce6b1de33-5611-before-404.png)
Figure: Before the fix, a newly created entry 404s on its own page until the dev server is restarted.

![After the fix: renders](https://raw.githubusercontent.com/kulesy/cc-uploads/main/img/bad8283e87f4-5611-after-200.png)
Figure: After the fix, the same entry resolves immediately, no restart needed.
