### PR TITLE
✨ Track editorial-workflow save option choice in PostHog

### DIFF
--- a/.changeset/editorial-workflow-save-metrics.md
+++ b/.changeset/editorial-workflow-save-metrics.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Add a PostHog `editorial-workflow-save` event that records which save option was used in the "Save changes to new branch" modal (draft, ready for review, or publish), whether the save succeeded, and the failure reason when it didn't.

--- a/packages/tinacms/src/lib/posthog/posthog.ts
+++ b/packages/tinacms/src/lib/posthog/posthog.ts
@@ -34,6 +34,16 @@ export type SaveContentErrorPayload = {
   error?: string;
 };
 
+// When a user saves from the editorial-workflow modal: which option they
+// chose (draft / ready for review / publish) and whether the save succeeded.
+export const EditorialWorkflowSaveEvent: string = 'editorial-workflow-save';
+export type EditorialWorkflowSavePayload = {
+  choice: 'draft' | 'review' | 'publish';
+  success: boolean;
+  // Failure reason when success is false.
+  error?: string;
+};
+
 // When a user resets a form in the TinaCMS Editor
 export const FormResetEvent: string = 'form-reset';
 

--- a/packages/tinacms/src/toolkit/form-builder/branch-deleted-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/branch-deleted-modal.tsx
@@ -50,7 +50,7 @@ export const BranchDeletedModal = ({
   } = useEditorialWorkflow();
 
   const handleCreate = async () => {
-    const success = await executeWorkflow({
+    const { success } = await executeWorkflow({
       branchName: `tina/${newBranchName}`,
       baseBranch,
       path,

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
@@ -148,6 +148,10 @@ export const CreateBranchModal = ({
       branchGuardAbortRef.current = null;
     }
 
+    // Cancelled mid-run (modal closed, branch renamed, another save started, or
+    // unmounted) — treat as a no-op and record nothing.
+    if (abortController.signal.aborted) return;
+
     captureEvent(EditorialWorkflowSaveEvent, {
       choice: isDraft ? 'draft' : 'review',
       success,

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
@@ -27,6 +27,8 @@ import {
   type SaveChoice,
   resolveSaveOptions,
 } from './save-options';
+import { EditorialWorkflowSaveEvent } from '../../lib/posthog/posthog';
+import { captureEvent } from '../../lib/posthog/posthogProvider';
 
 // Format the default branch name by removing content/ prefix and file extension
 const formatDefaultBranchName = (
@@ -65,7 +67,7 @@ export const CreateBranchModal = ({
   tinaForm,
   onBaseBranchDeleted,
 }: {
-  safeSubmit: () => Promise<void>;
+  safeSubmit: (editorialWorkflowChoice?: SaveChoice) => Promise<void>;
   close: () => void;
   path: string;
   values: Record<string, unknown>;
@@ -132,7 +134,7 @@ export const CreateBranchModal = ({
 
     setIsBranchGuardChecking(false);
 
-    const success = await executeWorkflow({
+    const { success, error } = await executeWorkflow({
       branchName: targetBranch,
       baseBranch,
       path,
@@ -145,6 +147,12 @@ export const CreateBranchModal = ({
     if (branchGuardAbortRef.current === abortController) {
       branchGuardAbortRef.current = null;
     }
+
+    captureEvent(EditorialWorkflowSaveEvent, {
+      choice: isDraft ? 'draft' : 'review',
+      success,
+      error,
+    });
 
     if (success) {
       close();
@@ -179,7 +187,7 @@ export const CreateBranchModal = ({
       onSaveToProtectedBranch={() => {
         abortBranchGuard();
         close();
-        safeSubmit();
+        safeSubmit('publish');
       }}
       showSaveOptions={true}
       disablePublish={!!tinaApi.usingProtectedBranch()}

--- a/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/form-builder.tsx
@@ -22,9 +22,11 @@ import { BranchDeletedModal } from './branch-deleted-modal';
 import {
   SavedContentEvent,
   SaveContentErrorEvent,
+  EditorialWorkflowSaveEvent,
   FormResetEvent,
 } from '../../lib/posthog/posthog';
 import { captureEvent } from '../../lib/posthog/posthogProvider';
+import type { SaveChoice } from './save-options';
 
 export interface FormBuilderProps {
   form: { tinaForm: Form; activeFieldName?: string };
@@ -184,7 +186,19 @@ export const FormBuilder: FC<FormBuilderProps> = ({
           !hasValidationErrors &&
           !(invalid && !dirtySinceLastSubmit);
 
-        const safeSubmit = async () => {
+        const safeSubmit = async (editorialWorkflowChoice?: SaveChoice) => {
+          // When invoked as the "Save and publish" choice from the editorial
+          // workflow modal, also record the choice + outcome in one event.
+          const captureWorkflowChoice = (success: boolean, error?: string) => {
+            if (editorialWorkflowChoice) {
+              captureEvent(EditorialWorkflowSaveEvent, {
+                choice: editorialWorkflowChoice,
+                success,
+                error,
+              });
+            }
+          };
+
           if (canSubmit) {
             const alertsBefore = new Set(cms.alerts.all.map((a) => a.id));
             console.debug(
@@ -214,6 +228,7 @@ export const FormBuilder: FC<FormBuilderProps> = ({
                     cms.alerts.dismiss(alert);
                   }
                 }
+                captureWorkflowChoice(false, errorMsg);
                 setDeletedBranchModalOpen(true);
                 return;
               }
@@ -222,10 +237,12 @@ export const FormBuilder: FC<FormBuilderProps> = ({
                 documentPath: tinaForm.path,
                 error: errorMsg,
               });
+              captureWorkflowChoice(false, errorMsg);
             } else {
               captureEvent(SavedContentEvent, {
                 documentPath: tinaForm.path,
               });
+              captureWorkflowChoice(true);
             }
           } else {
             console.debug(

--- a/packages/tinacms/src/toolkit/form-builder/use-editorial-workflow.ts
+++ b/packages/tinacms/src/toolkit/form-builder/use-editorial-workflow.ts
@@ -78,8 +78,10 @@ export interface UseEditorialWorkflowResult {
   errorMessage: string;
   currentStep: number;
   elapsedTime: number;
-  /** Returns true on success, false on failure (error captured in errorMessage) */
-  executeWorkflow: (opts: ExecuteWorkflowOptions) => Promise<boolean>;
+  /** Resolves with the outcome; on failure `error` holds the message. */
+  executeWorkflow: (
+    opts: ExecuteWorkflowOptions
+  ) => Promise<{ success: boolean; error?: string }>;
   /** Reset error/executing state so the form can be retried */
   reset: () => void;
 }
@@ -156,9 +158,9 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
     tinaForm,
     signal,
     isDraft,
-  }: ExecuteWorkflowOptions): Promise<boolean> => {
+  }: ExecuteWorkflowOptions): Promise<{ success: boolean; error?: string }> => {
     try {
-      if (signal?.aborted) return false;
+      if (signal?.aborted) return { success: false };
 
       const targetBranchExists = await checkTargetBranchExists(
         tinaApi,
@@ -167,13 +169,13 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
         signal
       );
 
-      if (signal?.aborted) return false;
+      if (signal?.aborted) return { success: false };
 
       if (targetBranchExists) {
         setErrorMessage(TARGET_BRANCH_EXISTS_ERROR);
         setIsExecuting(false);
         setCurrentStep(0);
-        return false;
+        return { success: false, error: TARGET_BRANCH_EXISTS_ERROR };
       }
 
       setIsExecuting(true);
@@ -261,7 +263,7 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
         }`;
       }
 
-      return true;
+      return { success: true };
     } catch (e: unknown) {
       console.error(e);
       const errMessage = getEditorialWorkflowErrorMessage(e);
@@ -270,7 +272,7 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
       setIsExecuting(false);
       setCurrentStep(0);
 
-      return false;
+      return { success: false, error: errMessage };
     }
   };
 


### PR DESCRIPTION
As per https://github.com/tinacms/tinacloud/issues/3815

## TL;DR

Adds a single PostHog event, `editorial-workflow-save`, that records which save option an editor used in the "Save changes to new branch" modal (`draft` / `review` / `publish`), whether it succeeded, and the failure reason.

## Reviewer notes

- **All three choices in one event.** draft/review fire from the modal with the workflow result; publish fires from the form-builder save path (`safeSubmit`) so its outcome is tagged too.
- **`executeWorkflow` now returns `{ success, error }`** (was `boolean`) so draft/review failures carry a message; both callers (`create-branch-modal`, `branch-deleted-modal`) were updated.
- Fires on the **outcome**, so a failed save is recorded as `success: false` (never counted as a save).

<img width="1317" height="246" alt="Screenshot 2026-07-03 at 10 09 42 am" src="https://github.com/user-attachments/assets/7f9aebb8-17e8-4801-b36d-18982edb84d6" />

<img width="1228" height="127" alt="Screenshot 2026-07-03 at 10 14 23 am" src="https://github.com/user-attachments/assets/00ad0507-42cd-4e43-8706-6f9abd875de5" />

**Figure: PostHog events w/ Properties**

## Links

- Metric for the save-options modal (#7138)