### PR TITLE
fix(cli): fail build on GraphQL validation errors

### DIFF
--- a/.changeset/quiet-codegen-builds.md
+++ b/.changeset/quiet-codegen-builds.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": patch
+---
+
+Fail CLI builds when generated GraphQL documents do not pass schema validation.

--- a/packages/@tinacms/cli/src/next/codegen/codegen/index.test.ts
+++ b/packages/@tinacms/cli/src/next/codegen/codegen/index.test.ts
@@ -1,0 +1,60 @@
+import { codegen } from '@graphql-codegen/core';
+import { loadDocuments } from '@graphql-tools/load';
+import { buildSchema, parse } from 'graphql';
+import { generateTypes } from './index';
+
+jest.mock('@graphql-codegen/core', () => ({
+  codegen: jest.fn(),
+}));
+
+jest.mock('@graphql-tools/load', () => ({
+  loadDocuments: jest.fn(),
+}));
+
+jest.mock('@graphql-tools/graphql-file-loader', () => ({
+  GraphQLFileLoader: jest.fn(),
+}));
+
+const mockedCodegen = codegen as jest.MockedFunction<typeof codegen>;
+const mockedLoadDocuments = loadDocuments as jest.MockedFunction<
+  typeof loadDocuments
+>;
+
+describe('generateTypes', () => {
+  beforeEach(() => {
+    mockedCodegen.mockReset();
+    mockedLoadDocuments.mockReset();
+  });
+
+  it('throws when loaded documents fail schema validation', async () => {
+    const schema = buildSchema(`
+      type Query {
+        post: Post
+      }
+
+      type Post {
+        title: String!
+      }
+    `);
+
+    mockedLoadDocuments
+      .mockResolvedValueOnce([
+        {
+          document: parse(`
+            query InvalidQuery {
+              post {
+                missingField
+              }
+            }
+          `),
+          location: 'queries.gql',
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    await expect(
+      generateTypes(schema, 'queries.gql', 'frags.gql', 'http://localhost:4001')
+    ).rejects.toThrow('GraphQL Document Validation failed with 1 errors');
+    expect(mockedCodegen).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@tinacms/cli/src/next/codegen/codegen/index.ts
+++ b/packages/@tinacms/cli/src/next/codegen/codegen/index.ts
@@ -2,7 +2,7 @@
 
 */
 
-import { GraphQLSchema, parse, printSchema } from 'graphql';
+import { concatAST, GraphQLSchema, parse, printSchema, validate } from 'graphql';
 
 import { AddGeneratedClient } from './plugin';
 import { GraphQLFileLoader } from '@graphql-tools/graphql-file-loader';
@@ -25,6 +25,23 @@ export const generateTypes = async (
 
   docs = await loadGraphQLDocuments(queryPathGlob);
   fragDocs = await loadGraphQLDocuments(fragDocPath);
+
+  const validationErrors = validate(
+    schema,
+    concatAST(
+      [...fragDocs, ...docs].flatMap((document) =>
+        document.document ? [document.document] : []
+      )
+    )
+  );
+
+  if (validationErrors.length) {
+    throw new Error(
+      `GraphQL Document Validation failed with ${validationErrors.length} errors;\n${validationErrors
+        .map((error, index) => `  Error ${index}: ${error.message}`)
+        .join('\n')}`
+    );
+  }
 
   // See https://www.graphql-code-generator.com/docs/getting-started/programmatic-usage for more details
   const res = await codegen({


### PR DESCRIPTION
## What problem does this address?

Fixes #7052.

`tinacms build` could continue successfully even when generated GraphQL documents failed schema validation during the codegen step.

## What is changed?

- Validate loaded query and fragment documents before invoking `@graphql-codegen/core`.
- Throw a build-stopping error with the validation error count when invalid documents are found.
- Add a focused regression test for invalid loaded documents.
- Add a patch changeset for `@tinacms/cli`.

## Testing

- `git diff --check`
- Attempted `npx --yes pnpm@11 --filter @tinacms/cli test -- src/next/codegen/codegen/index.test.ts --runInBand`, but local dependency installation timed out while fetching unrelated workspace packages. Local shell also reports unsupported Node `v26.0.0`; repo expects Node `22.x || 24.x`.
