### PR TITLE
🐛 Hard-reset before the @dev snapshot so beta stops publishing release versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -295,7 +295,12 @@ jobs:
       - name: Release to @dev channel
         if: steps.changesets.outputs.hasChangesets == 'true'
         run: |
-          git checkout ${{ github.sha }}
+          # Hard reset (not checkout) so the snapshot runs against the pristine
+          # release commit. changesets/action's github-api commit mode leaves the
+          # version bumps uncommitted in the working tree; a plain checkout keeps
+          # them, so `version:snapshot` finds no changesets and publishes the real
+          # release version to the beta tag, which then blocks the latest publish.
+          git reset --hard ${{ github.sha }}
           pnpm version:snapshot $(echo ${{ github.sha }} | cut -c1-7)
           pnpm run publish:beta
           echo "A release PR has been created: <https://github.com/tinacms/tinacms/pull/${{ steps.changesets.outputs.pullRequestNumber }}>" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## TL;DR

Since #7160 switched changesets to `commitMode: github-api`, the release-commit version bump is committed server-side and left **uncommitted in the runner's working tree**. The "Release to @dev channel" step then does `git checkout ${{ github.sha }}` (which *keeps* those dirty files), so `version:snapshot` finds no changesets and publishes the **clean release version** to the `beta` tag instead of a throwaway `0.0.0-<sha>`. That pre-claims the version the Version Packages publish needs, so the `latest` publish finds it already on npm and no-ops.

## Fix

Replace `git checkout` with `git reset --hard ${{ github.sha }}` so the snapshot runs against the pristine release commit (changesets restored) and emits a disposable `0.0.0-<sha>` version.

## Reviewer notes

- **Impact (separate from this PR):** the last release is already stranded, `latest` for ~16 packages (tinacms `3.10.1`, `@tinacms/cli` `2.5.5`, `create-tina-app` `2.1.11`, …) sits on `beta`. That needs a one-time `npm dist-tag add …@… latest` retag; this PR only stops it recurring.
- **Validate:** on a branch that still has a changeset, run `git reset --hard <sha> && pnpm version:snapshot deadbee` and confirm the bumped `package.json` reads `0.0.0-deadbee-…`, not a clean semver.

## Links

- Regression source: #7160

🤖 Generated with [Claude Code](https://claude.com/claude-code)