### PR TITLE
Adding a number field

### DIFF
--- a/packages/v4/@tinacms/tinacms/_docs/architecture.md
+++ b/packages/v4/@tinacms/tinacms/_docs/architecture.md
@@ -33,8 +33,8 @@ RHF's own `FormProvider`.
 
 `<Field address="title" />` (`editor/field.tsx`) finds the schema node by `name`,
 reads its `type`, pulls the `descriptor` from the registry, and renders
-`descriptor.Component` inside a `FieldAddressContext` carrying the address. The
-component takes no props.
+`descriptor.Component` inside a `FieldAddressContext` carrying the address and a
+`FieldSchemaContext` carrying the resolved node. The component takes no props.
 
 ## 4. Read & write through hooks
 
@@ -43,6 +43,7 @@ The component pulls everything from address-keyed hooks (`editor/hooks.ts`):
 | Hook | Backed by |
 |---|---|
 | `useFieldAddress()` | `FieldAddressContext` |
+| `useFieldSchema()` | `FieldSchemaContext` (the field's resolved node) |
 | `useFieldValue(address)` | RHF `useController` → `[value, setValue]` |
 | `useFieldErrors(address)` | RHF `useFormState`, keyed by field name |
 | `useFieldActivation(handler)` | fires when the active field equals this address |

--- a/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
@@ -26,7 +26,10 @@ below — substitute your own `type` for `string` throughout. For that field's
 exact config options and validation semantics, see
 [`string-field.md`](./string-field.md). The shipped `boolean` field
 ([`boolean-field.md`](./boolean-field.md)) is a second example — a two-state
-checkbox where `required` is a no-op.
+checkbox where `required` is a no-op. The shipped `number` field
+([`number-field.md`](./number-field.md)) is a third — a string editor value ↔
+numeric stored value via `parse`/`serialize`, reading its own config
+(`step`) through `useFieldSchema`.
 
 ### 1. Manifest (`.plugin.ts`)
 
@@ -89,10 +92,11 @@ export const string = (config: Omit<StringFieldSchema, 'type'>): StringFieldSche
 
 ### 4. The component (`.ui.tsx`)
 
-The component receives **only its address** via context and pulls value/errors
-through address-keyed hooks (`editor/hooks.ts`). No `value`/`onChange` props:
-that keeps each field an O(1) react-hook-form subscription instead of
-re-rendering the whole form on a keystroke.
+The component receives **its address and its resolved schema node** via context
+(both provided by `<Field>`) and pulls value/errors through address-keyed hooks
+(`editor/hooks.ts`). No `value`/`onChange` props: that keeps each field an O(1)
+react-hook-form subscription instead of re-rendering the whole form on a
+keystroke.
 
 ```tsx
 import { useRef } from 'react';
@@ -123,6 +127,7 @@ Hooks:
 | Hook | Does |
 |---|---|
 | `useFieldAddress()` | this field's address |
+| `useFieldSchema<T>()` | this field's resolved schema node (render hints, e.g. `step`) |
 | `useFieldValue<T>(address)` | `[value, setValue]` via the RHF controller |
 | `useFieldErrors(address)` | validation messages at the address |
 | `useFieldActivation(handler)` | run `handler` when this becomes the active field (visual editing) |

--- a/packages/v4/@tinacms/tinacms/_docs/number-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/number-field.md
@@ -30,16 +30,29 @@ Config (`NumberFieldSchema`, extends `BaseFieldSchema`):
 | `max` | `number` | maximum **value** |
 | `step` | `number` | the input's `step` (render hint; no validation role) |
 
+## Descriptor
+
+The client segment (`number-field.client.tsx`) claims the `number` key:
+
+```tsx
+defineClientPlugin({
+  field: {
+    type: 'number',            // NUMBER_FIELD_TYPE
+    Component: NumberField,
+    // no defaultValue — an absent field stays absent
+    metadata: { layout: 'inline' },
+    schema: numberSchema,
+    parse: (stored) => (stored == null ? undefined : String(stored)),  // load: number → string
+    serialize: (value) => Number(value),                               // save: string → number
+  },
+});
+```
+
 ## Editor value vs stored value
 
 The DOM gives `<input type="number">` a **string**, but the document stores a
-**number**. The descriptor bridges them, so partial entries (`-`, `1.`) survive
-typing and the document always gets a clean number back:
-
-```ts
-parse: (stored) => (stored == null ? undefined : String(stored)),  // load: number → string
-serialize: (value) => Number(value),                                // save: string → number
-```
+**number**. `parse`/`serialize` (above) bridge them, so partial entries
+(`-`, `1.`) survive typing and the document always gets a clean number back.
 
 Empty is `undefined`, converted in **one place** — the component's `onChange`
 (`'' → undefined`). There is no `defaultValue`, and `digestDocument` drops

--- a/packages/v4/@tinacms/tinacms/_docs/number-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/number-field.md
@@ -1,0 +1,109 @@
+# The `number` field
+
+A shipped field plugin: a numeric `<input type="number">` whose **stored value is
+a number** but whose **editor value is the raw input string**. Source:
+`plugins/fields/number/`.
+
+## Authoring
+
+`t.number({...})` stamps `type: 'number'` (`NUMBER_FIELD_TYPE`) onto the config:
+
+```ts
+import { t } from '@tinacms/tinacms';
+
+const collection = {
+  name: 'post',
+  fields: [
+    t.number({ name: 'rating', label: 'Rating', required: true, min: 1, max: 5, step: 0.5 }),
+  ],
+};
+```
+
+Config (`NumberFieldSchema`, extends `BaseFieldSchema`):
+
+| Key | Type | Effect |
+|---|---|---|
+| `name` | `string` (required) | field key in the document; also the fallback label |
+| `label` | `string` | display label; used in validation messages |
+| `required` | `boolean` | empty value fails validation |
+| `min` | `number` | minimum **value** (not length) |
+| `max` | `number` | maximum **value** |
+| `step` | `number` | the input's `step` (render hint; no validation role) |
+
+## Editor value vs stored value
+
+The DOM gives `<input type="number">` a **string**, but the document stores a
+**number**. The descriptor bridges them, so partial entries (`-`, `1.`) survive
+typing and the document always gets a clean number back:
+
+```ts
+parse: (stored) => (stored == null ? undefined : String(stored)),  // load: number → string
+serialize: (value) => Number(value),                                // save: string → number
+```
+
+Empty is `undefined`, converted in **one place** — the component's `onChange`
+(`'' → undefined`). There is no `defaultValue`, and `digestDocument` drops
+`undefined` before calling `serialize`, so `serialize` only ever sees a real
+string and returns a strict `number` (never `number | undefined`); an empty field
+is omitted from the saved document. A stored `null` is normalised to empty by
+`parse`, so it round-trips as absent rather than `"null"`/`NaN`.
+
+## Validation
+
+`numberSchema(node)` coerces the editor string, then applies the bounds. The
+coercion guards empty explicitly — never a falsy test, since `0` is valid and
+`Number('') === 0` would smuggle empty in as zero:
+
+| Config | Rule | Message |
+|---|---|---|
+| `min` | `.min(min)` | `<label> must be at least <min>` |
+| `max` | `.max(max)` | `<label> must be at most <max>` |
+| `required` | empty (`undefined`) fails `z.number()` | `<label> is required` |
+| — | a non-numeric string coerces to `NaN` | `<label> must be a number` |
+
+Zero passes `required` (present, not empty); negatives/decimals round-trip
+unchanged; an optional empty value passes as `.optional()`. Runs through the
+shared path (`validateField`); see
+[`field-plugins.md`](./field-plugins.md#validation--two-layers).
+
+## Component
+
+`NumberField` (`number-field.ui.tsx`) takes **no props** — it reads value/errors
+through address-keyed hooks and its own node through `useFieldSchema` to wire
+`step`:
+
+```tsx
+export function NumberField() {
+  const address = useFieldAddress();
+  const field = useFieldSchema<NumberFieldSchema>();
+  const [value, setValue] = useFieldValue<string | undefined>(address);
+  const errors = useFieldErrors(address);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useFieldActivation(() => inputRef.current?.focus());
+
+  return (
+    <div>
+      <input ref={inputRef} type='number' step={field.step} aria-label={address}
+        value={value ?? ''}
+        onChange={(e) => setValue(e.target.value === '' ? undefined : e.target.value)} />
+      {errors.map((e) => <span key={e} role='alert'>{e}</span>)}
+    </div>
+  );
+}
+```
+
+## Where it's wired
+
+- Manifest: `number-field.plugin.ts` — `tina:field:number`, exported as
+  `numberFieldPlugin`.
+- Registration: `plugins/fields/index.ts` adds it to `corePlugins` and exposes
+  `t.number`.
+
+## Tests
+
+`number-field.test.tsx` covers rendering (including a stored zero), the `step`
+wiring, decimal/negative keystrokes, min/max bounds, zero-is-not-empty under
+`required`, non-numeric rejection, ingest/digest round-trips, null/empty →
+absent, and the registered descriptor metadata.
+```

--- a/packages/v4/@tinacms/tinacms/_docs/plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/plugins.md
@@ -41,4 +41,5 @@ a *keyed* capability: many field plugins coexist, one per schema `type`
 - [Field plugins](./field-plugins.md) — how to build one
   - [The `string` field](./string-field.md) — the shipped text input
   - [The `boolean` field](./boolean-field.md) — the shipped checkbox
+  - [The `number` field](./number-field.md) — the shipped numeric input
 - [Architecture](./architecture.md) — how a plugin reaches the screen

--- a/packages/v4/@tinacms/tinacms/src/core/field/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/field/contract.ts
@@ -18,9 +18,9 @@ export interface FieldDescriptor<TValue = unknown, TStored = unknown> {
   metadata?: FieldMetadata;
   schema?: (node: FieldSchema) => ZodType;
   validate?: (value: TValue) => string | null;
-  // parse/serialize are the per-field ingest/digest transforms. Declared but not
-  // wired to any built-in field yet (string is identity) — image/datetime/reference
-  // will use them (e.g. path <-> media object, ISO string <-> Date).
+  // parse/serialize are the per-field ingest/digest transforms. string/boolean are
+  // identity; the number field uses them for string <-> number. image/datetime/reference
+  // will use them too (e.g. path <-> media object, ISO string <-> Date).
   parse?: (stored: TStored) => TValue;
   serialize?: (value: TValue) => TStored;
 }

--- a/packages/v4/@tinacms/tinacms/src/core/form/ingest.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/ingest.ts
@@ -3,8 +3,9 @@ import type { FieldSchema, TinaDocument } from '../schema/types';
 
 // Flatten on load (ADR-010): turn a stored document into the form's initial values.
 // Per field, run the field plugin's parse() (stored → editor value), or fall back to
-// its defaultValue when the key is absent. Every field is identity today (string);
-// image/datetime/reference will plug real transforms in here.
+// its defaultValue when the key is absent. string/boolean are identity; the number
+// field parses stored numbers to editor strings; image/datetime/reference will plug
+// real transforms in here.
 // Plan: the document source becomes the content capability (ADR-019) once the data
 // layer lands — today it's passed in directly.
 export const ingestDocument = (

--- a/packages/v4/@tinacms/tinacms/src/editor/context.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/context.ts
@@ -11,9 +11,9 @@ export interface ActiveField {
 // TODO(zustand): RegistryContext and ActiveFieldContext become reads off the global
 // store (ADR-003) once it exists. CollectionContext is form-scoped (the open
 // document's schema). FieldAddressContext and FieldSchemaContext are intentionally
-// plain React context — per ADR-009 a field receives its address and its resolved
-// schema node, both passed down by <Field>. The node carries the field's config for
-// rendering; declarative validation stays on the validation path (schema(node)).
+// plain React context. ADR-009 gives a field its address; we extend that so <Field>
+// also passes the resolved schema node — the field's config for rendering (declarative
+// validation stays on the validation path, schema(node)).
 export const RegistryContext = createContext<FieldRegistry | null>(null);
 export const CollectionContext = createContext<CollectionSchema | null>(null);
 export const FieldAddressContext = createContext<FieldAddress | null>(null);

--- a/packages/v4/@tinacms/tinacms/src/editor/context.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/context.ts
@@ -1,7 +1,7 @@
 import { createContext } from 'react';
 import type { FieldAddress } from '../core/field/address';
 import type { FieldRegistry } from '../core/field/registry';
-import type { CollectionSchema } from '../core/schema/types';
+import type { CollectionSchema, FieldSchema } from '../core/schema/types';
 
 export interface ActiveField {
   active: FieldAddress | null;
@@ -10,9 +10,12 @@ export interface ActiveField {
 
 // TODO(zustand): RegistryContext and ActiveFieldContext become reads off the global
 // store (ADR-003) once it exists. CollectionContext is form-scoped (the open
-// document's schema), and FieldAddressContext is intentionally plain React context —
-// per ADR-009 the only thing a field receives is its address, passed down by <Field>.
+// document's schema). FieldAddressContext and FieldSchemaContext are intentionally
+// plain React context — per ADR-009 a field receives its address and its resolved
+// schema node, both passed down by <Field>. The node carries the field's config for
+// rendering; declarative validation stays on the validation path (schema(node)).
 export const RegistryContext = createContext<FieldRegistry | null>(null);
 export const CollectionContext = createContext<CollectionSchema | null>(null);
 export const FieldAddressContext = createContext<FieldAddress | null>(null);
+export const FieldSchemaContext = createContext<FieldSchema | null>(null);
 export const ActiveFieldContext = createContext<ActiveField | null>(null);

--- a/packages/v4/@tinacms/tinacms/src/editor/field.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/field.tsx
@@ -3,6 +3,7 @@ import { toFieldAddress } from '../core/field/address';
 import {
   CollectionContext,
   FieldAddressContext,
+  FieldSchemaContext,
   RegistryContext,
 } from './context';
 
@@ -32,7 +33,9 @@ export function Field({ address }: FieldProps) {
   const Component = descriptor.Component;
   return (
     <FieldAddressContext value={toFieldAddress(address)}>
-      <Component />
+      <FieldSchemaContext value={node}>
+        <Component />
+      </FieldSchemaContext>
     </FieldAddressContext>
   );
 }

--- a/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
@@ -1,7 +1,12 @@
 import { use, useEffect, useRef } from 'react';
 import { useController, useFormState } from 'react-hook-form';
 import type { FieldAddress } from '../core/field/address';
-import { ActiveFieldContext, FieldAddressContext } from './context';
+import type { FieldSchema } from '../core/schema/types';
+import {
+  ActiveFieldContext,
+  FieldAddressContext,
+  FieldSchemaContext,
+} from './context';
 import { type FieldErrorEntry, fieldErrorMessages } from './field-errors';
 
 export function useFieldAddress(): FieldAddress {
@@ -10,6 +15,16 @@ export function useFieldAddress(): FieldAddress {
     throw new Error('useFieldAddress must be used within a <Field>');
   }
   return address;
+}
+
+// The field's own resolved schema node, for reading its config. `T` is
+// caller-asserted.
+export function useFieldSchema<T extends FieldSchema = FieldSchema>(): T {
+  const node = use(FieldSchemaContext);
+  if (node == null) {
+    throw new Error('useFieldSchema must be used within a <Field>');
+  }
+  return node as T;
 }
 
 export function useFieldValue<T = unknown>(

--- a/packages/v4/@tinacms/tinacms/src/editor/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/index.ts
@@ -17,5 +17,6 @@ export {
   useFieldActivation,
   useFieldAddress,
   useFieldErrors,
+  useFieldSchema,
   useFieldValue,
 } from './hooks';

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -18,5 +18,6 @@ export type {
 export { corePlugins, t } from './plugins/fields';
 export type {
   BooleanFieldSchema,
+  NumberFieldSchema,
   StringFieldSchema,
 } from './plugins/fields';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -1,11 +1,17 @@
 import booleanFieldPlugin from './boolean/boolean-field.plugin';
 import { boolean } from './boolean/boolean-field.schema';
+import numberFieldPlugin from './number/number-field.plugin';
+import { number } from './number/number-field.schema';
 import stringFieldPlugin from './string/string-field.plugin';
 import { string } from './string/string-field.schema';
 
 // The built-in field plugins TinaCMS ships. The "is this a core plugin" check
 // reads this list, not the plugin name.
-export const corePlugins = [stringFieldPlugin, booleanFieldPlugin];
+export const corePlugins = [
+  stringFieldPlugin,
+  booleanFieldPlugin,
+  numberFieldPlugin,
+];
 
 // Schema-authoring helpers, one per built-in field. Kept explicit (rather than
 // derived in a loop) so `t.string` stays statically typed; co-located with
@@ -13,7 +19,8 @@ export const corePlugins = [stringFieldPlugin, booleanFieldPlugin];
 // TODO: once defineConfig (ADR-024) lands, generate `t` from the configured plugin
 // set so user-registered field plugins join it (typed). This stays the built-in
 // default until then.
-export const t = { string, boolean };
+export const t = { string, boolean, number };
 
 export type { BooleanFieldSchema } from './boolean/boolean-field.schema';
+export type { NumberFieldSchema } from './number/number-field.schema';
 export type { StringFieldSchema } from './string/string-field.schema';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.client.tsx
@@ -1,0 +1,16 @@
+import { defineClientPlugin } from '../../../client';
+import { NUMBER_FIELD_TYPE, numberSchema } from './number-field.schema';
+import { NumberField } from './number-field.ui';
+
+export default defineClientPlugin({
+  field: {
+    type: NUMBER_FIELD_TYPE,
+    Component: NumberField,
+    // No defaultValue: empty stays `undefined`, so `serialize` only ever sees a number.
+    metadata: { layout: 'inline' },
+    schema: numberSchema,
+    // Normalise a stored `null` to empty rather than "null"/`NaN`.
+    parse: (stored) => (stored == null ? undefined : String(stored)),
+    serialize: (value) => Number(value),
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.client.tsx
@@ -11,6 +11,8 @@ export default defineClientPlugin({
     schema: numberSchema,
     // Normalise a stored `null` to empty rather than "null"/`NaN`.
     parse: (stored) => (stored == null ? undefined : String(stored)),
+    // Malformed stored data coerces to `NaN` here; guarding that belongs to the save
+    // flow (validate before digest, ADR-018), not serialize (which stays `-> number`).
     serialize: (value) => Number(value),
   },
 });

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.plugin.ts
@@ -1,0 +1,9 @@
+import { definePlugin } from '../../../core/plugin';
+
+export const numberFieldPlugin = definePlugin({
+  name: 'tina:field:number',
+  provides: ['field'],
+  client: () => import('./number-field.client'),
+});
+
+export default numberFieldPlugin;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
@@ -1,0 +1,49 @@
+import { type ZodType, z } from 'zod';
+import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
+
+export const NUMBER_FIELD_TYPE = 'number';
+
+export interface NumberFieldSchema extends BaseFieldSchema {
+  type: typeof NUMBER_FIELD_TYPE;
+  min?: number;
+  max?: number;
+  step?: number;
+}
+
+export const number = (
+  config: Omit<NumberFieldSchema, 'type'>
+): NumberFieldSchema => ({ ...config, type: NUMBER_FIELD_TYPE });
+
+const labelOf = (node: NumberFieldSchema): string => node.label ?? node.name;
+
+// Coerce the editor string before validating. Guard empty explicitly: `0` is valid
+// and a falsy test would smuggle empty in as zero (`Number('') === 0`).
+const toNumber = (value: unknown): unknown =>
+  value === '' || value == null ? undefined : Number(value);
+
+// `min`/`max` are value bounds (not string length); a non-numeric string becomes
+// `NaN`, which `z.number()` rejects.
+export const numberSchema = (node: FieldSchema): ZodType => {
+  const field = node as NumberFieldSchema;
+  let schema = z.number({
+    required_error: `${labelOf(field)} is required`,
+    invalid_type_error: `${labelOf(field)} must be a number`,
+  });
+  if (field.min != null) {
+    schema = schema.min(
+      field.min,
+      `${labelOf(field)} must be at least ${field.min}`
+    );
+  }
+  if (field.max != null) {
+    schema = schema.max(
+      field.max,
+      `${labelOf(field)} must be at most ${field.max}`
+    );
+  }
+  if (field.required) {
+    // Empty coerces to `undefined`, which fails the non-optional schema.
+    return z.preprocess(toNumber, schema);
+  }
+  return z.preprocess(toNumber, schema.optional());
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
@@ -16,19 +16,23 @@ export const number = (
 
 const labelOf = (node: NumberFieldSchema): string => node.label ?? node.name;
 
-// Coerce the editor string before validating. Guard empty explicitly: `0` is valid
-// and a falsy test would smuggle empty in as zero (`Number('') === 0`).
-const toNumber = (value: unknown): unknown =>
-  value === '' || value == null ? undefined : Number(value);
+// Coerce the editor string before validating. Guard empty (incl. whitespace-only)
+// explicitly: `0` is valid and a falsy test would smuggle empty in as zero.
+const toNumber = (value: unknown): unknown => {
+  const trimmed = typeof value === 'string' ? value.trim() : value;
+  return trimmed === '' || trimmed == null ? undefined : Number(trimmed);
+};
 
 // `min`/`max` are value bounds (not string length); a non-numeric string becomes
-// `NaN`, which `z.number()` rejects.
+// `NaN` and `.finite()` also rejects `Infinity` (which JSON would write as `null`).
 export const numberSchema = (node: FieldSchema): ZodType => {
   const field = node as NumberFieldSchema;
-  let schema = z.number({
-    required_error: `${labelOf(field)} is required`,
-    invalid_type_error: `${labelOf(field)} must be a number`,
-  });
+  let schema = z
+    .number({
+      required_error: `${labelOf(field)} is required`,
+      invalid_type_error: `${labelOf(field)} must be a number`,
+    })
+    .finite(`${labelOf(field)} must be a finite number`);
   if (field.min != null) {
     schema = schema.min(
       field.min,

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.test.tsx
@@ -1,0 +1,187 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import type {
+  CollectionSchema,
+  TinaDocument,
+} from '../../../core/schema/types';
+import { validateField } from '../../../core/validation';
+import { Field, FormProvider, TinaProvider } from '../../../editor';
+import { t } from '../../../index';
+import numberFieldPlugin from './number-field.plugin';
+
+const collection: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  fields: [
+    t.number({
+      name: 'rating',
+      label: 'Rating',
+      required: true,
+      min: 1,
+      max: 5,
+      step: 0.5,
+    }),
+    // Required but unbounded — proves `0` is a present value, not empty.
+    t.number({ name: 'count', label: 'Count', required: true }),
+    // Optional — for negatives, decimals, and empty handling.
+    t.number({ name: 'weight', label: 'Weight' }),
+  ],
+};
+
+const [ratingNode, countNode] = collection.fields;
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins([numberFieldPlugin]);
+
+const renderField = (address: string, document?: TinaDocument) =>
+  render(
+    <TinaProvider plugins={[numberFieldPlugin]}>
+      <FormProvider collection={collection} document={document}>
+        <Field address={address} />
+      </FormProvider>
+    </TinaProvider>
+  );
+
+describe('NumberField rendering', () => {
+  it('renders a stored number as its string value', async () => {
+    renderField('weight', { weight: 3 });
+    const input = (await screen.findByLabelText('weight')) as HTMLInputElement;
+    expect(input.value).toBe('3');
+  });
+
+  it('renders empty when the field is absent (no default value)', async () => {
+    renderField('weight');
+    const input = (await screen.findByLabelText('weight')) as HTMLInputElement;
+    expect(input.value).toBe('');
+  });
+
+  it('renders a stored zero rather than blanking it', async () => {
+    renderField('count', { count: 0 });
+    const input = (await screen.findByLabelText('count')) as HTMLInputElement;
+    expect(input.value).toBe('0');
+  });
+
+  it('applies the schema step to the input', async () => {
+    renderField('rating', { rating: 3 });
+    const input = (await screen.findByLabelText('rating')) as HTMLInputElement;
+    expect(input.step).toBe('0.5');
+  });
+});
+
+describe('NumberField value updates', () => {
+  it('writes a decimal keystroke sequence back through the store', async () => {
+    renderField('weight');
+    const input = (await screen.findByLabelText('weight')) as HTMLInputElement;
+    await userEvent.type(input, '1.5');
+    expect(input.value).toBe('1.5');
+  });
+
+  it('accepts a negative value', async () => {
+    renderField('weight');
+    const input = (await screen.findByLabelText('weight')) as HTMLInputElement;
+    await userEvent.type(input, '-5');
+    expect(input.value).toBe('-5');
+  });
+
+  it('surfaces the shared min message while editing', async () => {
+    renderField('rating');
+    const input = await screen.findByLabelText('rating');
+    await userEvent.type(input, '0');
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Rating must be at least 1'
+    );
+  });
+});
+
+describe('NumberField validation', () => {
+  it('coerces the editor string and applies min/max bounds', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(validateField(ratingNode, descriptor, '3')).toEqual([]);
+    expect(validateField(ratingNode, descriptor, '0')).toEqual([
+      'Rating must be at least 1',
+    ]);
+    expect(validateField(ratingNode, descriptor, '6')).toEqual([
+      'Rating must be at most 5',
+    ]);
+  });
+
+  it('treats zero as present, not empty, for a required field', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(validateField(countNode, descriptor, '0')).toEqual([]);
+    expect(validateField(countNode, descriptor, '')).toEqual([
+      'Count is required',
+    ]);
+  });
+
+  it('rejects a non-numeric value', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(validateField(countNode, descriptor, 'abc')).toEqual([
+      'Count must be a number',
+    ]);
+  });
+
+  it('appends a descriptor-level custom validate error', () => {
+    const descriptor = {
+      type: 'number',
+      Component: () => null,
+      validate: (value: unknown) => (value === '13' ? 'Unlucky' : null),
+    };
+    expect(validateField(countNode, descriptor, '13')).toContain('Unlucky');
+  });
+});
+
+describe('NumberField ingest and digest', () => {
+  it('round-trips numbers through parse (ingest) and serialize (digest)', async () => {
+    const registry = await resolveRegistry();
+    const stored = { rating: 3, count: 0, weight: -1.5 };
+    const ingested = ingestDocument(stored, collection.fields, registry);
+    // parse: stored number -> editor string
+    expect(ingested).toEqual({ rating: '3', count: '0', weight: '-1.5' });
+    // serialize: editor string -> stored number (zero and decimal preserved)
+    expect(digestDocument(ingested, collection.fields, registry)).toEqual(
+      stored
+    );
+  });
+
+  it('leaves an absent field absent (no default seeding)', async () => {
+    const registry = await resolveRegistry();
+    expect(ingestDocument({}, collection.fields, registry)).toEqual({});
+    expect(digestDocument({}, collection.fields, registry)).toEqual({});
+  });
+
+  it('drops an empty (undefined) field on digest', async () => {
+    const registry = await resolveRegistry();
+    expect(
+      digestDocument({ weight: undefined }, collection.fields, registry)
+    ).toEqual({});
+  });
+
+  it('normalises a stored null to empty rather than "null"/NaN', async () => {
+    const registry = await resolveRegistry();
+    const ingested = ingestDocument(
+      { weight: null },
+      collection.fields,
+      registry
+    );
+    expect(ingested.weight).toBeUndefined();
+    expect(digestDocument(ingested, collection.fields, registry)).toEqual({});
+  });
+});
+
+describe('NumberField metadata wrapping', () => {
+  it('registers the number descriptor with its declared metadata', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(descriptor?.metadata).toEqual({ layout: 'inline' });
+    expect(descriptor?.defaultValue).toBeUndefined();
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.test.tsx
@@ -34,7 +34,7 @@ const collection: CollectionSchema = {
   ],
 };
 
-const [ratingNode, countNode] = collection.fields;
+const [ratingNode, countNode, weightNode] = collection.fields;
 
 const resolveRegistry = (): Promise<FieldRegistry> =>
   resolveFieldPlugins([numberFieldPlugin]);
@@ -127,6 +127,29 @@ describe('NumberField validation', () => {
     expect(validateField(countNode, descriptor, 'abc')).toEqual([
       'Count must be a number',
     ]);
+  });
+
+  it('rejects a non-finite value (Infinity)', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(validateField(countNode, descriptor, '1e999')).toEqual([
+      'Count must be a finite number',
+    ]);
+  });
+
+  it('treats a whitespace-only value as empty', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(validateField(countNode, descriptor, '   ')).toEqual([
+      'Count is required',
+    ]);
+  });
+
+  it('passes an optional field left empty', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('number');
+    expect(validateField(weightNode, descriptor, '')).toEqual([]);
+    expect(validateField(weightNode, descriptor, undefined)).toEqual([]);
   });
 
   it('appends a descriptor-level custom validate error', () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.ui.tsx
@@ -27,12 +27,17 @@ export function NumberField() {
       <input
         ref={inputRef}
         type='number'
-        step={field.step}
+        // Default to 'any' so decimals aren't flagged as a stepMismatch.
+        step={field.step ?? 'any'}
         aria-label={address}
         value={value ?? ''}
+        // Browser `badInput` (e.g. "5e") reports '' here, so it collapses to empty;
+        // surfacing it needs the value model / save flow, deferred for now.
         onChange={(event) =>
           setValue(event.target.value === '' ? undefined : event.target.value)
         }
+        // Stop a scroll over a focused input from silently changing the value.
+        onWheel={(event) => event.currentTarget.blur()}
       />
       {errors.map((error) => (
         <span key={error} role='alert'>

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.ui.tsx
@@ -1,0 +1,44 @@
+import { useRef } from 'react';
+import {
+  useFieldActivation,
+  useFieldAddress,
+  useFieldErrors,
+  useFieldSchema,
+  useFieldValue,
+} from '../../../editor';
+import type { NumberFieldSchema } from './number-field.schema';
+
+export function NumberField() {
+  const address = useFieldAddress();
+  const field = useFieldSchema<NumberFieldSchema>();
+  // The stored value is a number, but the editor value is the raw input string
+  // (`undefined` when empty) so partial entries like `-` or `1.` survive typing.
+  const [value, setValue] = useFieldValue<string | undefined>(address);
+  const errors = useFieldErrors(address);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useFieldActivation(() => inputRef.current?.focus());
+
+  // TODO(shadcn): swap this raw input/markup for shared, themed primitives from
+  // src/ui/ (shadcn — Input/Label/form-field wrapper, added via the shadcn CLI) so
+  // every field looks consistent and is re-themeable without per-field redesign.
+  return (
+    <div>
+      <input
+        ref={inputRef}
+        type='number'
+        step={field.step}
+        aria-label={address}
+        value={value ?? ''}
+        onChange={(event) =>
+          setValue(event.target.value === '' ? undefined : event.target.value)
+        }
+      />
+      {errors.map((error) => (
+        <span key={error} role='alert'>
+          {error}
+        </span>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #6917 

* Number field plugin (schema, client, ui, plugin) with parse/serialize, min/max, step
* Adds useFieldSchema() hook so a field can read its own node (wires step)
* Tests + docs

This notably wires a schema into the field to be exposed through the context
