### PR TITLE
fix(tinacms): show the rich-text link popover above form fields

### DIFF
--- a/.changeset/link-popover-behind-form-fields.md
+++ b/.changeset/link-popover-behind-form-fields.md
@@ -1,0 +1,7 @@
+---
+"tinacms": patch
+---
+
+Fix the rich-text link popover not appearing when adding or editing a link.
+
+Since the popover was moved into a portal on `document.body`, `plate-floating`'s inline `z-index: 50` overrode its `z-[999999]` class, so it rendered behind the form field wrappers (which use z-index up to 1000) and was invisible. It now sits above them, so clicking the link button shows the URL input as expected.

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/link-floating-toolbar.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/link-floating-toolbar.tsx
@@ -237,7 +237,10 @@ export function LinkFloatingToolbar({
         {...insertProps}
         // Override plate-floating's inline z-index (which beats the z-[999999]
         // class) so the portaled popover sits above the form field wrappers.
-        style={{ ...(insertProps.style as React.CSSProperties), zIndex: 999999 }}
+        style={{
+          ...(insertProps.style as React.CSSProperties),
+          zIndex: 999999,
+        }}
       >
         {input}
       </div>

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/link-floating-toolbar.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/link-floating-toolbar.tsx
@@ -235,7 +235,9 @@ export function LinkFloatingToolbar({
         ref={insertRef}
         className={popoverVariants()}
         {...insertProps}
-        style={{ ...(insertProps.style as React.CSSProperties) }}
+        // Override plate-floating's inline z-index (which beats the z-[999999]
+        // class) so the portaled popover sits above the form field wrappers.
+        style={{ ...(insertProps.style as React.CSSProperties), zIndex: 999999 }}
       >
         {input}
       </div>
@@ -244,7 +246,7 @@ export function LinkFloatingToolbar({
         ref={editRef}
         className={popoverVariants()}
         {...editProps}
-        style={{ ...(editProps.style as React.CSSProperties) }}
+        style={{ ...(editProps.style as React.CSSProperties), zIndex: 999999 }}
       >
         {editContent}
       </div>


### PR DESCRIPTION
Closes #7250

**TL;DR** Adding or editing a link in the rich-text editor did nothing visible; the popover opened but rendered behind the form. This puts it back on top. Regression from #7131, reported on Discord (tinacms 3.10.0).

**Pain:** Clicking the link button in the rich-text toolbar (or floating toolbar) appeared to do nothing, no URL input showed up. Since #7131 moved the popover into a `PortalBody` on `document.body`, `plate-floating`'s inline `z-index: 50` overrides its `z-[999999]` class. At the body level that loses to Tina's form field wrappers (`wrap-field-with-meta` sets `z-index: 1000 - index`, up to 1000), so the opaque field paints over the popover. It was mounting, correctly positioned, and interactive the whole time, just hidden behind the form.

**Solution:** Override the inline z-index on both the insert and edit popovers so the intended `z-[999999]` wins and the popover sits above the form field wrappers.