### PR TITLE
fix(graphql): tolerate a dangling sort-index entry in collection queries

### DIFF
--- a/packages/@tinacms/graphql/src/database/database.sort-index-ghost.test.ts
+++ b/packages/@tinacms/graphql/src/database/database.sort-index-ghost.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Repro: "Error querying file <path> from collection <collection>" (surfaced as
+ * "GetCollection failed: Unable to fetch"), broken ONLY for users sorting by a
+ * field while default-sort users are fine.
+ *
+ * Index entries live in per-sort sublevels (contentLevel -> <collection> -> <sortKey>).
+ * The default `__filepath__` index is keyed by the bare path, so it can't go stale.
+ * A field-sort index (e.g. `score`) is keyed by `<value>\x1D<path>` and is removable
+ * only by a `del` derived from that value -- so a value change/reconcile that fails to
+ * `del` the old value (the incremental indexer's `if (item)` gap, or an interrupted
+ * batch) strands the old key. A later delete clears the path-keyed entries but not the
+ * stranded one: default list stays healthy while the field-sorted list breaks. The fix
+ * makes Database.query skip an index entry whose record is gone, so these tests assert
+ * the tolerant behavior (field-sorted list returns the healthy items, no throw).
+ *
+ * Real Database + MemoryLevel + in-memory Bridge; the desync is injected to model the
+ * post-crash / post-reconcile end-state.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MemoryLevel } from 'memory-level';
+import { buildSchema, createDatabaseInternal } from '..';
+import type { Bridge } from './bridge';
+import type { Schema } from '@tinacms/schema-tools';
+import { CONTENT_ROOT_PREFIX, SUBLEVEL_OPTIONS } from './level';
+import { DEFAULT_COLLECTION_SORT_KEY } from './datalayer';
+
+class InMemoryBridge implements Bridge {
+  rootPath = '';
+  private files: Map<string, string> = new Map();
+
+  seed(filepath: string, content: string) {
+    this.files.set(filepath, content);
+    return this;
+  }
+  async glob(pattern: string, extension: string): Promise<string[]> {
+    return Array.from(this.files.keys()).filter(
+      (p) => p.startsWith(pattern) && p.endsWith(`.${extension}`)
+    );
+  }
+  async get(filepath: string): Promise<string> {
+    const content = this.files.get(filepath);
+    if (content === undefined)
+      throw new Error(`InMemoryBridge: file not found: ${filepath}`);
+    return content;
+  }
+  async put(filepath: string, data: string): Promise<void> {
+    this.files.set(filepath, data);
+  }
+  async delete(filepath: string): Promise<void> {
+    this.files.delete(filepath);
+  }
+}
+
+const testSchema: Schema = {
+  collections: [
+    {
+      name: 'post',
+      label: 'Post',
+      path: 'content/posts',
+      format: 'json',
+      fields: [
+        { name: 'title', label: 'Title', type: 'string' },
+        { name: 'score', label: 'Score', type: 'number' },
+      ],
+    },
+  ],
+};
+
+const jsonDoc = (data: Record<string, unknown>) => JSON.stringify(data);
+
+const GHOST = 'content/posts/ghost.json';
+const KEEP = 'content/posts/keep.json';
+
+async function setupDatabase() {
+  const bridge = new InMemoryBridge();
+  bridge.seed(KEEP, jsonDoc({ title: 'Keep', score: 1 }));
+  bridge.seed(GHOST, jsonDoc({ title: 'Ghost', score: 42 }));
+
+  const level = new MemoryLevel<string, Record<string, any>>({
+    valueEncoding: 'json',
+  });
+  const database = createDatabaseInternal({
+    bridge,
+    level,
+    tinaDirectory: 'tina',
+  });
+  await database.indexContent(await buildSchema({ schema: testSchema }));
+  return { database };
+}
+
+// Mirrors the collection-connection resolver, which loads each node's full
+// record via database.get(). The trivial `(p, v) => ({...})` hydrator used by
+// other tests never calls get(), so it would NOT surface this bug.
+const resolverHydrate = (database: any) => (path: string) => database.get(path);
+
+describe('field-sort index ghost (GetCollection failed)', () => {
+  it('tolerates a stranded field-sort entry instead of failing the whole collection', async () => {
+    const { database } = await setupDatabase();
+    const hydrate = resolverHydrate(database);
+
+    // Healthy to start: both the default and the `score` sort resolve.
+    await expect(
+      database.query(
+        { collection: 'post', sort: 'score', filterChain: [] },
+        hydrate
+      )
+    ).resolves.toBeTruthy();
+
+    // Model the desync: remove ghost's path-keyed entries (default __filepath__
+    // index + CONTENT_ROOT record) but leave its real, indexer-written
+    // `score` entry (`42\x1D content/posts/ghost.json`) stranded.
+    const content = database.contentLevel!;
+    await content
+      .sublevel('post', SUBLEVEL_OPTIONS)
+      .sublevel(DEFAULT_COLLECTION_SORT_KEY, SUBLEVEL_OPTIONS)
+      .del(GHOST);
+    await content.sublevel(CONTENT_ROOT_PREFIX, SUBLEVEL_OPTIONS).del(GHOST);
+
+    // Default-sorted list is fine: it never reads the `score` sublevel.
+    const defaultSorted = await database.query(
+      { collection: 'post', filterChain: [] },
+      hydrate
+    );
+    expect(defaultSorted.edges).toHaveLength(1);
+
+    // Field-sorted list now skips the stranded entry and returns the healthy
+    // items instead of throwing "Error querying file ... from collection".
+    const fieldSorted = await database.query(
+      { collection: 'post', sort: 'score', filterChain: [] },
+      hydrate
+    );
+    expect(fieldSorted.edges).toHaveLength(1);
+  });
+
+  it('control: a normal in-band delete cleans the field-sort index (no ghost)', async () => {
+    const { database } = await setupDatabase();
+    const hydrate = resolverHydrate(database);
+
+    // The in-band delete path rebuilds the field-sort `del` key from the stored
+    // record, so it correctly clears the `score` entry. No strand, no error.
+    await database.delete(GHOST);
+
+    const fieldSorted = await database.query(
+      { collection: 'post', sort: 'score', filterChain: [] },
+      hydrate
+    );
+    expect(fieldSorted.edges).toHaveLength(1);
+  });
+});

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1175,42 +1175,51 @@ export class Database {
       edges = [...edges, { cursor: key, path: filepath, value: itemRecord }];
     }
 
-    return {
-      edges: await sequential(
-        edges,
-        async ({
-          cursor,
-          path,
-          value,
-        }: {
-          cursor: string;
-          path: string;
-          value?: Record<string, any>;
-        }) => {
-          try {
-            // pass the path to the matched item and the raw index value
-            const node = await hydrator(path, value);
-            return {
-              node,
-              cursor: btoa(cursor),
-            };
-          } catch (error) {
-            console.log(error);
-            if (
-              error instanceof Error &&
-              (!path.includes('.tina/__generated__/_graphql.json') ||
-                !path.includes('tina/__generated__/_graphql.json'))
-            ) {
-              throw new TinaQueryError({
-                originalError: error,
-                file: path,
-                collection: collection.name,
-              });
-            }
-            // I dont think this should ever happen
-            throw error;
+    const hydratedEdges = await sequential(
+      edges,
+      async ({
+        cursor,
+        path,
+        value,
+      }: {
+        cursor: string;
+        path: string;
+        value?: Record<string, any>;
+      }) => {
+        try {
+          // pass the path to the matched item and the raw index value
+          const node = await hydrator(path, value);
+          return {
+            node,
+            cursor: btoa(cursor),
+          };
+        } catch (error) {
+          // A sort-index entry can outlive its record (a stale entry stranded by a
+          // partial index write). Drop the dangling entry rather than failing the
+          // whole collection; audit/reindex removes it permanently.
+          if (error instanceof NotFoundError) {
+            return null;
           }
+          console.log(error);
+          if (
+            error instanceof Error &&
+            (!path.includes('.tina/__generated__/_graphql.json') ||
+              !path.includes('tina/__generated__/_graphql.json'))
+          ) {
+            throw new TinaQueryError({
+              originalError: error,
+              file: path,
+              collection: collection.name,
+            });
+          }
+          // I dont think this should ever happen
+          throw error;
         }
+      }
+    );
+    return {
+      edges: hydratedEdges.filter(
+        (edge): edge is NonNullable<typeof edge> => edge !== null
       ),
       pageInfo: {
         hasPreviousPage,


### PR DESCRIPTION
**TL;DR** A stale (dangling) entry in a collection's field-sort index made `Database.query` throw for the entire collection list; this skips the dangling entry instead of failing, so the collection loads (`tinacms audit` / re-index still purges the orphan).

**Pain:** Index entries live in per-sort sublevels (`contentLevel -> <collection> -> <sortKey>`). The default `__filepath__` index is keyed by the bare path and can't go stale, but a field-sort index is keyed by `` `<value>\x1D<path>` `` and a key can only be removed by a `del` derived from that value. A value-change or reconcile that doesn't `del` the old value's key (the incremental indexer's `if (item)` cleanup gap, or an index batch interrupted by a crashed/timed-out process) strands the old entry; a later delete clears the path-keyed entries (the `__filepath__` index + the `CONTENT_ROOT` record) but not the stranded value-keyed one. `Database.query` then hydrates the dangling entry, `Database.get` throws `NotFoundError`, and it surfaces as `TinaQueryError` ("Error querying file ... from collection ...") for the whole collection. It presents as intermittent and per-user because the selected sort is cached per-browser in `localStorage`, so only editors on the affected field sort hit it while default-sort editors are fine. Previously closed as Windows / local re-index timing (#4018, #4150), but it is neither Windows-specific nor fixed by re-indexing a different index.

**Solution:** In `Database.query`, when hydrating a node throws `NotFoundError` (its record is gone), drop that edge instead of rethrowing `TinaQueryError`, so the collection loads and the orphan is skipped; `tinacms audit` / re-index still removes it permanently. This is resilience, not prevention (never stranding a value-keyed index entry is a deeper change to index maintenance, left as a follow-up). Adds `database.sort-index-ghost.test.ts` (real `Database` + `MemoryLevel` + in-memory bridge) reproducing the exact error and asserting the tolerant behavior, plus a control test showing the in-band delete path is unaffected.
