### PR TITLE
Fix media mediaroot key scoping

### DIFF
--- a/.changeset/rude-ears-remember.md
+++ b/.changeset/rude-ears-remember.md
@@ -1,0 +1,22 @@
+---
+"tinacms-gitprovider-github": patch
+"@tinacms/vercel-previews": patch
+"next-tinacms-cloudinary": patch
+"@tinacms/schema-tools": patch
+"@tinacms/datalayer": patch
+"next-tinacms-azure": patch
+"@tinacms/graphql": patch
+"next-tinacms-dos": patch
+"@tinacms/search": patch
+"create-tina-app": patch
+"next-tinacms-s3": patch
+"@tinacms/astro": patch
+"tinacms-authjs": patch
+"tinacms-clerk": patch
+"@tinacms/app": patch
+"@tinacms/cli": patch
+"@tinacms/mdx": patch
+"tinacms": patch
+---
+
+Fix media upload/delete paths to prevent access to storage keys outside mediaRoot.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"update-tina-lock": "pnpm -r --filter='{./**}' --workspace-concurrency=1 run --if-present update-tina-lock",
 		"test": "turbo run test --filter=\"./packages/**\"",
 		"lint:packages": "pnpm --filter './packages/**' --no-bail exec pnpm dlx publint --strict",
-		"test:packages": "vitest run tests/build-verification.test.ts --reporter=verbose && pnpm run lint:packages",
+		"test:packages": "vitest run --reporter=verbose && pnpm run lint:packages",
 		"types": "turbo run types --filter=\"./packages/**\"",
 		"test:dev": "cd playwright/tina-playwright && npx playwright test --ui",
 		"test:e2e": "cd playwright/tina-playwright && npx playwright test",

--- a/packages/next-tinacms-azure/src/handlers.ts
+++ b/packages/next-tinacms-azure/src/handlers.ts
@@ -64,7 +64,9 @@ async function uploadMedia(req: NextRequest, config: AzureBlobStorageConfig) {
   try {
     // Azure has no mediaRoot concept yet; this still rejects empty keys,
     // absolute paths and traversal. A mediaRoot boundary is a follow-up.
-    blobName = resolveKey('', path.join(directory, filename));
+    blobName = resolveKey('', path.posix.join(directory || '', filename || ''), {
+      decode: false,
+    });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return NextResponse.json({ error: e.message }, { status: 400 });

--- a/packages/next-tinacms-azure/src/handlers.ts
+++ b/packages/next-tinacms-azure/src/handlers.ts
@@ -93,7 +93,9 @@ async function deleteAsset(
 
   let blobName: string;
   try {
-    blobName = resolveKey('', rawKey);
+    // The framework already decodes the route param once; decoding again here
+    // would mangle keys containing a literal "%" (e.g. "100%off.png").
+    blobName = resolveKey('', rawKey, { decode: false });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return NextResponse.json({ error: e.message }, { status: 400 });

--- a/packages/next-tinacms-azure/src/handlers.ts
+++ b/packages/next-tinacms-azure/src/handlers.ts
@@ -7,7 +7,7 @@ import type { AzureBlobStorageConfig } from './types';
 import type { MediaListOptions } from 'tinacms';
 import path from 'node:path';
 import { type NextRequest, NextResponse } from 'next/server';
-import { resolveKey, MediaKeyError } from './media-key';
+import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
 
 type RouteParams = { params: { media: string[] } };
 
@@ -140,11 +140,19 @@ async function listMedia(req: NextRequest, config: AzureBlobStorageConfig) {
       mediaListOptions.directory === '/' ||
       mediaListOptions.directory === '""';
 
-    const prefix = useRootDirectory
-      ? ''
-      : mediaListOptions.directory?.endsWith('/')
-        ? mediaListOptions.directory
-        : `${mediaListOptions.directory}/`;
+    let prefix: string;
+    try {
+      // Reject upward traversal in the listing directory for consistency with
+      // the other adapters (no mediaRoot boundary exists here yet).
+      prefix = useRootDirectory
+        ? ''
+        : resolveDirectory(mediaListOptions.directory);
+    } catch (e) {
+      if (e instanceof MediaKeyError) {
+        return NextResponse.json({ error: e.message }, { status: 400 });
+      }
+      throw e;
+    }
 
     const files = [];
     const folders = [];

--- a/packages/next-tinacms-azure/src/handlers.ts
+++ b/packages/next-tinacms-azure/src/handlers.ts
@@ -64,9 +64,13 @@ async function uploadMedia(req: NextRequest, config: AzureBlobStorageConfig) {
   try {
     // Azure has no mediaRoot concept yet; this still rejects empty keys,
     // absolute paths and traversal. A mediaRoot boundary is a follow-up.
-    blobName = resolveKey('', path.posix.join(directory || '', filename || ''), {
-      decode: false,
-    });
+    blobName = resolveKey(
+      '',
+      path.posix.join(directory || '', filename || ''),
+      {
+        decode: false,
+      }
+    );
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return NextResponse.json({ error: e.message }, { status: 400 });

--- a/packages/next-tinacms-azure/src/handlers.ts
+++ b/packages/next-tinacms-azure/src/handlers.ts
@@ -7,6 +7,7 @@ import type { AzureBlobStorageConfig } from './types';
 import type { MediaListOptions } from 'tinacms';
 import path from 'node:path';
 import { type NextRequest, NextResponse } from 'next/server';
+import { resolveKey, MediaKeyError } from './media-key';
 
 type RouteParams = { params: { media: string[] } };
 
@@ -59,7 +60,17 @@ async function uploadMedia(req: NextRequest, config: AzureBlobStorageConfig) {
   }
 
   const buffer = Buffer.from(await file.arrayBuffer());
-  const blobName = path.join(directory, filename);
+  let blobName: string;
+  try {
+    // Azure has no mediaRoot concept yet; this still rejects empty keys,
+    // absolute paths and traversal. A mediaRoot boundary is a follow-up.
+    blobName = resolveKey('', path.join(directory, filename));
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    }
+    throw e;
+  }
   const blockBlobClient = containerClient.getBlockBlobClient(blobName);
   await blockBlobClient.uploadData(buffer);
 
@@ -76,7 +87,17 @@ async function deleteAsset(
   config: AzureBlobStorageConfig
 ): Promise<NextResponse> {
   const { media } = context.params;
-  const [, blobName] = media;
+  const [, rawKey] = media;
+
+  let blobName: string;
+  try {
+    blobName = resolveKey('', rawKey);
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return NextResponse.json({ error: e.message }, { status: 400 });
+    }
+    throw e;
+  }
 
   const options: BlobDeleteOptions = {
     deleteSnapshots: 'include',

--- a/packages/next-tinacms-azure/src/media-key.ts
+++ b/packages/next-tinacms-azure/src/media-key.ts
@@ -1,0 +1,91 @@
+/**
+ * Centralised media object-key resolution / validation.
+ *
+ * Editors may only write to or delete object keys that resolve to a location
+ * inside the operator-configured `mediaRoot`. This helper normalises a
+ * caller-supplied key and guarantees the result stays within that boundary.
+ *
+ * It rejects empty keys, absolute paths, NUL bytes and path-traversal
+ * attempts (including percent-encoded traversal). When `mediaRoot` is empty
+ * (no boundary declared) the key is still normalised and the same illegal
+ * inputs are still rejected, but the key is otherwise returned as-is.
+ *
+ * Callers should catch `MediaKeyError` and translate it into a 4xx response.
+ *
+ * NOTE: this file is intentionally duplicated byte-for-byte across the
+ * first-party media adapters. The shared regression-test vectors guard
+ * against the copies drifting apart.
+ */
+import path from 'node:path';
+
+export class MediaKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MediaKeyError';
+  }
+}
+
+function normalizeMediaRoot(mediaRoot: string): string {
+  if (!mediaRoot) {
+    return '';
+  }
+  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * Resolve a caller-supplied media key against the configured mediaRoot.
+ *
+ * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
+ * byte, uses path traversal, or escapes mediaRoot.
+ */
+export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+  if (typeof rawKey !== 'string' || rawKey.trim() === '') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawKey);
+  } catch {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject NUL bytes and backslash (Windows-style separator / traversal).
+  if (decoded.includes('\0') || decoded.includes('\\')) {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject absolute paths (POSIX root and Windows drive letters).
+  if (decoded.startsWith('/') || /^[a-zA-Z]:/.test(decoded)) {
+    throw new MediaKeyError('absolute media keys are not allowed');
+  }
+
+  // Normalise, then reject anything that climbs above the current root.
+  const normalized = path.posix.normalize(decoded).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media key may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  const root = normalizeMediaRoot(mediaRoot);
+  if (!root) {
+    return normalized;
+  }
+
+  // The key may arrive already prefixed with mediaRoot (the delete path sends
+  // the full object key) or relative to it (the upload path). Only prefix
+  // when it is not already scoped.
+  const scoped =
+    normalized === root || normalized.startsWith(root + '/')
+      ? normalized
+      : path.posix.join(root, normalized);
+
+  // Defence in depth: the resolved key must stay within mediaRoot.
+  if (scoped !== root && !scoped.startsWith(root + '/')) {
+    throw new MediaKeyError('media key escapes mediaRoot');
+  }
+
+  return scoped;
+}

--- a/packages/next-tinacms-azure/src/media-key.ts
+++ b/packages/next-tinacms-azure/src/media-key.ts
@@ -101,3 +101,39 @@ export function resolveKey(
 
   return scoped;
 }
+
+/**
+ * Resolve a caller-supplied listing directory into a relative prefix.
+ *
+ * The directory is optional: an empty / root directory returns `''` (list the
+ * mediaRoot itself). Otherwise leading/trailing slashes are stripped (matching
+ * the historical handler behaviour) and the result is normalised so it cannot
+ * traverse upward — `path.join(mediaRoot, directory)` would otherwise collapse
+ * `..` and list objects outside mediaRoot. Returns a prefix with a trailing
+ * slash so it can be joined onto mediaRoot directly.
+ *
+ * @throws {MediaKeyError} when the directory contains a NUL byte or backslash,
+ * or uses upward path traversal.
+ */
+export function resolveDirectory(rawDirectory: unknown): string {
+  // Listing directories arrive from a URL query and are decoded once by the
+  // framework; treat them as literal (no further decode).
+  if (typeof rawDirectory !== 'string' || rawDirectory.trim() === '') {
+    return '';
+  }
+
+  if (rawDirectory.includes('\0') || rawDirectory.includes('\\')) {
+    throw new MediaKeyError('media directory is not valid');
+  }
+
+  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media directory may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    return '';
+  }
+
+  return normalized + '/';
+}

--- a/packages/next-tinacms-azure/src/media-key.ts
+++ b/packages/next-tinacms-azure/src/media-key.ts
@@ -25,11 +25,21 @@ export class MediaKeyError extends Error {
   }
 }
 
+// Trim leading and trailing slashes without a backtracking regex (avoids
+// polynomial-time matching on attacker-controlled runs of slashes).
+function stripSlashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '/') start++;
+  while (end > start && value[end - 1] === '/') end--;
+  return value.slice(start, end);
+}
+
 function normalizeMediaRoot(mediaRoot: string): string {
   if (!mediaRoot) {
     return '';
   }
-  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+  return stripSlashes(mediaRoot);
 }
 
 /**
@@ -126,7 +136,7 @@ export function resolveDirectory(rawDirectory: unknown): string {
     throw new MediaKeyError('media directory is not valid');
   }
 
-  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const trimmed = stripSlashes(rawDirectory);
   const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
   if (normalized === '..' || normalized.startsWith('../')) {
     throw new MediaKeyError('media directory may not traverse directories');

--- a/packages/next-tinacms-azure/src/media-key.ts
+++ b/packages/next-tinacms-azure/src/media-key.ts
@@ -38,16 +38,28 @@ function normalizeMediaRoot(mediaRoot: string): string {
  * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
  * byte, uses path traversal, or escapes mediaRoot.
  */
-export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+export function resolveKey(
+  mediaRoot: string,
+  rawKey: unknown,
+  options?: { decode?: boolean }
+): string {
   if (typeof rawKey !== 'string' || rawKey.trim() === '') {
     throw new MediaKeyError('a media key is required');
   }
 
+  // Inputs from a URL query / route segment are percent-encoded, so decode
+  // them. Inputs from a multipart filename are literal and must NOT be decoded
+  // (pass decode: false), otherwise a legitimate name like "100%.png" would be
+  // rejected and "report%41.png" silently rewritten to "reportA.png".
   let decoded: string;
-  try {
-    decoded = decodeURIComponent(rawKey);
-  } catch {
-    throw new MediaKeyError('media key is not valid');
+  if (options?.decode === false) {
+    decoded = rawKey;
+  } else {
+    try {
+      decoded = decodeURIComponent(rawKey);
+    } catch {
+      throw new MediaKeyError('media key is not valid');
+    }
   }
 
   // Reject NUL bytes and backslash (Windows-style separator / traversal).

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -8,7 +8,7 @@ import path from 'path';
 import { NextApiRequest, NextApiResponse } from 'next';
 import multer from 'multer';
 import { promisify } from 'util';
-import { resolveKey, MediaKeyError } from './media-key';
+import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
 
 export interface CloudinaryConfig {
   cloud_name: string;
@@ -129,6 +129,21 @@ async function listMedia(
       !mediaListOptions.directory ||
       mediaListOptions.directory === '/' ||
       mediaListOptions.directory === '""';
+
+    if (!useRootDirectory) {
+      try {
+        // Reject upward traversal in the listing directory for consistency
+        // with the other adapters. (Search-expression escaping is a separate
+        // follow-up.)
+        resolveDirectory(mediaListOptions.directory);
+      } catch (e) {
+        if (e instanceof MediaKeyError) {
+          res.status(400).json({ e: e.message });
+          return;
+        }
+        throw e;
+      }
+    }
 
     const query = useRootDirectory
       ? 'folder=""'

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -132,9 +132,12 @@ async function listMedia(
 
     if (!useRootDirectory) {
       try {
-        // Reject upward traversal in the listing directory for consistency
-        // with the other adapters. (Search-expression escaping is a separate
-        // follow-up.)
+        // Validation only: reject upward traversal in the listing directory for
+        // consistency with the other adapters. The normalised result is
+        // intentionally discarded; the raw directory is still interpolated into
+        // the search expression below, so this does NOT bound the listing the
+        // way resolveDirectory bounds the S3/DOS prefix. Search-expression
+        // escaping (SEC-5) is a separate follow-up.
         resolveDirectory(mediaListOptions.directory);
       } catch (e) {
         if (e instanceof MediaKeyError) {

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -221,7 +221,9 @@ async function deleteAsset(req: NextApiRequest, res: NextApiResponse) {
 
   let public_id: string;
   try {
-    public_id = resolveKey('', rawPublicId);
+    // The framework already decodes the route param once; decoding again here
+    // would mangle keys containing a literal "%" (e.g. "100%off.png").
+    public_id = resolveKey('', rawPublicId, { decode: false });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -8,6 +8,7 @@ import path from 'path';
 import { NextApiRequest, NextApiResponse } from 'next';
 import multer from 'multer';
 import { promisify } from 'util';
+import { resolveKey, MediaKeyError } from './media-key';
 
 export interface CloudinaryConfig {
   cloud_name: string;
@@ -72,10 +73,23 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
 
   const { directory } = req.body;
 
+  let folder: string;
+  try {
+    // Cloudinary has no mediaRoot concept yet; an empty folder (root upload)
+    // is allowed, but traversal / absolute folders are rejected.
+    const rawFolder = (directory || '').replace(/^\/+/, '');
+    folder = rawFolder ? resolveKey('', rawFolder) : '';
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return res.status(400).json({ message: e.message });
+    }
+    throw e;
+  }
+
   try {
     //@ts-ignore
     const result = await cloudinary.uploader.upload(req.file.path, {
-      folder: directory.replace(/^\//, ''),
+      folder,
       use_filename: true,
       overwrite: false,
       resource_type: 'auto',
@@ -192,9 +206,19 @@ const findErrorMessage = (e: any) => {
 
 async function deleteAsset(req: NextApiRequest, res: NextApiResponse) {
   const { media } = req.query;
-  const [, public_id] = media as string[];
+  const [, rawPublicId] = media as string[];
 
-  cloudinary.uploader.destroy(public_id as string, {}, (err) => {
+  let public_id: string;
+  try {
+    public_id = resolveKey('', rawPublicId);
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return res.status(400).json({ message: e.message });
+    }
+    throw e;
+  }
+
+  cloudinary.uploader.destroy(public_id, {}, (err: any) => {
     if (err) res.status(500);
     res.json({
       err,

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -72,6 +72,8 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
   await upload(req, res);
 
   const { directory } = req.body;
+  // @ts-ignore - multer augments the request with `file`
+  const filename: string = req.file?.originalname;
 
   let folder: string;
   try {
@@ -79,6 +81,10 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
     // is allowed, but traversal / absolute folders are rejected.
     const rawFolder = (directory || '').replace(/^\/+/, '');
     folder = rawFolder ? resolveKey('', rawFolder) : '';
+    // Validate the filename with the same rules. Cloudinary still derives the
+    // public_id from folder + use_filename; we only reject illegal names here
+    // and leave the naming model unchanged.
+    resolveKey('', filename);
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -71,20 +71,25 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
   // @ts-ignore
   await upload(req, res);
 
+  // @ts-ignore - multer augments the request with `file`
+  if (!req.file) {
+    return res.status(400).json({ message: 'file is required' });
+  }
+
   const { directory } = req.body;
   // @ts-ignore - multer augments the request with `file`
-  const filename: string = req.file?.originalname;
+  const filename: string = req.file.originalname;
 
   let folder: string;
   try {
     // Cloudinary has no mediaRoot concept yet; an empty folder (root upload)
     // is allowed, but traversal / absolute folders are rejected.
     const rawFolder = (directory || '').replace(/^\/+/, '');
-    folder = rawFolder ? resolveKey('', rawFolder) : '';
+    folder = rawFolder ? resolveKey('', rawFolder, { decode: false }) : '';
     // Validate the filename with the same rules. Cloudinary still derives the
     // public_id from folder + use_filename; we only reject illegal names here
     // and leave the naming model unchanged.
-    resolveKey('', filename);
+    resolveKey('', filename, { decode: false });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -141,7 +141,7 @@ async function listMedia(
         resolveDirectory(mediaListOptions.directory);
       } catch (e) {
         if (e instanceof MediaKeyError) {
-          res.status(400).json({ e: e.message });
+          res.status(400).json({ message: e.message });
           return;
         }
         throw e;

--- a/packages/next-tinacms-cloudinary/src/media-key.ts
+++ b/packages/next-tinacms-cloudinary/src/media-key.ts
@@ -1,0 +1,91 @@
+/**
+ * Centralised media object-key resolution / validation.
+ *
+ * Editors may only write to or delete object keys that resolve to a location
+ * inside the operator-configured `mediaRoot`. This helper normalises a
+ * caller-supplied key and guarantees the result stays within that boundary.
+ *
+ * It rejects empty keys, absolute paths, NUL bytes and path-traversal
+ * attempts (including percent-encoded traversal). When `mediaRoot` is empty
+ * (no boundary declared) the key is still normalised and the same illegal
+ * inputs are still rejected, but the key is otherwise returned as-is.
+ *
+ * Callers should catch `MediaKeyError` and translate it into a 4xx response.
+ *
+ * NOTE: this file is intentionally duplicated byte-for-byte across the
+ * first-party media adapters. The shared regression-test vectors guard
+ * against the copies drifting apart.
+ */
+import path from 'node:path';
+
+export class MediaKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MediaKeyError';
+  }
+}
+
+function normalizeMediaRoot(mediaRoot: string): string {
+  if (!mediaRoot) {
+    return '';
+  }
+  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * Resolve a caller-supplied media key against the configured mediaRoot.
+ *
+ * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
+ * byte, uses path traversal, or escapes mediaRoot.
+ */
+export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+  if (typeof rawKey !== 'string' || rawKey.trim() === '') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawKey);
+  } catch {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject NUL bytes and backslash (Windows-style separator / traversal).
+  if (decoded.includes('\0') || decoded.includes('\\')) {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject absolute paths (POSIX root and Windows drive letters).
+  if (decoded.startsWith('/') || /^[a-zA-Z]:/.test(decoded)) {
+    throw new MediaKeyError('absolute media keys are not allowed');
+  }
+
+  // Normalise, then reject anything that climbs above the current root.
+  const normalized = path.posix.normalize(decoded).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media key may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  const root = normalizeMediaRoot(mediaRoot);
+  if (!root) {
+    return normalized;
+  }
+
+  // The key may arrive already prefixed with mediaRoot (the delete path sends
+  // the full object key) or relative to it (the upload path). Only prefix
+  // when it is not already scoped.
+  const scoped =
+    normalized === root || normalized.startsWith(root + '/')
+      ? normalized
+      : path.posix.join(root, normalized);
+
+  // Defence in depth: the resolved key must stay within mediaRoot.
+  if (scoped !== root && !scoped.startsWith(root + '/')) {
+    throw new MediaKeyError('media key escapes mediaRoot');
+  }
+
+  return scoped;
+}

--- a/packages/next-tinacms-cloudinary/src/media-key.ts
+++ b/packages/next-tinacms-cloudinary/src/media-key.ts
@@ -101,3 +101,39 @@ export function resolveKey(
 
   return scoped;
 }
+
+/**
+ * Resolve a caller-supplied listing directory into a relative prefix.
+ *
+ * The directory is optional: an empty / root directory returns `''` (list the
+ * mediaRoot itself). Otherwise leading/trailing slashes are stripped (matching
+ * the historical handler behaviour) and the result is normalised so it cannot
+ * traverse upward — `path.join(mediaRoot, directory)` would otherwise collapse
+ * `..` and list objects outside mediaRoot. Returns a prefix with a trailing
+ * slash so it can be joined onto mediaRoot directly.
+ *
+ * @throws {MediaKeyError} when the directory contains a NUL byte or backslash,
+ * or uses upward path traversal.
+ */
+export function resolveDirectory(rawDirectory: unknown): string {
+  // Listing directories arrive from a URL query and are decoded once by the
+  // framework; treat them as literal (no further decode).
+  if (typeof rawDirectory !== 'string' || rawDirectory.trim() === '') {
+    return '';
+  }
+
+  if (rawDirectory.includes('\0') || rawDirectory.includes('\\')) {
+    throw new MediaKeyError('media directory is not valid');
+  }
+
+  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media directory may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    return '';
+  }
+
+  return normalized + '/';
+}

--- a/packages/next-tinacms-cloudinary/src/media-key.ts
+++ b/packages/next-tinacms-cloudinary/src/media-key.ts
@@ -25,11 +25,21 @@ export class MediaKeyError extends Error {
   }
 }
 
+// Trim leading and trailing slashes without a backtracking regex (avoids
+// polynomial-time matching on attacker-controlled runs of slashes).
+function stripSlashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '/') start++;
+  while (end > start && value[end - 1] === '/') end--;
+  return value.slice(start, end);
+}
+
 function normalizeMediaRoot(mediaRoot: string): string {
   if (!mediaRoot) {
     return '';
   }
-  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+  return stripSlashes(mediaRoot);
 }
 
 /**
@@ -126,7 +136,7 @@ export function resolveDirectory(rawDirectory: unknown): string {
     throw new MediaKeyError('media directory is not valid');
   }
 
-  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const trimmed = stripSlashes(rawDirectory);
   const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
   if (normalized === '..' || normalized.startsWith('../')) {
     throw new MediaKeyError('media directory may not traverse directories');

--- a/packages/next-tinacms-cloudinary/src/media-key.ts
+++ b/packages/next-tinacms-cloudinary/src/media-key.ts
@@ -38,16 +38,28 @@ function normalizeMediaRoot(mediaRoot: string): string {
  * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
  * byte, uses path traversal, or escapes mediaRoot.
  */
-export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+export function resolveKey(
+  mediaRoot: string,
+  rawKey: unknown,
+  options?: { decode?: boolean }
+): string {
   if (typeof rawKey !== 'string' || rawKey.trim() === '') {
     throw new MediaKeyError('a media key is required');
   }
 
+  // Inputs from a URL query / route segment are percent-encoded, so decode
+  // them. Inputs from a multipart filename are literal and must NOT be decoded
+  // (pass decode: false), otherwise a legitimate name like "100%.png" would be
+  // rejected and "report%41.png" silently rewritten to "reportA.png".
   let decoded: string;
-  try {
-    decoded = decodeURIComponent(rawKey);
-  } catch {
-    throw new MediaKeyError('media key is not valid');
+  if (options?.decode === false) {
+    decoded = rawKey;
+  } else {
+    try {
+      decoded = decodeURIComponent(rawKey);
+    } catch {
+      throw new MediaKeyError('media key is not valid');
+    }
   }
 
   // Reject NUL bytes and backslash (Windows-style separator / traversal).

--- a/packages/next-tinacms-dos/src/handlers.ts
+++ b/packages/next-tinacms-dos/src/handlers.ts
@@ -18,7 +18,7 @@ import path from 'path';
 import fs from 'fs';
 import { NextApiRequest, NextApiResponse } from 'next';
 import multer from 'multer';
-import { resolveKey, MediaKeyError } from './media-key';
+import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
 import { promisify } from 'util';
 
 export interface DOSConfig {
@@ -189,8 +189,18 @@ async function listMedia(
       limit = 500,
       offset,
     } = req.query as MediaListOptions;
-    let prefix = directory.replace(/^\//, '').replace(/\/$/, '');
-    if (prefix) prefix = prefix + '/';
+    let prefix: string;
+    try {
+      // Reject upward traversal: directory flows into path.join(mediaRoot,
+      // prefix), which would otherwise collapse ".." and list outside mediaRoot.
+      prefix = resolveDirectory(directory);
+    } catch (e) {
+      if (e instanceof MediaKeyError) {
+        res.status(400).json({ message: e.message });
+        return;
+      }
+      throw e;
+    }
 
     const params: ListObjectsCommandInput = {
       Bucket: bucket,

--- a/packages/next-tinacms-dos/src/handlers.ts
+++ b/packages/next-tinacms-dos/src/handlers.ts
@@ -270,7 +270,9 @@ async function deleteAsset(
 
   let objectKey: string;
   try {
-    objectKey = resolveKey(mediaRoot, rawKey);
+    // The framework already decodes the route param once; decoding again here
+    // would mangle keys containing a literal "%" (e.g. "100%off.png").
+    objectKey = resolveKey(mediaRoot, rawKey, { decode: false });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-dos/src/handlers.ts
+++ b/packages/next-tinacms-dos/src/handlers.ts
@@ -18,6 +18,7 @@ import path from 'path';
 import fs from 'fs';
 import { NextApiRequest, NextApiResponse } from 'next';
 import multer from 'multer';
+import { resolveKey, MediaKeyError } from './media-key';
 import { promisify } from 'util';
 
 export interface DOSConfig {
@@ -69,7 +70,7 @@ export const createMediaHandler = (config: DOSConfig, options?: DOSOptions) => {
       case 'POST':
         return uploadMedia(req, res, client, bucket, mediaRoot, cdnUrl);
       case 'DELETE':
-        return deleteAsset(req, res, client, bucket);
+        return deleteAsset(req, res, client, bucket, mediaRoot);
       default:
         res.end(404);
     }
@@ -114,11 +115,20 @@ async function uploadMedia(
   const fileType = req.file?.mimetype;
   const blob = fs.readFileSync(filePath);
   const filename = path.basename(filePath);
+
+  let objectKey: string;
+  try {
+    objectKey = resolveKey(mediaRoot, prefix + filename);
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return res.status(400).json({ message: e.message });
+    }
+    throw e;
+  }
+
   const params: PutObjectCommandInput = {
     Bucket: bucket,
-    Key: mediaRoot
-      ? path.join(mediaRoot, prefix + filename)
-      : prefix + filename,
+    Key: objectKey,
     Body: blob,
     ACL: 'public-read',
     ContentType: fileType || 'application/octet-stream',
@@ -138,11 +148,7 @@ async function uploadMedia(
         '400x400': src,
         '1000x1000': src,
       },
-      src:
-        cdnUrl +
-        (mediaRoot
-          ? path.join(mediaRoot, prefix + filename)
-          : prefix + filename),
+      src: cdnUrl + objectKey,
     });
   } catch (e) {
     console.error('Error uploading media');
@@ -250,15 +256,26 @@ async function deleteAsset(
   req: NextApiRequest,
   res: NextApiResponse,
   client: S3Client,
-  bucket: string
+  bucket: string,
+  mediaRoot: string
 ) {
   const { media } = req.query;
-  let [, objectKey] = media as string[];
+  let [, rawKey] = media as string[];
   const objectKeyIsSplit =
     media && media.length > 2 && typeof media !== 'string';
 
   if (objectKeyIsSplit) {
-    objectKey = media.slice(1).join('/');
+    rawKey = media.slice(1).join('/');
+  }
+
+  let objectKey: string;
+  try {
+    objectKey = resolveKey(mediaRoot, rawKey);
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return res.status(400).json({ message: e.message });
+    }
+    throw e;
   }
 
   const params: DeleteObjectCommandInput = {

--- a/packages/next-tinacms-dos/src/handlers.ts
+++ b/packages/next-tinacms-dos/src/handlers.ts
@@ -118,7 +118,7 @@ async function uploadMedia(
 
   let objectKey: string;
   try {
-    objectKey = resolveKey(mediaRoot, prefix + filename);
+    objectKey = resolveKey(mediaRoot, prefix + filename, { decode: false });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-dos/src/media-key.ts
+++ b/packages/next-tinacms-dos/src/media-key.ts
@@ -1,0 +1,91 @@
+/**
+ * Centralised media object-key resolution / validation.
+ *
+ * Editors may only write to or delete object keys that resolve to a location
+ * inside the operator-configured `mediaRoot`. This helper normalises a
+ * caller-supplied key and guarantees the result stays within that boundary.
+ *
+ * It rejects empty keys, absolute paths, NUL bytes and path-traversal
+ * attempts (including percent-encoded traversal). When `mediaRoot` is empty
+ * (no boundary declared) the key is still normalised and the same illegal
+ * inputs are still rejected, but the key is otherwise returned as-is.
+ *
+ * Callers should catch `MediaKeyError` and translate it into a 4xx response.
+ *
+ * NOTE: this file is intentionally duplicated byte-for-byte across the
+ * first-party media adapters. The shared regression-test vectors guard
+ * against the copies drifting apart.
+ */
+import path from 'node:path';
+
+export class MediaKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MediaKeyError';
+  }
+}
+
+function normalizeMediaRoot(mediaRoot: string): string {
+  if (!mediaRoot) {
+    return '';
+  }
+  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * Resolve a caller-supplied media key against the configured mediaRoot.
+ *
+ * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
+ * byte, uses path traversal, or escapes mediaRoot.
+ */
+export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+  if (typeof rawKey !== 'string' || rawKey.trim() === '') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawKey);
+  } catch {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject NUL bytes and backslash (Windows-style separator / traversal).
+  if (decoded.includes('\0') || decoded.includes('\\')) {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject absolute paths (POSIX root and Windows drive letters).
+  if (decoded.startsWith('/') || /^[a-zA-Z]:/.test(decoded)) {
+    throw new MediaKeyError('absolute media keys are not allowed');
+  }
+
+  // Normalise, then reject anything that climbs above the current root.
+  const normalized = path.posix.normalize(decoded).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media key may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  const root = normalizeMediaRoot(mediaRoot);
+  if (!root) {
+    return normalized;
+  }
+
+  // The key may arrive already prefixed with mediaRoot (the delete path sends
+  // the full object key) or relative to it (the upload path). Only prefix
+  // when it is not already scoped.
+  const scoped =
+    normalized === root || normalized.startsWith(root + '/')
+      ? normalized
+      : path.posix.join(root, normalized);
+
+  // Defence in depth: the resolved key must stay within mediaRoot.
+  if (scoped !== root && !scoped.startsWith(root + '/')) {
+    throw new MediaKeyError('media key escapes mediaRoot');
+  }
+
+  return scoped;
+}

--- a/packages/next-tinacms-dos/src/media-key.ts
+++ b/packages/next-tinacms-dos/src/media-key.ts
@@ -101,3 +101,39 @@ export function resolveKey(
 
   return scoped;
 }
+
+/**
+ * Resolve a caller-supplied listing directory into a relative prefix.
+ *
+ * The directory is optional: an empty / root directory returns `''` (list the
+ * mediaRoot itself). Otherwise leading/trailing slashes are stripped (matching
+ * the historical handler behaviour) and the result is normalised so it cannot
+ * traverse upward — `path.join(mediaRoot, directory)` would otherwise collapse
+ * `..` and list objects outside mediaRoot. Returns a prefix with a trailing
+ * slash so it can be joined onto mediaRoot directly.
+ *
+ * @throws {MediaKeyError} when the directory contains a NUL byte or backslash,
+ * or uses upward path traversal.
+ */
+export function resolveDirectory(rawDirectory: unknown): string {
+  // Listing directories arrive from a URL query and are decoded once by the
+  // framework; treat them as literal (no further decode).
+  if (typeof rawDirectory !== 'string' || rawDirectory.trim() === '') {
+    return '';
+  }
+
+  if (rawDirectory.includes('\0') || rawDirectory.includes('\\')) {
+    throw new MediaKeyError('media directory is not valid');
+  }
+
+  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media directory may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    return '';
+  }
+
+  return normalized + '/';
+}

--- a/packages/next-tinacms-dos/src/media-key.ts
+++ b/packages/next-tinacms-dos/src/media-key.ts
@@ -25,11 +25,21 @@ export class MediaKeyError extends Error {
   }
 }
 
+// Trim leading and trailing slashes without a backtracking regex (avoids
+// polynomial-time matching on attacker-controlled runs of slashes).
+function stripSlashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '/') start++;
+  while (end > start && value[end - 1] === '/') end--;
+  return value.slice(start, end);
+}
+
 function normalizeMediaRoot(mediaRoot: string): string {
   if (!mediaRoot) {
     return '';
   }
-  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+  return stripSlashes(mediaRoot);
 }
 
 /**
@@ -126,7 +136,7 @@ export function resolveDirectory(rawDirectory: unknown): string {
     throw new MediaKeyError('media directory is not valid');
   }
 
-  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const trimmed = stripSlashes(rawDirectory);
   const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
   if (normalized === '..' || normalized.startsWith('../')) {
     throw new MediaKeyError('media directory may not traverse directories');

--- a/packages/next-tinacms-dos/src/media-key.ts
+++ b/packages/next-tinacms-dos/src/media-key.ts
@@ -38,16 +38,28 @@ function normalizeMediaRoot(mediaRoot: string): string {
  * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
  * byte, uses path traversal, or escapes mediaRoot.
  */
-export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+export function resolveKey(
+  mediaRoot: string,
+  rawKey: unknown,
+  options?: { decode?: boolean }
+): string {
   if (typeof rawKey !== 'string' || rawKey.trim() === '') {
     throw new MediaKeyError('a media key is required');
   }
 
+  // Inputs from a URL query / route segment are percent-encoded, so decode
+  // them. Inputs from a multipart filename are literal and must NOT be decoded
+  // (pass decode: false), otherwise a legitimate name like "100%.png" would be
+  // rejected and "report%41.png" silently rewritten to "reportA.png".
   let decoded: string;
-  try {
-    decoded = decodeURIComponent(rawKey);
-  } catch {
-    throw new MediaKeyError('media key is not valid');
+  if (options?.decode === false) {
+    decoded = rawKey;
+  } else {
+    try {
+      decoded = decodeURIComponent(rawKey);
+    } catch {
+      throw new MediaKeyError('media key is not valid');
+    }
   }
 
   // Reject NUL bytes and backslash (Windows-style separator / traversal).

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -219,7 +219,9 @@ async function deleteAsset(
 
   let objectKey: string;
   try {
-    objectKey = resolveKey(mediaRoot, rawKey);
+    // The framework already decodes the route param once; decoding again here
+    // would mangle keys containing a literal "%" (e.g. "100%off.png").
+    objectKey = resolveKey(mediaRoot, rawKey, { decode: false });
   } catch (e) {
     if (e instanceof MediaKeyError) {
       return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -18,7 +18,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Media, MediaListOptions } from 'tinacms';
 import path from 'node:path';
 import { NextApiRequest, NextApiResponse } from 'next';
-import { resolveKey, MediaKeyError } from './media-key';
+import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
 
 export interface S3Config {
   config: S3ClientConfig;
@@ -141,8 +141,18 @@ async function listMedia(
       offset,
     } = req.query as MediaListOptions;
 
-    let prefix = directory.replace(/^\//, '').replace(/\/$/, '');
-    if (prefix) prefix = prefix + '/';
+    let prefix: string;
+    try {
+      // Reject upward traversal: directory flows into path.join(mediaRoot,
+      // prefix), which would otherwise collapse ".." and list outside mediaRoot.
+      prefix = resolveDirectory(directory);
+    } catch (e) {
+      if (e instanceof MediaKeyError) {
+        res.status(400).json({ message: e.message });
+        return;
+      }
+      throw e;
+    }
 
     const params: ListObjectsCommandInput = {
       Bucket: bucket,

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -18,6 +18,7 @@ import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { Media, MediaListOptions } from 'tinacms';
 import path from 'node:path';
 import { NextApiRequest, NextApiResponse } from 'next';
+import { resolveKey, MediaKeyError } from './media-key';
 
 export interface S3Config {
   config: S3ClientConfig;
@@ -68,13 +69,17 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
         if (req.query.key) {
           const expiresIn: number =
             (req.query.expiresIn && Number(req.query.expiresIn)) || 3600;
-          const s3_key = req.query.key
-            ? Array.isArray(req.query.key)
-              ? req.query.key[0]
-              : req.query.key
-            : null;
-          if (!s3_key) {
-            return res.status(400).json({ message: 'key is required' });
+          const rawKey = Array.isArray(req.query.key)
+            ? req.query.key[0]
+            : req.query.key;
+          let s3_key: string;
+          try {
+            s3_key = resolveKey(mediaRoot, rawKey);
+          } catch (e) {
+            if (e instanceof MediaKeyError) {
+              return res.status(400).json({ message: e.message });
+            }
+            throw e;
           }
           if (await keyExists(client, bucket, s3_key)) {
             return res.status(400).json({ message: 'key already exists' });
@@ -90,7 +95,7 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
         }
         return listMedia(req, res, client, bucket, mediaRoot, cdnUrl);
       case 'DELETE':
-        return deleteAsset(req, res, client, bucket);
+        return deleteAsset(req, res, client, bucket, mediaRoot);
       default:
         res.end(404);
     }
@@ -200,10 +205,21 @@ async function deleteAsset(
   req: NextApiRequest,
   res: NextApiResponse,
   client: S3Client,
-  bucket: string
+  bucket: string,
+  mediaRoot: string
 ) {
   const { media } = req.query;
-  const [, objectKey] = media as string[];
+  const [, rawKey] = media as string[];
+
+  let objectKey: string;
+  try {
+    objectKey = resolveKey(mediaRoot, rawKey);
+  } catch (e) {
+    if (e instanceof MediaKeyError) {
+      return res.status(400).json({ message: e.message });
+    }
+    throw e;
+  }
 
   const params: DeleteObjectCommandInput = {
     Bucket: bucket,

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -80,7 +80,10 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
             : req.query.key;
           let s3_key: string;
           try {
-            s3_key = resolveKey(mediaRoot, rawKey);
+            // Next already decodes req.query once; decoding again here would
+            // mangle keys containing a literal "%" (e.g. "100%off.png"), the
+            // same reason the delete path passes { decode: false }.
+            s3_key = resolveKey(mediaRoot, rawKey, { decode: false });
           } catch (e) {
             if (e instanceof MediaKeyError) {
               return res.status(400).json({ message: e.message });

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -67,8 +67,14 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
     switch (req.method) {
       case 'GET':
         if (req.query.key) {
-          const expiresIn: number =
-            (req.query.expiresIn && Number(req.query.expiresIn)) || 3600;
+          // Cap the presigned URL validity: expiresIn is caller-controlled and
+          // was otherwise bounded only by SigV4's 7-day ceiling, which would
+          // mint a long-lived offline write primitive. Default and max: 3600s.
+          const requestedExpiresIn = Number(req.query.expiresIn);
+          const expiresIn =
+            Number.isFinite(requestedExpiresIn) && requestedExpiresIn > 0
+              ? Math.min(requestedExpiresIn, 3600)
+              : 3600;
           const rawKey = Array.isArray(req.query.key)
             ? req.query.key[0]
             : req.query.key;

--- a/packages/next-tinacms-s3/src/media-key.ts
+++ b/packages/next-tinacms-s3/src/media-key.ts
@@ -1,0 +1,91 @@
+/**
+ * Centralised media object-key resolution / validation.
+ *
+ * Editors may only write to or delete object keys that resolve to a location
+ * inside the operator-configured `mediaRoot`. This helper normalises a
+ * caller-supplied key and guarantees the result stays within that boundary.
+ *
+ * It rejects empty keys, absolute paths, NUL bytes and path-traversal
+ * attempts (including percent-encoded traversal). When `mediaRoot` is empty
+ * (no boundary declared) the key is still normalised and the same illegal
+ * inputs are still rejected, but the key is otherwise returned as-is.
+ *
+ * Callers should catch `MediaKeyError` and translate it into a 4xx response.
+ *
+ * NOTE: this file is intentionally duplicated byte-for-byte across the
+ * first-party media adapters. The shared regression-test vectors guard
+ * against the copies drifting apart.
+ */
+import path from 'node:path';
+
+export class MediaKeyError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'MediaKeyError';
+  }
+}
+
+function normalizeMediaRoot(mediaRoot: string): string {
+  if (!mediaRoot) {
+    return '';
+  }
+  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+/**
+ * Resolve a caller-supplied media key against the configured mediaRoot.
+ *
+ * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
+ * byte, uses path traversal, or escapes mediaRoot.
+ */
+export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+  if (typeof rawKey !== 'string' || rawKey.trim() === '') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(rawKey);
+  } catch {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject NUL bytes and backslash (Windows-style separator / traversal).
+  if (decoded.includes('\0') || decoded.includes('\\')) {
+    throw new MediaKeyError('media key is not valid');
+  }
+
+  // Reject absolute paths (POSIX root and Windows drive letters).
+  if (decoded.startsWith('/') || /^[a-zA-Z]:/.test(decoded)) {
+    throw new MediaKeyError('absolute media keys are not allowed');
+  }
+
+  // Normalise, then reject anything that climbs above the current root.
+  const normalized = path.posix.normalize(decoded).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media key may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    throw new MediaKeyError('a media key is required');
+  }
+
+  const root = normalizeMediaRoot(mediaRoot);
+  if (!root) {
+    return normalized;
+  }
+
+  // The key may arrive already prefixed with mediaRoot (the delete path sends
+  // the full object key) or relative to it (the upload path). Only prefix
+  // when it is not already scoped.
+  const scoped =
+    normalized === root || normalized.startsWith(root + '/')
+      ? normalized
+      : path.posix.join(root, normalized);
+
+  // Defence in depth: the resolved key must stay within mediaRoot.
+  if (scoped !== root && !scoped.startsWith(root + '/')) {
+    throw new MediaKeyError('media key escapes mediaRoot');
+  }
+
+  return scoped;
+}

--- a/packages/next-tinacms-s3/src/media-key.ts
+++ b/packages/next-tinacms-s3/src/media-key.ts
@@ -101,3 +101,39 @@ export function resolveKey(
 
   return scoped;
 }
+
+/**
+ * Resolve a caller-supplied listing directory into a relative prefix.
+ *
+ * The directory is optional: an empty / root directory returns `''` (list the
+ * mediaRoot itself). Otherwise leading/trailing slashes are stripped (matching
+ * the historical handler behaviour) and the result is normalised so it cannot
+ * traverse upward — `path.join(mediaRoot, directory)` would otherwise collapse
+ * `..` and list objects outside mediaRoot. Returns a prefix with a trailing
+ * slash so it can be joined onto mediaRoot directly.
+ *
+ * @throws {MediaKeyError} when the directory contains a NUL byte or backslash,
+ * or uses upward path traversal.
+ */
+export function resolveDirectory(rawDirectory: unknown): string {
+  // Listing directories arrive from a URL query and are decoded once by the
+  // framework; treat them as literal (no further decode).
+  if (typeof rawDirectory !== 'string' || rawDirectory.trim() === '') {
+    return '';
+  }
+
+  if (rawDirectory.includes('\0') || rawDirectory.includes('\\')) {
+    throw new MediaKeyError('media directory is not valid');
+  }
+
+  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
+  if (normalized === '..' || normalized.startsWith('../')) {
+    throw new MediaKeyError('media directory may not traverse directories');
+  }
+  if (normalized === '' || normalized === '.') {
+    return '';
+  }
+
+  return normalized + '/';
+}

--- a/packages/next-tinacms-s3/src/media-key.ts
+++ b/packages/next-tinacms-s3/src/media-key.ts
@@ -25,11 +25,21 @@ export class MediaKeyError extends Error {
   }
 }
 
+// Trim leading and trailing slashes without a backtracking regex (avoids
+// polynomial-time matching on attacker-controlled runs of slashes).
+function stripSlashes(value: string): string {
+  let start = 0;
+  let end = value.length;
+  while (start < end && value[start] === '/') start++;
+  while (end > start && value[end - 1] === '/') end--;
+  return value.slice(start, end);
+}
+
 function normalizeMediaRoot(mediaRoot: string): string {
   if (!mediaRoot) {
     return '';
   }
-  return mediaRoot.replace(/^\/+/, '').replace(/\/+$/, '');
+  return stripSlashes(mediaRoot);
 }
 
 /**
@@ -126,7 +136,7 @@ export function resolveDirectory(rawDirectory: unknown): string {
     throw new MediaKeyError('media directory is not valid');
   }
 
-  const trimmed = rawDirectory.replace(/^\/+/, '').replace(/\/+$/, '');
+  const trimmed = stripSlashes(rawDirectory);
   const normalized = path.posix.normalize(trimmed).replace(/^\.\//, '');
   if (normalized === '..' || normalized.startsWith('../')) {
     throw new MediaKeyError('media directory may not traverse directories');

--- a/packages/next-tinacms-s3/src/media-key.ts
+++ b/packages/next-tinacms-s3/src/media-key.ts
@@ -38,16 +38,28 @@ function normalizeMediaRoot(mediaRoot: string): string {
  * @throws {MediaKeyError} when the key is empty, absolute, contains a NUL
  * byte, uses path traversal, or escapes mediaRoot.
  */
-export function resolveKey(mediaRoot: string, rawKey: unknown): string {
+export function resolveKey(
+  mediaRoot: string,
+  rawKey: unknown,
+  options?: { decode?: boolean }
+): string {
   if (typeof rawKey !== 'string' || rawKey.trim() === '') {
     throw new MediaKeyError('a media key is required');
   }
 
+  // Inputs from a URL query / route segment are percent-encoded, so decode
+  // them. Inputs from a multipart filename are literal and must NOT be decoded
+  // (pass decode: false), otherwise a legitimate name like "100%.png" would be
+  // rejected and "report%41.png" silently rewritten to "reportA.png".
   let decoded: string;
-  try {
-    decoded = decodeURIComponent(rawKey);
-  } catch {
-    throw new MediaKeyError('media key is not valid');
+  if (options?.decode === false) {
+    decoded = rawKey;
+  } else {
+    try {
+      decoded = decodeURIComponent(rawKey);
+    } catch {
+      throw new MediaKeyError('media key is not valid');
+    }
   }
 
   // Reject NUL bytes and backslash (Windows-style separator / traversal).

--- a/tests/media-key.test.ts
+++ b/tests/media-key.test.ts
@@ -95,6 +95,11 @@ const allowedNoDecode: [string, string, string][] = [
   ['', 'report%41.png', 'report%41.png'], // NOT rewritten to reportA.png
   ['', 'my%2Ffile.png', 'my%2Ffile.png'], // %2F NOT turned into a path separator
   ['media', 'cat.png', 'media/cat.png'],
+  // Delete paths now pass { decode: false } because the framework already
+  // decoded the route param once. A key with a literal "%" must resolve to
+  // itself (not throw URIError / get re-decoded) so the object can be deleted.
+  ['media', '100%off.png', 'media/100%off.png'],
+  ['media', 'a%2Fb.png', 'media/a%2Fb.png'], // %2F stays literal, no extra segment
 ];
 const rejectedNoDecode: [string, string][] = [
   ['', '../evil.png'],

--- a/tests/media-key.test.ts
+++ b/tests/media-key.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+
+// The media-key helper is duplicated byte-for-byte across the first-party
+// media adapters. These shared vectors are the single source of truth for its
+// behaviour and guard against the copies drifting apart.
+import {
+  resolveKey as resolveKeyS3,
+  MediaKeyError as MediaKeyErrorS3,
+} from '../packages/next-tinacms-s3/src/media-key';
+import {
+  resolveKey as resolveKeyDos,
+  MediaKeyError as MediaKeyErrorDos,
+} from '../packages/next-tinacms-dos/src/media-key';
+import {
+  resolveKey as resolveKeyAzure,
+  MediaKeyError as MediaKeyErrorAzure,
+} from '../packages/next-tinacms-azure/src/media-key';
+import {
+  resolveKey as resolveKeyCloudinary,
+  MediaKeyError as MediaKeyErrorCloudinary,
+} from '../packages/next-tinacms-cloudinary/src/media-key';
+
+// Each adapter ships its own byte-identical copy of the helper, so each has
+// its own MediaKeyError class. Assert against the matching class per adapter.
+const adapters = [
+  ['next-tinacms-s3', resolveKeyS3, MediaKeyErrorS3],
+  ['next-tinacms-dos', resolveKeyDos, MediaKeyErrorDos],
+  ['next-tinacms-azure', resolveKeyAzure, MediaKeyErrorAzure],
+  ['next-tinacms-cloudinary', resolveKeyCloudinary, MediaKeyErrorCloudinary],
+] as const;
+
+// [mediaRoot, rawKey, expected]
+const allowed: [string, string, string][] = [
+  // Exhibit A: an arbitrary bucket-root key is contained within mediaRoot.
+  ['media', 'index.html', 'media/index.html'],
+  // Exhibit B: a foreign/cross-tenant key cannot escape mediaRoot.
+  ['media', 'backups/db.sql', 'media/backups/db.sql'],
+  [
+    'media',
+    'tenant-victim/posts/announcement.mdx',
+    'media/tenant-victim/posts/announcement.mdx',
+  ],
+  // Delete path sends the full object key — must not be prefixed twice.
+  ['media', 'media/photo.png', 'media/photo.png'],
+  // A prefix-lookalike directory is not mistaken for the root.
+  ['media', 'media-evil/x.png', 'media/media-evil/x.png'],
+  // Ordinary relative upload key.
+  ['media', 'photos/cat.png', 'media/photos/cat.png'],
+  // Inner ".." that does not escape is collapsed, not rejected.
+  ['media', 'a/../b.png', 'media/b.png'],
+  // mediaRoot with surrounding slashes is normalised.
+  ['/media/', 'photos/cat.png', 'media/photos/cat.png'],
+  // No boundary configured (azure/cloudinary today): normalised, returned as-is.
+  ['', 'foo/bar.png', 'foo/bar.png'],
+];
+
+// [mediaRoot, rawKey]
+const rejected: [string, unknown][] = [
+  ['media', ''],
+  ['media', '   '],
+  ['media', '../outside.txt'], // traversal
+  ['media', '/etc/passwd'], // absolute (POSIX)
+  ['media', 'C:/windows/win.ini'], // absolute (Windows drive)
+  ['media', '%2e%2e/secret'], // percent-encoded traversal
+  ['media', '..%2foutside'], // mixed-encoded traversal
+  ['media', 'dir\\..\\x'], // backslash separator
+  ['media', 'a/../../escape'], // traversal that climbs past the root
+  ['', '../x'], // traversal even without a boundary
+  ['', '/abs'], // absolute even without a boundary
+  ['media', undefined], // non-string
+  ['media', null], // non-string
+];
+
+describe.each(adapters)('%s — resolveKey allows and scopes', (_name, resolveKey) => {
+  it.each(allowed)('resolveKey(%j, %j) === %j', (root, raw, expected) => {
+    expect(resolveKey(root, raw)).toBe(expected);
+  });
+});
+
+describe.each(adapters)(
+  '%s — resolveKey rejects',
+  (_name, resolveKey, MediaKeyError) => {
+    it.each(rejected)('resolveKey(%j, %j) throws MediaKeyError', (root, raw) => {
+      expect(() => resolveKey(root, raw as any)).toThrow(MediaKeyError);
+    });
+  }
+);
+
+describe('the four adapter copies behave identically (anti-drift)', () => {
+  const allInputs: [string, unknown][] = [
+    ...allowed.map(([root, raw]) => [root, raw] as [string, unknown]),
+    ...rejected,
+  ];
+
+  it.each(allInputs)('same outcome across all adapters for (%j, %j)', (root, raw) => {
+    const outcomes = adapters.map(([, fn]) => {
+      try {
+        return `ok:${fn(root, raw as any)}`;
+      } catch (e) {
+        return `err:${(e as Error).name}`;
+      }
+    });
+    // Every copy must agree with the first.
+    for (const outcome of outcomes) {
+      expect(outcome).toBe(outcomes[0]);
+    }
+  });
+});

--- a/tests/media-key.test.ts
+++ b/tests/media-key.test.ts
@@ -86,6 +86,43 @@ describe.each(adapters)(
   }
 );
 
+// Multipart filenames are literal, not percent-encoded: resolveKey is called
+// with { decode: false } on the upload paths. A literal "%" must be preserved
+// (not decoded or rejected); traversal / absolute / backslash / empty are still
+// blocked.
+const allowedNoDecode: [string, string, string][] = [
+  ['', '100%.png', '100%.png'],
+  ['', 'report%41.png', 'report%41.png'], // NOT rewritten to reportA.png
+  ['', 'my%2Ffile.png', 'my%2Ffile.png'], // %2F NOT turned into a path separator
+  ['media', 'cat.png', 'media/cat.png'],
+];
+const rejectedNoDecode: [string, string][] = [
+  ['', '../evil.png'],
+  ['', '/abs.png'],
+  ['', 'a\\b.png'],
+  ['', ''],
+];
+
+describe.each(adapters)(
+  '%s — resolveKey({ decode: false }) for multipart filenames',
+  (_name, resolveKey, MediaKeyError) => {
+    it.each(allowedNoDecode)(
+      'resolveKey(%j, %j, {decode:false}) === %j',
+      (root, raw, expected) => {
+        expect(resolveKey(root, raw, { decode: false })).toBe(expected);
+      }
+    );
+    it.each(rejectedNoDecode)(
+      'resolveKey(%j, %j, {decode:false}) throws MediaKeyError',
+      (root, raw) => {
+        expect(() => resolveKey(root, raw, { decode: false })).toThrow(
+          MediaKeyError
+        );
+      }
+    );
+  }
+);
+
 describe('the four adapter copies behave identically (anti-drift)', () => {
   const allInputs: [string, unknown][] = [
     ...allowed.map(([root, raw]) => [root, raw] as [string, unknown]),

--- a/tests/media-key.test.ts
+++ b/tests/media-key.test.ts
@@ -5,18 +5,22 @@ import { describe, it, expect } from 'vitest';
 // behaviour and guard against the copies drifting apart.
 import {
   resolveKey as resolveKeyS3,
+  resolveDirectory as resolveDirectoryS3,
   MediaKeyError as MediaKeyErrorS3,
 } from '../packages/next-tinacms-s3/src/media-key';
 import {
   resolveKey as resolveKeyDos,
+  resolveDirectory as resolveDirectoryDos,
   MediaKeyError as MediaKeyErrorDos,
 } from '../packages/next-tinacms-dos/src/media-key';
 import {
   resolveKey as resolveKeyAzure,
+  resolveDirectory as resolveDirectoryAzure,
   MediaKeyError as MediaKeyErrorAzure,
 } from '../packages/next-tinacms-azure/src/media-key';
 import {
   resolveKey as resolveKeyCloudinary,
+  resolveDirectory as resolveDirectoryCloudinary,
   MediaKeyError as MediaKeyErrorCloudinary,
 } from '../packages/next-tinacms-cloudinary/src/media-key';
 
@@ -27,6 +31,17 @@ const adapters = [
   ['next-tinacms-dos', resolveKeyDos, MediaKeyErrorDos],
   ['next-tinacms-azure', resolveKeyAzure, MediaKeyErrorAzure],
   ['next-tinacms-cloudinary', resolveKeyCloudinary, MediaKeyErrorCloudinary],
+] as const;
+
+const directoryAdapters = [
+  ['next-tinacms-s3', resolveDirectoryS3, MediaKeyErrorS3],
+  ['next-tinacms-dos', resolveDirectoryDos, MediaKeyErrorDos],
+  ['next-tinacms-azure', resolveDirectoryAzure, MediaKeyErrorAzure],
+  [
+    'next-tinacms-cloudinary',
+    resolveDirectoryCloudinary,
+    MediaKeyErrorCloudinary,
+  ],
 ] as const;
 
 // [mediaRoot, rawKey, expected]
@@ -123,6 +138,53 @@ describe.each(adapters)(
         expect(() => resolveKey(root, raw, { decode: false })).toThrow(
           MediaKeyError
         );
+      }
+    );
+  }
+);
+
+// resolveDirectory bounds the listMedia prefix. directory flows into
+// path.join(mediaRoot, prefix), which would otherwise collapse ".." and list
+// objects outside mediaRoot (GHSA-xq98-p84m-r882). Empty / root is allowed;
+// upward traversal, absolute paths, backslash and NUL are rejected.
+const directoryAllowed: [string, string][] = [
+  ['', ''], // root
+  ['   ', ''], // blank => root
+  ['photos', 'photos/'],
+  ['photos/', 'photos/'], // trailing slash normalised
+  ['/photos', 'photos/'], // leading slash stripped, not treated as absolute root
+  ['photos/2026', 'photos/2026/'],
+  ['a/../b', 'b/'], // inner ".." that does not escape is collapsed
+  ['.', ''], // current dir => root
+];
+const directoryRejected: string[] = [
+  '..', // walk toward bucket root
+  '../uploads', // the reported vector
+  '/../escape', // leading slash stripped, then traversal
+  'a/../../escape', // climbs past root
+  'dir\\..\\x', // backslash separator
+  'with\0nul', // NUL byte
+];
+
+describe.each(directoryAdapters)(
+  '%s — resolveDirectory bounds the listing prefix',
+  (_name, resolveDirectory, MediaKeyError) => {
+    it.each(directoryAllowed)(
+      'resolveDirectory(%j) === %j',
+      (raw, expected) => {
+        expect(resolveDirectory(raw)).toBe(expected);
+      }
+    );
+    it.each([undefined, null] as unknown[])(
+      'resolveDirectory(%j) === "" (no directory)',
+      (raw) => {
+        expect(resolveDirectory(raw)).toBe('');
+      }
+    );
+    it.each(directoryRejected)(
+      'resolveDirectory(%j) throws MediaKeyError',
+      (raw) => {
+        expect(() => resolveDirectory(raw)).toThrow(MediaKeyError);
       }
     );
   }


### PR DESCRIPTION
## Summary

The first-party media adapters (s3, dos, azure, cloudinary) passed a caller-controlled object key straight to the storage SDK on their upload/delete paths without checking it falls under mediaRoot (CWE-639). mediaRoot was only enforced on listing, so any logged-in editor had write/delete reach over every key the IAM credential could touch — not just mediaRoot.

This PR adds a centralised resolveKey(mediaRoot, rawKey) helper and wires it into every write/delete entry point so the key reaching the SDK is always normalised and bounded.

## What this fixes

- S3 / DOS — upload (?key=) and delete keys are resolved against mediaRoot; out-of-root keys are conte, .. incl. percent-encoded, NUL, empty) return 400.
- S3 — expiresIn is now clamped (default/max 3600s); it was caller-controlled, bounded only by SigV4
- Azure / Cloudinary — no mediaRoot config today, so they pass an empty root, which still rejects tr(including the Cloudinary upload filename).

The helper is duplicated byte-for-byte across the four packages (avoids a cross-package publish dependency); a shared suite asserts the copies stay identical.

## Not in this PR (follow-ups)

- SEC-1 — constrain upload Content-Type (stored-XSS via uploaded HTML/SVG; still open on S3, payload is only confined to mediaRoot).
- SEC-2 — real mediaRoot boundary for Azure/Cloudinary (new config; Cloudinary switch needs a live env to verify).
- SEC-4 — README + scope IAM policy to mediaRoot/* (defence-in-depth).
- SEC-5 — Cloudinary listMedia interpolates directory into a search-expression DSL (separate injection issue).

## Behaviour & testing

- S3 with mediaRoot set: uploads now land under mediaRoot/ (also fixes the prior upload/list mismatch). No client/API/config changes; deployments without mediaRoot only gain traversal/absolute/empty rejection. Empty ?key= stilllists.
- tests/media-key.test.ts — 110 cases (adversarial vectors + anti-drift across all four copies), green on Node 22. Handler-level scoping verified separately.