### PR TITLE
Reject cross-origin state-changing requests on the dev server

### DIFF
--- a/.changeset/media-upload-cross-origin.md
+++ b/.changeset/media-upload-cross-origin.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": patch
+---
+
+Reject cross-origin state-changing requests on the dev server. Previously the `cors` middleware only suppressed response headers, so an attacker-controlled page could still drive a cross-origin multipart upload to completion (writing files into the media root). State-changing routes (`/media/upload`, `/media` DELETE, and `searchIndex` POST/DELETE) now reject disallowed origins server-side with a 403.

--- a/.changeset/media-upload-cross-origin.md
+++ b/.changeset/media-upload-cross-origin.md
@@ -2,4 +2,4 @@
 "@tinacms/cli": patch
 ---
 
-Reject cross-origin state-changing requests on the dev server. Previously the `cors` middleware only suppressed response headers, so an attacker-controlled page could still drive a cross-origin multipart upload to completion (writing files into the media root). State-changing routes (`/media/upload`, `/media` DELETE, and `searchIndex` POST/DELETE) now reject disallowed origins server-side with a 403.
+Reject cross-origin state-changing requests on the dev server. Previously the `cors` middleware only suppressed response headers, so an attacker-controlled page could still drive a cross-origin multipart upload to completion (writing files into the media root). State-changing routes (`/media/upload`, `/media` DELETE, `searchIndex` POST/DELETE, and `/graphql` POST) now reject disallowed origins server-side with a 403.

--- a/packages/@tinacms/cli/src/next/vite/cors.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/cors.test.ts
@@ -150,7 +150,9 @@ describe('isOriginAllowed', () => {
   });
 
   it('honors the "private" keyword', () => {
-    expect(isOriginAllowed('http://192.168.1.100:3000', ['private'])).toBe(true);
+    expect(isOriginAllowed('http://192.168.1.100:3000', ['private'])).toBe(
+      true
+    );
     expect(isOriginAllowed('http://8.8.8.8:3000', ['private'])).toBe(false);
   });
 

--- a/packages/@tinacms/cli/src/next/vite/cors.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/cors.test.ts
@@ -1,4 +1,4 @@
-import { buildCorsOriginCheck } from './cors';
+import { buildCorsOriginCheck, isOriginAllowed } from './cors';
 
 describe('buildCorsOriginCheck', () => {
   const check = (
@@ -122,5 +122,41 @@ describe('buildCorsOriginCheck', () => {
     it('blocks non-matching origins', async () => {
       expect(await check(fn, 'https://evil.com')).toBe(false);
     });
+  });
+});
+
+describe('isOriginAllowed', () => {
+  it('allows requests with no Origin header', () => {
+    expect(isOriginAllowed(undefined)).toBe(true);
+  });
+
+  it('allows localhost regardless of port', () => {
+    expect(isOriginAllowed('http://localhost:3000')).toBe(true);
+    expect(isOriginAllowed('http://127.0.0.1:4001')).toBe(true);
+    expect(isOriginAllowed('http://[::1]:4001')).toBe(true);
+  });
+
+  it('blocks disallowed cross-origins', () => {
+    expect(isOriginAllowed('http://evil.test:8000')).toBe(false);
+    expect(isOriginAllowed('https://evil.com')).toBe(false);
+  });
+
+  it('honors configured exact origins', () => {
+    const allowed = ['https://my-codespace.github.dev'];
+    expect(isOriginAllowed('https://my-codespace.github.dev', allowed)).toBe(
+      true
+    );
+    expect(isOriginAllowed('https://evil.com', allowed)).toBe(false);
+  });
+
+  it('honors the "private" keyword', () => {
+    expect(isOriginAllowed('http://192.168.1.100:3000', ['private'])).toBe(true);
+    expect(isOriginAllowed('http://8.8.8.8:3000', ['private'])).toBe(false);
+  });
+
+  it('honors RegExp entries', () => {
+    const allowed = [/^https:\/\/.*\.preview\.app$/];
+    expect(isOriginAllowed('https://foo.preview.app', allowed)).toBe(true);
+    expect(isOriginAllowed('https://evil.com', allowed)).toBe(false);
   });
 });

--- a/packages/@tinacms/cli/src/next/vite/cors.ts
+++ b/packages/@tinacms/cli/src/next/vite/cors.ts
@@ -25,7 +25,49 @@ function expandOrigins(raw: (string | RegExp)[]): (string | RegExp)[] {
 }
 
 /**
+ * Decide whether a request `Origin` is allowed to reach the dev server.
+ *
+ * Requests with no `Origin` header (curl, same-origin navigations, CLI
+ * tooling, etc.) are always allowed. Localhost is always allowed; any extra
+ * `allowedOrigins` (expanded for the `'private'` keyword) are matched by
+ * exact string or RegExp.
+ *
+ * @param origin - The request `Origin` header (may be undefined).
+ * @param allowedOrigins - Raw `server.allowedOrigins` from the tina config.
+ */
+export function isOriginAllowed(
+  origin: string | undefined,
+  allowedOrigins: (string | RegExp)[] = []
+): boolean {
+  // Allow requests with no Origin header (curl, same-origin, etc.).
+  if (!origin) {
+    return true;
+  }
+  if (LOCALHOST_RE.test(origin)) {
+    return true;
+  }
+  for (const allowed of expandOrigins(allowedOrigins)) {
+    if (typeof allowed === 'string') {
+      if (allowed === origin) {
+        return true;
+      }
+    } else {
+      allowed.lastIndex = 0;
+      if (allowed.test(origin)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Build a CORS `origin` callback compatible with the `cors` npm package.
+ *
+ * NOTE: the `cors` package only uses this to decide whether to emit the
+ * `Access-Control-Allow-Origin` header — it does NOT reject disallowed
+ * requests server-side. State-changing routes must additionally gate on
+ * {@link isOriginAllowed} to prevent cross-origin CSRF writes.
  */
 export function buildCorsOriginCheck(
   allowedOrigins: (string | RegExp)[] = []
@@ -33,32 +75,7 @@ export function buildCorsOriginCheck(
   origin: string | undefined,
   callback: (err: Error | null, allow?: boolean) => void
 ) => void {
-  const extra = expandOrigins(allowedOrigins);
-
   return (origin, callback) => {
-    // Allow requests with no Origin header (curl, same-origin, etc.).
-    if (!origin) {
-      callback(null, true);
-      return;
-    }
-    if (LOCALHOST_RE.test(origin)) {
-      callback(null, true);
-      return;
-    }
-    for (const allowed of extra) {
-      if (typeof allowed === 'string') {
-        if (allowed === origin) {
-          callback(null, true);
-          return;
-        }
-      } else {
-        allowed.lastIndex = 0;
-        if (allowed.test(origin)) {
-          callback(null, true);
-          return;
-        }
-      }
-    }
-    callback(null, false);
+    callback(null, isOriginAllowed(origin, allowedOrigins));
   };
 }

--- a/packages/@tinacms/cli/src/next/vite/cors.ts
+++ b/packages/@tinacms/cli/src/next/vite/cors.ts
@@ -27,13 +27,9 @@ function expandOrigins(raw: (string | RegExp)[]): (string | RegExp)[] {
 /**
  * Decide whether a request `Origin` is allowed to reach the dev server.
  *
- * Requests with no `Origin` header (curl, same-origin navigations, CLI
- * tooling, etc.) are always allowed. Localhost is always allowed; any extra
- * `allowedOrigins` (expanded for the `'private'` keyword) are matched by
- * exact string or RegExp.
- *
- * @param origin - The request `Origin` header (may be undefined).
- * @param allowedOrigins - Raw `server.allowedOrigins` from the tina config.
+ * No `Origin` (curl, same-origin, CLI tooling) and localhost are always
+ * allowed; extra `allowedOrigins` (with `'private'` expanded) match by exact
+ * string or RegExp.
  */
 export function isOriginAllowed(
   origin: string | undefined,
@@ -62,12 +58,11 @@ export function isOriginAllowed(
 }
 
 /**
- * Build a CORS `origin` callback compatible with the `cors` npm package.
+ * Build a CORS `origin` callback for the `cors` npm package.
  *
- * NOTE: the `cors` package only uses this to decide whether to emit the
- * `Access-Control-Allow-Origin` header — it does NOT reject disallowed
- * requests server-side. State-changing routes must additionally gate on
- * {@link isOriginAllowed} to prevent cross-origin CSRF writes.
+ * NOTE: `cors` only uses this to set the `Access-Control-Allow-Origin` header;
+ * it does NOT reject disallowed requests server-side. State-changing routes
+ * must also gate on {@link isOriginAllowed} (see plugins.ts).
  */
 export function buildCorsOriginCheck(
   allowedOrigins: (string | RegExp)[] = []

--- a/packages/@tinacms/cli/src/next/vite/plugins.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.test.ts
@@ -1,18 +1,12 @@
 import { devServerEndPointsPlugin } from './plugins';
 
 /**
- * Middleware-layer regression test for the cross-origin upload flaw.
- *
- * The `cors` package only controls response headers — it does NOT reject
- * disallowed origins server-side. Because multipart uploads are "simple"
- * requests that skip the CORS preflight, an attacker page could otherwise
- * drive a state-changing request to completion (writing files into the media
- * root) even though the browser can't read the response.
- *
- * These tests exercise the real request middleware registered by
- * `devServerEndPointsPlugin` and assert that disallowed cross-origin
- * state-changing requests are rejected with a 403 *before* they reach the
- * media/searchIndex handlers.
+ * Middleware-layer regression test for the cross-origin write flaw: because
+ * `cors` only sets headers and multipart uploads skip the CORS preflight, an
+ * attacker page could otherwise drive a state-changing request to completion.
+ * These tests exercise the real `devServerEndPointsPlugin` middleware and
+ * assert disallowed cross-origin writes are rejected with a 403 before they
+ * reach the handlers.
  */
 
 // jest.mock factories may only reference vars prefixed with `mock`.
@@ -47,9 +41,7 @@ jest.mock('../commands/dev-command/server/searchIndex', () => ({
   }),
 }));
 
-// Avoid pulling the heavy graphql package into this unit test. `virtual` is
-// required because the workspace package isn't resolvable from this test's
-// module graph without a build.
+// `virtual` because @tinacms/graphql isn't resolvable here without a build.
 jest.mock(
   '@tinacms/graphql',
   () => ({ resolve: jest.fn(async () => ({ data: {} })) }),
@@ -85,11 +77,8 @@ const makeConfigManager = (allowedOrigins?: (string | RegExp)[]) =>
     },
   }) as any;
 
-/**
- * Build the plugin and return its request-handling middleware (the last
- * middleware registered via `server.middlewares.use`, after `cors` and
- * `bodyParser`).
- */
+// Returns the request-handling middleware (registered last, after `cors`
+// and `bodyParser`).
 const getRequestMiddleware = (allowedOrigins?: (string | RegExp)[]) => {
   const plugin = devServerEndPointsPlugin({
     configManager: makeConfigManager(allowedOrigins),

--- a/packages/@tinacms/cli/src/next/vite/plugins.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.test.ts
@@ -50,9 +50,15 @@ jest.mock('../commands/dev-command/server/searchIndex', () => ({
 // Avoid pulling the heavy graphql package into this unit test. `virtual` is
 // required because the workspace package isn't resolvable from this test's
 // module graph without a build.
-jest.mock('@tinacms/graphql', () => ({ resolve: jest.fn() }), {
-  virtual: true,
-});
+jest.mock(
+  '@tinacms/graphql',
+  () => ({ resolve: jest.fn(async () => ({ data: {} })) }),
+  { virtual: true }
+);
+
+// Reference to the mocked resolver (same module instance plugins.ts uses).
+import { resolve as gqlResolve } from '@tinacms/graphql';
+const mockGqlResolve = gqlResolve as unknown as jest.Mock;
 
 type FakeRes = {
   statusCode: number;
@@ -103,7 +109,12 @@ const getRequestMiddleware = (allowedOrigins?: (string | RegExp)[]) => {
 
 const invoke = async (
   mw: Function,
-  req: { url: string; method?: string; headers?: Record<string, string> }
+  req: {
+    url: string;
+    method?: string;
+    headers?: Record<string, string>;
+    body?: any;
+  }
 ) => {
   const res = makeRes();
   const next = jest.fn();
@@ -154,6 +165,19 @@ describe('devServerEndPointsPlugin cross-origin gate', () => {
       expect(res.statusCode).toBe(403);
       expect(mockSearchPut).not.toHaveBeenCalled();
     });
+
+    it('rejects cross-origin POST /graphql before reaching the handler', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/graphql',
+        method: 'POST',
+        headers: { origin: 'https://evil.com' },
+        body: { query: 'mutation { addPendingDocument }', variables: {} },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(mockGqlResolve).not.toHaveBeenCalled();
+    });
   });
 
   describe('allowed requests reach the upload handler', () => {
@@ -203,6 +227,45 @@ describe('devServerEndPointsPlugin cross-origin gate', () => {
 
       expect(res.statusCode).toBe(403);
       expect(mockHandlePost).not.toHaveBeenCalled();
+    });
+
+    it('allows a no-Origin POST /graphql to reach the resolver', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/graphql',
+        method: 'POST',
+        headers: {},
+        body: { query: '{ __typename }', variables: {} },
+      });
+
+      expect(res.statusCode).not.toBe(403);
+      expect(mockGqlResolve).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a localhost POST /graphql to reach the resolver', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/graphql',
+        method: 'POST',
+        headers: { origin: 'http://localhost:3000' },
+        body: { query: '{ __typename }', variables: {} },
+      });
+
+      expect(res.statusCode).not.toBe(403);
+      expect(mockGqlResolve).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not gate GET /graphql (read), even cross-origin', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/graphql',
+        method: 'GET',
+        headers: { origin: 'https://evil.com' },
+        body: { query: '{ __typename }', variables: {} },
+      });
+
+      expect(res.statusCode).not.toBe(403);
+      expect(mockGqlResolve).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/@tinacms/cli/src/next/vite/plugins.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.test.ts
@@ -1,0 +1,208 @@
+import { devServerEndPointsPlugin } from './plugins';
+
+/**
+ * Middleware-layer regression test for the cross-origin upload flaw.
+ *
+ * The `cors` package only controls response headers — it does NOT reject
+ * disallowed origins server-side. Because multipart uploads are "simple"
+ * requests that skip the CORS preflight, an attacker page could otherwise
+ * drive a state-changing request to completion (writing files into the media
+ * root) even though the browser can't read the response.
+ *
+ * These tests exercise the real request middleware registered by
+ * `devServerEndPointsPlugin` and assert that disallowed cross-origin
+ * state-changing requests are rejected with a 403 *before* they reach the
+ * media/searchIndex handlers.
+ */
+
+// jest.mock factories may only reference vars prefixed with `mock`.
+const mockHandlePost = jest.fn(async (_req: any, res: any) => {
+  res.statusCode = 200;
+  res.end(JSON.stringify({ success: true }));
+});
+const mockHandleDelete = jest.fn(async (_req: any, res: any) => {
+  res.statusCode = 200;
+  res.end(JSON.stringify({ ok: true }));
+});
+const mockHandleList = jest.fn();
+const mockSearchPut = jest.fn(async (_req: any, res: any) => {
+  res.statusCode = 200;
+  res.end('{}');
+});
+
+jest.mock('../commands/dev-command/server/media', () => ({
+  createMediaRouter: () => ({
+    handlePost: mockHandlePost,
+    handleDelete: mockHandleDelete,
+    handleList: mockHandleList,
+  }),
+  parseMediaFolder: (s: string) => s,
+}));
+
+jest.mock('../commands/dev-command/server/searchIndex', () => ({
+  createSearchIndexRouter: () => ({
+    put: mockSearchPut,
+    get: jest.fn(),
+    del: jest.fn(),
+  }),
+}));
+
+// Avoid pulling the heavy graphql package into this unit test. `virtual` is
+// required because the workspace package isn't resolvable from this test's
+// module graph without a build.
+jest.mock('@tinacms/graphql', () => ({ resolve: jest.fn() }), {
+  virtual: true,
+});
+
+type FakeRes = {
+  statusCode: number;
+  ended: boolean;
+  body?: string;
+  end: (body?: string) => void;
+};
+
+const makeRes = (): FakeRes => ({
+  statusCode: 200,
+  ended: false,
+  end(body?: string) {
+    this.ended = true;
+    this.body = body;
+  },
+});
+
+const makeConfigManager = (allowedOrigins?: (string | RegExp)[]) =>
+  ({
+    rootPath: '/tmp/project-root',
+    config: {
+      media: { tina: { publicFolder: 'public', mediaRoot: 'uploads' } },
+      server: { allowedOrigins },
+    },
+  }) as any;
+
+/**
+ * Build the plugin and return its request-handling middleware (the last
+ * middleware registered via `server.middlewares.use`, after `cors` and
+ * `bodyParser`).
+ */
+const getRequestMiddleware = (allowedOrigins?: (string | RegExp)[]) => {
+  const plugin = devServerEndPointsPlugin({
+    configManager: makeConfigManager(allowedOrigins),
+    apiURL: 'http://localhost:4001',
+    database: {} as any,
+    searchIndex: {},
+    databaseLock: async (fn) => fn(),
+  });
+  const middlewares: Function[] = [];
+  const server: any = {
+    middlewares: { use: (fn: Function) => middlewares.push(fn) },
+  };
+  // @ts-ignore - configureServer only needs the `middlewares` shape here.
+  plugin.configureServer(server);
+  return middlewares[middlewares.length - 1];
+};
+
+const invoke = async (
+  mw: Function,
+  req: { url: string; method?: string; headers?: Record<string, string> }
+) => {
+  const res = makeRes();
+  const next = jest.fn();
+  await mw({ method: 'GET', headers: {}, ...req }, res, next);
+  return { res, next };
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('devServerEndPointsPlugin cross-origin gate', () => {
+  describe('disallowed cross-origin state-changing requests', () => {
+    it('rejects POST /media/upload with 403 before reaching the handler', async () => {
+      const mw = getRequestMiddleware();
+      const { res, next } = await invoke(mw, {
+        url: '/media/upload/poc.txt',
+        method: 'POST',
+        headers: { origin: 'http://evil.test:8000' },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toContain('Origin not allowed');
+      expect(mockHandlePost).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('rejects cross-origin DELETE /media before reaching the handler', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/media/uploads/poc.txt',
+        method: 'DELETE',
+        headers: { origin: 'https://evil.com' },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(mockHandleDelete).not.toHaveBeenCalled();
+    });
+
+    it('rejects cross-origin POST /searchIndex before reaching the handler', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/searchIndex',
+        method: 'POST',
+        headers: { origin: 'https://evil.com' },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(mockSearchPut).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('allowed requests reach the upload handler', () => {
+    it('allows a request with no Origin header (curl / same-origin)', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/media/upload/ok.txt',
+        method: 'POST',
+        headers: {},
+      });
+
+      expect(res.statusCode).not.toBe(403);
+      expect(mockHandlePost).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a localhost Origin', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/media/upload/ok.txt',
+        method: 'POST',
+        headers: { origin: 'http://localhost:3000' },
+      });
+
+      expect(res.statusCode).not.toBe(403);
+      expect(mockHandlePost).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows an Origin configured via server.allowedOrigins', async () => {
+      const mw = getRequestMiddleware(['https://my-codespace.github.dev']);
+      const { res } = await invoke(mw, {
+        url: '/media/upload/ok.txt',
+        method: 'POST',
+        headers: { origin: 'https://my-codespace.github.dev' },
+      });
+
+      expect(res.statusCode).not.toBe(403);
+      expect(mockHandlePost).toHaveBeenCalledTimes(1);
+    });
+
+    it('still blocks a disallowed Origin even when allowedOrigins is set', async () => {
+      const mw = getRequestMiddleware(['https://my-codespace.github.dev']);
+      const { res } = await invoke(mw, {
+        url: '/media/upload/poc.txt',
+        method: 'POST',
+        headers: { origin: 'http://evil.test:8000' },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(mockHandlePost).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -75,6 +75,7 @@ export const devServerEndPointsPlugin = ({
     const url = req.url || '';
     if (url.startsWith('/media/upload')) return true;
     if (url.startsWith('/media') && req.method === 'DELETE') return true;
+    if (url.startsWith('/graphql') && req.method === 'POST') return true;
     if (
       (url.startsWith('/searchIndex') || url.startsWith('/v2/searchIndex')) &&
       (req.method === 'POST' || req.method === 'DELETE')

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -64,11 +64,9 @@ export const devServerEndPointsPlugin = ({
   const corsOriginCheck = buildCorsOriginCheck(allowedOrigins);
 
   /**
-   * @security The `cors` middleware only controls response headers; it does
-   * NOT reject disallowed origins server-side. Because multipart uploads are
-   * "simple" requests that skip the CORS preflight, an attacker-controlled
-   * page can still drive a state-changing request to completion (the browser
-   * just can't read the response). State-changing routes must therefore
+   * @security `cors` only sets response headers; it does NOT reject requests.
+   * Multipart uploads are "simple" requests that skip the CORS preflight, so
+   * an attacker page can still drive these routes to completion. They must
    * reject disallowed origins explicitly to prevent cross-origin CSRF writes.
    */
   const isStateChangingRequest = (req: { url?: string; method?: string }) => {
@@ -107,8 +105,7 @@ export const devServerEndPointsPlugin = ({
           searchIndex,
         });
 
-        // @security Reject cross-origin state-changing requests server-side.
-        // CORS headers alone don't stop the server from processing them.
+        // @security Reject disallowed cross-origin writes (see isStateChangingRequest).
         if (
           isStateChangingRequest(req) &&
           !isOriginAllowed(req.headers.origin, allowedOrigins)

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -16,7 +16,7 @@ import {
 } from '../commands/dev-command/server/media';
 import { createSearchIndexRouter } from '../commands/dev-command/server/searchIndex';
 import type { ConfigManager } from '../config-manager';
-import { buildCorsOriginCheck } from './cors';
+import { buildCorsOriginCheck, isOriginAllowed } from './cors';
 
 export const transformTsxPlugin = ({
   configManager: _configManager,
@@ -60,9 +60,28 @@ export const devServerEndPointsPlugin = ({
   searchIndex: any;
   databaseLock: (fn: () => Promise<void>) => Promise<void>;
 }) => {
-  const corsOriginCheck = buildCorsOriginCheck(
-    configManager.config?.server?.allowedOrigins
-  );
+  const allowedOrigins = configManager.config?.server?.allowedOrigins;
+  const corsOriginCheck = buildCorsOriginCheck(allowedOrigins);
+
+  /**
+   * @security The `cors` middleware only controls response headers; it does
+   * NOT reject disallowed origins server-side. Because multipart uploads are
+   * "simple" requests that skip the CORS preflight, an attacker-controlled
+   * page can still drive a state-changing request to completion (the browser
+   * just can't read the response). State-changing routes must therefore
+   * reject disallowed origins explicitly to prevent cross-origin CSRF writes.
+   */
+  const isStateChangingRequest = (req: { url?: string; method?: string }) => {
+    const url = req.url || '';
+    if (url.startsWith('/media/upload')) return true;
+    if (url.startsWith('/media') && req.method === 'DELETE') return true;
+    if (
+      (url.startsWith('/searchIndex') || url.startsWith('/v2/searchIndex')) &&
+      (req.method === 'POST' || req.method === 'DELETE')
+    )
+      return true;
+    return false;
+  };
 
   const plug: Plugin = {
     name: 'graphql-endpoints',
@@ -86,6 +105,17 @@ export const devServerEndPointsPlugin = ({
           config: { apiURL, searchPath: 'searchIndex' },
           searchIndex,
         });
+
+        // @security Reject cross-origin state-changing requests server-side.
+        // CORS headers alone don't stop the server from processing them.
+        if (
+          isStateChangingRequest(req) &&
+          !isOriginAllowed(req.headers.origin, allowedOrigins)
+        ) {
+          res.statusCode = 403;
+          res.end(JSON.stringify({ error: 'Origin not allowed' }));
+          return;
+        }
 
         if (req.url.startsWith('/media/upload')) {
           await mediaRouter.handlePost(req, res);


### PR DESCRIPTION
Closes https://github.com/tinacms/tinacloud/issues/3601

## Summary

The `@tinacms/cli` Vite dev server currently uses `cors({ origin: corsOriginCheck })`, but the `cors` middleware only controls CORS response headers. It does not reject disallowed origins server-side.

This matters for state-changing routes such as `POST /media/upload`: `multipart/form-data` can be sent as a CORS simple request without a preflight, so a malicious page can trigger the request from a developer's browser. The browser cannot read the response, but the server may still process the request and write a file into the configured media root.

## Fix

* Extracted the origin allow-list logic into `isOriginAllowed(origin, allowedOrigins)` in `cors.ts`.
* Added a server-side origin gate in `plugins.ts` before route handling.
* Disallowed cross-origin state-changing requests now return `403` before reaching handlers.

The gate applies to:

* `POST /media/upload`
* `DELETE /media`
* `POST` / `DELETE` search index routes

Existing CORS header behavior is unchanged.

Requests without an `Origin` header remain allowed to preserve existing behavior for non-browser clients such as curl, CLI tooling, and same-origin/server-side calls. Browser-driven cross-origin state-changing requests include an `Origin` header and are rejected when disallowed.

## Testing

Added coverage for:

* `isOriginAllowed` and the existing CORS origin callback behavior.
* The plugin middleware rejecting disallowed cross-origin state-changing requests before handlers run.
* Allowed cases, including no-Origin requests, localhost, and configured `allowedOrigins`.

The behavior was also verified locally with real HTTP multipart uploads:

* Before the fix, a disallowed cross-origin upload completed and wrote a file.
* After the fix, the same request returns `403` and no file is written.