### PR TITLE
feat: add deno support

### DIFF
--- a/packages/@tinacms/cli/src/cmds/init/apply.ts
+++ b/packages/@tinacms/cli/src/cmds/init/apply.ts
@@ -398,6 +398,7 @@ const addDependencies = async (
     npm: `npm install ${deps.join(' ')}`,
     yarn: `yarn add ${deps.join(' ')}`,
     bun: `bun add ${deps.join(' ')}`,
+    deno: `deno install ${deps.join(' ')}`,
   };
 
   if (packageManagers[packageManager] && deps.length > 0) {
@@ -415,6 +416,7 @@ const addDependencies = async (
       npm: `npm install -D ${devDeps.join(' ')}`,
       yarn: `yarn add -D ${devDeps.join(' ')}`,
       bun: `bun add -D ${devDeps.join(' ')}`,
+      deno: `deno add -D ${devDeps.join(' ')}`,
     };
     if (packageManagers[packageManager]) {
       logger.info(
@@ -643,6 +645,7 @@ const other = ({ packageManager }: { packageManager: string }) => {
     npm: `npx`, // npx is the way to run executables that aren't in your "scripts"
     yarn: `yarn`,
     bun: `bun run`,
+    deno: `deno run`,
   };
   return `${packageManagers[packageManager]} tinacms dev -c "<your dev command>"`;
 };
@@ -653,6 +656,7 @@ const runDevScript = ({ packageManager }: { packageManager: string }) => {
     npm: `npm run`,
     yarn: `yarn`,
     bun: `bun run`,
+    deno: `deno run`,
   };
   return `${packageManagers[packageManager]} dev`;
 };

--- a/packages/@tinacms/cli/src/cmds/init/prompts/index.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/index.ts
@@ -42,6 +42,7 @@ export const askCommonSetUp = async () => {
         { title: 'Yarn', value: 'yarn' },
         { title: 'NPM', value: 'npm' },
         { title: 'Bun', value: 'bun' },
+        { title: 'Deno', value: 'deno' },
       ],
     },
   ]);
@@ -53,7 +54,7 @@ export const askCommonSetUp = async () => {
   }
   return answers as {
     framework: Framework;
-    packageManager: 'pnpm' | 'yarn' | 'npm' | 'bun';
+    packageManager: 'pnpm' | 'yarn' | 'npm' | 'bun' | 'deno';
   };
 };
 export const askForestryMigrate = async ({

--- a/packages/@tinacms/cli/src/cmds/init/prompts/types.ts
+++ b/packages/@tinacms/cli/src/cmds/init/prompts/types.ts
@@ -5,7 +5,7 @@ export type Config = {
   typescript: boolean;
   publicFolder?: string;
   framework: Framework;
-  packageManager: 'pnpm' | 'yarn' | 'npm' | 'bun';
+  packageManager: 'pnpm' | 'yarn' | 'npm' | 'bun' | 'deno';
   forestryMigrate: boolean;
   frontMatterFormat?: ContentFrontmatterFormat;
   hosting?: 'tina-cloud' | 'self-host';

--- a/packages/@tinacms/cli/src/next/config-manager.ts
+++ b/packages/@tinacms/cli/src/next/config-manager.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import os from 'os';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import * as esbuild from 'esbuild';
 import type { Loader } from 'esbuild';
 import { Config } from '@tinacms/schema-tools';
@@ -430,6 +430,11 @@ export class ConfigManager {
       js: `import { createRequire } from 'module';const require = createRequire(import.meta.url);`,
     };
 
+    // Externalize react/react-dom from the config build so they're resolved from
+    // the project's node_modules at runtime. This resolves CJS interop issues with
+    // the createRequire polyfill.
+    const configExternalPackages = ['react', 'react-dom', 'react-dom/client'];
+
     fs.outputFileSync(tempTSConfigFile, '{}');
     const result2 = await esbuild.build({
       entryPoints: [configFilePath],
@@ -463,6 +468,7 @@ export class ConfigManager {
       outfile,
       loader: loaders,
       banner: esmRequireBanner,
+      external: configExternalPackages,
     });
     await esbuild.build({
       entryPoints: [outfile],
@@ -473,6 +479,7 @@ export class ConfigManager {
       format: 'esm',
       outfile: outfile2,
       loader: loaders,
+      external: configExternalPackages,
     });
     let result: { default: any };
     try {

--- a/packages/create-tina-app/src/util/packageManagers.ts
+++ b/packages/create-tina-app/src/util/packageManagers.ts
@@ -3,5 +3,5 @@
  * To add a new supported package manager, add the usage command to this list.
  * The `PackageManager` type will be automatically updated as a result.
  */
-export const PKG_MANAGERS = ['pnpm', 'yarn', 'bun', 'npm'] as const;
+export const PKG_MANAGERS = ['pnpm', 'yarn', 'bun', 'npm', 'deno'] as const;
 export type PackageManager = (typeof PKG_MANAGERS)[number];


### PR DESCRIPTION
```
This PR adds Deno support to the installer. 

It also resolves an esbuild issue that occurred when attempting to dev/build an
astro + deno project. Additional information is as follows:

    Esbuild 2 and 3 bundled `react` and `react-dom` into `config.build.mjs`.
    When the bundled react-dom called `require('react')` internally, the
    `createRequire` polyfill resolved a different copy of React from the
    filesystem. This lead to an undefined `ReactCurrentDispatcher` issue. react
    and react-dom are now resolved via the projects node modules on import for
    node-targeted builds.

EDIT: Removing the react pre-fill is probably not the right solution and needs more thought
```