### PR TITLE
Harden media uploads: server-side file-type validation

### DIFF
--- a/.changeset/media-upload-filetype-validation.md
+++ b/.changeset/media-upload-filetype-validation.md
@@ -7,4 +7,4 @@
 "next-tinacms-azure": patch
 ---
 
-Validate media upload file types on the server and reject active document types (e.g. `.html`, `.svg`, `.js`) instead of relying on the client-side accept filter alone.
+Validate media upload file types on the server and reject active document types (e.g. `.html`, `.js`, `.xml`) instead of relying on the client-side accept filter alone.

--- a/.changeset/media-upload-filetype-validation.md
+++ b/.changeset/media-upload-filetype-validation.md
@@ -1,0 +1,10 @@
+---
+"@tinacms/cli": patch
+"tinacms": patch
+"next-tinacms-dos": patch
+"next-tinacms-s3": patch
+"next-tinacms-cloudinary": patch
+"next-tinacms-azure": patch
+---
+
+Validate media upload file types on the server and reject active document types (e.g. `.html`, `.svg`, `.js`) instead of relying on the client-side accept filter alone.

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -340,5 +340,42 @@ describe('createMediaRouter', () => {
       expect(JSON.parse(body)).toHaveProperty('error');
       expect(JSON.parse(body).error).toContain('Path traversal detected');
     });
+
+    it.each(['evil.html', 'evil.svg', 'nested/evil.js'])(
+      'returns 415 and writes nothing for disallowed type %s',
+      async (name) => {
+        const router = createMediaRouter(config);
+        const req = makeMultipartReq(`/media/upload/${name}`, 'payload');
+        let statusCode: number = 0;
+        let body: string = '';
+        const res = {
+          set statusCode(code: number) {
+            statusCode = code;
+          },
+          end(data: string) {
+            body = data;
+          },
+        } as any;
+
+        await new Promise<void>((resolve) => {
+          const origEnd = res.end;
+          res.end = (data: string) => {
+            origEnd(data);
+            setTimeout(resolve, 50);
+          };
+          router.handlePost(req, res);
+        });
+
+        expect(statusCode).toBe(415);
+        expect(JSON.parse(body)).toHaveProperty('error');
+        const written = path.join(
+          tmpDir,
+          'public',
+          'uploads',
+          name.split('/').pop() as string
+        );
+        expect(await fs.pathExists(written)).toBe(false);
+      }
+    );
   });
 });

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -341,7 +341,7 @@ describe('createMediaRouter', () => {
       expect(JSON.parse(body).error).toContain('Path traversal detected');
     });
 
-    it.each(['evil.html', 'evil.svg', 'nested/evil.js'])(
+    it.each(['evil.html', 'evil.xml', 'nested/evil.js'])(
       'returns 415 and writes nothing for disallowed type %s',
       async (name) => {
         const router = createMediaRouter(config);

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -4,6 +4,7 @@ import busboy from 'busboy';
 import fs from 'fs-extra';
 import type { Connect } from 'vite';
 import { PathTraversalError } from '../../../../utils/path';
+import { isDisallowedUploadType } from '../../../../utils/upload-type';
 
 export const createMediaRouter = (config: PathConfig) => {
   const mediaFolder = path.join(
@@ -82,6 +83,14 @@ export const createMediaRouter = (config: PathConfig) => {
             error: `Path traversal detected: ${fullPath}`,
           })
         );
+        return;
+      }
+      // Reject file types that are not allowed for media uploads.
+      if (isDisallowedUploadType(fullPath)) {
+        responded = true;
+        file.resume(); // drain the stream to avoid hanging
+        res.statusCode = 415;
+        res.end(JSON.stringify({ error: 'Unsupported file type' }));
         return;
       }
       // make sure the directory exists before writing the file. This is needed for creating new folders

--- a/packages/@tinacms/cli/src/utils/upload-type.test.ts
+++ b/packages/@tinacms/cli/src/utils/upload-type.test.ts
@@ -20,14 +20,21 @@ describe('getFinalExtension', () => {
 });
 
 describe('isDisallowedUploadType', () => {
-  it('allows common media types', () => {
-    for (const name of ['photo.png', 'clip.mp4', 'doc.pdf', 'model.riv']) {
+  it('allows common media types, including SVG', () => {
+    for (const name of [
+      'photo.png',
+      'clip.mp4',
+      'doc.pdf',
+      'model.riv',
+      'logo.svg',
+      'logo.svgz',
+    ]) {
       expect(isDisallowedUploadType(name)).toBe(false);
     }
   });
 
   it('rejects active document types regardless of case', () => {
-    for (const name of ['a.html', 'a.HTM', 'a.svg', 'a.svgz', 'a.js', 'a.xml']) {
+    for (const name of ['a.html', 'a.HTM', 'a.js', 'a.mjs', 'a.xml', 'a.xhtml']) {
       expect(isDisallowedUploadType(name)).toBe(true);
     }
   });

--- a/packages/@tinacms/cli/src/utils/upload-type.test.ts
+++ b/packages/@tinacms/cli/src/utils/upload-type.test.ts
@@ -1,0 +1,39 @@
+import { getFinalExtension, isDisallowedUploadType } from './upload-type';
+
+describe('getFinalExtension', () => {
+  it('returns the lowercased final extension', () => {
+    expect(getFinalExtension('photo.PNG')).toBe('png');
+    expect(getFinalExtension('archive.tar.gz')).toBe('gz');
+  });
+
+  it('returns empty when there is no extension', () => {
+    expect(getFinalExtension('README')).toBe('');
+    expect(getFinalExtension('.gitignore')).toBe('');
+    expect(getFinalExtension('trailing.')).toBe('');
+    expect(getFinalExtension('')).toBe('');
+  });
+
+  it('ignores directory segments', () => {
+    expect(getFinalExtension('a/b/c.jpg')).toBe('jpg');
+    expect(getFinalExtension('a\\b\\c.jpg')).toBe('jpg');
+  });
+});
+
+describe('isDisallowedUploadType', () => {
+  it('allows common media types', () => {
+    for (const name of ['photo.png', 'clip.mp4', 'doc.pdf', 'model.riv']) {
+      expect(isDisallowedUploadType(name)).toBe(false);
+    }
+  });
+
+  it('rejects active document types regardless of case', () => {
+    for (const name of ['a.html', 'a.HTM', 'a.svg', 'a.svgz', 'a.js', 'a.xml']) {
+      expect(isDisallowedUploadType(name)).toBe(true);
+    }
+  });
+
+  it('checks the final extension only', () => {
+    expect(isDisallowedUploadType('a.html.png')).toBe(false);
+    expect(isDisallowedUploadType('a.png.html')).toBe(true);
+  });
+});

--- a/packages/@tinacms/cli/src/utils/upload-type.ts
+++ b/packages/@tinacms/cli/src/utils/upload-type.ts
@@ -9,8 +9,6 @@ const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
   'xhtml',
   'xht',
   'shtml',
-  'svg',
-  'svgz',
   'xml',
   'xsl',
   'xslt',

--- a/packages/@tinacms/cli/src/utils/upload-type.ts
+++ b/packages/@tinacms/cli/src/utils/upload-type.ts
@@ -1,0 +1,34 @@
+/**
+ * Extensions a browser may run as an active document when a media file is
+ * served inline from the app origin. The static server picks a content-type
+ * from the final extension, so only that extension is checked.
+ */
+const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'xhtml',
+  'xht',
+  'shtml',
+  'svg',
+  'svgz',
+  'xml',
+  'xsl',
+  'xslt',
+  'js',
+  'mjs',
+  'cjs',
+  'mhtml',
+  'mht',
+]);
+
+/** Lowercased final extension of a filename, or '' when there is none. */
+export const getFinalExtension = (filename: string): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0 || dot === base.length - 1) return '';
+  return base.slice(dot + 1).toLowerCase();
+};
+
+/** True when a filename's final extension is not allowed for media uploads. */
+export const isDisallowedUploadType = (filename: string): boolean =>
+  DISALLOWED_UPLOAD_EXTENSIONS.has(getFinalExtension(filename));

--- a/packages/next-tinacms-azure/src/handlers.ts
+++ b/packages/next-tinacms-azure/src/handlers.ts
@@ -8,6 +8,7 @@ import type { MediaListOptions } from 'tinacms';
 import path from 'node:path';
 import { type NextRequest, NextResponse } from 'next/server';
 import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
+import { isDisallowedUploadType } from './upload-type';
 
 type RouteParams = { params: { media: string[] } };
 
@@ -77,6 +78,13 @@ async function uploadMedia(req: NextRequest, config: AzureBlobStorageConfig) {
     }
     throw e;
   }
+  if (isDisallowedUploadType(blobName)) {
+    return NextResponse.json(
+      { error: 'Unsupported file type' },
+      { status: 415 }
+    );
+  }
+
   const blockBlobClient = containerClient.getBlockBlobClient(blobName);
   await blockBlobClient.uploadData(buffer);
 

--- a/packages/next-tinacms-azure/src/upload-type.ts
+++ b/packages/next-tinacms-azure/src/upload-type.ts
@@ -9,8 +9,6 @@ const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
   'xhtml',
   'xht',
   'shtml',
-  'svg',
-  'svgz',
   'xml',
   'xsl',
   'xslt',

--- a/packages/next-tinacms-azure/src/upload-type.ts
+++ b/packages/next-tinacms-azure/src/upload-type.ts
@@ -1,0 +1,33 @@
+/**
+ * Extensions a browser may run as an active document when a media file is
+ * served inline. Only the final extension is checked, since that is what a
+ * static server / CDN derives the content-type from.
+ */
+const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'xhtml',
+  'xht',
+  'shtml',
+  'svg',
+  'svgz',
+  'xml',
+  'xsl',
+  'xslt',
+  'js',
+  'mjs',
+  'cjs',
+  'mhtml',
+  'mht',
+]);
+
+const getFinalExtension = (filename: string): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0 || dot === base.length - 1) return '';
+  return base.slice(dot + 1).toLowerCase();
+};
+
+/** True when a filename's final extension is not allowed for media uploads. */
+export const isDisallowedUploadType = (filename: string): boolean =>
+  DISALLOWED_UPLOAD_EXTENSIONS.has(getFinalExtension(filename));

--- a/packages/next-tinacms-cloudinary/src/handlers.ts
+++ b/packages/next-tinacms-cloudinary/src/handlers.ts
@@ -9,6 +9,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import multer from 'multer';
 import { promisify } from 'util';
 import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
+import { isDisallowedUploadType } from './upload-type';
 
 export interface CloudinaryConfig {
   cloud_name: string;
@@ -79,6 +80,10 @@ async function uploadMedia(req: NextApiRequest, res: NextApiResponse) {
   const { directory } = req.body;
   // @ts-ignore - multer augments the request with `file`
   const filename: string = req.file.originalname;
+
+  if (isDisallowedUploadType(filename)) {
+    return res.status(415).json({ message: 'Unsupported file type' });
+  }
 
   let folder: string;
   try {

--- a/packages/next-tinacms-cloudinary/src/upload-type.ts
+++ b/packages/next-tinacms-cloudinary/src/upload-type.ts
@@ -9,8 +9,6 @@ const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
   'xhtml',
   'xht',
   'shtml',
-  'svg',
-  'svgz',
   'xml',
   'xsl',
   'xslt',

--- a/packages/next-tinacms-cloudinary/src/upload-type.ts
+++ b/packages/next-tinacms-cloudinary/src/upload-type.ts
@@ -1,0 +1,33 @@
+/**
+ * Extensions a browser may run as an active document when a media file is
+ * served inline. Only the final extension is checked, since that is what a
+ * static server / CDN derives the content-type from.
+ */
+const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'xhtml',
+  'xht',
+  'shtml',
+  'svg',
+  'svgz',
+  'xml',
+  'xsl',
+  'xslt',
+  'js',
+  'mjs',
+  'cjs',
+  'mhtml',
+  'mht',
+]);
+
+const getFinalExtension = (filename: string): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0 || dot === base.length - 1) return '';
+  return base.slice(dot + 1).toLowerCase();
+};
+
+/** True when a filename's final extension is not allowed for media uploads. */
+export const isDisallowedUploadType = (filename: string): boolean =>
+  DISALLOWED_UPLOAD_EXTENSIONS.has(getFinalExtension(filename));

--- a/packages/next-tinacms-dos/src/handlers.ts
+++ b/packages/next-tinacms-dos/src/handlers.ts
@@ -19,6 +19,7 @@ import fs from 'fs';
 import { NextApiRequest, NextApiResponse } from 'next';
 import multer from 'multer';
 import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
+import { isDisallowedUploadType } from './upload-type';
 import { promisify } from 'util';
 
 export interface DOSConfig {
@@ -115,6 +116,10 @@ async function uploadMedia(
   const fileType = req.file?.mimetype;
   const blob = fs.readFileSync(filePath);
   const filename = path.basename(filePath);
+
+  if (isDisallowedUploadType(filename)) {
+    return res.status(415).json({ message: 'Unsupported file type' });
+  }
 
   let objectKey: string;
   try {

--- a/packages/next-tinacms-dos/src/upload-type.ts
+++ b/packages/next-tinacms-dos/src/upload-type.ts
@@ -9,8 +9,6 @@ const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
   'xhtml',
   'xht',
   'shtml',
-  'svg',
-  'svgz',
   'xml',
   'xsl',
   'xslt',

--- a/packages/next-tinacms-dos/src/upload-type.ts
+++ b/packages/next-tinacms-dos/src/upload-type.ts
@@ -1,0 +1,33 @@
+/**
+ * Extensions a browser may run as an active document when a media file is
+ * served inline. Only the final extension is checked, since that is what a
+ * static server / CDN derives the content-type from.
+ */
+const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'xhtml',
+  'xht',
+  'shtml',
+  'svg',
+  'svgz',
+  'xml',
+  'xsl',
+  'xslt',
+  'js',
+  'mjs',
+  'cjs',
+  'mhtml',
+  'mht',
+]);
+
+const getFinalExtension = (filename: string): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0 || dot === base.length - 1) return '';
+  return base.slice(dot + 1).toLowerCase();
+};
+
+/** True when a filename's final extension is not allowed for media uploads. */
+export const isDisallowedUploadType = (filename: string): boolean =>
+  DISALLOWED_UPLOAD_EXTENSIONS.has(getFinalExtension(filename));

--- a/packages/next-tinacms-s3/src/handlers.ts
+++ b/packages/next-tinacms-s3/src/handlers.ts
@@ -19,6 +19,7 @@ import { Media, MediaListOptions } from 'tinacms';
 import path from 'node:path';
 import { NextApiRequest, NextApiResponse } from 'next';
 import { resolveKey, resolveDirectory, MediaKeyError } from './media-key';
+import { isDisallowedUploadType } from './upload-type';
 
 export interface S3Config {
   config: S3ClientConfig;
@@ -89,6 +90,9 @@ export const createMediaHandler = (config: S3Config, options?: S3Options) => {
               return res.status(400).json({ message: e.message });
             }
             throw e;
+          }
+          if (isDisallowedUploadType(s3_key)) {
+            return res.status(415).json({ message: 'Unsupported file type' });
           }
           if (await keyExists(client, bucket, s3_key)) {
             return res.status(400).json({ message: 'key already exists' });

--- a/packages/next-tinacms-s3/src/upload-type.ts
+++ b/packages/next-tinacms-s3/src/upload-type.ts
@@ -9,8 +9,6 @@ const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
   'xhtml',
   'xht',
   'shtml',
-  'svg',
-  'svgz',
   'xml',
   'xsl',
   'xslt',

--- a/packages/next-tinacms-s3/src/upload-type.ts
+++ b/packages/next-tinacms-s3/src/upload-type.ts
@@ -1,0 +1,33 @@
+/**
+ * Extensions a browser may run as an active document when a media file is
+ * served inline. Only the final extension is checked, since that is what a
+ * static server / CDN derives the content-type from.
+ */
+const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'xhtml',
+  'xht',
+  'shtml',
+  'svg',
+  'svgz',
+  'xml',
+  'xsl',
+  'xslt',
+  'js',
+  'mjs',
+  'cjs',
+  'mhtml',
+  'mht',
+]);
+
+const getFinalExtension = (filename: string): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0 || dot === base.length - 1) return '';
+  return base.slice(dot + 1).toLowerCase();
+};
+
+/** True when a filename's final extension is not allowed for media uploads. */
+export const isDisallowedUploadType = (filename: string): boolean =>
+  DISALLOWED_UPLOAD_EXTENSIONS.has(getFinalExtension(filename));

--- a/packages/tinacms/src/toolkit/components/media/index.ts
+++ b/packages/tinacms/src/toolkit/components/media/index.ts
@@ -3,4 +3,8 @@ export { ListMediaItem, GridMediaItem } from './media-item';
 export { Breadcrumb } from './breadcrumb';
 export { CursorPaginator } from './pagination';
 export type { MediaPaginatorProps } from './pagination';
-export { DEFAULT_MEDIA_UPLOAD_TYPES, sanitizeFilename } from './utils';
+export {
+  DEFAULT_MEDIA_UPLOAD_TYPES,
+  sanitizeFilename,
+  isDisallowedUploadType,
+} from './utils';

--- a/packages/tinacms/src/toolkit/components/media/utils.test.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.test.ts
@@ -76,14 +76,21 @@ describe('sanitizeFilename', () => {
 });
 
 describe('isDisallowedUploadType', () => {
-  it('allows common media types', () => {
-    for (const name of ['photo.png', 'clip.mp4', 'doc.pdf', 'model.riv']) {
+  it('allows common media types, including SVG', () => {
+    for (const name of [
+      'photo.png',
+      'clip.mp4',
+      'doc.pdf',
+      'model.riv',
+      'logo.svg',
+      'logo.svgz',
+    ]) {
       expect(isDisallowedUploadType(name)).toBe(false);
     }
   });
 
   it('rejects active document types regardless of case', () => {
-    for (const name of ['a.html', 'a.HTM', 'a.svg', 'a.svgz', 'a.js', 'a.xml']) {
+    for (const name of ['a.html', 'a.HTM', 'a.js', 'a.mjs', 'a.xml', 'a.xhtml']) {
       expect(isDisallowedUploadType(name)).toBe(true);
     }
   });

--- a/packages/tinacms/src/toolkit/components/media/utils.test.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeFilename } from './utils';
+import { isDisallowedUploadType, sanitizeFilename } from './utils';
 
 describe('sanitizeFilename', () => {
   it('returns simple ASCII names unchanged', () => {
@@ -72,5 +72,24 @@ describe('sanitizeFilename', () => {
     const result = sanitizeFilename(`${'a'.repeat(500)}.jpg`);
     expect(result.endsWith('.jpg')).toBe(true);
     expect(result.length).toBeLessThanOrEqual(204);
+  });
+});
+
+describe('isDisallowedUploadType', () => {
+  it('allows common media types', () => {
+    for (const name of ['photo.png', 'clip.mp4', 'doc.pdf', 'model.riv']) {
+      expect(isDisallowedUploadType(name)).toBe(false);
+    }
+  });
+
+  it('rejects active document types regardless of case', () => {
+    for (const name of ['a.html', 'a.HTM', 'a.svg', 'a.svgz', 'a.js', 'a.xml']) {
+      expect(isDisallowedUploadType(name)).toBe(true);
+    }
+  });
+
+  it('checks the final extension only', () => {
+    expect(isDisallowedUploadType('a.html.png')).toBe(false);
+    expect(isDisallowedUploadType('a.png.html')).toBe(true);
   });
 });

--- a/packages/tinacms/src/toolkit/components/media/utils.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.ts
@@ -30,6 +30,41 @@ export const dropzoneAcceptFromString = (str: string) => {
   );
 };
 
+/**
+ * Extensions a browser may run as an active document when a media file is
+ * served inline from the app origin. Only the final extension is checked,
+ * since that is what a static server derives the content-type from.
+ */
+const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
+  'html',
+  'htm',
+  'xhtml',
+  'xht',
+  'shtml',
+  'svg',
+  'svgz',
+  'xml',
+  'xsl',
+  'xslt',
+  'js',
+  'mjs',
+  'cjs',
+  'mhtml',
+  'mht',
+]);
+
+/** Lowercased final extension of a filename, or '' when there is none. */
+export const getFinalExtension = (filename: string): string => {
+  const base = (filename || '').split(/[\\/]/).pop() || '';
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0 || dot === base.length - 1) return '';
+  return base.slice(dot + 1).toLowerCase();
+};
+
+/** True when a filename's final extension is not allowed for media uploads. */
+export const isDisallowedUploadType = (filename: string): boolean =>
+  DISALLOWED_UPLOAD_EXTENSIONS.has(getFinalExtension(filename));
+
 export const isImage = (filename: string): boolean => {
   // http://stackoverflow.com/questions/10473185/regex-javascript-image-file-extension
   // (\?.*)? is to match query strings (like from TinaCloud)

--- a/packages/tinacms/src/toolkit/components/media/utils.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.ts
@@ -41,8 +41,6 @@ const DISALLOWED_UPLOAD_EXTENSIONS = new Set([
   'xhtml',
   'xht',
   'shtml',
-  'svg',
-  'svgz',
   'xml',
   'xsl',
   'xslt',

--- a/packages/tinacms/src/toolkit/index.ts
+++ b/packages/tinacms/src/toolkit/index.ts
@@ -70,5 +70,6 @@ export { CursorPaginator } from './components/media/pagination';
 export {
   DEFAULT_MEDIA_UPLOAD_TYPES,
   sanitizeFilename,
+  isDisallowedUploadType,
 } from './components/media';
 export { MediaWorkflowOverlay } from './components/media/media-workflow-overlay';


### PR DESCRIPTION
## Summary

Media upload handlers only enforced allowed file types on the client (the dropzone `accept` list). This adds **server-side** validation so uploads are checked before anything is written/stored.

Every upload entry point now rejects a set of active-document file types (`.html/.htm/.xhtml/.js/.mjs/.cjs/.xml/.xsl(t)/.mhtml`, …) with `415`. The check is on the **final extension** (what a static server / CDN derives the content-type from), so `logo.png` passes while `logo.png.html` does not.

Covered paths:
- `@tinacms/cli` dev-command media upload handler
- `next-tinacms-dos`, `next-tinacms-cloudinary`, `next-tinacms-azure` upload handlers
- `next-tinacms-s3` (validated at the presign step, since bytes go directly to S3)

A shared helper is exported from `tinacms`; the server adapters keep a small local copy to avoid pulling `tinacms` into server bundles (they already import it type-only).

## SVG — intentionally still allowed (draft)

SVG/svgz is **not** rejected here. Rejecting it would break a common asset (logos/icons). The follow-up is upload-time SVG **sanitization** rather than rejection — see open questions below. Until that lands, SVG is allowed as-is.

## Follow-ups (not in this PR)
- [ ] Upload-time SVG sanitization (strip scripts/handlers/external refs). Note: not possible for `next-tinacms-s3` (presigned direct upload — server never sees the bytes), so behavior there may differ.
- [ ] Serving-layer defense-in-depth (`X-Content-Type-Options: nosniff`, `Content-Disposition` on paths Tina controls / object metadata).
- [ ] Narrow the client `text/*` accept entry.

## Tests
- `@tinacms/cli`: util + dev-handler tests (rejects `.html/.xml/.js`, writes nothing; allows SVG).
- `tinacms`: util tests.
- Adapters have no in-repo test runner; logic is shared and covered centrally.

Opening as **draft** pending the SVG sanitization decision.