### PR TITLE
feat(@tinacms/astro): forward containerOptions to island route container

### DIFF
--- a/.changeset/astro-island-route-container-options.md
+++ b/.changeset/astro-island-route-container-options.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/astro': minor
+---
+
+`experimental_createIslandRoute` now accepts an optional `containerOptions` argument that is forwarded to `AstroContainer.create`. This lets islands that use a UI framework (React, Vue, Svelte, ...) be rendered in visual editing — the container is created empty and, unlike the page pipeline, does not inherit renderers from the Astro config, so framework islands previously failed to render. Pass `{ containerOptions: { renderers: [...] } }` to register them. Existing callers are unaffected (the argument is optional).

--- a/packages/@tinacms/astro/src/__tests__/island-route.test.ts
+++ b/packages/@tinacms/astro/src/__tests__/island-route.test.ts
@@ -1,6 +1,7 @@
 import { PREVIEW_CONTENT_TYPE, PRIME_HEADER } from '@tinacms/bridge/preview';
 import type { APIContext } from 'astro';
-import { describe, expect, it } from 'vitest';
+import { experimental_AstroContainer as AstroContainer } from 'astro/container';
+import { describe, expect, it, vi } from 'vitest';
 import { requestWithMetadata } from '../data';
 import { experimental_createIslandRoute } from '../island-route';
 import IslandStub from './IslandStub.astro';
@@ -91,6 +92,46 @@ describe('experimental_createIslandRoute', () => {
     ).text();
     expect(globalHtml).toContain('data-tina-form=');
     expect(globalHtml).not.toContain('data-tina-primary');
+  });
+
+  it('forwards containerOptions to AstroContainer.create', async () => {
+    const spy = vi.spyOn(AstroContainer, 'create');
+    // Renderers is the motivating use: framework islands (React, etc.) need
+    // renderers registered on the container, which is otherwise created empty.
+    const containerOptions = { renderers: [] };
+    const routeWithOptions = experimental_createIslandRoute(
+      {
+        post: {
+          fetch: () =>
+            requestWithMetadata(
+              Promise.resolve({
+                data: { post: { title: 'Hi' } },
+                query: 'query Post',
+                variables: { relativePath: 'hello.md' },
+              })
+            ),
+          component: IslandStub,
+          wrapper: { tag: 'article' },
+          propsFromData: (data) => ({ value: data }),
+        },
+      },
+      { containerOptions }
+    );
+
+    const url = new URL('http://localhost/tina-island/post');
+    const res = (await routeWithOptions({
+      params: { name: 'post' },
+      request: new Request(url, {
+        method: 'POST',
+        headers: { 'content-type': PREVIEW_CONTENT_TYPE },
+        body: '{}',
+      }),
+      url,
+    } as unknown as APIContext)) as Response;
+
+    expect(res.status).toBe(200);
+    expect(spy).toHaveBeenCalledWith(containerOptions);
+    spy.mockRestore();
   });
 
   it('rejects non-preview requests', async () => {

--- a/packages/@tinacms/astro/src/experimental.ts
+++ b/packages/@tinacms/astro/src/experimental.ts
@@ -11,4 +11,5 @@ export {
   experimental_createIslandRoute,
   type IslandConfig,
   type IslandRegistry,
+  type IslandRouteOptions,
 } from './island-route';

--- a/packages/@tinacms/astro/src/island-route.ts
+++ b/packages/@tinacms/astro/src/island-route.ts
@@ -36,8 +36,25 @@ export interface IslandConfig {
 
 export type IslandRegistry = Record<string, IslandConfig>;
 
+export interface IslandRouteOptions {
+  /**
+   * Options forwarded to `AstroContainer.create`. Pass `renderers` here so
+   * islands that use a UI framework (React, Vue, Svelte, ...) can be rendered —
+   * the container is created empty and, unlike the page pipeline, does not
+   * inherit renderers from the Astro config.
+   *
+   * @example
+   * import reactRenderer from '@astrojs/react/server.js';
+   * experimental_createIslandRoute(islands, {
+   *   containerOptions: { renderers: [{ name: '@astrojs/react', ssr: reactRenderer }] },
+   * });
+   */
+  containerOptions?: Parameters<typeof AstroContainer.create>[0];
+}
+
 export function experimental_createIslandRoute(
-  islands: IslandRegistry
+  islands: IslandRegistry,
+  options?: IslandRouteOptions
 ): APIRoute {
   return async ({ params, request, url }) => {
     const rejection = rejectIfUnsafe(request);
@@ -55,7 +72,7 @@ export function experimental_createIslandRoute(
       const html = await requestStore.run(request, () =>
         formsStore.run(forms, async () => {
           const data = await island.fetch(request, url.searchParams);
-          const container = await AstroContainer.create();
+          const container = await AstroContainer.create(options?.containerOptions);
           return container.renderToString(island.component, {
             props: island.propsFromData(data, url.searchParams),
           });


### PR DESCRIPTION
## Problem

`experimental_createIslandRoute` renders each island through a fresh `AstroContainer` created with `AstroContainer.create()` — no renderers. Unlike Astro's page pipeline, the container does **not** inherit renderers from the project's Astro config, so any island that renders a **UI-framework component** (React, Vue, Svelte, …) fails to render during visual editing. The island-refresh request 500s and the editor silently falls back to form-only editing (no live preview).

This doesn't affect islands that render plain Astro/markdown, which is why it hasn't surfaced in the `examples/astro/visual-editing` app — but it reliably bites projects that put framework components inside visually-edited regions (in our case, a React component library rendered in TinaMarkdown blocks and an interactive search island).

## Fix

Add an optional `containerOptions` argument to `experimental_createIslandRoute`, forwarded to `AstroContainer.create`. Callers register renderers explicitly:

```ts
import reactRenderer from '@astrojs/react/server.js';

export const ALL = experimental_createIslandRoute(islands, {
  containerOptions: { renderers: [{ name: '@astrojs/react', ssr: reactRenderer }] },
});
```

Passing renderers explicitly (rather than auto-loading via `astro:container`'s `loadRenderers`) keeps this working in a plain Node/SSR context — the `astro:container` virtual module only resolves inside Vite.

The argument is optional, so existing callers are unchanged.

## Changes

- `island-route.ts`: `IslandRouteOptions` type; forward `options?.containerOptions` to `AstroContainer.create`.
- `experimental.ts`: export `IslandRouteOptions`.
- Test: assert `containerOptions` is forwarded to `AstroContainer.create`.
- Changeset (minor).

## Validation

Verified in a downstream Astro + React project: with this change the island route renders React islands in visual editing; without it the same islands 500. I did not run the full monorepo suite locally — deferring to CI — but the added unit test follows the existing `island-route.test.ts` patterns.

## Notes

Happy to adjust the API shape (e.g. accept `renderers` directly instead of the nested `containerOptions`) or add auto-loading behind a flag if preferred.

Made with [Cursor](https://cursor.com)