### PR TITLE
Adding a boolean field scaffold to the v4

### DIFF
--- a/packages/v4/@tinacms/tinacms/_docs/boolean-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/boolean-field.md
@@ -1,0 +1,123 @@
+# The `boolean` field
+
+One of the field plugins v4 ships: a single checkbox backed by a Zod type guard.
+
+## Files
+
+All four live in `plugins/fields/boolean/`:
+
+| File | Role |
+|---|---|
+| `boolean-field.schema.ts` | the `t.boolean()` helper + the `booleanSchema` guard |
+| `boolean-field.client.tsx` | the descriptor — claims the `boolean` key |
+| `boolean-field.ui.tsx` | the `BooleanField` checkbox component |
+| `boolean-field.plugin.ts` | the manifest — `tina:field:boolean` |
+
+## Authoring
+
+`t.boolean({...})` stamps `type: 'boolean'` (`BOOLEAN_FIELD_TYPE`) onto the config:
+
+```ts
+import { t } from '@tinacms/tinacms';
+
+const collection = {
+  name: 'post',
+  fields: [t.boolean({ name: 'featured', label: 'Featured' })],
+};
+```
+
+`BooleanFieldSchema` extends `BaseFieldSchema` — `name` (field key + fallback
+label), `label`, and `required`. There's no `min`/`max`/`pattern`; a boolean has
+nothing to constrain. `required` is accepted but a **no-op** (see below).
+
+## Descriptor
+
+The client segment (`boolean-field.client.tsx`) claims the `boolean` key:
+
+```tsx
+defineClientPlugin({
+  field: {
+    type: 'boolean',          // BOOLEAN_FIELD_TYPE
+    Component: BooleanField,
+    defaultValue: false,      // seeds a new/absent field on ingest
+    metadata: { layout: 'inline' },
+    schema: booleanSchema,
+  },
+});
+```
+
+No `validate`/`parse`/`serialize`: the value is stored as-is (a JSON/YAML boolean).
+
+## Two-state model — why `required` is a no-op
+
+A boolean is `true` or `false`; `false` is a first-class value, never "empty". The
+checkbox can't show an "unanswered" state, so the field is seeded to
+`defaultValue: false` and always renders a definite value. That leaves `required`
+nothing coherent to enforce — rejecting `false` would mean "must be checked"
+(conflating a deliberate "no" with empty), and rejecting an unset value would force
+a check-then-uncheck to produce `false`. So `required?` is accepted (inherited from
+`BaseFieldSchema`) but adds no rule. The legacy toggle field failed on
+`undefined`/`null` and had exactly that flaw; v4 doesn't reproduce it.
+
+## Validation
+
+`booleanSchema` is a type guard, not a constraint set — it ignores the node and
+only ensures a stored value is a boolean:
+
+```ts
+export const booleanSchema = (_node: FieldSchema): ZodType =>
+  z.preprocess((v) => (v == null ? undefined : v), z.boolean().optional());
+```
+
+`true`/`false` pass; `undefined`/`null` normalise to `undefined` and pass as
+optional; a non-boolean (e.g. `'yes'`) fails the type check. This runs through the
+shared path (`validateField`); a descriptor-level `validate(value)` can still add
+custom rules on top.
+
+## Ingest & digest
+
+On load, `ingestDocument` seeds `defaultValue` (`false`) for an absent field, so
+the checkbox always starts with a value; a stored boolean is taken as-is (no
+`parse`). From there the checkbox only ever produces `true` or `false`, so on save
+`digestDocument` writes that boolean straight back — the field defines no
+`parse`/`serialize`, so values pass through the shared ingest/digest unchanged.
+
+## Component
+
+`BooleanField` (`boolean-field.ui.tsx`) takes no props — it reads its address from
+context and pulls value/errors through address-keyed hooks, so toggling it
+re-renders only this field:
+
+```tsx
+export function BooleanField() {
+  const address = useFieldAddress();
+  const [value, setValue] = useFieldValue<boolean>(address);
+  const errors = useFieldErrors(address);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useFieldActivation(() => inputRef.current?.focus()); // focus when active
+
+  return (
+    <div>
+      <input ref={inputRef} type='checkbox' aria-label={address}
+        checked={value ?? false}
+        onChange={(e) => setValue(e.target.checked)} />
+      {errors.map((e) => <span key={e} role='alert'>{e}</span>)}
+    </div>
+  );
+}
+```
+
+## Where it's wired
+
+- Manifest: `boolean-field.plugin.ts` — `tina:field:boolean`, exported as
+  `booleanFieldPlugin`.
+- Registration: `plugins/fields/index.ts` adds it to `corePlugins` and exposes
+  `t.boolean`.
+
+## Tests
+
+`boolean-field.test.tsx` covers rendering true/false/absent, toggling back through
+the store, the `required` no-op (true and false both pass), the non-boolean
+rejection, true/false ingest/digest round-trips (plus default seeding on absent),
+and the descriptor metadata.

--- a/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
@@ -24,7 +24,9 @@ bundle when the plugin's `client()` import runs.
 The shipped `string` field (`plugins/fields/string/`) is the worked example
 below — substitute your own `type` for `string` throughout. For that field's
 exact config options and validation semantics, see
-[`string-field.md`](./string-field.md).
+[`string-field.md`](./string-field.md). The shipped `boolean` field
+([`boolean-field.md`](./boolean-field.md)) is a second example — a two-state
+checkbox where `required` is a no-op.
 
 ### 1. Manifest (`.plugin.ts`)
 

--- a/packages/v4/@tinacms/tinacms/_docs/plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/plugins.md
@@ -39,5 +39,6 @@ a *keyed* capability: many field plugins coexist, one per schema `type`
 ## More
 
 - [Field plugins](./field-plugins.md) — how to build one
-- [The `string` field](./string-field.md) — the shipped field, in detail
+  - [The `string` field](./string-field.md) — the shipped text input
+  - [The `boolean` field](./boolean-field.md) — the shipped checkbox
 - [Architecture](./architecture.md) — how a plugin reaches the screen

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -16,4 +16,7 @@ export type {
   TinaDocument,
 } from './core/schema/types';
 export { corePlugins, t } from './plugins/fields';
-export type { StringFieldSchema } from './plugins/fields';
+export type {
+  BooleanFieldSchema,
+  StringFieldSchema,
+} from './plugins/fields';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.client.tsx
@@ -1,0 +1,13 @@
+import { defineClientPlugin } from '../../../client';
+import { BOOLEAN_FIELD_TYPE, booleanSchema } from './boolean-field.schema';
+import { BooleanField } from './boolean-field.ui';
+
+export default defineClientPlugin({
+  field: {
+    type: BOOLEAN_FIELD_TYPE,
+    Component: BooleanField,
+    defaultValue: false,
+    metadata: { layout: 'inline' },
+    schema: booleanSchema,
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.plugin.ts
@@ -1,0 +1,9 @@
+import { definePlugin } from '../../../core/plugin';
+
+export const booleanFieldPlugin = definePlugin({
+  name: 'tina:field:boolean',
+  provides: ['field'],
+  client: () => import('./boolean-field.client'),
+});
+
+export default booleanFieldPlugin;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.schema.ts
@@ -1,0 +1,20 @@
+import { type ZodType, z } from 'zod';
+import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
+
+export const BOOLEAN_FIELD_TYPE = 'boolean';
+
+export interface BooleanFieldSchema extends BaseFieldSchema {
+  type: typeof BOOLEAN_FIELD_TYPE;
+}
+
+export const boolean = (
+  config: Omit<BooleanFieldSchema, 'type'>
+): BooleanFieldSchema => ({ ...config, type: BOOLEAN_FIELD_TYPE });
+
+// Two-state: `false` is valid and there's no empty state, so `required` can't be
+// enforced — this only type-guards the value (`null` passes as absent).
+export const booleanSchema = (_node: FieldSchema): ZodType =>
+  z.preprocess(
+    (value) => (value == null ? undefined : value),
+    z.boolean().optional()
+  );

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.test.tsx
@@ -1,0 +1,146 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import type {
+  CollectionSchema,
+  TinaDocument,
+} from '../../../core/schema/types';
+import { validateField } from '../../../core/validation';
+import { Field, FormProvider, TinaProvider } from '../../../editor';
+import { t } from '../../../index';
+import booleanFieldPlugin from './boolean-field.plugin';
+
+const collection: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  fields: [t.boolean({ name: 'featured', label: 'Featured', required: true })],
+};
+
+const featuredNode = collection.fields[0];
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins([booleanFieldPlugin]);
+
+const renderFeatured = (document?: TinaDocument) =>
+  render(
+    <TinaProvider plugins={[booleanFieldPlugin]}>
+      <FormProvider collection={collection} document={document}>
+        <Field address='featured' />
+      </FormProvider>
+    </TinaProvider>
+  );
+
+describe('BooleanField rendering', () => {
+  it('renders a stored true value as a checked box', async () => {
+    renderFeatured({ featured: true });
+    const input = (await screen.findByLabelText(
+      'featured'
+    )) as HTMLInputElement;
+    expect(input).toBeChecked();
+  });
+
+  it('renders a stored false value as an unchecked box', async () => {
+    renderFeatured({ featured: false });
+    const input = (await screen.findByLabelText(
+      'featured'
+    )) as HTMLInputElement;
+    expect(input).not.toBeChecked();
+  });
+
+  it('falls back to the descriptor default (false) when absent', async () => {
+    renderFeatured();
+    const input = (await screen.findByLabelText(
+      'featured'
+    )) as HTMLInputElement;
+    expect(input).not.toBeChecked();
+  });
+});
+
+describe('BooleanField value updates', () => {
+  it('toggles the value back through the form store', async () => {
+    renderFeatured({ featured: false });
+    const input = (await screen.findByLabelText(
+      'featured'
+    )) as HTMLInputElement;
+
+    await userEvent.click(input);
+    expect(input).toBeChecked();
+
+    await userEvent.click(input);
+    expect(input).not.toBeChecked();
+  });
+});
+
+describe('BooleanField validation', () => {
+  // `required` is a no-op for boolean by design: a checkbox has no empty state
+  // and `false` is a first-class value, so neither true nor false is rejected.
+  it('accepts both true and false even when the field is required', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('boolean');
+    expect(validateField(featuredNode, descriptor, true)).toEqual([]);
+    expect(validateField(featuredNode, descriptor, false)).toEqual([]);
+  });
+
+  it('accepts an absent value as optional', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('boolean');
+    expect(validateField(featuredNode, descriptor, undefined)).toEqual([]);
+    expect(validateField(featuredNode, descriptor, null)).toEqual([]);
+  });
+
+  it('rejects a non-boolean stored value', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('boolean');
+    expect(validateField(featuredNode, descriptor, 'yes')).not.toEqual([]);
+  });
+
+  it('appends a descriptor-level custom validate error', () => {
+    const descriptor = {
+      type: 'boolean',
+      Component: () => null,
+      validate: (value: boolean) =>
+        value === false ? 'Must be enabled' : null,
+    };
+    expect(validateField(featuredNode, descriptor, false)).toContain(
+      'Must be enabled'
+    );
+  });
+});
+
+describe('BooleanField ingest and digest', () => {
+  it('round-trips true and false through ingest and digest', async () => {
+    const registry = await resolveRegistry();
+    for (const featured of [true, false]) {
+      const ingested = ingestDocument(
+        { featured },
+        collection.fields,
+        registry
+      );
+      expect(ingested).toEqual({ featured });
+      expect(digestDocument(ingested, collection.fields, registry)).toEqual({
+        featured,
+      });
+    }
+  });
+
+  it('seeds the default value on ingest when the field is absent', async () => {
+    const registry = await resolveRegistry();
+    expect(ingestDocument({}, collection.fields, registry)).toEqual({
+      featured: false,
+    });
+  });
+});
+
+describe('BooleanField metadata wrapping', () => {
+  it('registers the boolean descriptor with its declared metadata', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('boolean');
+    expect(descriptor?.metadata).toEqual({ layout: 'inline' });
+    expect(descriptor?.defaultValue).toBe(false);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.ui.tsx
@@ -1,0 +1,36 @@
+import { useRef } from 'react';
+import {
+  useFieldActivation,
+  useFieldAddress,
+  useFieldErrors,
+  useFieldValue,
+} from '../../../editor';
+
+export function BooleanField() {
+  const address = useFieldAddress();
+  const [value, setValue] = useFieldValue<boolean>(address);
+  const errors = useFieldErrors(address);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useFieldActivation(() => inputRef.current?.focus());
+
+  // TODO(shadcn): swap this raw checkbox/markup for shared, themed primitives from
+  // src/ui/ (shadcn — Checkbox/Label/form-field wrapper, added via the shadcn CLI) so
+  // every field looks consistent and is re-themeable without per-field redesign.
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type='checkbox'
+        aria-label={address}
+        checked={value ?? false}
+        onChange={(event) => setValue(event.target.checked)}
+      />
+      {errors.map((error) => (
+        <span key={error} role='alert'>
+          {error}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -1,9 +1,11 @@
+import booleanFieldPlugin from './boolean/boolean-field.plugin';
+import { boolean } from './boolean/boolean-field.schema';
 import stringFieldPlugin from './string/string-field.plugin';
 import { string } from './string/string-field.schema';
 
 // The built-in field plugins TinaCMS ships. The "is this a core plugin" check
 // reads this list, not the plugin name.
-export const corePlugins = [stringFieldPlugin];
+export const corePlugins = [stringFieldPlugin, booleanFieldPlugin];
 
 // Schema-authoring helpers, one per built-in field. Kept explicit (rather than
 // derived in a loop) so `t.string` stays statically typed; co-located with
@@ -11,6 +13,7 @@ export const corePlugins = [stringFieldPlugin];
 // TODO: once defineConfig (ADR-024) lands, generate `t` from the configured plugin
 // set so user-registered field plugins join it (typed). This stays the built-in
 // default until then.
-export const t = { string };
+export const t = { string, boolean };
 
+export type { BooleanFieldSchema } from './boolean/boolean-field.schema';
 export type { StringFieldSchema } from './string/string-field.schema';


### PR DESCRIPTION
Closes #6916 

* Wires in the client, schema, plugin and ui for the boolean field
* Boolean field is a 2 state by design
* Tests
* Updated docos
