### PR TITLE
Pin npm to 11 in the Publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
@@ -240,7 +240,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: npm install -g npm@11
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,7 +51,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@11
+        run: npm install -g npm@$(node -p "require('./package.json').engines.npm")
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
@@ -240,7 +240,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@11
+        run: npm install -g npm@$(node -p "require('./package.json').engines.npm")
 
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	],
 	"engines": {
 		"node": "22.x || 24.x",
+		"npm": "11.x",
 		"pnpm": ">=11"
 	},
 	"scripts": {


### PR DESCRIPTION
* Latest right now is npm 12, using that requires bumping engines for tina, pinning to 11 instead

Triggered by https://github.com/tinacms/tinacms/actions/runs/29057020703/job/86250518374
