### PR TITLE
🧹 Reference renamed tina-react-starter in create-tina-app and DoD

### DIFF
--- a/.changeset/rename-react-starter-template.md
+++ b/.changeset/rename-react-starter-template.md
@@ -1,0 +1,5 @@
+---
+"create-tina-app": patch
+---
+
+Rename the "Bare bones starter" template to "React Starter" and point it at the renamed `tina-react-starter` repository. The `--template basic` flag value is unchanged.

--- a/_docs/Definition-of-Done.md
+++ b/_docs/Definition-of-Done.md
@@ -11,7 +11,7 @@ An issue can be considered "done" when the following criteria are met:
 7. TinaCloud has been updated if affected
 8. The starter templates have been updated if they are affected:
    1. [tina-self-hosted-demo](https://github.com/tinacms/tina-self-hosted-demo)
-   2. [tina-barebones-starter](https://github.com/tinacms/tina-barebones-starter)
+   2. [tina-react-starter](https://github.com/tinacms/tina-react-starter)
    3. [tina-nextjs-starter](https://github.com/tinacms/tina-nextjs-starter)
 9. All user and developer documentation has been updated, including:
    1. [README.md](/README.md)

--- a/packages/create-tina-app/src/templates.ts
+++ b/packages/create-tina-app/src/templates.ts
@@ -171,7 +171,7 @@ export const TEMPLATES: Template[] = [
   {
     title: 'React Starter',
     description:
-      'Stripped down to essentials, this starter is the canvas for pure, unadulterated code creativity. Built with Next.js.',
+      'Stripped down to essentials, this starter is the canvas for pure, unadulterated code creativity. Built with Vite and React.',
     value: 'basic',
     isInternal: false,
     features: [

--- a/packages/create-tina-app/src/templates.ts
+++ b/packages/create-tina-app/src/templates.ts
@@ -169,7 +169,7 @@ export const TEMPLATES: Template[] = [
     devUrl: 'http://localhost:3000',
   },
   {
-    title: 'Bare bones starter',
+    title: 'React Starter',
     description:
       'Stripped down to essentials, this starter is the canvas for pure, unadulterated code creativity. Built with Next.js.',
     value: 'basic',
@@ -188,7 +188,7 @@ export const TEMPLATES: Template[] = [
         description: '✅',
       },
     ],
-    gitURL: 'https://github.com/tinacms/tina-barebones-starter',
+    gitURL: 'https://github.com/tinacms/tina-react-starter',
     branch: 'main',
     devUrl: 'http://localhost:3000',
   },


### PR DESCRIPTION
## TL;DR

Part of the `tina-barebones-starter` → `tina-react-starter` rename (#7185). Updates `create-tina-app` and the Definition of Done to reference the renamed repo, and renames the CLI template's display title to "React Starter".

## Reviewer notes

- **Template `value: 'basic'` kept.** It is the `--template basic` CLI flag value and the PostHog telemetry key; renaming it would break existing scripts and split analytics history. Only the display title and git URL change.

## Note

Merge after the GitHub repo rename lands (GitHub keeps a redirect from the old slug afterward).

## Links

- Tracking PBI: #7185
