### PR TITLE
🔏 Use changesets github-api commit mode so release commits are signed

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -285,6 +285,9 @@ jobs:
           publish: pnpm run publish
           createGithubReleases: true
           setupGitUser: false
+          # github-api mode makes GitHub create and sign the Version Packages
+          # commit server-side, satisfying main's required-signatures rule
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token  }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## TL;DR

"Version Packages" PRs (e.g. #7130) can never merge because `main` requires signed commits and `changesets/action` commits via git CLI on the runner, unsigned. Setting `commitMode: github-api` (native in the pinned v1.9.0) has GitHub create and sign the commit server-side; no key to provision, no extra workflow step.

One-line alternative to #7159, which recreates the commit with a custom script after the fact. Commits will be attributed to the `release-bot-allow-prs-and-push[bot]` app identity instead of "Tina Release Bot".

## Links

- Closes #7158
- Alternative to #7159
- Blocked example: #7130