### PR TITLE
fix: omit empty optional image fields

### DIFF
--- a/.changeset/quiet-images-smile.md
+++ b/.changeset/quiet-images-smile.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+Omit empty optional image fields from document payloads.

--- a/packages/@tinacms/graphql/src/resolver/index.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.test.ts
@@ -1,16 +1,16 @@
+import path from 'path';
+import { describe, expect, it, vi } from 'vitest';
+import { generatePasswordHash } from '../auth/utils';
+import { parseMDX, serializeMDX } from '../mdx';
 import {
   createResolver,
   resolveFieldData,
   updateObjectWithJsonPath,
 } from './index';
-import { describe, expect, it, vi } from 'vitest';
-import path from 'path';
-import { parseMDX, serializeMDX } from '../mdx';
 import {
   resolveMediaCloudToRelative,
   resolveMediaRelativeToCloud,
 } from './media-utils';
-import { generatePasswordHash } from '../auth/utils';
 
 vi.mock('../mdx', () => ({
   parseMDX: vi.fn(),
@@ -463,6 +463,27 @@ describe('index', () => {
 
       await resolveFieldData(field, { author: null }, accumulator, tinaSchema);
 
+      expect(accumulator).toEqual({});
+    });
+
+    it('omits optional image fields when value is empty', async () => {
+      vi.mocked(resolveMediaRelativeToCloud).mockClear();
+      const field = {
+        name: 'coverImage',
+        type: 'image',
+        namespace: ['post', 'coverImage'],
+        required: false,
+      } as any;
+      const accumulator: Record<string, unknown> = {};
+
+      await resolveFieldData(
+        field,
+        { coverImage: '' },
+        accumulator,
+        tinaSchema
+      );
+
+      expect(resolveMediaRelativeToCloud).not.toHaveBeenCalled();
       expect(accumulator).toEqual({});
     });
 
@@ -947,6 +968,19 @@ describe('index', () => {
         {}
       );
       expect(result).toEqual({ hero: 'images/hero.png' });
+    });
+
+    it('omits optional image fields when the submitted value is empty', async () => {
+      vi.mocked(resolveMediaCloudToRelative).mockClear();
+      const { build } = setup();
+      const template = {
+        fields: [{ name: 'coverImage', type: 'image', required: false }],
+      } as any;
+
+      const result = await build({ coverImage: '' }, template);
+
+      expect(resolveMediaCloudToRelative).not.toHaveBeenCalled();
+      expect(result).toEqual({});
     });
 
     it('serializes rich-text via serializeMDX before storage', async () => {

--- a/packages/@tinacms/graphql/src/resolver/index.test.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.test.ts
@@ -983,6 +983,23 @@ describe('index', () => {
       expect(result).toEqual({});
     });
 
+    it('clears an existing optional image when the submitted value is empty', async () => {
+      vi.mocked(resolveMediaCloudToRelative).mockClear();
+      const { build } = setup();
+      const template = {
+        fields: [{ name: 'coverImage', type: 'image', required: false }],
+      } as any;
+
+      const result = await build(
+        { coverImage: '' },
+        template,
+        { coverImage: 'images/old.png' }
+      );
+
+      expect(resolveMediaCloudToRelative).not.toHaveBeenCalled();
+      expect(result).toEqual({ coverImage: '' });
+    });
+
     it('serializes rich-text via serializeMDX before storage', async () => {
       vi.mocked(serializeMDX).mockReturnValue('# Hello');
       const { build } = setup();

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -38,6 +38,11 @@ import {
   resolveMediaRelativeToCloud,
 } from './media-utils';
 
+const isEmptyOptionalImageValue = (
+  value: unknown,
+  field: Pick<TinaField<true>, 'type' | 'required' | 'list'>
+) => field.type === 'image' && !field.required && !field.list && !value;
+
 interface ResolverConfig {
   config?: GraphQLConfig;
   database: Database;
@@ -90,6 +95,9 @@ export const resolveFieldData = async (
       };
       break;
     case 'image':
+      if (isEmptyOptionalImageValue(value, field)) {
+        break;
+      }
       accumulator[field.name] = resolveMediaRelativeToCloud(
         value as string,
         config,
@@ -1553,6 +1561,9 @@ export class Resolver {
       const field = template.fields.find((field) => field.name === fieldName);
       if (!field) {
         throw new Error(`Expected to find field by name ${fieldName}`);
+      }
+      if (isEmptyOptionalImageValue(fieldValue, field)) {
+        continue;
       }
       switch (field.type) {
         case 'displayOnly':

--- a/packages/@tinacms/graphql/src/resolver/index.ts
+++ b/packages/@tinacms/graphql/src/resolver/index.ts
@@ -1563,6 +1563,12 @@ export class Resolver {
         throw new Error(`Expected to find field by name ${fieldName}`);
       }
       if (isEmptyOptionalImageValue(fieldValue, field)) {
+        if (
+          existingData &&
+          Object.prototype.hasOwnProperty.call(existingData, fieldName)
+        ) {
+          accum[fieldName] = '';
+        }
         continue;
       }
       switch (field.type) {


### PR DESCRIPTION
Fixes #5229.

Omit empty optional image fields from document payloads so blank image fields are not written to frontmatter.

Tests:
- pnpm --filter @tinacms/graphql exec vitest run src/resolver/index.test.ts --coverage.enabled
- pnpm exec biome check packages/@tinacms/graphql/src/resolver/index.ts packages/@tinacms/graphql/src/resolver/index.test.ts
- pnpm turbo run build --filter=@tinacms/graphql
