### PR TITLE
Fix folder collection auto-open

### DIFF
--- a/.changeset/fuzzy-cameras-wait.md
+++ b/.changeset/fuzzy-cameras-wait.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Keep folder collection views open when they only contain one document.

--- a/packages/tinacms/src/admin/components/GetCollection.test.ts
+++ b/packages/tinacms/src/admin/components/GetCollection.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CollectionResponse } from '../types';
+import { shouldAutoOpenCollectionDocument } from './GetCollection.utils';
+
+const collectionWithNode = (node: { __typename: string }) =>
+  ({
+    documents: {
+      edges: [{ node }],
+    },
+  }) as CollectionResponse;
+
+describe('shouldAutoOpenCollectionDocument', () => {
+  it('auto-opens a single document at the collection root when create and delete are disabled', () => {
+    expect(
+      shouldAutoOpenCollectionDocument({
+        allowCreate: false,
+        allowDelete: false,
+        collection: collectionWithNode({ __typename: 'Document' }),
+        folder: { fullyQualifiedName: '~' },
+      })
+    ).toBe(true);
+  });
+
+  it('does not auto-open a single document inside a folder view', () => {
+    expect(
+      shouldAutoOpenCollectionDocument({
+        allowCreate: false,
+        allowDelete: false,
+        collection: collectionWithNode({ __typename: 'Document' }),
+        folder: { fullyQualifiedName: '~/album-one' },
+      })
+    ).toBe(false);
+  });
+
+  it('does not auto-open folders', () => {
+    expect(
+      shouldAutoOpenCollectionDocument({
+        allowCreate: false,
+        allowDelete: false,
+        collection: collectionWithNode({ __typename: 'Folder' }),
+        folder: { fullyQualifiedName: '~' },
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/tinacms/src/admin/components/GetCollection.tsx
+++ b/packages/tinacms/src/admin/components/GetCollection.tsx
@@ -11,6 +11,7 @@ import LoadingPage from '../components/LoadingPage';
 import { handleNavigate } from '../pages/CollectionListPage';
 import type { CollectionResponse, DocumentForm } from '../types';
 import { FullscreenError } from './FullscreenError';
+import { shouldAutoOpenCollectionDocument } from './GetCollection.utils';
 
 const isValidSortKey = (sortKey: string, collection: Collection<true>) => {
   if (collection.fields) {
@@ -300,12 +301,12 @@ const GetCollection = ({
 
     const collectionResponse = collection as CollectionResponse;
     if (
-      !allowCreate &&
-      !allowDelete &&
-      // Check there is only one document
-      collectionResponse.documents?.edges?.length === 1 &&
-      // Check to make sure the file is not a folder
-      collectionResponse.documents?.edges[0]?.node?.__typename !== 'Folder'
+      shouldAutoOpenCollectionDocument({
+        allowCreate,
+        allowDelete,
+        collection: collectionResponse,
+        folder,
+      })
     ) {
       const doc = collectionResponse.documents.edges[0].node;
       handleNavigate(

--- a/packages/tinacms/src/admin/components/GetCollection.utils.ts
+++ b/packages/tinacms/src/admin/components/GetCollection.utils.ts
@@ -1,0 +1,25 @@
+import type { CollectionResponse } from '../types';
+
+export const shouldAutoOpenCollectionDocument = ({
+  allowCreate,
+  allowDelete,
+  collection,
+  folder,
+}: {
+  allowCreate: boolean;
+  allowDelete: boolean;
+  collection: CollectionResponse;
+  folder: { fullyQualifiedName: string };
+}) => {
+  return (
+    !allowCreate &&
+    !allowDelete &&
+    // Only auto-open at the collection root. Folder views can legitimately
+    // contain a single index document and must stay navigable.
+    (!folder.fullyQualifiedName || folder.fullyQualifiedName === '~') &&
+    // Check there is only one document
+    collection.documents?.edges?.length === 1 &&
+    // Check to make sure the file is not a folder
+    collection.documents?.edges[0]?.node?.__typename !== 'Folder'
+  );
+};


### PR DESCRIPTION
Fixes #7148.

This keeps the single-document auto-open behavior at the collection root, but leaves folder views open so nested items can still be selected.

Checked with:
- pnpm exec vitest run src/admin/components/GetCollection.test.ts
- pnpm exec biome check packages/tinacms/src/admin/components/GetCollection.tsx packages/tinacms/src/admin/components/GetCollection.utils.ts packages/tinacms/src/admin/components/GetCollection.test.ts
