### PR TITLE
✨ Add source-agnostic `_sys.lastUpdated` with server-side collection sort

### DIFF
--- a/.changeset/sys-last-updated.md
+++ b/.changeset/sys-last-updated.md
@@ -4,3 +4,5 @@
 ---
 
 Add a `lastUpdated` field to documents' `_sys` (`SystemInfo`) and a `lastUpdated` collection sort, both sourced from an optional `Bridge.lastUpdated(filepath)` capability that integrators can plug in (defaults: git commit time for the isomorphic bridge, file mtime for the filesystem bridge). The value is materialized into the index at index time, so `_sys.lastUpdated` and server-side `documents(sort: "lastUpdated")` work across any store/backend (including self-hosted), not just TinaCloud. The admin collection-listing page shows a "Last Updated" column and offers "Last Updated" in its sort control. Requires a reindex to populate the new sort index.
+
+Note: the value's meaning is bridge-defined and not identical across bridges — the isomorphic (git) bridge reports the file's last commit time (which is stale for uncommitted working-tree edits), while the filesystem bridge reports file mtime. Documents the bridge can't time are ordered last and shown empty.

--- a/.changeset/sys-last-updated.md
+++ b/.changeset/sys-last-updated.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/graphql": minor
+"tinacms": minor
+---
+
+Add a `lastUpdated` field to documents' `_sys` (`SystemInfo`), sourced from the content store's last-write time when the store can report it. The admin collection-listing page now shows a "Last Updated" column with relative times and lets you sort the loaded page by filename or last updated via clickable column headers.

--- a/.changeset/sys-last-updated.md
+++ b/.changeset/sys-last-updated.md
@@ -3,4 +3,4 @@
 "tinacms": minor
 ---
 
-Add a `lastUpdated` field to documents' `_sys` (`SystemInfo`), sourced from the content store's last-write time when the store can report it. The admin collection-listing page now shows a "Last Updated" column with relative times and lets you sort the loaded page by filename or last updated via clickable column headers.
+Add a `lastUpdated` field to documents' `_sys` (`SystemInfo`) and a `lastUpdated` collection sort, both sourced from an optional `Bridge.lastUpdated(filepath)` capability that integrators can plug in (defaults: git commit time for the isomorphic bridge, file mtime for the filesystem bridge). The value is materialized into the index at index time, so `_sys.lastUpdated` and server-side `documents(sort: "lastUpdated")` work across any store/backend (including self-hosted), not just TinaCloud. The admin collection-listing page shows a "Last Updated" column and offers "Last Updated" in its sort control. Requires a reindex to populate the new sort index.

--- a/packages/@tinacms/graphql/src/builder/static-definitions.ts
+++ b/packages/@tinacms/graphql/src/builder/static-definitions.ts
@@ -145,6 +145,11 @@ const scalarDefinitions = [
         type: astBuilder.TYPES.String,
       }),
       astBuilder.FieldDefinition({
+        name: 'lastUpdated',
+        required: false,
+        type: astBuilder.TYPES.String,
+      }),
+      astBuilder.FieldDefinition({
         name: 'collection',
         required: true,
         type: astBuilder.TYPES.Collection,

--- a/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/filesystem.ts
@@ -168,6 +168,17 @@ export class FilesystemBridge implements Bridge {
     return (await fs.readFile(resolved)).toString();
   }
 
+  public async lastUpdated(filepath: string) {
+    const resolved = assertWithinBase(filepath, this.baseFor(filepath));
+    this.assertGeneratedSubtree(filepath, resolved);
+    try {
+      const stat = await fs.stat(resolved);
+      return stat.mtimeMs;
+    } catch {
+      return null;
+    }
+  }
+
   public async put(filepath: string, data: string, basePathOverride?: string) {
     const basePath = basePathOverride || this.baseFor(filepath);
     const resolved = assertWithinBase(filepath, basePath);

--- a/packages/@tinacms/graphql/src/database/bridge/index.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/index.ts
@@ -37,4 +37,5 @@ export interface Bridge {
    * operations in a separate path.
    */
   outputPath?: string;
+  lastUpdated?(filepath: string): Promise<number | null>;
 }

--- a/packages/@tinacms/graphql/src/database/bridge/isomorphic.ts
+++ b/packages/@tinacms/graphql/src/database/bridge/isomorphic.ts
@@ -549,6 +549,25 @@ export class IsomorphicBridge implements Bridge {
     return Buffer.from(blob).toString('utf8');
   }
 
+  public async lastUpdated(filepath: string) {
+    assertWithinBase(filepath, this.relativePath);
+    const ref = await this.getRef();
+    try {
+      const commits = await git.log({
+        ...this.isomorphicConfig,
+        ref,
+        filepath: this.qualifyPath(filepath),
+        depth: 1,
+        force: true,
+        cache: this.cache,
+      });
+      const timestamp = commits[0]?.commit?.committer?.timestamp;
+      return typeof timestamp === 'number' ? timestamp * 1000 : null;
+    } catch {
+      return null;
+    }
+  }
+
   public async put(filepath: string, data: string) {
     assertWithinBase(filepath, this.relativePath);
     const ref = await this.getRef();

--- a/packages/@tinacms/graphql/src/database/database.test.ts
+++ b/packages/@tinacms/graphql/src/database/database.test.ts
@@ -15,12 +15,12 @@
  * coerceFilterChainOperands() which throws on undefined.
  */
 
-import { beforeEach, describe, expect, it } from 'vitest';
-import { MemoryLevel } from 'memory-level';
-import { buildSchema, createDatabaseInternal } from '..';
-import type { Bridge } from './bridge';
 import type { Schema } from '@tinacms/schema-tools';
+import { MemoryLevel } from 'memory-level';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildSchema, createDatabaseInternal } from '..';
 import { atob } from '../util';
+import type { Bridge } from './bridge';
 
 // ─── InMemoryBridge ──────────────────────────────────────────────────────────
 
@@ -635,5 +635,68 @@ describe('Database.getDocumentTimestamp()', () => {
     await expect(
       database.getDocumentTimestamp('content/posts/alpha.json')
     ).resolves.toBe(1700000000000);
+  });
+});
+
+describe('Database lastUpdated materialization + sort', () => {
+  const TIMES: Record<string, number> = {
+    'content/posts/alpha.json': Date.parse('2026-01-01T00:00:00.000Z'),
+    'content/posts/beta.json': Date.parse('2026-03-01T00:00:00.000Z'),
+    'content/posts/gamma.json': Date.parse('2026-02-01T00:00:00.000Z'),
+    'content/posts/delta.json': Date.parse('2026-05-01T00:00:00.000Z'),
+    'content/posts/epsilon.json': Date.parse('2026-04-01T00:00:00.000Z'),
+  };
+
+  async function setup() {
+    class TimestampedBridge extends InMemoryBridge {
+      async lastUpdated(filepath: string): Promise<number | null> {
+        return TIMES[filepath] ?? null;
+      }
+    }
+    const bridge = new TimestampedBridge();
+    for (const { path, data } of POSTS) {
+      bridge.seed(path, jsonDoc(data));
+    }
+    const level = new MemoryLevel<string, Record<string, any>>({
+      valueEncoding: 'json',
+    });
+    const database = createDatabaseInternal({
+      bridge,
+      level,
+      tinaDirectory: 'tina',
+    });
+    const builtSchema = await buildSchema({ schema: testSchema });
+    await database.indexContent(builtSchema);
+    const hydrate = async (path: string, value: Record<string, any>) => ({
+      path,
+      ...value,
+    });
+    return { database, hydrate };
+  }
+
+  it('sorts by lastUpdated ascending (oldest first)', async () => {
+    const { database, hydrate } = await setup();
+    const result = await database.query(
+      { collection: 'post', sort: 'lastUpdated', filterChain: noFilter() },
+      hydrate
+    );
+    expect(result.edges.map((e) => (e.node as any).path)).toEqual([
+      'content/posts/alpha.json',
+      'content/posts/gamma.json',
+      'content/posts/beta.json',
+      'content/posts/epsilon.json',
+      'content/posts/delta.json',
+    ]);
+  });
+
+  it('materializes the bridge timestamp onto the stored record', async () => {
+    const { database, hydrate } = await setup();
+    const result = await database.query(
+      { collection: 'post', sort: 'lastUpdated', filterChain: noFilter() },
+      hydrate
+    );
+    expect((result.edges[0].node as any).__lastUpdated).toBe(
+      '2026-01-01T00:00:00.000Z'
+    );
   });
 });

--- a/packages/@tinacms/graphql/src/database/database.test.ts
+++ b/packages/@tinacms/graphql/src/database/database.test.ts
@@ -699,4 +699,36 @@ describe('Database lastUpdated materialization + sort', () => {
       '2026-01-01T00:00:00.000Z'
     );
   });
+
+  it('keeps documents with no bridge timestamp in the sort (sentinel)', async () => {
+    class NullBridge extends InMemoryBridge {
+      async lastUpdated(): Promise<number | null> {
+        return null;
+      }
+    }
+    const bridge = new NullBridge();
+    for (const { path, data } of POSTS) {
+      bridge.seed(path, jsonDoc(data));
+    }
+    const level = new MemoryLevel<string, Record<string, any>>({
+      valueEncoding: 'json',
+    });
+    const database = createDatabaseInternal({
+      bridge,
+      level,
+      tinaDirectory: 'tina',
+    });
+    const builtSchema = await buildSchema({ schema: testSchema });
+    await database.indexContent(builtSchema);
+    const hydrate = async (path: string, value: Record<string, any>) => ({
+      path,
+      ...value,
+    });
+
+    const result = await database.query(
+      { collection: 'post', sort: 'lastUpdated', filterChain: noFilter() },
+      hydrate
+    );
+    expect(result.edges).toHaveLength(POSTS.length);
+  });
 });

--- a/packages/@tinacms/graphql/src/database/database.test.ts
+++ b/packages/@tinacms/graphql/src/database/database.test.ts
@@ -600,3 +600,40 @@ describe('Database.indexContent()', () => {
     expect(result.edges).toHaveLength(2);
   });
 });
+
+describe('Database.getDocumentTimestamp()', () => {
+  it('returns null when the store does not track write times', async () => {
+    const { database } = await setupDatabase();
+    await expect(
+      database.getDocumentTimestamp('content/posts/alpha.json')
+    ).resolves.toBeNull();
+  });
+
+  it('returns the store timestamp when the store implements getTimestamp', async () => {
+    class TimestampedMemoryLevel extends MemoryLevel<
+      string,
+      Record<string, any>
+    > {
+      getTimestamp(_key: string): number | undefined {
+        return 1700000000000;
+      }
+    }
+
+    const bridge = new InMemoryBridge();
+    for (const { path, data } of POSTS) {
+      bridge.seed(path, jsonDoc(data));
+    }
+    const level = new TimestampedMemoryLevel({ valueEncoding: 'json' });
+    const database = createDatabaseInternal({
+      bridge,
+      level,
+      tinaDirectory: 'tina',
+    });
+    const builtSchema = await buildSchema({ schema: testSchema });
+    await database.indexContent(builtSchema);
+
+    await expect(
+      database.getDocumentTimestamp('content/posts/alpha.json')
+    ).resolves.toBe(1700000000000);
+  });
+});

--- a/packages/@tinacms/graphql/src/database/datalayer.ts
+++ b/packages/@tinacms/graphql/src/database/datalayer.ts
@@ -70,6 +70,7 @@ export const DEFAULT_COLLECTION_SORT_KEY = '__filepath__';
 export const REFS_COLLECTIONS_SORT_KEY = '__refs__';
 export const LAST_UPDATED_SORT_KEY = 'lastUpdated';
 export const LAST_UPDATED_FIELD = '__lastUpdated';
+export const LAST_UPDATED_SENTINEL = new Date(0).toISOString();
 export const REFS_REFERENCE_FIELD = '__tina_ref__';
 export const REFS_PATH_FIELD = '__tina_ref_path__';
 export const DEFAULT_NUMERIC_LPAD = 4;

--- a/packages/@tinacms/graphql/src/database/datalayer.ts
+++ b/packages/@tinacms/graphql/src/database/datalayer.ts
@@ -2,8 +2,10 @@
 
 */
 
-import { JSONPath } from 'jsonpath-plus';
+import path from 'path';
+import type { Collection } from '@tinacms/schema-tools';
 import sha from 'js-sha1';
+import { JSONPath } from 'jsonpath-plus';
 import {
   ARRAY_ITEM_VALUE_SEPARATOR,
   BatchOp,
@@ -12,8 +14,6 @@ import {
   Level,
   SUBLEVEL_OPTIONS,
 } from './level';
-import type { Collection } from '@tinacms/schema-tools';
-import path from 'path';
 import { normalizePath } from './util';
 
 export enum OP {
@@ -68,6 +68,8 @@ type StringEscaper = <T extends string | string[]>(input: T) => T;
 
 export const DEFAULT_COLLECTION_SORT_KEY = '__filepath__';
 export const REFS_COLLECTIONS_SORT_KEY = '__refs__';
+export const LAST_UPDATED_SORT_KEY = 'lastUpdated';
+export const LAST_UPDATED_FIELD = '__lastUpdated';
 export const REFS_REFERENCE_FIELD = '__tina_ref__';
 export const REFS_PATH_FIELD = '__tina_ref_path__';
 export const DEFAULT_NUMERIC_LPAD = 4;

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -29,6 +29,8 @@ import {
   FOLDER_ROOT,
   FolderTreeBuilder,
   type IndexDefinition,
+  LAST_UPDATED_FIELD,
+  LAST_UPDATED_SORT_KEY,
   REFS_COLLECTIONS_SORT_KEY,
   REFS_PATH_FIELD,
   REFS_REFERENCE_FIELD,
@@ -944,6 +946,15 @@ export class Database {
                   },
                 ],
               },
+              [LAST_UPDATED_SORT_KEY]: {
+                fields: [
+                  {
+                    name: LAST_UPDATED_FIELD,
+                    type: 'datetime',
+                    list: false,
+                  },
+                ],
+              },
             };
 
             let fields: TinaField<true>[] = [];
@@ -1694,6 +1705,11 @@ const _indexContent = async ({
       // if we aren't able to load the data, we can't index it
       if (!aliasedData) {
         return;
+      }
+
+      const lastUpdatedMs = await database.bridge.lastUpdated?.(filepath);
+      if (typeof lastUpdatedMs === 'number') {
+        aliasedData[LAST_UPDATED_FIELD] = new Date(lastUpdatedMs).toISOString();
       }
 
       if (passwordFields?.length) {

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -30,6 +30,7 @@ import {
   FolderTreeBuilder,
   type IndexDefinition,
   LAST_UPDATED_FIELD,
+  LAST_UPDATED_SENTINEL,
   LAST_UPDATED_SORT_KEY,
   REFS_COLLECTIONS_SORT_KEY,
   REFS_PATH_FIELD,
@@ -432,9 +433,10 @@ export class Database {
     }
 
     const lastUpdatedMs = await this.bridge?.lastUpdated?.(normalizedPath);
-    if (typeof lastUpdatedMs === 'number') {
-      dataFields[LAST_UPDATED_FIELD] = new Date(lastUpdatedMs).toISOString();
-    }
+    dataFields[LAST_UPDATED_FIELD] =
+      typeof lastUpdatedMs === 'number'
+        ? new Date(lastUpdatedMs).toISOString()
+        : LAST_UPDATED_SENTINEL;
 
     let level = this.contentLevel;
     if (collection?.isDetached) {
@@ -613,11 +615,10 @@ export class Database {
         }
 
         const lastUpdatedMs = await this.bridge?.lastUpdated?.(normalizedPath);
-        if (typeof lastUpdatedMs === 'number') {
-          dataFields[LAST_UPDATED_FIELD] = new Date(
-            lastUpdatedMs
-          ).toISOString();
-        }
+        dataFields[LAST_UPDATED_FIELD] =
+          typeof lastUpdatedMs === 'number'
+            ? new Date(lastUpdatedMs).toISOString()
+            : LAST_UPDATED_SENTINEL;
 
         const folderTreeBuilder = new FolderTreeBuilder();
         const folderKey = folderTreeBuilder.update(
@@ -1720,9 +1721,10 @@ const _indexContent = async ({
       }
 
       const lastUpdatedMs = await database.bridge.lastUpdated?.(filepath);
-      if (typeof lastUpdatedMs === 'number') {
-        aliasedData[LAST_UPDATED_FIELD] = new Date(lastUpdatedMs).toISOString();
-      }
+      aliasedData[LAST_UPDATED_FIELD] =
+        typeof lastUpdatedMs === 'number'
+          ? new Date(lastUpdatedMs).toISOString()
+          : LAST_UPDATED_SENTINEL;
 
       if (passwordFields?.length) {
         await hashPasswordValues(aliasedData, passwordFields);

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -12,8 +12,8 @@ import type {
   TinaField,
   TinaSchema,
 } from '@tinacms/schema-tools';
-import sha from 'js-sha1';
 import { set } from 'es-toolkit/compat';
+import sha from 'js-sha1';
 import { FilesystemBridge, TinaLevelClient } from '..';
 import { generatePasswordHash, mapUserFields } from '../auth/utils';
 import { NotFoundError } from '../error';
@@ -50,6 +50,7 @@ import {
   LevelProxy,
   type PutOp,
   SUBLEVEL_OPTIONS,
+  isTimestampedStore,
 } from './level';
 import {
   getTemplateForFile,
@@ -360,6 +361,29 @@ export class Database {
         await this.getSchema(this.contentLevel)
       );
     }
+  };
+
+  public getDocumentTimestamp = async (
+    filepath: string
+  ): Promise<number | null> => {
+    await this.initLevel();
+    const store = this.config.level;
+    if (!isTimestampedStore(store)) {
+      return null;
+    }
+    let level = this.contentLevel;
+    if (this.appLevel) {
+      const collection = await this.collectionForPath(filepath);
+      if (collection?.isDetached) {
+        level = this.appLevel.sublevel(collection.name, SUBLEVEL_OPTIONS);
+      }
+    }
+    const contentSublevel = level.sublevel<string, Record<string, any>>(
+      CONTENT_ROOT_PREFIX,
+      SUBLEVEL_OPTIONS
+    );
+    const levelKey = contentSublevel.prefixKey(normalizePath(filepath), 'utf8');
+    return store.getTimestamp(levelKey) ?? null;
   };
 
   public addPendingDocument = async (

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -431,6 +431,11 @@ export class Database {
       }
     }
 
+    const lastUpdatedMs = await this.bridge?.lastUpdated?.(normalizedPath);
+    if (typeof lastUpdatedMs === 'number') {
+      dataFields[LAST_UPDATED_FIELD] = new Date(lastUpdatedMs).toISOString();
+    }
+
     let level = this.contentLevel;
     if (collection?.isDetached) {
       level = this.appLevel.sublevel(collection.name, SUBLEVEL_OPTIONS);
@@ -605,6 +610,13 @@ export class Database {
               e
             );
           }
+        }
+
+        const lastUpdatedMs = await this.bridge?.lastUpdated?.(normalizedPath);
+        if (typeof lastUpdatedMs === 'number') {
+          dataFields[LAST_UPDATED_FIELD] = new Date(
+            lastUpdatedMs
+          ).toISOString();
         }
 
         const folderTreeBuilder = new FolderTreeBuilder();

--- a/packages/@tinacms/graphql/src/database/level.ts
+++ b/packages/@tinacms/graphql/src/database/level.ts
@@ -14,6 +14,16 @@ export type Level = AbstractLevel<
   Record<string, any>
 >;
 
+export interface TimestampedStore {
+  getTimestamp(key: string): number | undefined;
+}
+
+export const isTimestampedStore = (
+  store: object | undefined
+): store is TimestampedStore =>
+  !!store &&
+  typeof (store as Partial<TimestampedStore>).getTimestamp === 'function';
+
 export type PutOp = {
   type: 'put';
   key: string;

--- a/packages/@tinacms/graphql/src/database/util.ts
+++ b/packages/@tinacms/graphql/src/database/util.ts
@@ -93,6 +93,7 @@ export const stringifyFile = (
     _template,
     _collection,
     $_body,
+    __lastUpdated,
     ...rest
   } = content as {
     _relativePath: string;
@@ -101,6 +102,7 @@ export const stringifyFile = (
     _template: string;
     _collection: string;
     $_body: string;
+    __lastUpdated: string;
   };
   const extra: { [key: string]: string } = {};
   if (keepTemplateKey) {

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -26,6 +26,7 @@ import { generatePasswordHash } from '../auth/utils';
 import {
   FilterCondition,
   LAST_UPDATED_FIELD,
+  LAST_UPDATED_SENTINEL,
   REFS_COLLECTIONS_SORT_KEY,
   REFS_PATH_FIELD,
   REFS_REFERENCE_FIELD,
@@ -270,10 +271,12 @@ export const transformDocumentIntoPayload = async (
         collection,
         template: lastItem(template.namespace),
         lastUpdated:
-          (rawData[LAST_UPDATED_FIELD] as string | undefined) ??
-          (typeof lastUpdated === 'number'
-            ? new Date(lastUpdated).toISOString()
-            : null),
+          rawData[LAST_UPDATED_FIELD] &&
+          rawData[LAST_UPDATED_FIELD] !== LAST_UPDATED_SENTINEL
+            ? (rawData[LAST_UPDATED_FIELD] as string)
+            : typeof lastUpdated === 'number'
+              ? new Date(lastUpdated).toISOString()
+              : null,
       },
       _values: data,
       _rawData: rawData,

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -195,7 +195,8 @@ export const transformDocumentIntoPayload = async (
   tinaSchema: TinaSchema,
   config?: GraphQLConfig,
   isAudit?: boolean,
-  hasReferences?: boolean
+  hasReferences?: boolean,
+  lastUpdated?: number | null
 ) => {
   const collection = tinaSchema.getCollection(rawData._collection);
   try {
@@ -267,6 +268,10 @@ export const transformDocumentIntoPayload = async (
         breadcrumbs,
         collection,
         template: lastItem(template.namespace),
+        lastUpdated:
+          typeof lastUpdated === 'number'
+            ? new Date(lastUpdated).toISOString()
+            : null,
       },
       _values: data,
       _rawData: rawData,
@@ -400,12 +405,15 @@ export class Resolver {
         path: rawData['__folderPath'],
       };
     } else {
+      const lastUpdated = await this.database.getDocumentTimestamp(fullPath);
       return transformDocumentIntoPayload(
         fullPath,
         rawData,
         this.tinaSchema,
         this.config,
-        this.isAudit
+        this.isAudit,
+        undefined,
+        lastUpdated
       );
     }
   };
@@ -427,13 +435,15 @@ export class Resolver {
     const hasReferences = opts?.checkReferences
       ? await this.hasReferences(fullPath, opts.collection)
       : undefined;
+    const lastUpdated = await this.database.getDocumentTimestamp(fullPath);
     return transformDocumentIntoPayload(
       fullPath,
       rawData,
       this.tinaSchema,
       this.config,
       this.isAudit,
-      hasReferences
+      hasReferences,
+      lastUpdated
     );
   };
 

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -25,6 +25,7 @@ import { GraphQLError } from 'graphql';
 import { generatePasswordHash } from '../auth/utils';
 import {
   FilterCondition,
+  LAST_UPDATED_FIELD,
   REFS_COLLECTIONS_SORT_KEY,
   REFS_PATH_FIELD,
   REFS_REFERENCE_FIELD,
@@ -191,7 +192,7 @@ export const resolveFieldData = async (
 
 export const transformDocumentIntoPayload = async (
   fullPath: string,
-  rawData: { _collection; _template },
+  rawData: { _collection; _template; [key: string]: unknown },
   tinaSchema: TinaSchema,
   config?: GraphQLConfig,
   isAudit?: boolean,
@@ -269,9 +270,10 @@ export const transformDocumentIntoPayload = async (
         collection,
         template: lastItem(template.namespace),
         lastUpdated:
-          typeof lastUpdated === 'number'
+          (rawData[LAST_UPDATED_FIELD] as string | undefined) ??
+          (typeof lastUpdated === 'number'
             ? new Date(lastUpdated).toISOString()
-            : null,
+            : null),
       },
       _values: data,
       _rawData: rawData,

--- a/packages/tinacms/src/admin/api.ts
+++ b/packages/tinacms/src/admin/api.ts
@@ -211,6 +211,7 @@ export class TinaAdminApi {
                     relativePath
                     filename
                     extension
+                    lastUpdated
                     hasReferences
                   }
                 }
@@ -264,6 +265,7 @@ export class TinaAdminApi {
                     relativePath
                     filename
                     extension
+                    lastUpdated
                   }
                 }
               }

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -12,7 +12,12 @@ import { handleNavigate } from '../pages/CollectionListPage';
 import type { CollectionResponse, DocumentForm } from '../types';
 import { FullscreenError } from './FullscreenError';
 
+const SYSTEM_SORT_KEYS = ['lastUpdated'];
+
 const isValidSortKey = (sortKey: string, collection: Collection<true>) => {
+  if (SYSTEM_SORT_KEYS.includes(sortKey)) {
+    return true;
+  }
   if (collection.fields) {
     const sortKeys = collection.fields.map((x) => x.name);
     return sortKeys.includes(sortKey);

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -12,7 +12,8 @@ import { handleNavigate } from '../pages/CollectionListPage';
 import type { CollectionResponse, DocumentForm } from '../types';
 import { FullscreenError } from './FullscreenError';
 
-export const SYSTEM_SORT_KEYS = ['lastUpdated'];
+export const FILENAME_SORT_KEY = '__filepath__';
+export const SYSTEM_SORT_KEYS = ['lastUpdated', FILENAME_SORT_KEY];
 
 const isValidSortKey = (sortKey: string, collection: Collection<true>) => {
   if (SYSTEM_SORT_KEYS.includes(sortKey)) {

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -12,7 +12,7 @@ import { handleNavigate } from '../pages/CollectionListPage';
 import type { CollectionResponse, DocumentForm } from '../types';
 import { FullscreenError } from './FullscreenError';
 
-const SYSTEM_SORT_KEYS = ['lastUpdated'];
+export const SYSTEM_SORT_KEYS = ['lastUpdated'];
 
 const isValidSortKey = (sortKey: string, collection: Collection<true>) => {
   if (SYSTEM_SORT_KEYS.includes(sortKey)) {

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -28,8 +28,6 @@ import { formatDistanceToNow } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 import {
   BiArrowBack,
-  BiChevronDown,
-  BiChevronUp,
   BiCopy,
   BiEdit,
   BiFile,
@@ -37,7 +35,6 @@ import {
   BiPlus,
   BiRename,
   BiSearch,
-  BiSortAlt2,
   BiTrash,
   BiX,
 } from 'react-icons/bi';
@@ -218,54 +215,6 @@ function getUniqueTemplateFields(collection: Collection<true>): TinaField[] {
   return [...fieldSet];
 }
 
-type TableSortColumn = 'name' | 'lastUpdated';
-type TableSort = { key: 'default' | TableSortColumn; order: 'asc' | 'desc' };
-
-type DocumentEdge = {
-  node: {
-    __typename: string;
-    _sys?: {
-      title?: string;
-      filename?: string;
-      lastUpdated?: string | null;
-    };
-  };
-};
-
-const applyTableSort = <T extends DocumentEdge>(
-  edges: T[],
-  sort: TableSort
-): T[] => {
-  if (sort.key === 'default') {
-    return edges;
-  }
-  const folders = edges.filter((e) => e.node.__typename === 'Folder');
-  const documents = edges.filter((e) => e.node.__typename !== 'Folder');
-  const direction = sort.order === 'asc' ? 1 : -1;
-  const sorted = [...documents].sort((a, b) => {
-    if (sort.key === 'lastUpdated') {
-      const aValue = a.node._sys?.lastUpdated;
-      const bValue = b.node._sys?.lastUpdated;
-      if (!aValue && !bValue) return 0;
-      if (!aValue) return 1;
-      if (!bValue) return -1;
-      return aValue.localeCompare(bValue) * direction;
-    }
-    const aName = (
-      a.node._sys?.title ||
-      a.node._sys?.filename ||
-      ''
-    ).toLowerCase();
-    const bName = (
-      b.node._sys?.title ||
-      b.node._sys?.filename ||
-      ''
-    ).toLowerCase();
-    return aName.localeCompare(bName) * direction;
-  });
-  return [...folders, ...sorted];
-};
-
 const CollectionListPage = () => {
   const navigate = useNavigate();
   const { collectionName } = useParams();
@@ -287,17 +236,6 @@ const CollectionListPage = () => {
   });
   const [endCursor, setEndCursor] = useState('');
   const [prevCursors, setPrevCursors] = useState([]);
-  const [tableSort, setTableSort] = useState<TableSort>({
-    key: 'default',
-    order: 'asc',
-  });
-
-  const toggleTableSort = (column: TableSortColumn) =>
-    setTableSort((prev) =>
-      prev.key === column
-        ? { key: column, order: prev.order === 'asc' ? 'desc' : 'asc' }
-        : { key: column, order: 'asc' }
-    );
   const [sortKey, setSortKey] = useState(
     // set sort key to cached value if it exists
     isSSR
@@ -361,24 +299,6 @@ const CollectionListPage = () => {
     'px-3 py-3 text-left text-xs font-bold text-gray-700 tracking-wider';
 
   const tableHeadingStyle = 'bg-gray-100 border-b-2 border-gray-200';
-
-  const renderSortIcon = (column: TableSortColumn) => {
-    if (tableSort.key !== column) {
-      return <BiSortAlt2 className='opacity-40' />;
-    }
-    return tableSort.order === 'asc' ? <BiChevronUp /> : <BiChevronDown />;
-  };
-
-  const sortableHeading = (label: string, column: TableSortColumn) => (
-    <button
-      type='button'
-      onClick={() => toggleTableSort(column)}
-      className='flex items-center gap-1 uppercase tracking-wider hover:text-gray-900'
-    >
-      {label}
-      {renderSortIcon(column)}
-    </button>
-  );
 
   return (
     <GetCMS>
@@ -452,14 +372,20 @@ const CollectionListPage = () => {
                 }
 
                 // get unique fields from all templates
-                const fields = (
-                  collectionExtra.templates?.length
+                const fields = [
+                  ...(collectionExtra.templates?.length
                     ? getUniqueTemplateFields(collectionExtra)
                     : collectionExtra.fields
-                ).filter((x) =>
-                  // only allow sortable fields
-                  ['string', 'number', 'datetime', 'boolean'].includes(x.type)
-                );
+                  ).filter((x) =>
+                    // only allow sortable fields
+                    ['string', 'number', 'datetime', 'boolean'].includes(x.type)
+                  ),
+                  {
+                    name: 'lastUpdated',
+                    label: 'Last Updated',
+                    type: 'datetime',
+                  } as TinaField<true>,
+                ];
 
                 const sortField = fields?.find(
                   (field) => field.name === sortName
@@ -947,12 +873,9 @@ const CollectionListPage = () => {
                                             className={tableHeadingCellStyle}
                                             colSpan={hasAnyTitles ? 1 : 2}
                                           >
-                                            {sortableHeading(
-                                              hasAnyTitles
-                                                ? 'Title'
-                                                : 'Filename',
-                                              'name'
-                                            )}
+                                            {hasAnyTitles
+                                              ? 'Title'
+                                              : 'Filename'}
                                           </th>
                                           {hasAnyTitles && (
                                             <th
@@ -968,10 +891,7 @@ const CollectionListPage = () => {
                                             Template
                                           </th>
                                           <th className={tableHeadingCellStyle}>
-                                            {sortableHeading(
-                                              'Last Updated',
-                                              'lastUpdated'
-                                            )}
+                                            Last Updated
                                           </th>
                                           <th>
                                             {/* Empty heading for options column */}
@@ -1007,10 +927,7 @@ const CollectionListPage = () => {
                                         </tr>
                                       ) : null}
                                       {documents.length > 0 &&
-                                        applyTableSort(
-                                          documents,
-                                          tableSort
-                                        ).map((document) => {
+                                        documents.map((document) => {
                                           if (
                                             document.node.__typename ===
                                             'Folder'

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -28,6 +28,8 @@ import { formatDistanceToNow } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 import {
   BiArrowBack,
+  BiChevronDown,
+  BiChevronUp,
   BiCopy,
   BiEdit,
   BiFile,
@@ -35,6 +37,7 @@ import {
   BiPlus,
   BiRename,
   BiSearch,
+  BiSortAlt2,
   BiTrash,
   BiX,
 } from 'react-icons/bi';
@@ -251,6 +254,48 @@ const CollectionListPage = () => {
 
   const { order = 'asc', name: sortName } = JSON.parse(sortKey || '{}');
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>(order);
+
+  const applyServerSort = (name: string, nextOrder: 'asc' | 'desc') => {
+    const value = JSON.stringify({ name, order: nextOrder });
+    captureEvent(CollectionListPageSortEvent, {
+      sortKey: value,
+      collectionName,
+    });
+    setEndCursor('');
+    setPrevCursors([]);
+    window?.localStorage.setItem(
+      `${LOCAL_STORAGE_KEY}.${collectionName}`,
+      value
+    );
+    setSortKey(value);
+    setSortOrder(nextOrder);
+  };
+
+  const toggleColumnSort = (name: string) =>
+    applyServerSort(
+      name,
+      sortName === name && sortOrder === 'asc' ? 'desc' : 'asc'
+    );
+
+  const sortableHeader = (label: string, name: string) => (
+    <button
+      type='button'
+      onClick={() => toggleColumnSort(name)}
+      className='flex items-center gap-1 uppercase tracking-wider hover:text-gray-900'
+    >
+      {label}
+      {sortName === name ? (
+        sortOrder === 'asc' ? (
+          <BiChevronUp />
+        ) : (
+          <BiChevronDown />
+        )
+      ) : (
+        <BiSortAlt2 className='opacity-40' />
+      )}
+    </button>
+  );
+
   const loc = useLocation();
   const folder = useCollectionFolder();
   useEffect(() => {
@@ -661,24 +706,10 @@ const CollectionListPage = () => {
                                         name: 'sort',
                                         value: sortKey,
                                         onChange: (e) => {
-                                          captureEvent(
-                                            CollectionListPageSortEvent,
-                                            {
-                                              sortKey: e.target.value,
-                                              collectionName: collectionName,
-                                            }
-                                          );
                                           const val = JSON.parse(
                                             e.target.value
                                           );
-                                          setEndCursor('');
-                                          setPrevCursors([]);
-                                          window?.localStorage.setItem(
-                                            `${LOCAL_STORAGE_KEY}.${collectionName}`,
-                                            e.target.value
-                                          );
-                                          setSortKey(e.target.value);
-                                          setSortOrder(val.order);
+                                          applyServerSort(val.name, val.order);
                                         },
                                       }}
                                     />
@@ -873,9 +904,12 @@ const CollectionListPage = () => {
                                             className={tableHeadingCellStyle}
                                             colSpan={hasAnyTitles ? 1 : 2}
                                           >
-                                            {hasAnyTitles
-                                              ? 'Title'
-                                              : 'Filename'}
+                                            {sortableHeader(
+                                              hasAnyTitles
+                                                ? 'Title'
+                                                : 'Filename',
+                                              hasAnyTitles ? 'title' : ''
+                                            )}
                                           </th>
                                           {hasAnyTitles && (
                                             <th
@@ -891,7 +925,10 @@ const CollectionListPage = () => {
                                             Template
                                           </th>
                                           <th className={tableHeadingCellStyle}>
-                                            Last Updated
+                                            {sortableHeader(
+                                              'Last Updated',
+                                              'lastUpdated'
+                                            )}
                                           </th>
                                           <th>
                                             {/* Empty heading for options column */}

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -59,7 +59,7 @@ import {
 import { captureEvent } from '../../lib/posthog/posthogProvider';
 import type { TinaAdminApi } from '../api';
 import GetCMS from '../components/GetCMS';
-import GetCollection from '../components/GetCollection';
+import GetCollection, { SYSTEM_SORT_KEYS } from '../components/GetCollection';
 import LoadingPage from '../components/LoadingPage';
 import { PageBody, PageHeader, PageWrapper } from '../components/Page';
 import {
@@ -874,15 +874,17 @@ const CollectionListPage = () => {
                     </PageHeader>
                     <PageBody>
                       <div className='w-full mx-auto max-w-screen-xl'>
-                        {sortField && !sortField.required && (
-                          <p className='mb-4 text-gray-500'>
-                            <em>
-                              Sorting on a non-required field. Some documents
-                              may be excluded (if they don't have a value for{' '}
-                              {sortName})
-                            </em>
-                          </p>
-                        )}
+                        {sortField &&
+                          !sortField.required &&
+                          !SYSTEM_SORT_KEYS.includes(sortName) && (
+                            <p className='mb-4 text-gray-500'>
+                              <em>
+                                Sorting on a non-required field. Some documents
+                                may be excluded (if they don't have a value for{' '}
+                                {sortName})
+                              </em>
+                            </p>
+                          )}
                         <div className='w-full overflow-x-auto shadow-md rounded-md'>
                           {((folder.name && !search) ||
                             documents.length > 0) && (

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -24,9 +24,12 @@ import {
 } from '@tinacms/toolkit';
 import { Callout } from '@toolkit/react-sidebar/components/callout';
 import { cn } from '@utils/cn';
+import { formatDistanceToNow } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 import {
   BiArrowBack,
+  BiChevronDown,
+  BiChevronUp,
   BiCopy,
   BiEdit,
   BiFile,
@@ -34,6 +37,7 @@ import {
   BiPlus,
   BiRename,
   BiSearch,
+  BiSortAlt2,
   BiTrash,
   BiX,
 } from 'react-icons/bi';
@@ -214,6 +218,54 @@ function getUniqueTemplateFields(collection: Collection<true>): TinaField[] {
   return [...fieldSet];
 }
 
+type TableSortColumn = 'name' | 'lastUpdated';
+type TableSort = { key: 'default' | TableSortColumn; order: 'asc' | 'desc' };
+
+type DocumentEdge = {
+  node: {
+    __typename: string;
+    _sys?: {
+      title?: string;
+      filename?: string;
+      lastUpdated?: string | null;
+    };
+  };
+};
+
+const applyTableSort = <T extends DocumentEdge>(
+  edges: T[],
+  sort: TableSort
+): T[] => {
+  if (sort.key === 'default') {
+    return edges;
+  }
+  const folders = edges.filter((e) => e.node.__typename === 'Folder');
+  const documents = edges.filter((e) => e.node.__typename !== 'Folder');
+  const direction = sort.order === 'asc' ? 1 : -1;
+  const sorted = [...documents].sort((a, b) => {
+    if (sort.key === 'lastUpdated') {
+      const aValue = a.node._sys?.lastUpdated;
+      const bValue = b.node._sys?.lastUpdated;
+      if (!aValue && !bValue) return 0;
+      if (!aValue) return 1;
+      if (!bValue) return -1;
+      return aValue.localeCompare(bValue) * direction;
+    }
+    const aName = (
+      a.node._sys?.title ||
+      a.node._sys?.filename ||
+      ''
+    ).toLowerCase();
+    const bName = (
+      b.node._sys?.title ||
+      b.node._sys?.filename ||
+      ''
+    ).toLowerCase();
+    return aName.localeCompare(bName) * direction;
+  });
+  return [...folders, ...sorted];
+};
+
 const CollectionListPage = () => {
   const navigate = useNavigate();
   const { collectionName } = useParams();
@@ -235,6 +287,17 @@ const CollectionListPage = () => {
   });
   const [endCursor, setEndCursor] = useState('');
   const [prevCursors, setPrevCursors] = useState([]);
+  const [tableSort, setTableSort] = useState<TableSort>({
+    key: 'default',
+    order: 'asc',
+  });
+
+  const toggleTableSort = (column: TableSortColumn) =>
+    setTableSort((prev) =>
+      prev.key === column
+        ? { key: column, order: prev.order === 'asc' ? 'desc' : 'asc' }
+        : { key: column, order: 'asc' }
+    );
   const [sortKey, setSortKey] = useState(
     // set sort key to cached value if it exists
     isSSR
@@ -298,6 +361,25 @@ const CollectionListPage = () => {
     'px-3 py-3 text-left text-xs font-bold text-gray-700 tracking-wider';
 
   const tableHeadingStyle = 'bg-gray-100 border-b-2 border-gray-200';
+
+  const renderSortIcon = (column: TableSortColumn) => {
+    if (tableSort.key !== column) {
+      return <BiSortAlt2 className='opacity-40' />;
+    }
+    return tableSort.order === 'asc' ? <BiChevronUp /> : <BiChevronDown />;
+  };
+
+  const sortableHeading = (label: string, column: TableSortColumn) => (
+    <button
+      type='button'
+      onClick={() => toggleTableSort(column)}
+      className='flex items-center gap-1 uppercase tracking-wider hover:text-gray-900'
+    >
+      {label}
+      {renderSortIcon(column)}
+    </button>
+  );
+
   return (
     <GetCMS>
       {(cms: TinaCMS) => {
@@ -865,9 +947,12 @@ const CollectionListPage = () => {
                                             className={tableHeadingCellStyle}
                                             colSpan={hasAnyTitles ? 1 : 2}
                                           >
-                                            {hasAnyTitles
-                                              ? 'Title'
-                                              : 'Filename'}
+                                            {sortableHeading(
+                                              hasAnyTitles
+                                                ? 'Title'
+                                                : 'Filename',
+                                              'name'
+                                            )}
                                           </th>
                                           {hasAnyTitles && (
                                             <th
@@ -881,6 +966,12 @@ const CollectionListPage = () => {
                                           </th>
                                           <th className={tableHeadingCellStyle}>
                                             Template
+                                          </th>
+                                          <th className={tableHeadingCellStyle}>
+                                            {sortableHeading(
+                                              'Last Updated',
+                                              'lastUpdated'
+                                            )}
                                           </th>
                                           <th>
                                             {/* Empty heading for options column */}
@@ -906,7 +997,7 @@ const CollectionListPage = () => {
                                     <tbody>
                                       {folder.name && !search ? (
                                         <tr>
-                                          <td colSpan={5}>
+                                          <td colSpan={6}>
                                             <Breadcrumb
                                               folder={folder}
                                               navigate={navigate}
@@ -916,7 +1007,10 @@ const CollectionListPage = () => {
                                         </tr>
                                       ) : null}
                                       {documents.length > 0 &&
-                                        documents.map((document) => {
+                                        applyTableSort(
+                                          documents,
+                                          tableSort
+                                        ).map((document) => {
                                           if (
                                             document.node.__typename ===
                                             'Folder'
@@ -962,7 +1056,7 @@ const CollectionListPage = () => {
                                                 </td>
                                                 <td
                                                   className='px-3 py-3'
-                                                  colSpan={4}
+                                                  colSpan={5}
                                                 >
                                                   <span className='leading-5 block text-sm font-medium text-gray-400 truncate'>
                                                     {document.node.path
@@ -1077,6 +1171,30 @@ const CollectionListPage = () => {
                                                 <span className='leading-5 block text-sm font-medium text-gray-900'>
                                                   {document.node._sys.template}
                                                 </span>
+                                              </td>
+                                              <td className='px-3 py-3'>
+                                                {document.node._sys
+                                                  .lastUpdated ? (
+                                                  <span
+                                                    className='leading-5 block text-sm text-gray-500'
+                                                    title={new Date(
+                                                      document.node._sys
+                                                        .lastUpdated
+                                                    ).toLocaleString()}
+                                                  >
+                                                    {formatDistanceToNow(
+                                                      new Date(
+                                                        document.node._sys
+                                                          .lastUpdated
+                                                      ),
+                                                      { addSuffix: true }
+                                                    )}
+                                                  </span>
+                                                ) : (
+                                                  <span className='leading-5 block text-sm text-gray-300'>
+                                                    —
+                                                  </span>
+                                                )}
                                               </td>
                                               <td className='w-0'>
                                                 <OverflowMenu

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -59,7 +59,10 @@ import {
 import { captureEvent } from '../../lib/posthog/posthogProvider';
 import type { TinaAdminApi } from '../api';
 import GetCMS from '../components/GetCMS';
-import GetCollection, { SYSTEM_SORT_KEYS } from '../components/GetCollection';
+import GetCollection, {
+  FILENAME_SORT_KEY,
+  SYSTEM_SORT_KEYS,
+} from '../components/GetCollection';
 import LoadingPage from '../components/LoadingPage';
 import { PageBody, PageHeader, PageWrapper } from '../components/Page';
 import {
@@ -902,6 +905,10 @@ const CollectionListPage = () => {
                                     doc.node.__typename !== 'Folder' &&
                                     Boolean(doc.node._sys?.title)
                                 );
+                                const titleFieldName =
+                                  cms.api.tina.schema.getIsTitleFieldName(
+                                    collectionName
+                                  ) || FILENAME_SORT_KEY;
 
                                 return (
                                   <>
@@ -916,14 +923,19 @@ const CollectionListPage = () => {
                                               hasAnyTitles
                                                 ? 'Title'
                                                 : 'Filename',
-                                              hasAnyTitles ? 'title' : ''
+                                              hasAnyTitles
+                                                ? titleFieldName
+                                                : FILENAME_SORT_KEY
                                             )}
                                           </th>
                                           {hasAnyTitles && (
                                             <th
                                               className={tableHeadingCellStyle}
                                             >
-                                              Filename
+                                              {sortableHeader(
+                                                'Filename',
+                                                FILENAME_SORT_KEY
+                                              )}
                                             </th>
                                           )}
                                           <th className={tableHeadingCellStyle}>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -964,7 +964,7 @@ const CollectionListPage = () => {
                                           </th>
                                           <th
                                             className={tableHeadingCellStyle}
-                                            colSpan={4}
+                                            colSpan={5}
                                           >
                                             Path
                                           </th>

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -417,20 +417,26 @@ const CollectionListPage = () => {
                 }
 
                 // get unique fields from all templates
-                const fields = [
-                  ...(collectionExtra.templates?.length
+                const sortableFields = (
+                  collectionExtra.templates?.length
                     ? getUniqueTemplateFields(collectionExtra)
                     : collectionExtra.fields
-                  ).filter((x) =>
-                    // only allow sortable fields
-                    ['string', 'number', 'datetime', 'boolean'].includes(x.type)
-                  ),
-                  {
-                    name: 'lastUpdated',
-                    label: 'Last Updated',
-                    type: 'datetime',
-                  } as TinaField<true>,
-                ];
+                ).filter((x) =>
+                  // only allow sortable fields
+                  ['string', 'number', 'datetime', 'boolean'].includes(x.type)
+                );
+                const fields = sortableFields.some(
+                  (f) => f.name === 'lastUpdated'
+                )
+                  ? sortableFields
+                  : [
+                      ...sortableFields,
+                      {
+                        name: 'lastUpdated',
+                        label: 'Last Updated',
+                        type: 'datetime',
+                      } as TinaField<true>,
+                    ];
 
                 const sortField = fields?.find(
                   (field) => field.name === sortName

--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -281,7 +281,7 @@ const CollectionListPage = () => {
     <button
       type='button'
       onClick={() => toggleColumnSort(name)}
-      className='flex items-center gap-1 uppercase tracking-wider hover:text-gray-900'
+      className='flex items-center gap-1 hover:text-gray-900'
     >
       {label}
       {sortName === name ? (

--- a/packages/tinacms/src/admin/types.ts
+++ b/packages/tinacms/src/admin/types.ts
@@ -22,6 +22,7 @@ export interface DocumentNode {
       filename: string;
       extension: string;
       title?: string;
+      lastUpdated?: string | null;
     };
   };
 }


### PR DESCRIPTION
## TL;DR

Adds a "Last updated" column to the collection list, sortable by recency or name via clickable headers or the dropdown. Sorting is server-side across the whole collection, sourced from a pluggable `Bridge.lastUpdated()`, so it works on any backend (self-hosted included).

<img width="1320" height="464" alt="Screenshot 2026-06-29 at 12 31 16 pm" src="https://github.com/user-attachments/assets/e80e0e9b-3707-4ead-9ca4-1096e00b0277" />

**Figure: UI using tagged version on tina.io**

**Testing**

Tagged and built into a preview deployment of Tina.io : https://tina-io-git-jb-test-last-updated-tagged-version-tinacms.vercel.app/admin/index.html#/collections/page/~

## Notes

- Value is materialized into the index at index time (reserved `__lastUpdated`, stripped from content files); `_sys.lastUpdated` reads it.
- Defaults: git commit time (isomorphic) / file mtime (filesystem). Requires a reindex to backfill.

## Links

- Issue: https://github.com/tinacms/tinacloud/issues/3771
- TinaCloud timestamp source (merged): https://github.com/tinacms/tinacloud/pull/3779
