### PR TITLE
⬆️ Bump postcss to 8.5.16

### DIFF
--- a/examples/astro/kitchen-sink/package.json
+++ b/examples/astro/kitchen-sink/package.json
@@ -42,7 +42,7 @@
     "@playwright/test": "catalog:",
     "autoprefixer": "catalog:",
     "cross-env": "^7.0.3",
-    "postcss": "^8.5.2",
+    "postcss": "catalog:",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3"
   }

--- a/examples/hugo/kitchen-sink/package.json
+++ b/examples/hugo/kitchen-sink/package.json
@@ -33,7 +33,7 @@
     "autoprefixer": "catalog:",
     "cross-env": "^7.0.3",
     "hugo-extended": "^0.158.0",
-    "postcss": "^8.5.2",
+    "postcss": "catalog:",
     "postcss-cli": "^11.0.0",
     "tailwindcss": "^4.0.0",
     "@playwright/test": "catalog:",

--- a/examples/next/kitchen-sink/package.json
+++ b/examples/next/kitchen-sink/package.json
@@ -39,7 +39,7 @@
     "@types/node": "^25.1.0",
     "autoprefixer": "catalog:",
     "cross-env": "^7.0.3",
-    "postcss": "^8.5.2",
+    "postcss": "catalog:",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.3"
   }

--- a/examples/next/tina-self-hosted-demo/package.json
+++ b/examples/next/tina-self-hosted-demo/package.json
@@ -40,7 +40,7 @@
     "autoprefixer": "catalog:",
     "cross-env": "^7.0.3",
     "eslint": "^8.57.1",
-    "postcss": "^8.5.2",
+    "postcss": "catalog:",
     "postcss-import": "catalog:",
     "postcss-nesting": "catalog:",
     "tailwindcss": "^3.4.17",

--- a/examples/react/kitchen-sink/package.json
+++ b/examples/react/kitchen-sink/package.json
@@ -36,7 +36,7 @@
     "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "catalog:",
     "cross-env": "^7.0.3",
-    "postcss": "^8.5.2",
+    "postcss": "catalog:",
     "tailwindcss": "^4.0.0",
     "@playwright/test": "^1.49.0",
     "typescript": "^5.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -519,6 +519,9 @@ catalogs:
     picomatch-browser:
       specifier: 2.2.6
       version: 2.2.6
+    postcss:
+      specifier: ^8.5.16
+      version: 8.5.16
     postcss-import:
       specifier: ^14.1.0
       version: 14.1.0
@@ -767,13 +770,13 @@ importers:
         version: 18.3.7(@types/react@18.3.27)
       autoprefixer:
         specifier: 'catalog:'
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.16)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
       postcss:
-        specifier: ^8.5.2
-        version: 8.5.6
+        specifier: 'catalog:'
+        version: 8.5.16
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -910,7 +913,7 @@ importers:
         version: link:../../../packages/@tinacms/scripts
       autoprefixer:
         specifier: 'catalog:'
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.16)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -918,11 +921,11 @@ importers:
         specifier: ^0.158.0
         version: 0.158.0
       postcss:
-        specifier: ^8.5.2
-        version: 8.5.6
+        specifier: 'catalog:'
+        version: 8.5.16
       postcss-cli:
         specifier: ^11.0.0
-        version: 11.0.1(jiti@2.6.1)(postcss@8.5.6)
+        version: 11.0.1(jiti@2.6.1)(postcss@8.5.16)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -989,13 +992,13 @@ importers:
         version: 25.1.0
       autoprefixer:
         specifier: 'catalog:'
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.16)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
       postcss:
-        specifier: ^8.5.2
-        version: 8.5.6
+        specifier: 'catalog:'
+        version: 8.5.16
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -1074,7 +1077,7 @@ importers:
         version: 5.62.0(eslint@8.57.1)(typescript@5.9.3)
       autoprefixer:
         specifier: 'catalog:'
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.16)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
@@ -1082,14 +1085,14 @@ importers:
         specifier: ^8.57.1
         version: 8.57.1
       postcss:
-        specifier: ^8.5.2
-        version: 8.5.6
+        specifier: 'catalog:'
+        version: 8.5.16
       postcss-import:
         specifier: 'catalog:'
-        version: 14.1.0(postcss@8.5.6)
+        version: 14.1.0(postcss@8.5.16)
       postcss-nesting:
         specifier: 'catalog:'
-        version: 10.2.0(postcss@8.5.6)
+        version: 10.2.0(postcss@8.5.16)
       tailwindcss:
         specifier: ^3.4.17
         version: 3.4.19(yaml@2.8.2)
@@ -1162,13 +1165,13 @@ importers:
         version: 4.7.0(vite@6.4.1(@types/node@25.1.0)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
       autoprefixer:
         specifier: 'catalog:'
-        version: 10.4.23(postcss@8.5.6)
+        version: 10.4.23(postcss@8.5.16)
       cross-env:
         specifier: ^7.0.3
         version: 7.0.3
       postcss:
-        specifier: ^8.5.2
-        version: 8.5.6
+        specifier: 'catalog:'
+        version: 8.5.16
       tailwindcss:
         specifier: ^4.0.0
         version: 4.2.1
@@ -13081,6 +13084,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.6:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
@@ -13696,6 +13704,10 @@ packages:
 
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.6:
@@ -24003,13 +24015,13 @@ snapshots:
 
   auto-bind@4.0.0: {}
 
-  autoprefixer@10.4.23(postcss@8.5.6):
+  autoprefixer@10.4.23(postcss@8.5.16):
     dependencies:
       browserslist: 4.28.1
       caniuse-lite: 1.0.30001760
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.16
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -29784,6 +29796,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.15: {}
+
   nanoid@5.1.6: {}
 
   napi-build-utils@2.0.0: {}
@@ -30403,15 +30417,15 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.6):
+  postcss-cli@11.0.1(jiti@2.6.1)(postcss@8.5.16):
     dependencies:
       chokidar: 3.6.0
       dependency-graph: 1.0.0
       fs-extra: 11.3.2
       picocolors: 1.1.1
-      postcss: 8.5.6
-      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.6)
-      postcss-reporter: 7.1.0(postcss@8.5.6)
+      postcss: 8.5.16
+      postcss-load-config: 5.1.0(jiti@2.6.1)(postcss@8.5.16)
+      postcss-reporter: 7.1.0(postcss@8.5.16)
       pretty-hrtime: 1.0.3
       read-cache: 1.0.0
       slash: 5.1.0
@@ -30421,9 +30435,9 @@ snapshots:
       - jiti
       - tsx
 
-  postcss-import@14.1.0(postcss@8.5.6):
+  postcss-import@14.1.0(postcss@8.5.16):
     dependencies:
-      postcss: 8.5.6
+      postcss: 8.5.16
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.11
@@ -30440,13 +30454,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.6
 
-  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.6):
+  postcss-load-config@5.1.0(jiti@2.6.1)(postcss@8.5.16):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.2
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.6
+      postcss: 8.5.16
 
   postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.6)(yaml@2.8.2):
     dependencies:
@@ -30469,16 +30483,16 @@ snapshots:
       postcss: 8.5.6
       postcss-selector-parser: 6.1.2
 
-  postcss-nesting@10.2.0(postcss@8.5.6):
+  postcss-nesting@10.2.0(postcss@8.5.16):
     dependencies:
       '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.1.2)
-      postcss: 8.5.6
+      postcss: 8.5.16
       postcss-selector-parser: 6.1.2
 
-  postcss-reporter@7.1.0(postcss@8.5.6):
+  postcss-reporter@7.1.0(postcss@8.5.16):
     dependencies:
       picocolors: 1.1.1
-      postcss: 8.5.6
+      postcss: 8.5.16
       thenby: 1.3.4
 
   postcss-selector-parser@6.0.10:
@@ -30496,6 +30510,12 @@ snapshots:
   postcss@8.4.31:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -213,6 +213,7 @@ catalog:
     parse-entities: 4.0.1
     picomatch: ^4.0.2
     picomatch-browser: 2.2.6
+    postcss: ^8.5.16
     postcss-import: ^14.1.0
     postcss-nesting: ^10.2.0
     prettier: ^2.8.8


### PR DESCRIPTION
## TL;DR

All five example apps hardcoded `postcss` at `^8.5.2` (resolving 8.5.6), ten bug-fix patches behind. This adds `postcss: ^8.5.16` to the workspace catalog and points every consumer at `catalog:`, so they stay in lockstep and future bumps are a one-line edit.

Dev/build-only dependency of private example apps — no changeset needed; the example build jobs in CI exercise it.

## Links

- Dependency audit: tinacms/tinacloud#3820