### PR TITLE
✨ Add draft / ready-for-review control to the editorial workflow modal

### DIFF
--- a/.changeset/blue-vans-begin.md
+++ b/.changeset/blue-vans-begin.md
@@ -1,0 +1,5 @@
+---
+"tinacms": minor
+---
+
+editorial workflow - add toggle to switch PRs created between draft and ready to review mode

--- a/packages/tinacms/src/internalClient/index.test.ts
+++ b/packages/tinacms/src/internalClient/index.test.ts
@@ -604,6 +604,28 @@ describe('Tina Client', () => {
       });
     });
 
+    it('includes isDraft in the request body', async () => {
+      fetchWithToken.mockResolvedValueOnce(
+        makeResponse({
+          status: 200,
+          body: { branchName: 'feature/test' },
+        })
+      );
+
+      await client.executeEditorialWorkflow({
+        branchName: 'feature/test',
+        baseBranch: 'main',
+        isDraft: false,
+      });
+
+      const requestBody = JSON.parse(fetchWithToken.mock.calls[0][1].body);
+      expect(requestBody).toMatchObject({
+        branchName: 'feature/test',
+        baseBranch: 'main',
+        isDraft: false,
+      });
+    });
+
     it('polls until the workflow completes', async () => {
       const onStatusUpdate = vi.fn();
 

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -762,6 +762,8 @@ mutation addPendingDocumentMutation(
     branchName: string;
     baseBranch: string;
     prTitle?: string;
+    // When false, opens a ready-for-review PR. Omitted keeps the server's draft-first default.
+    isDraft?: boolean;
     graphQLContentOp?: {
       query: string;
       variables: Record<string, unknown>;
@@ -777,6 +779,7 @@ mutation addPendingDocumentMutation(
           branchName: options.branchName,
           baseBranch: options.baseBranch,
           prTitle: options.prTitle,
+          isDraft: options.isDraft,
           graphQLContentOp: options.graphQLContentOp,
         },
         'Failed to start editorial workflow'

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
@@ -15,10 +15,10 @@ import { Form } from '@toolkit/forms';
 import { EditorialWorkflowProgressModal } from './editorial-workflow-progress-modal';
 import { checkBaseBranchExists } from './editorial-workflow-utils';
 import { useEditorialWorkflow } from './use-editorial-workflow';
+import { useLocalStorage } from '@toolkit/hooks/use-local-storage';
 import {
+  IS_DRAFT_STORAGE_KEY,
   PullRequestStatusField,
-  getPersistedIsDraft,
-  persistIsDraft,
 } from './pull-request-status-field';
 
 // Format the default branch name by removing content/ prefix and file extension
@@ -200,7 +200,10 @@ export const CreateBranchPromptModal = ({
   // workflow reuses this modal but does not thread isDraft, so it stays hidden there.
   showPullRequestStatus?: boolean;
 }) => {
-  const [isDraft, setIsDraft] = React.useState(getPersistedIsDraft);
+  const [isDraft, setIsDraft] = useLocalStorage(IS_DRAFT_STORAGE_KEY, true) as [
+    boolean,
+    (value: boolean) => void,
+  ];
   return (
     <Modal className='flex'>
       <PopupModal className='w-auto'>
@@ -247,13 +250,7 @@ export const CreateBranchPromptModal = ({
               }}
             />
             {showPullRequestStatus && (
-              <PullRequestStatusField
-                isDraft={isDraft}
-                onChange={(value) => {
-                  setIsDraft(value);
-                  persistIsDraft(value);
-                }}
-              />
+              <PullRequestStatusField isDraft={isDraft} onChange={setIsDraft} />
             )}
           </div>
         </ModalBody>

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
@@ -15,6 +15,11 @@ import { Form } from '@toolkit/forms';
 import { EditorialWorkflowProgressModal } from './editorial-workflow-progress-modal';
 import { checkBaseBranchExists } from './editorial-workflow-utils';
 import { useEditorialWorkflow } from './use-editorial-workflow';
+import {
+  PullRequestStatusField,
+  getPersistedIsDraft,
+  persistIsDraft,
+} from './pull-request-status-field';
 
 // Format the default branch name by removing content/ prefix and file extension
 const formatDefaultBranchName = (
@@ -91,7 +96,7 @@ export const CreateBranchModal = ({
     };
   }, []);
 
-  const executeEditorialWorkflow = async () => {
+  const executeEditorialWorkflow = async (isDraft: boolean) => {
     abortBranchGuard();
     const abortController = new AbortController();
     branchGuardAbortRef.current = abortController;
@@ -128,6 +133,7 @@ export const CreateBranchModal = ({
       crudType,
       tinaForm,
       signal: abortController.signal,
+      isDraft,
     });
     if (branchGuardAbortRef.current === abortController) {
       branchGuardAbortRef.current = null;
@@ -168,6 +174,7 @@ export const CreateBranchModal = ({
         close();
         safeSubmit();
       }}
+      showPullRequestStatus={true}
     />
   );
 };
@@ -180,15 +187,20 @@ export const CreateBranchPromptModal = ({
   onBranchNameChange,
   onCreateBranch,
   onSaveToProtectedBranch,
+  showPullRequestStatus = false,
 }: {
   branchName: string;
   close: () => void;
   disabled?: boolean;
   errorMessage?: string;
   onBranchNameChange: (value: string) => void;
-  onCreateBranch: () => void;
+  onCreateBranch: (isDraft: boolean) => void;
   onSaveToProtectedBranch: () => void;
+  // Content editorial workflow opts in to the draft/ready control. The media
+  // workflow reuses this modal but does not thread isDraft, so it stays hidden there.
+  showPullRequestStatus?: boolean;
 }) => {
+  const [isDraft, setIsDraft] = React.useState(getPersistedIsDraft);
   return (
     <Modal className='flex'>
       <PopupModal className='w-auto'>
@@ -234,6 +246,15 @@ export const CreateBranchPromptModal = ({
                 onBranchNameChange(e.target.value);
               }}
             />
+            {showPullRequestStatus && (
+              <PullRequestStatusField
+                isDraft={isDraft}
+                onChange={(value) => {
+                  setIsDraft(value);
+                  persistIsDraft(value);
+                }}
+              />
+            )}
           </div>
         </ModalBody>
         <ModalActions align='end'>
@@ -249,7 +270,7 @@ export const CreateBranchPromptModal = ({
             align='start'
             className='w-full sm:w-auto'
             disabled={disabled}
-            onMainAction={onCreateBranch}
+            onMainAction={() => onCreateBranch(isDraft)}
             items={[
               {
                 label: 'Save to Protected Branch',

--- a/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.test.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  IS_DRAFT_STORAGE_KEY,
+  PullRequestStatusField,
+  getPersistedIsDraft,
+  persistIsDraft,
+} from './pull-request-status-field';
+
+describe('isDraft persistence', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('defaults to draft (true) when nothing is stored', () => {
+    expect(getPersistedIsDraft()).toBe(true);
+  });
+
+  it('round-trips the stored preference', () => {
+    persistIsDraft(false);
+    expect(window.localStorage.getItem(IS_DRAFT_STORAGE_KEY)).toBe('false');
+    expect(getPersistedIsDraft()).toBe(false);
+
+    persistIsDraft(true);
+    expect(getPersistedIsDraft()).toBe(true);
+  });
+});
+
+describe('PullRequestStatusField', () => {
+  it('marks the active segment based on the isDraft prop', () => {
+    const { getByRole } = render(
+      <PullRequestStatusField isDraft={true} onChange={() => {}} />
+    );
+    expect(
+      getByRole('button', { name: 'Draft' }).getAttribute('aria-pressed')
+    ).toBe('true');
+    expect(
+      getByRole('button', { name: 'Ready for review' }).getAttribute(
+        'aria-pressed'
+      )
+    ).toBe('false');
+  });
+
+  it('calls onChange(false) when Ready for review is chosen', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { getByRole } = render(
+      <PullRequestStatusField isDraft={true} onChange={onChange} />
+    );
+
+    await user.click(getByRole('button', { name: 'Ready for review' }));
+
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it('calls onChange(true) when Draft is chosen', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const { getByRole } = render(
+      <PullRequestStatusField isDraft={false} onChange={onChange} />
+    );
+
+    await user.click(getByRole('button', { name: 'Draft' }));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.test.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.test.tsx
@@ -1,31 +1,9 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as React from 'react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import {
-  IS_DRAFT_STORAGE_KEY,
-  PullRequestStatusField,
-  getPersistedIsDraft,
-  persistIsDraft,
-} from './pull-request-status-field';
-
-describe('isDraft persistence', () => {
-  beforeEach(() => window.localStorage.clear());
-
-  it('defaults to draft (true) when nothing is stored', () => {
-    expect(getPersistedIsDraft()).toBe(true);
-  });
-
-  it('round-trips the stored preference', () => {
-    persistIsDraft(false);
-    expect(window.localStorage.getItem(IS_DRAFT_STORAGE_KEY)).toBe('false');
-    expect(getPersistedIsDraft()).toBe(false);
-
-    persistIsDraft(true);
-    expect(getPersistedIsDraft()).toBe(true);
-  });
-});
+import { PullRequestStatusField } from './pull-request-status-field';
 
 describe('PullRequestStatusField', () => {
   it('marks the active segment based on the isDraft prop', () => {

--- a/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.tsx
@@ -1,32 +1,9 @@
 import * as React from 'react';
 
-// Persisted preference for whether editorial-workflow saves open a draft PR.
-// Global (not per-project): one editor, one preference.
+// Persisted preference key for whether editorial-workflow saves open a draft PR.
+// Global (not per-project): one editor, one preference. Persistence itself is
+// handled by the shared `useLocalStorage` hook at the call site.
 export const IS_DRAFT_STORAGE_KEY = 'tina.editorialWorkflow.isDraft';
-
-/**
- * Reads the editor's last "draft vs ready for review" choice.
- * Defaults to draft (true) when nothing is stored, matching the server default.
- * Guards against environments where localStorage is unavailable.
- */
-export const getPersistedIsDraft = (): boolean => {
-  try {
-    const stored = window.localStorage.getItem(IS_DRAFT_STORAGE_KEY);
-    if (stored === null) return true;
-    return stored === 'true';
-  } catch {
-    return true;
-  }
-};
-
-/** Persists the editor's choice; silently ignores storage failures. */
-export const persistIsDraft = (isDraft: boolean): void => {
-  try {
-    window.localStorage.setItem(IS_DRAFT_STORAGE_KEY, String(isDraft));
-  } catch {
-    // Private browsing / SSR — non-fatal, just skip persistence.
-  }
-};
 
 const Segment = ({
   active,

--- a/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/pull-request-status-field.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+
+// Persisted preference for whether editorial-workflow saves open a draft PR.
+// Global (not per-project): one editor, one preference.
+export const IS_DRAFT_STORAGE_KEY = 'tina.editorialWorkflow.isDraft';
+
+/**
+ * Reads the editor's last "draft vs ready for review" choice.
+ * Defaults to draft (true) when nothing is stored, matching the server default.
+ * Guards against environments where localStorage is unavailable.
+ */
+export const getPersistedIsDraft = (): boolean => {
+  try {
+    const stored = window.localStorage.getItem(IS_DRAFT_STORAGE_KEY);
+    if (stored === null) return true;
+    return stored === 'true';
+  } catch {
+    return true;
+  }
+};
+
+/** Persists the editor's choice; silently ignores storage failures. */
+export const persistIsDraft = (isDraft: boolean): void => {
+  try {
+    window.localStorage.setItem(IS_DRAFT_STORAGE_KEY, String(isDraft));
+  } catch {
+    // Private browsing / SSR — non-fatal, just skip persistence.
+  }
+};
+
+const Segment = ({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) => (
+  <button
+    type='button'
+    aria-pressed={active}
+    onClick={onClick}
+    className={`flex-1 text-center text-sm font-semibold py-[7px] px-2 rounded-md transition-all duration-150 ease-out ${
+      active
+        ? 'bg-white text-tina-orange-dark shadow-sm'
+        : 'text-gray-500 hover:text-gray-700'
+    }`}
+  >
+    {children}
+  </button>
+);
+
+/**
+ * Segmented "Draft / Ready for review" control for the editorial-workflow modal.
+ * Controlled: `isDraft` selects the active segment, `onChange` reports the new value.
+ */
+export const PullRequestStatusField = ({
+  isDraft,
+  onChange,
+}: {
+  isDraft: boolean;
+  onChange: (isDraft: boolean) => void;
+}) => {
+  return (
+    <div className='mt-4'>
+      <label className='block font-sans text-xs font-semibold text-gray-700 whitespace-normal mb-2'>
+        Pull request status
+      </label>
+      <div className='flex bg-gray-100 border border-gray-200 rounded-lg p-[3px] gap-[3px]'>
+        <Segment active={isDraft} onClick={() => onChange(true)}>
+          Draft
+        </Segment>
+        <Segment active={!isDraft} onClick={() => onChange(false)}>
+          Ready for review
+        </Segment>
+      </div>
+      <p className='text-xs text-gray-500 mt-2 leading-snug'>
+        {isDraft
+          ? 'Drafts stay hidden from reviewers until you mark them ready.'
+          : 'Reviewers are notified right away and can start reviewing.'}
+      </p>
+    </div>
+  );
+};

--- a/packages/tinacms/src/toolkit/form-builder/use-editorial-workflow.ts
+++ b/packages/tinacms/src/toolkit/form-builder/use-editorial-workflow.ts
@@ -69,6 +69,8 @@ export interface ExecuteWorkflowOptions {
   crudType: string;
   tinaForm?: Form;
   signal?: AbortSignal;
+  // When false, opens a ready-for-review PR. Omitted keeps the server's draft-first default.
+  isDraft?: boolean;
 }
 
 export interface UseEditorialWorkflowResult {
@@ -153,6 +155,7 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
     crudType,
     tinaForm,
     signal,
+    isDraft,
   }: ExecuteWorkflowOptions): Promise<boolean> => {
     try {
       if (signal?.aborted) return false;
@@ -202,6 +205,7 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
         branchName,
         baseBranch,
         prTitle: getEditorialWorkflowPrTitle(branchName),
+        isDraft,
         graphQLContentOp: {
           query: graphql,
           variables: {

--- a/packages/tinacms/src/toolkit/hooks/use-local-storage.test.tsx
+++ b/packages/tinacms/src/toolkit/hooks/use-local-storage.test.tsx
@@ -1,0 +1,47 @@
+import { act, render } from '@testing-library/react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { useLocalStorage } from './use-local-storage';
+
+// Renders a probe component and records the value from every render, so we can
+// assert what the very first render saw (i.e. whether storage is read
+// synchronously or only after a post-mount effect).
+const renderProbe = (key: string, initialValue: unknown) => {
+  const renders: unknown[] = [];
+  let setValue: (value: unknown) => void = () => {};
+  const Probe = () => {
+    const [value, set] = useLocalStorage(key, initialValue);
+    setValue = set;
+    renders.push(value);
+    return null;
+  };
+  render(<Probe />);
+  return { renders, setValue: (v: unknown) => setValue(v) };
+};
+
+describe('useLocalStorage', () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it('returns the initial value on first render when nothing is stored', () => {
+    const { renders } = renderProbe('k', 'fallback');
+    expect(renders[0]).toBe('fallback');
+  });
+
+  it('reads the stored value synchronously on first render (no flicker)', () => {
+    window.localStorage.setItem('k', JSON.stringify(false));
+
+    const { renders } = renderProbe('k', true);
+
+    // The first render must already reflect storage, not the initial value.
+    expect(renders[0]).toBe(false);
+  });
+
+  it('persists updates as JSON via the setter', () => {
+    const { setValue } = renderProbe('k', true);
+
+    act(() => setValue(false));
+
+    expect(window.localStorage.getItem('k')).toBe('false');
+  });
+});

--- a/packages/tinacms/src/toolkit/hooks/use-local-storage.ts
+++ b/packages/tinacms/src/toolkit/hooks/use-local-storage.ts
@@ -1,7 +1,23 @@
 import * as React from 'react';
 
 export function useLocalStorage(key, initialValue) {
-  const [storedValue, setStoredValue] = React.useState(initialValue);
+  // Read synchronously during init so consumers get the stored value on the
+  // first render, instead of flashing `initialValue` for a frame before the
+  // effect below runs. Guarded for SSR / disabled-storage environments.
+  const [storedValue, setStoredValue] = React.useState(() => {
+    try {
+      const valueFromStorage =
+        typeof window !== 'undefined' &&
+        window.localStorage &&
+        window.localStorage.getItem(key);
+      if (valueFromStorage != null) {
+        return JSON.parse(valueFromStorage);
+      }
+    } catch (error) {
+      // Fall through to the provided initial value.
+    }
+    return initialValue;
+  });
   React.useEffect(() => {
     // localStorage may be intentionally disabled for site visitors,
     // in that case Tina can't be used so just bail out of value storing


### PR DESCRIPTION
## TL;DR

Editorial-workflow saves (the protected-branch "Save changes to new branch" modal) always open a **draft** PR today. This adds a segmented **Draft / Ready for review** control to that modal, remembers the last choice in `localStorage`, and threads `isDraft` through the client to the content API.

## Reviewer notes

- **Pairs with tinacms/tinacloud#3808**, which accepts and honors `isDraft`. Until that ships, the field is inert (server keeps creating drafts).
- **Content modal only.** `CreateBranchPromptModal` is shared with the media workflow; the control is gated behind an opt-in `showPullRequestStatus` prop so it stays hidden there (media doesn't thread `isDraft`).

## Links

- Server side: tinacms/tinacloud#3808

## Testing

Tested a tagged version on a preview deployment of tina.io at https://tina-io-git-jb-test-tagged-v-tinacms.vercel.app/admin#/~

It successfully created a "ready for review" PR at https://github.com/tinacms/tina.io/pull/4674

<img width="743" height="566" alt="Screenshot 2026-07-02 at 9 17 58 am" src="https://github.com/user-attachments/assets/78556953-8267-4532-94f9-4ea1d44c09d1" />

**Figure: UI on preview deployment**

<img width="1466" height="782" alt="Screenshot 2026-07-02 at 9 18 44 am" src="https://github.com/user-attachments/assets/e6bf32bb-cc85-4ce4-8d2c-e7fc8f1e675d" />

**Figure: ✅ Ready for review PR**