### PR TITLE
🐛 Fix markdown table alignment positions

### DIFF
--- a/.changeset/tall-tables-align.md
+++ b/.changeset/tall-tables-align.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/mdx": patch
+---
+
+Preserve markdown table alignment positions when only later columns are explicitly aligned.

--- a/packages/@tinacms/mdx/src/next/tests/markdown-basic-tables/in.md
+++ b/packages/@tinacms/mdx/src/next/tests/markdown-basic-tables/in.md
@@ -7,3 +7,7 @@
 | :-------- | :---------- | ----------: |
 | Header    | Title       | Here's this |
 | Paragraph | Text        |    And more |
+
+| First | Second | Third |
+| ----- | ------ | ----: |
+| One   | Two    | Three |

--- a/packages/@tinacms/mdx/src/next/tests/markdown-basic-tables/node.json
+++ b/packages/@tinacms/mdx/src/next/tests/markdown-basic-tables/node.json
@@ -260,6 +260,112 @@
           "right"
         ]
       }
+    },
+    {
+      "type": "table",
+      "children": [
+        {
+          "type": "tr",
+          "children": [
+            {
+              "type": "td",
+              "children": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "First"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "td",
+              "children": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "Second"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "td",
+              "children": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "Third"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "tr",
+          "children": [
+            {
+              "type": "td",
+              "children": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "One"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "td",
+              "children": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "Two"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "td",
+              "children": [
+                {
+                  "type": "p",
+                  "children": [
+                    {
+                      "type": "text",
+                      "text": "Three"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "props": {
+        "align": [
+          null,
+          null,
+          "right"
+        ]
+      }
     }
   ]
 }

--- a/packages/@tinacms/mdx/src/next/tests/markdown-basic-tables/out.md
+++ b/packages/@tinacms/mdx/src/next/tests/markdown-basic-tables/out.md
@@ -7,3 +7,7 @@
 | :-------- | :---------- | ----------: |
 | Header    | Title       | Here's this |
 | Paragraph | Text        |    And more |
+
+| First | Second | Third |
+| ----- | ------ | ----: |
+| One   | Two    | Three |

--- a/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
+++ b/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
@@ -65,7 +65,7 @@ export const remarkToSlate = (
             };
           }),
           props: {
-            align: content.align?.filter((item) => !!item),
+            align: content.align?.some((item) => !!item) ? content.align : [],
           },
         };
       }


### PR DESCRIPTION
The real issue was that Tina’s markdown table parser was losing column positions for alignment metadata.

Markdown parsers represent this table:

```md
| First | Second | Third |
| ----- | ------ | ----: |
```

as an alignment array like:

```ts
[null, null, "right"]
```

That means:

- column 1: default alignment
- column 2: default alignment
- column 3: right-aligned

But Tina was doing this in `remarkToPlate.ts`:

```ts
content.align?.filter((item) => !!item)
```

So `[null, null, "right"]` became:

```ts
["right"]
```

When Tina later serialized the document back to markdown, it treated `"right"` as the alignment for column 1, not column 3. That’s why alignment appeared to “shift left” after saving.

The fix is to preserve the array positions when any alignment exists:

```ts
align: content.align?.some((item) => !!item) ? content.align : []
```

So default-only tables still stay as `[]`, but mixed tables keep `[null, null, "right"]` and serialize correctly.