### PR TITLE
fix(graphql): clear stale sort-index entries on delete (deleteIndexEntriesForPaths)

### DIFF
--- a/packages/@tinacms/graphql/src/database/database.delete-index-entries.test.ts
+++ b/packages/@tinacms/graphql/src/database/database.delete-index-entries.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Prevention for the field-sort "ghost" that fails a collection list: a field-sort
+ * index is keyed by `<value>\x1D<path>`, and delete()/deleteContentByPaths() only
+ * remove the CURRENT value's key. A value change that never removed the old key
+ * strands `<oldValue>\x1D<path>`; a later delete can't target it, so a field-sorted
+ * query later loads its missing record and throws.
+ *
+ * deleteIndexEntriesForPaths() matches on the path instead of the value, so it clears
+ * every entry for a removed path, including stranded ones, from the collection index
+ * and its folder index. Real Database + MemoryLevel + in-memory Bridge.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { MemoryLevel } from 'memory-level';
+import { buildSchema, createDatabaseInternal } from '..';
+import type { Bridge } from './bridge';
+import type { Schema } from '@tinacms/schema-tools';
+import {
+  CONTENT_ROOT_PREFIX,
+  INDEX_KEY_FIELD_SEPARATOR,
+  SUBLEVEL_OPTIONS,
+} from './level';
+
+class InMemoryBridge implements Bridge {
+  rootPath = '';
+  private files: Map<string, string> = new Map();
+
+  seed(filepath: string, content: string) {
+    this.files.set(filepath, content);
+    return this;
+  }
+  async glob(pattern: string, extension: string): Promise<string[]> {
+    return Array.from(this.files.keys()).filter(
+      (p) => p.startsWith(pattern) && p.endsWith(`.${extension}`)
+    );
+  }
+  async get(filepath: string): Promise<string> {
+    const content = this.files.get(filepath);
+    if (content === undefined)
+      throw new Error(`InMemoryBridge: file not found: ${filepath}`);
+    return content;
+  }
+  async put(filepath: string, data: string): Promise<void> {
+    this.files.set(filepath, data);
+  }
+  async delete(filepath: string): Promise<void> {
+    this.files.delete(filepath);
+  }
+}
+
+const testSchema: Schema = {
+  collections: [
+    {
+      name: 'post',
+      label: 'Post',
+      path: 'content/posts',
+      format: 'json',
+      fields: [
+        { name: 'title', label: 'Title', type: 'string' },
+        { name: 'score', label: 'Score', type: 'number' },
+      ],
+    },
+  ],
+};
+
+const jsonDoc = (data: Record<string, unknown>) => JSON.stringify(data);
+
+const GHOST = 'content/posts/ghost.json';
+const KEEP = 'content/posts/keep.json';
+
+async function setupDatabase() {
+  const bridge = new InMemoryBridge();
+  bridge.seed(KEEP, jsonDoc({ title: 'Keep', score: 1 }));
+  bridge.seed(GHOST, jsonDoc({ title: 'Ghost', score: 42 }));
+
+  const level = new MemoryLevel<string, Record<string, any>>({
+    valueEncoding: 'json',
+  });
+  const database = createDatabaseInternal({
+    bridge,
+    level,
+    tinaDirectory: 'tina',
+  });
+  await database.indexContent(await buildSchema({ schema: testSchema }));
+  return { database };
+}
+
+async function ghostKeysIn(sublevel: any): Promise<string[]> {
+  const keys: string[] = [];
+  for await (const [key] of sublevel.iterator()) {
+    if (key.endsWith(GHOST)) keys.push(key);
+  }
+  return keys;
+}
+
+describe('Database.deleteIndexEntriesForPaths()', () => {
+  it('clears every sort-index entry for a path, including a stranded value key', async () => {
+    const { database } = await setupDatabase();
+    const content = database.contentLevel!;
+
+    // Simulate a stranded old-value entry (from a prior un-cleaned value change)
+    // in both the collection and root-folder `score` sort indexes.
+    const strandedKey = `OLD${INDEX_KEY_FIELD_SEPARATOR}${GHOST}`;
+    for (const name of ['post', 'post_~']) {
+      await content
+        .sublevel(name, SUBLEVEL_OPTIONS)
+        .sublevel('score', SUBLEVEL_OPTIONS)
+        .put(strandedKey, {} as any);
+    }
+
+    await database.deleteIndexEntriesForPaths([GHOST]);
+
+    // No `score` entry (real or stranded) for the removed path survives in the
+    // collection index or the root-folder index.
+    for (const name of ['post', 'post_~']) {
+      const scoreSub = content
+        .sublevel(name, SUBLEVEL_OPTIONS)
+        .sublevel('score', SUBLEVEL_OPTIONS);
+      expect(await ghostKeysIn(scoreSub)).toEqual([]);
+    }
+
+    // The record is gone too, and (without the read-time tolerance) a field-sorted
+    // query resolves cleanly rather than throwing on a dangling entry.
+    const rootSub = content.sublevel(CONTENT_ROOT_PREFIX, SUBLEVEL_OPTIONS);
+    expect(await rootSub.get(GHOST)).toBeUndefined();
+
+    const hydrate = (path: string) => database.get(path);
+    const fieldSorted = await database.query(
+      { collection: 'post', sort: 'score', filterChain: [] },
+      hydrate
+    );
+    expect(fieldSorted.edges).toHaveLength(1);
+  });
+
+  it('leaves other documents untouched', async () => {
+    const { database } = await setupDatabase();
+
+    await database.deleteIndexEntriesForPaths([GHOST]);
+
+    const hydrate = (path: string) => database.get(path);
+    const byTitle = await database.query(
+      { collection: 'post', sort: 'title', filterChain: [] },
+      hydrate
+    );
+    expect(byTitle.edges).toHaveLength(1);
+    expect((byTitle.edges[0].node as any).title).toBe('Keep');
+  });
+});

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -1355,6 +1355,93 @@ export class Database {
     }
   };
 
+  /**
+   * Deletes every index entry for the given paths by matching on the path rather
+   * than the stored value. Unlike delete()/deleteContentByPaths(), which target
+   * `<currentValue>\x1D<path>`, this also clears stale value-keyed sort entries
+   * left by an earlier value change that never removed the old key, so a removed
+   * document leaves no dangling entry that would fail a field-sorted collection query.
+   */
+  public deleteIndexEntriesForPaths = async (documentPaths: string[]) => {
+    await this.initLevel();
+    if (!documentPaths.length) {
+      return;
+    }
+    const tinaSchema = await this.getSchema(this.contentLevel);
+    const { pathsByCollection, collections } = await partitionPathsByCollection(
+      tinaSchema,
+      documentPaths
+    );
+    const indexDefinitions = await this.getIndexDefinitions(this.contentLevel);
+    const rootSublevel = this.contentLevel.sublevel(
+      CONTENT_ROOT_PREFIX,
+      SUBLEVEL_OPTIONS
+    );
+    const ops: DelOp[] = [];
+
+    for (const collectionName of Object.keys(pathsByCollection)) {
+      const collection = collections[collectionName];
+      const paths = pathsByCollection[collectionName].map(normalizePath);
+      const pathSet = new Set(paths);
+      const collectionIndexDefinitions =
+        indexDefinitions?.[collectionName] ?? {};
+
+      // Each document is indexed under the collection index and its folder
+      // index, so sweep both for every affected folder.
+      const folderKeys = new Set<string>();
+      const folderTreeBuilder = new FolderTreeBuilder();
+      for (const p of paths) {
+        folderKeys.add(folderTreeBuilder.update(p, collection?.path || ''));
+      }
+      const collectionSublevelNames = [
+        collectionName,
+        ...[...folderKeys].map((folderKey) => `${collectionName}_${folderKey}`),
+      ];
+
+      for (const sublevelName of collectionSublevelNames) {
+        const collectionSublevel = this.contentLevel.sublevel(
+          sublevelName,
+          SUBLEVEL_OPTIONS
+        );
+        for (const sortKey of Object.keys(collectionIndexDefinitions)) {
+          // Reference entries are keyed under the referenced collection and
+          // cleaned via delete(); leave them alone.
+          if (sortKey === REFS_COLLECTIONS_SORT_KEY) {
+            continue;
+          }
+          const indexSublevel = collectionSublevel.sublevel(
+            sortKey,
+            SUBLEVEL_OPTIONS
+          );
+          if (sortKey === DEFAULT_COLLECTION_SORT_KEY) {
+            for (const p of paths) {
+              ops.push({ type: 'del', key: p, sublevel: indexSublevel });
+            }
+          } else {
+            // Value-keyed (`<value>\x1D<path>`): the path is a suffix and can't
+            // be seeked, so scan and match the trailing path segment.
+            for await (const [key] of indexSublevel.iterator()) {
+              const keyPath = key.slice(
+                key.lastIndexOf(INDEX_KEY_FIELD_SEPARATOR) + 1
+              );
+              if (pathSet.has(keyPath)) {
+                ops.push({ type: 'del', key, sublevel: indexSublevel });
+              }
+            }
+          }
+        }
+      }
+
+      for (const p of paths) {
+        ops.push({ type: 'del', key: p, sublevel: rootSublevel });
+      }
+    }
+
+    for (let i = 0; i < ops.length; i += this.levelBatchSize) {
+      await this.contentLevel.batch(ops.slice(i, i + this.levelBatchSize));
+    }
+  };
+
   public indexContentByPaths = async (documentPaths: string[]) => {
     await this.initLevel();
     const operations: BatchOp[] = [];


### PR DESCRIPTION
**TL;DR** Adds `Database.deleteIndexEntriesForPaths(paths)`, which removes every index entry for the given paths by matching on the path (not the stored value), so a caller can ensure a deleted document doesn't leave a stale field-sort entry that fails the whole collection list. Prevention complement to #7133 (read-time tolerance). **Mechanism only: this is not wired into `delete()` / `deleteContentByPaths()` and has no caller, so on its own it is inert.** Activation is a follow-up: the tinacloud content-api calling it on delete, and/or wiring it into the OSS delete path so self-hosted is covered too.

**Pain:** Field-sort index entries are keyed by `<value>\x1D<path>`, and `delete()` / `deleteContentByPaths()` only remove the *current* value's key (reconstructed from the stored record). A value change that never removed the old key strands `<oldValue>\x1D<path>`; a later delete can't target it because it only knows the current value. `Database.query` then hydrates that dangling entry, `Database.get` throws `NotFoundError`, and the whole field-sorted collection list fails (surfaced as `TinaQueryError`, "Error querying file ... from collection ..."). #7133 makes the read tolerate it; this provides the mechanism to stop it being left behind in the first place.

**Solution:** `deleteIndexEntriesForPaths(paths)` matches on the *path* instead of the value: for each collection it scans the value-keyed sort sublevels (the collection index plus each affected folder index) and deletes any key whose trailing path segment is one of the removed paths, then point-deletes the default index and the record store. So when a caller runs it for a removed document, that document leaves no `<*>\x1D<path>` orphan, stranded or current. Reference indexes are keyed under the referenced collection and left to `delete()`. It is deliberately a standalone method rather than being called from the existing delete paths, because the field-sort sweep is O(sublevel size) per sort field (value-keyed, so the path can't be seeked), so the caller decides where to run it rather than taxing every delete. Includes a test (real `Database` + `MemoryLevel` + in-memory bridge) that strands a value key and asserts every entry for the path is cleared and the field-sorted query resolves cleanly.
