### PR TITLE
fix(tinacms): spin the create-branch save button during pre-flight

### DIFF
--- a/.changeset/spin-create-branch-save-button.md
+++ b/.changeset/spin-create-branch-save-button.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+Show a spinner on the editorial-workflow "Save to a new branch" button while the pre-flight branch checks run, so the click gives immediate feedback instead of a brief unresponsive gap before the progress modal appears.

--- a/packages/tinacms/src/toolkit/components/media/media-workflow-overlay.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-workflow-overlay.tsx
@@ -1,5 +1,12 @@
-import * as React from 'react';
-import { BiError } from 'react-icons/bi';
+import { CreateBranchPromptModal } from '@toolkit/form-builder/create-branch-modal';
+import { EditorialWorkflowProgressModal } from '@toolkit/form-builder/editorial-workflow-progress-modal';
+import {
+  type MediaWorkflowConfirmBranchEvent,
+  TARGET_BRANCH_EXISTS_ERROR,
+  checkBaseBranchExists,
+  checkTargetBranchExists,
+} from '@toolkit/form-builder/editorial-workflow-utils';
+import { getEditorialWorkflowErrorMessage } from '@toolkit/form-builder/use-editorial-workflow';
 import { useBranchData } from '@toolkit/plugin-branch-switcher';
 import { useCMS } from '@toolkit/react-core';
 import {
@@ -8,15 +15,8 @@ import {
   ModalHeader,
   PopupModal,
 } from '@toolkit/react-modals';
-import { CreateBranchPromptModal } from '@toolkit/form-builder/create-branch-modal';
-import {
-  checkBaseBranchExists,
-  checkTargetBranchExists,
-  type MediaWorkflowConfirmBranchEvent,
-  TARGET_BRANCH_EXISTS_ERROR,
-} from '@toolkit/form-builder/editorial-workflow-utils';
-import { EditorialWorkflowProgressModal } from '@toolkit/form-builder/editorial-workflow-progress-modal';
-import { getEditorialWorkflowErrorMessage } from '@toolkit/form-builder/use-editorial-workflow';
+import * as React from 'react';
+import { BiError } from 'react-icons/bi';
 
 type WorkflowState =
   | { phase: 'idle' }
@@ -199,7 +199,8 @@ export const MediaWorkflowOverlay = () => {
           state.onCancel();
           setState({ phase: 'idle' });
         }}
-        disabled={state.branchName === '' || state.isChecking}
+        disabled={state.branchName === ''}
+        busy={state.isChecking}
         errorMessage={state.errorMessage}
         onBranchNameChange={(branchName) => {
           abortPreflight();

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.test.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Base-branch guard check that never resolves, so we can assert what the UI
+// shows while the pre-flight network request is still in flight.
+const checkBaseBranchExists = vi.fn(() => new Promise<boolean>(() => {}));
+vi.mock('./editorial-workflow-utils', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  checkBaseBranchExists: (...args: any[]) => checkBaseBranchExists(...args),
+}));
+
+const executeWorkflow = vi.fn(
+  () => new Promise<{ success: boolean; error?: string }>(() => {})
+);
+vi.mock('./use-editorial-workflow', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  useEditorialWorkflow: () => ({
+    isExecuting: false,
+    errorMessage: '',
+    currentStep: 0,
+    elapsedTime: 0,
+    executeWorkflow,
+    reset: vi.fn(),
+  }),
+}));
+
+vi.mock('../react-core', () => ({
+  useCMS: () => ({
+    api: { tina: { branch: 'main', usingProtectedBranch: () => false } },
+  }),
+}));
+
+vi.mock('@toolkit/styles', async (importOriginal) => ({
+  ...(await importOriginal<any>()),
+  DropdownButton: ({ children, onMainAction, disabled }: any) => (
+    <button type='button' disabled={disabled} onClick={onMainAction}>
+      {children}
+    </button>
+  ),
+}));
+
+vi.mock('@toolkit/react-modals', async (importOriginal) => {
+  const passthrough = ({ children }: any) => <div>{children}</div>;
+  return {
+    ...(await importOriginal<any>()),
+    Modal: passthrough,
+    PopupModal: passthrough,
+    ModalHeader: passthrough,
+    ModalBody: passthrough,
+    ModalActions: passthrough,
+  };
+});
+
+import { CreateBranchModal } from './create-branch-modal';
+
+function renderModal() {
+  const user = userEvent.setup();
+  return {
+    user,
+    ...render(
+      <CreateBranchModal
+        close={vi.fn()}
+        safeSubmit={vi.fn()}
+        path='content/posts/hello.md'
+        values={{}}
+        crudType='update'
+      />
+    ),
+  };
+}
+
+describe('CreateBranchModal', () => {
+  beforeEach(() => {
+    checkBaseBranchExists.mockClear();
+    executeWorkflow.mockClear();
+  });
+
+  it('spins the submit button while the branch-guard check runs, without jumping to the progress modal', async () => {
+    const { user, container } = renderModal();
+
+    expect(screen.getByText(/First, let's create a copy/i)).toBeTruthy();
+
+    await user.click(screen.getByText(/Save draft/i));
+
+    // Immediate feedback: the button swaps its label for the loading dots
+    // while the pre-flight check is still in flight.
+    expect(container.querySelector('[style*="loading-dots"]')).toBeTruthy();
+    expect(screen.queryByText(/Save draft/i)).toBeNull();
+    expect(checkBaseBranchExists).toHaveBeenCalledTimes(1);
+
+    // But we have NOT prematurely shown the "Creating branch" progress modal,
+    // nor started the workflow — so a validation failure here would simply drop
+    // back to the prompt with an error.
+    expect(screen.getByText(/First, let's create a copy/i)).toBeTruthy();
+    expect(screen.queryByText(/Estimated time/i)).toBeNull();
+    expect(executeWorkflow).not.toHaveBeenCalled();
+  });
+});

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
@@ -1,5 +1,7 @@
-import * as React from 'react';
-import { BiError } from 'react-icons/bi';
+import { FieldLabel } from '@toolkit/fields';
+import { Form } from '@toolkit/forms';
+import { useLocalStorage } from '@toolkit/hooks/use-local-storage';
+import { Button, DropdownButton } from '@toolkit/styles';
 import {
   Eye,
   FileText,
@@ -7,7 +9,10 @@ import {
   Globe,
   TriangleAlert,
 } from 'lucide-react';
-import { Button, DropdownButton } from '@toolkit/styles';
+import * as React from 'react';
+import { BiError } from 'react-icons/bi';
+import { EditorialWorkflowSaveEvent } from '../../lib/posthog/posthog';
+import { captureEvent } from '../../lib/posthog/posthogProvider';
 import { useCMS } from '../react-core';
 import {
   Modal,
@@ -16,19 +21,15 @@ import {
   ModalHeader,
   PopupModal,
 } from '../react-modals';
-import { FieldLabel } from '@toolkit/fields';
-import { Form } from '@toolkit/forms';
 import { EditorialWorkflowProgressModal } from './editorial-workflow-progress-modal';
 import { checkBaseBranchExists } from './editorial-workflow-utils';
-import { useEditorialWorkflow } from './use-editorial-workflow';
-import { useLocalStorage } from '@toolkit/hooks/use-local-storage';
+import { LoadingDots } from './loading-dots';
 import {
   SAVE_CHOICE_KEY,
   type SaveChoice,
   resolveSaveOptions,
 } from './save-options';
-import { EditorialWorkflowSaveEvent } from '../../lib/posthog/posthog';
-import { captureEvent } from '../../lib/posthog/posthogProvider';
+import { useEditorialWorkflow } from './use-editorial-workflow';
 
 // Format the default branch name by removing content/ prefix and file extension
 const formatDefaultBranchName = (
@@ -80,8 +81,7 @@ export const CreateBranchModal = ({
   const [newBranchName, setNewBranchName] = React.useState(
     formatDefaultBranchName(path, crudType)
   );
-  const [isBranchGuardChecking, setIsBranchGuardChecking] =
-    React.useState(false);
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const branchGuardAbortRef = React.useRef<AbortController | null>(null);
 
   const {
@@ -96,7 +96,7 @@ export const CreateBranchModal = ({
   const abortBranchGuard = React.useCallback(() => {
     branchGuardAbortRef.current?.abort();
     branchGuardAbortRef.current = null;
-    setIsBranchGuardChecking(false);
+    setIsSubmitting(false);
   }, []);
 
   React.useEffect(() => {
@@ -109,7 +109,9 @@ export const CreateBranchModal = ({
     abortBranchGuard();
     const abortController = new AbortController();
     branchGuardAbortRef.current = abortController;
-    setIsBranchGuardChecking(true);
+    // Keep the submit button spinning through the whole async guard + workflow
+    // start, so the click gives immediate feedback instead of a dead beat.
+    setIsSubmitting(true);
 
     const baseBranch = decodeURIComponent(tinaApi.branch);
     const targetBranch = `tina/${newBranchName}`;
@@ -132,8 +134,6 @@ export const CreateBranchModal = ({
       return;
     }
 
-    setIsBranchGuardChecking(false);
-
     const { success, error } = await executeWorkflow({
       branchName: targetBranch,
       baseBranch,
@@ -147,6 +147,10 @@ export const CreateBranchModal = ({
     if (branchGuardAbortRef.current === abortController) {
       branchGuardAbortRef.current = null;
     }
+
+    // On success the progress modal has already taken over; on failure this
+    // drops the spinner so the prompt shows the error.
+    setIsSubmitting(false);
 
     // Cancelled mid-run (modal closed, branch renamed, another save started, or
     // unmounted) — treat as a no-op and record nothing.
@@ -181,7 +185,8 @@ export const CreateBranchModal = ({
         close();
       }}
       errorMessage={errorMessage}
-      disabled={newBranchName === '' || isBranchGuardChecking}
+      disabled={newBranchName === ''}
+      busy={isSubmitting}
       onBranchNameChange={(value) => {
         abortBranchGuard();
         reset();
@@ -203,6 +208,7 @@ export const CreateBranchPromptModal = ({
   branchName,
   close,
   disabled,
+  busy,
   errorMessage,
   onBranchNameChange,
   onCreateBranch,
@@ -213,6 +219,7 @@ export const CreateBranchPromptModal = ({
   branchName: string;
   close: () => void;
   disabled?: boolean;
+  busy?: boolean;
   errorMessage?: string;
   onBranchNameChange: (value: string) => void;
   onCreateBranch: (isDraft: boolean) => void;
@@ -325,6 +332,7 @@ export const CreateBranchPromptModal = ({
               align='start'
               className='w-full sm:w-auto'
               disabled={disabled}
+              busy={busy}
               onMainAction={mainChoice.run}
               items={menu.map((choice) => {
                 const option = choices[choice];
@@ -341,8 +349,14 @@ export const CreateBranchPromptModal = ({
                 };
               })}
             >
-              <MainIcon className='w-4 h-4 mr-1' style={{ fill: 'none' }} />
-              {mainChoice.label}
+              {busy ? (
+                <LoadingDots />
+              ) : (
+                <>
+                  <MainIcon className='w-4 h-4 mr-1' style={{ fill: 'none' }} />
+                  {mainChoice.label}
+                </>
+              )}
             </DropdownButton>
           ) : (
             <DropdownButton
@@ -350,6 +364,7 @@ export const CreateBranchPromptModal = ({
               align='start'
               className='w-full sm:w-auto'
               disabled={disabled}
+              busy={busy}
               onMainAction={() => onCreateBranch(false)}
               items={[
                 {
@@ -359,11 +374,17 @@ export const CreateBranchPromptModal = ({
                 },
               ]}
             >
-              <GitBranchIcon
-                className='w-4 h-4 mr-1'
-                style={{ fill: 'none' }}
-              />
-              Save to a new branch
+              {busy ? (
+                <LoadingDots />
+              ) : (
+                <>
+                  <GitBranchIcon
+                    className='w-4 h-4 mr-1'
+                    style={{ fill: 'none' }}
+                  />
+                  Save to a new branch
+                </>
+              )}
             </DropdownButton>
           )}
         </ModalActions>


### PR DESCRIPTION
Closes #7191

**TL;DR** Clicking the create-branch save button in the editorial workflow left it unresponsive for about a second before the progress modal appeared; this keeps a spinner on the button through the whole pre-flight so the click feels immediate.

**Pain:** On a protected branch, saving opens the create-branch modal, and clicking the save button runs two sequential branch-existence checks (`checkBaseBranchExists`, then `checkTargetBranchExists` inside `executeWorkflow`) before `isExecuting` flips and the progress modal renders. During that window the button is only `disabled` with no feedback, and the checking flag was cleared before the target check, so it reads as a frozen one second gap.

**Solution:** Keep the submit button in a `busy` spinner state for the entire async span (guard checks plus workflow start) via a renamed `isSubmitting` flag and a new `busy` prop on the shared `CreateBranchPromptModal` that swaps the button icon for a spinner. Both the content flow (`isSubmitting`) and the media-store flow (`isChecking`) feed it, and a validation failure during pre-flight drops the spinner back to the prompt with the error instead of showing a premature "Creating branch" state. Adds a regression test covering the spinner behavior.
