### PR TITLE
Harden npm publish pipeline and package manifests

### DIFF
--- a/.changeset/shaggy-bananas-admire.md
+++ b/.changeset/shaggy-bananas-admire.md
@@ -1,4 +1,5 @@
 ---
+"@tinacms/app": patch
 "@tinacms/metrics": patch
 "@tinacms/scripts": patch
 "@tinacms/cli": patch

--- a/.changeset/shaggy-bananas-admire.md
+++ b/.changeset/shaggy-bananas-admire.md
@@ -1,0 +1,7 @@
+---
+"@tinacms/metrics": patch
+"@tinacms/scripts": patch
+"@tinacms/cli": patch
+---
+
+Harden npm publish pipeline and package manifests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,7 +71,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
@@ -88,6 +88,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+          NPM_CONFIG_PROVENANCE: true
 
       - name: Get published package versions
         id: package-versions
@@ -259,7 +260,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -2,6 +2,11 @@
 	"name": "@tinacms/app",
 	"version": "2.5.6",
 	"main": "src/main.tsx",
+	"files": [
+		"src",
+		"index.html",
+		"favicon.svg"
+	],
 	"license": "Apache-2.0",
 	"scripts": {
 		"test": "vitest run",

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -5,7 +5,9 @@
 	"files": [
 		"src",
 		"index.html",
-		"favicon.svg"
+		"favicon.svg",
+		"tsconfig.json",
+		"tsconfig.node.json"
 	],
 	"license": "Apache-2.0",
 	"scripts": {

--- a/packages/@tinacms/cli/package.json
+++ b/packages/@tinacms/cli/package.json
@@ -6,8 +6,7 @@
     "typings": "dist/index.d.ts",
     "files": [
         "dist",
-        "bin/*",
-        ".env"
+        "bin/*"
     ],
     "license": "Apache-2.0",
     "bin": {
@@ -57,7 +56,7 @@
     },
     "dependencies": {
         "@graphql-codegen/core": "catalog:",
-        "@graphql-codegen/plugin-helpers": "latest",
+        "@graphql-codegen/plugin-helpers": "^7.0.1",
         "@graphql-codegen/typescript": "catalog:",
         "@graphql-codegen/typescript-operations": "catalog:",
         "@graphql-codegen/visitor-plugin-common": "catalog:",

--- a/packages/@tinacms/metrics/package.json
+++ b/packages/@tinacms/metrics/package.json
@@ -5,8 +5,7 @@
     "type": "module",
     "typings": "dist/index.d.ts",
     "files": [
-        "dist",
-        ".env"
+        "dist"
     ],
     "license": "Apache-2.0",
     "buildConfig": {

--- a/packages/@tinacms/scripts/package.json
+++ b/packages/@tinacms/scripts/package.json
@@ -6,8 +6,7 @@
     "files": [
         "dist",
         "bin/*",
-        "__mocks__/styleMock.js",
-        ".env"
+        "__mocks__/styleMock.js"
     ],
     "license": "Apache-2.0",
     "bin": {

--- a/packages/tinacms-authjs/package.json
+++ b/packages/tinacms-authjs/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@tinacms/datalayer": "workspace:*",
     "@tinacms/scripts": "workspace:*",
-    "next": "^15.5.9",
+    "next": "^15.5.16",
     "next-auth": "^4.24.13",
     "react": "^19.2.3",
     "tinacms": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1316,7 +1316,7 @@ importers:
         specifier: 'catalog:'
         version: 2.6.8(graphql@15.8.0)
       '@graphql-codegen/plugin-helpers':
-        specifier: latest
+        specifier: ^7.0.1
         version: 7.0.1(graphql@15.8.0)
       '@graphql-codegen/typescript':
         specifier: 'catalog:'
@@ -19109,7 +19109,7 @@ snapshots:
       '@graphql-tools/merge': 8.4.2(graphql@15.8.0)
       '@graphql-tools/utils': 9.2.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.4.1
+      tslib: 2.8.1
       value-or-promise: 1.0.12
 
   '@graphql-tools/utils@10.11.0(graphql@15.8.0)':
@@ -19132,7 +19132,7 @@ snapshots:
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.4.1
+      tslib: 2.8.1
 
   '@graphql-typed-document-node/core@3.2.0(graphql@15.8.0)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2546,11 +2546,11 @@ importers:
         specifier: workspace:*
         version: link:../@tinacms/scripts
       next:
-        specifier: ^15.5.9
-        version: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+        specifier: ^15.5.16
+        version: 15.5.19(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       next-auth:
         specifier: ^4.24.13
-        version: 4.24.13(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)
+        version: 4.24.13(next@15.5.19(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3)
       react:
         specifier: ^19.2.3
         version: 19.2.3
@@ -5711,8 +5711,8 @@ packages:
   '@next/env@15.5.12':
     resolution: {integrity: sha512-pUvdJN1on574wQHjaBfNGDt9Mz5utDSZFsIIQkMzPgNS8ZvT4H2mwOrOIClwsQOb6EGx5M76/CZr6G8i6pSpLg==}
 
-  '@next/env@15.5.9':
-    resolution: {integrity: sha512-4GlTZ+EJM7WaW2HEZcyU317tIQDjkQIyENDLxYJfSWlfqguN+dHkZgyQTV/7ykvobU7yEH5gKvreNrH4B6QgIg==}
+  '@next/env@15.5.19':
+    resolution: {integrity: sha512-sWWluFvcv5v3Fxznmf2ZfjyoVQt/64oCnYqS90inQWGzMPK1VjvekPiz3OPHKmFT30EnHrjlbyaHLt3M0vWabw==}
 
   '@next/eslint-plugin-next@12.0.3':
     resolution: {integrity: sha512-P7i+bMypneQcoRN+CX79xssvvIJCaw7Fndzbe7/lB0+LyRbVvGVyMUsFmLLbSxtZq4hvFMJ1p8wML/gsulMZWQ==}
@@ -5729,8 +5729,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-arm64@15.5.7':
-    resolution: {integrity: sha512-IZwtxCEpI91HVU/rAUOOobWSZv4P2DeTtNaCdHqLcTJU4wdNXgAySvKa/qJCgR5m6KI8UsKDXtO2B31jcaw1Yw==}
+  '@next/swc-darwin-arm64@15.5.19':
+    resolution: {integrity: sha512-jx9wWlTKueHKPvVOndyr7WuaevWCkuYqsQ8gC0TMPKAVWG3MhcdMrjfo9tvIZNXd0QOUYXXvAcZ325y8Uq7uzg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
@@ -5747,8 +5747,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.5.7':
-    resolution: {integrity: sha512-UP6CaDBcqaCBuiq/gfCEJw7sPEoX1aIjZHnBWN9v9qYHQdMKvCKcAVs4OX1vIjeE+tC5EIuwDTVIoXpUes29lg==}
+  '@next/swc-darwin-x64@15.5.19':
+    resolution: {integrity: sha512-291KFcsIQ3OenRdiUDFOR6W3wezzH4auENXm1gbm1Bjd4ANMMRgxPrWTUztQN43BnVoVuMnHCrLeECIMwgFKbA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
@@ -5767,8 +5767,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
-    resolution: {integrity: sha512-NCslw3GrNIw7OgmRBxHtdWFQYhexoUCq+0oS2ccjyYLtcn1SzGzeM54jpTFonIMUjNbHmpKpziXnpxhSWLcmBA==}
+  '@next/swc-linux-arm64-gnu@15.5.19':
+    resolution: {integrity: sha512-WeH+nelQyyMeE2f8FxBRZNrGipya5zHZV2vjzfCOAYyiI6am+NbnWAAldOBFQBB2w0DjJcsvrKqoFT2b7+5YoA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -5788,8 +5788,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-arm64-musl@15.5.7':
-    resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
+  '@next/swc-linux-arm64-musl@15.5.19':
+    resolution: {integrity: sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
@@ -5809,8 +5809,8 @@ packages:
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-gnu@15.5.7':
-    resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
+  '@next/swc-linux-x64-gnu@15.5.19':
+    resolution: {integrity: sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -5830,8 +5830,8 @@ packages:
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-musl@15.5.7':
-    resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
+  '@next/swc-linux-x64-musl@15.5.19':
+    resolution: {integrity: sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -5849,8 +5849,8 @@ packages:
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
-    resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
+  '@next/swc-win32-arm64-msvc@15.5.19':
+    resolution: {integrity: sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
@@ -5873,8 +5873,8 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.5.7':
-    resolution: {integrity: sha512-gMzgBX164I6DN+9/PGA+9dQiwmTkE4TloBNx8Kv9UiGARsr9Nba7IpcBRA1iTV9vwlYnrE3Uy6I7Aj6qLjQuqw==}
+  '@next/swc-win32-x64-msvc@15.5.19':
+    resolution: {integrity: sha512-PhmojAHyqMne56HBLGu9dhDnHPuFmEjrXSQMM/nW0J6j849lk3ESrVtqNJcCk8CKOV7brpTTbaYAjwKPzKM69w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -12841,8 +12841,8 @@ packages:
       sass:
         optional: true
 
-  next@15.5.9:
-    resolution: {integrity: sha512-agNLK89seZEtC5zUHwtut0+tNrc0Xw4FT/Dg+B/VLEo9pAcS9rtTKpek3V6kVcVwsB2YlqMaHdfZL4eLEVYuCg==}
+  next@15.5.19:
+    resolution: {integrity: sha512-xNOW6tYshGX1/Oi3F8uuk4gpDeWsSUE/1Z0G5uUMekIxaQ0xc03UXd9II0VQHYMWviMeA0OHpJFAKsHf8bTYVg==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -19977,7 +19977,7 @@ snapshots:
 
   '@next/env@15.5.12': {}
 
-  '@next/env@15.5.9': {}
+  '@next/env@15.5.19': {}
 
   '@next/eslint-plugin-next@12.0.3':
     dependencies:
@@ -19989,7 +19989,7 @@ snapshots:
   '@next/swc-darwin-arm64@15.5.12':
     optional: true
 
-  '@next/swc-darwin-arm64@15.5.7':
+  '@next/swc-darwin-arm64@15.5.19':
     optional: true
 
   '@next/swc-darwin-x64@14.2.33':
@@ -19998,7 +19998,7 @@ snapshots:
   '@next/swc-darwin-x64@15.5.12':
     optional: true
 
-  '@next/swc-darwin-x64@15.5.7':
+  '@next/swc-darwin-x64@15.5.19':
     optional: true
 
   '@next/swc-linux-arm64-gnu@14.2.33':
@@ -20007,7 +20007,7 @@ snapshots:
   '@next/swc-linux-arm64-gnu@15.5.12':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.5.7':
+  '@next/swc-linux-arm64-gnu@15.5.19':
     optional: true
 
   '@next/swc-linux-arm64-musl@14.2.33':
@@ -20016,7 +20016,7 @@ snapshots:
   '@next/swc-linux-arm64-musl@15.5.12':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.5.7':
+  '@next/swc-linux-arm64-musl@15.5.19':
     optional: true
 
   '@next/swc-linux-x64-gnu@14.2.33':
@@ -20025,7 +20025,7 @@ snapshots:
   '@next/swc-linux-x64-gnu@15.5.12':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.5.7':
+  '@next/swc-linux-x64-gnu@15.5.19':
     optional: true
 
   '@next/swc-linux-x64-musl@14.2.33':
@@ -20034,7 +20034,7 @@ snapshots:
   '@next/swc-linux-x64-musl@15.5.12':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.5.7':
+  '@next/swc-linux-x64-musl@15.5.19':
     optional: true
 
   '@next/swc-win32-arm64-msvc@14.2.33':
@@ -20043,7 +20043,7 @@ snapshots:
   '@next/swc-win32-arm64-msvc@15.5.12':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.5.7':
+  '@next/swc-win32-arm64-msvc@15.5.19':
     optional: true
 
   '@next/swc-win32-ia32-msvc@14.2.33':
@@ -20055,7 +20055,7 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.5.12':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.5.7':
+  '@next/swc-win32-x64-msvc@15.5.19':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -29197,13 +29197,13 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       uuid: 8.3.2
 
-  next-auth@4.24.13(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3):
+  next-auth@4.24.13(next@15.5.19(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3))(react-dom@18.3.1(react@19.2.3))(react@19.2.3):
     dependencies:
       '@babel/runtime': 7.28.6
       '@panva/hkdf': 1.2.1
       cookie: 0.7.2
       jose: 4.15.9
-      next: 15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3)
+      next: 15.5.19(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3)
       oauth: 0.9.15
       openid-client: 5.7.1
       preact: 10.28.3
@@ -29322,9 +29322,9 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3):
+  next@15.5.19(@opentelemetry/api@1.9.0)(@playwright/test@1.57.0)(react-dom@18.3.1(react@19.2.3))(react@19.2.3)(sass@1.97.3):
     dependencies:
-      '@next/env': 15.5.9
+      '@next/env': 15.5.19
       '@swc/helpers': 0.5.15
       caniuse-lite: 1.0.30001760
       postcss: 8.4.31
@@ -29332,14 +29332,14 @@ snapshots:
       react-dom: 18.3.1(react@19.2.3)
       styled-jsx: 5.1.6(react@19.2.3)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.7
-      '@next/swc-darwin-x64': 15.5.7
-      '@next/swc-linux-arm64-gnu': 15.5.7
-      '@next/swc-linux-arm64-musl': 15.5.7
-      '@next/swc-linux-x64-gnu': 15.5.7
-      '@next/swc-linux-x64-musl': 15.5.7
-      '@next/swc-win32-arm64-msvc': 15.5.7
-      '@next/swc-win32-x64-msvc': 15.5.7
+      '@next/swc-darwin-arm64': 15.5.19
+      '@next/swc-darwin-x64': 15.5.19
+      '@next/swc-linux-arm64-gnu': 15.5.19
+      '@next/swc-linux-arm64-musl': 15.5.19
+      '@next/swc-linux-x64-gnu': 15.5.19
+      '@next/swc-linux-x64-musl': 15.5.19
+      '@next/swc-win32-arm64-msvc': 15.5.19
+      '@next/swc-win32-x64-msvc': 15.5.19
       '@opentelemetry/api': 1.9.0
       '@playwright/test': 1.57.0
       sass: 1.97.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,16 @@ packages:
     - examples/*/*
     - e2e/*
     - playwright/*
+# Supply-chain cooldown: don't install registry releases newer than 1 day,
+# giving time to react to a compromised/yanked package. Our own packages are
+# excluded so freshly published @tinacms releases aren't blocked.
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+    - "@tinacms/*"
+    - tinacms
+    - tinacms-*
+    - create-tina-app
+    - next-tinacms-*
 overrides:
     "@clerk/clerk-js>react": 19.2.3
     "@clerk/clerk-js>react-dom": 19.2.3


### PR DESCRIPTION
Relates to https://github.com/tinacms/tinacloud/issues/3596

## Summary

This PR hardens the npm publish pipeline with a few focused supply-chain safety improvements. It makes publish jobs install dependencies strictly from the committed lockfile, enables npm provenance for the tagged-PR publish path, replaces a `"latest"` dependency with the lockfile-resolved version, and removes `.env` from package publish allowlists.

It also bumps a dev-only `next` dependency past a known middleware-bypass advisory.

There are no consumer-facing behavior changes.

## Changes

* Use `pnpm install --frozen-lockfile` in both publish jobs.
* Set `NPM_CONFIG_PROVENANCE: true` for the tagged-PR publish step.
* Replace `@graphql-codegen/plugin-helpers: "latest"` with `^7.0.1`.
* Remove `.env` from the `files` allowlist in `@tinacms/cli`, `@tinacms/metrics`, and `@tinacms/scripts`.
* Bump `next` from `^15.5.9` to `^15.5.16` in `tinacms-authjs` (devDependency) to clear the `< 15.5.16` middleware-bypass advisories; the lockfile resolves to `15.5.19`.
