### PR TITLE
⚡ Collapse editorial-workflow branch guard to a single branch-list fetch

### DIFF
--- a/.changeset/editorial-workflow-single-branch-check.md
+++ b/.changeset/editorial-workflow-single-branch-check.md
@@ -1,0 +1,5 @@
+---
+"tinacms": minor
+---
+
+Editorial-workflow saves (Save draft / Save to a new branch, and the media create-branch flow) now run a single branch-list lookup instead of two sequential ones, roughly halving the delay before the progress modal appears.

--- a/packages/tinacms/src/internalClient/index.test.ts
+++ b/packages/tinacms/src/internalClient/index.test.ts
@@ -402,6 +402,36 @@ describe('Tina Client', () => {
       expect(result).toBe(true);
       expect(localFetchWithToken).not.toHaveBeenCalled();
     });
+
+    it('branchesExist resolves several branches from a single list_branches fetch', async () => {
+      fetchWithToken.mockResolvedValueOnce(
+        makeResponse({
+          status: 200,
+          body: [
+            { name: 'main', protected: true },
+            { name: 'tina/existing', protected: false },
+          ] as unknown as Record<string, unknown>,
+        })
+      );
+
+      const result = await client.branchesExist(['main', 'tina/new-branch']);
+
+      expect(result).toEqual({ main: true, 'tina/new-branch': false });
+      expect(fetchWithToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('branchesExist returns all-true in local mode without calling listBranches', async () => {
+      const localClient = new LocalClient();
+      const localFetchWithToken = vi.fn();
+      localClient.authProvider = {
+        fetchWithToken: localFetchWithToken,
+      } as any;
+
+      const result = await localClient.branchesExist(['main', 'tina/x']);
+
+      expect(result).toEqual({ main: true, 'tina/x': true });
+      expect(localFetchWithToken).not.toHaveBeenCalled();
+    });
   });
 
   describe('request() — error handling', () => {

--- a/packages/tinacms/src/internalClient/index.ts
+++ b/packages/tinacms/src/internalClient/index.ts
@@ -588,6 +588,23 @@ mutation addPendingDocumentMutation(
     return branches.some((b) => b.name === branchName);
   }
 
+  async branchesExist(
+    branchNames: string[],
+    args?: { signal?: AbortSignal }
+  ): Promise<Record<string, boolean>> {
+    if (this.isLocalMode) {
+      return Object.fromEntries(branchNames.map((name) => [name, true]));
+    }
+    const branches = await this.listBranches({
+      includeIndexStatus: false,
+      signal: args?.signal,
+    });
+    const existing = new Set(branches.map((b) => b.name));
+    return Object.fromEntries(
+      branchNames.map((name) => [name, existing.has(name)])
+    );
+  }
+
   async createBranch({ baseBranch, branchName }: BranchData) {
     const url = `${this.contentApiBase}/github/${this.clientId}/create_branch`;
 

--- a/packages/tinacms/src/toolkit/components/media/media-workflow-overlay.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-workflow-overlay.tsx
@@ -10,8 +10,7 @@ import {
 } from '@toolkit/react-modals';
 import { CreateBranchPromptModal } from '@toolkit/form-builder/create-branch-modal';
 import {
-  checkBaseBranchExists,
-  checkTargetBranchExists,
+  checkBranchGuard,
   type MediaWorkflowConfirmBranchEvent,
   TARGET_BRANCH_EXISTS_ERROR,
 } from '@toolkit/form-builder/editorial-workflow-utils';
@@ -127,9 +126,10 @@ export const MediaWorkflowOverlay = () => {
       errorMessage: '',
     });
 
-    const baseBranchExists = await checkBaseBranchExists(
+    const { baseBranchExists, targetBranchExists } = await checkBranchGuard(
       cms.api.tina,
       confirmState.baseBranch,
+      targetBranch,
       'media workflow',
       abortController.signal
     );
@@ -148,15 +148,6 @@ export const MediaWorkflowOverlay = () => {
       });
       return;
     }
-
-    const targetBranchExists = await checkTargetBranchExists(
-      cms.api.tina,
-      targetBranch,
-      'media workflow',
-      abortController.signal
-    );
-
-    if (abortController.signal.aborted) return;
 
     if (targetBranchExists) {
       if (preflightAbortRef.current === abortController) {

--- a/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
+++ b/packages/tinacms/src/toolkit/form-builder/create-branch-modal.tsx
@@ -19,7 +19,7 @@ import {
 import { FieldLabel } from '@toolkit/fields';
 import { Form } from '@toolkit/forms';
 import { EditorialWorkflowProgressModal } from './editorial-workflow-progress-modal';
-import { checkBaseBranchExists } from './editorial-workflow-utils';
+import { checkBranchGuard } from './editorial-workflow-utils';
 import { useEditorialWorkflow } from './use-editorial-workflow';
 import { useLocalStorage } from '@toolkit/hooks/use-local-storage';
 import {
@@ -114,9 +114,10 @@ export const CreateBranchModal = ({
     const baseBranch = decodeURIComponent(tinaApi.branch);
     const targetBranch = `tina/${newBranchName}`;
 
-    const baseBranchExists = await checkBaseBranchExists(
+    const { baseBranchExists, targetBranchExists } = await checkBranchGuard(
       tinaApi,
       baseBranch,
+      targetBranch,
       'executeEditorialWorkflow',
       abortController.signal
     );
@@ -142,6 +143,7 @@ export const CreateBranchModal = ({
       crudType,
       tinaForm,
       signal: abortController.signal,
+      targetBranchExists,
       isDraft,
     });
     if (branchGuardAbortRef.current === abortController) {

--- a/packages/tinacms/src/toolkit/form-builder/editorial-workflow-utils.test.ts
+++ b/packages/tinacms/src/toolkit/form-builder/editorial-workflow-utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { checkBranchGuard } from './editorial-workflow-utils';
+
+describe('checkBranchGuard', () => {
+  it('resolves base + target existence from a single branchesExist call', async () => {
+    const branchesExist = vi.fn().mockResolvedValue({
+      main: true,
+      'tina/new-branch': false,
+    });
+
+    const result = await checkBranchGuard(
+      { branchesExist },
+      'main',
+      'tina/new-branch',
+      'test'
+    );
+
+    expect(result).toEqual({
+      baseBranchExists: true,
+      targetBranchExists: false,
+    });
+    expect(branchesExist).toHaveBeenCalledTimes(1);
+    expect(branchesExist).toHaveBeenCalledWith(['main', 'tina/new-branch'], {
+      signal: undefined,
+    });
+  });
+
+  it('fails open when the lookup throws: base treated as existing, target as absent', async () => {
+    const branchesExist = vi.fn().mockRejectedValue(new Error('network down'));
+
+    const result = await checkBranchGuard(
+      { branchesExist },
+      'main',
+      'tina/new-branch',
+      'test'
+    );
+
+    expect(result).toEqual({
+      baseBranchExists: true,
+      targetBranchExists: false,
+    });
+  });
+
+  it('fails open when the request is aborted', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const branchesExist = vi
+      .fn()
+      .mockRejectedValue(new DOMException('aborted', 'AbortError'));
+
+    const result = await checkBranchGuard(
+      { branchesExist },
+      'main',
+      'tina/new-branch',
+      'test',
+      controller.signal
+    );
+
+    expect(result).toEqual({
+      baseBranchExists: true,
+      targetBranchExists: false,
+    });
+  });
+});

--- a/packages/tinacms/src/toolkit/form-builder/editorial-workflow-utils.ts
+++ b/packages/tinacms/src/toolkit/form-builder/editorial-workflow-utils.ts
@@ -47,19 +47,6 @@ const checkBranchExists = async (
   }
 };
 
-export const checkBaseBranchExists = async (
-  tinaApi: {
-    branchExists: (
-      branchName: string,
-      args?: { signal?: AbortSignal }
-    ) => Promise<boolean>;
-  },
-  baseBranch: string,
-  debugLabel: string,
-  signal?: AbortSignal
-): Promise<boolean> =>
-  checkBranchExists(tinaApi, baseBranch, debugLabel, 'base', true, signal);
-
 export const checkTargetBranchExists = async (
   tinaApi: {
     branchExists: (
@@ -72,3 +59,51 @@ export const checkTargetBranchExists = async (
   signal?: AbortSignal
 ): Promise<boolean> =>
   checkBranchExists(tinaApi, targetBranch, debugLabel, 'target', false, signal);
+
+export interface BranchGuardResult {
+  baseBranchExists: boolean;
+  targetBranchExists: boolean;
+}
+
+export const checkBranchGuard = async (
+  tinaApi: {
+    branchesExist: (
+      branchNames: string[],
+      args?: { signal?: AbortSignal }
+    ) => Promise<Record<string, boolean>>;
+  },
+  baseBranch: string,
+  targetBranch: string,
+  debugLabel: string,
+  signal?: AbortSignal
+): Promise<BranchGuardResult> => {
+  try {
+    console.debug(
+      `[tina:branch-guard] ${debugLabel}: checking base + target branches:`,
+      baseBranch,
+      targetBranch
+    );
+    const existence = await tinaApi.branchesExist([baseBranch, targetBranch], {
+      signal,
+    });
+    const result = {
+      baseBranchExists: existence[baseBranch] ?? true,
+      targetBranchExists: existence[targetBranch] ?? false,
+    };
+    console.debug(
+      `[tina:branch-guard] ${debugLabel}: base exists?`,
+      result.baseBranchExists,
+      'target exists?',
+      result.targetBranchExists
+    );
+    return result;
+  } catch (err) {
+    if (!signal?.aborted) {
+      console.error(
+        `[tina:branch-guard] ${debugLabel}: branchesExist threw, failing open:`,
+        err
+      );
+    }
+    return { baseBranchExists: true, targetBranchExists: false };
+  }
+};

--- a/packages/tinacms/src/toolkit/form-builder/use-editorial-workflow.ts
+++ b/packages/tinacms/src/toolkit/form-builder/use-editorial-workflow.ts
@@ -71,6 +71,7 @@ export interface ExecuteWorkflowOptions {
   signal?: AbortSignal;
   // When false, opens a ready-for-review PR. Omitted keeps the server's draft-first default.
   isDraft?: boolean;
+  targetBranchExists?: boolean;
 }
 
 export interface UseEditorialWorkflowResult {
@@ -158,16 +159,19 @@ export function useEditorialWorkflow(): UseEditorialWorkflowResult {
     tinaForm,
     signal,
     isDraft,
+    targetBranchExists: precomputedTargetBranchExists,
   }: ExecuteWorkflowOptions): Promise<{ success: boolean; error?: string }> => {
     try {
       if (signal?.aborted) return { success: false };
 
-      const targetBranchExists = await checkTargetBranchExists(
-        tinaApi,
-        branchName,
-        'executeEditorialWorkflow',
-        signal
-      );
+      const targetBranchExists =
+        precomputedTargetBranchExists ??
+        (await checkTargetBranchExists(
+          tinaApi,
+          branchName,
+          'executeEditorialWorkflow',
+          signal
+        ));
 
       if (signal?.aborted) return { success: false };
 


### PR DESCRIPTION
## TL;DR

Clicking **Save draft** / **Save to a new branch** in the editorial workflow sat unresponsive for ~1s before the progress modal appeared, because the guard ran **two sequential `branchExists` checks** (base, then target) — each a full `listBranches` round-trip — before `isExecuting` flipped. This collapses them into **one** branch-list fetch, roughly halving the delay. Fixes #7191.

## Why

`branchExists` fetches the whole branch list every call ([`internalClient/index.ts`](https://github.com/tinacms/tinacms/blob/main/packages/tinacms/src/internalClient/index.ts)). The save handler did it twice back-to-back — `checkBaseBranchExists` in the modal, then `checkTargetBranchExists` inside `executeWorkflow` — and nothing rendered until the second one resolved, so the button read as frozen.

```mermaid
graph LR
  subgraph Before
    A[click] --> B[listBranches: base?] --> C[listBranches: target?] --> D[progress modal]
  end
  subgraph After
    A2[click] --> B2["listBranches: base + target"] --> D2[progress modal]
  end
```

## How

- **`Client.branchesExist(names[])`** — resolves several branches from one `list_branches` fetch; keeps `branchExists`'s local-mode short-circuit.
- **`checkBranchGuard()`** — wraps it, returning `{ baseBranchExists, targetBranchExists }` with the same fail-open fallbacks as before (base assumed present, target assumed absent, so a flaky lookup never blocks a save).
- **Content flow** (`create-branch-modal`) calls the guard once and passes `targetBranchExists` into `executeWorkflow`, which now skips its own fetch. Callers with no guard (`BranchDeletedModal`) fall back to their own check.
- **Media flow** (`media-workflow-overlay`) gets the same two-to-one collapse.

## Reviewer notes

- **Fail-open preserved.** On error/abort the guard returns base=exists, target=absent — identical to the old per-check fallbacks.
- **No behavior change on the branch-deleted path.** `executeWorkflow` only reuses a pre-computed result when the caller supplies one.

## Tests

- `branchesExist`: asserts a **single** fetch, correct map, local-mode short-circuit.
- `checkBranchGuard`: correct results + fail-open on both throw and abort.
- All touched suites green.

## Links

- Fixes #7191

---
Scope note: this is the latency fix (approach B). The complementary UX option — a spinner from click → progress modal so the remaining wait *feels* instant — is left as a follow-up.