### PR TITLE
Publish snapshots with exact internal pins, not caret prerelease ranges

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,6 +87,9 @@ jobs:
         run: |
           echo running on branch ${BRANCH_NAME}
           pnpm version:snapshot $(echo ${{ github.sha }} | cut -c1-7)
+          # Re-pin to workspace:* so snapshots publish exact internal versions —
+          # caret prerelease ranges can resolve to a different snapshot batch.
+          git diff --name-only -- '*package.json' | xargs -r sed -i 's/"workspace:\^"/"workspace:*"/g'
           pnpm publish -r --tag ${BRANCH_NAME} --no-git-checks --access public
           echo "Published NPM tag: $BRANCH_NAME" >> $GITHUB_STEP_SUMMARY
         env:
@@ -302,6 +305,9 @@ jobs:
           # release version to the beta tag, which then blocks the latest publish.
           git reset --hard ${{ github.sha }}
           pnpm version:snapshot $(echo ${{ github.sha }} | cut -c1-7)
+          # Re-pin to workspace:* so snapshots publish exact internal versions —
+          # caret prerelease ranges can resolve to a different snapshot batch.
+          git diff --name-only -- '*package.json' | xargs -r sed -i 's/"workspace:\^"/"workspace:*"/g'
           pnpm run publish:beta
           echo "A release PR has been created: <https://github.com/tinacms/tinacms/pull/${{ steps.changesets.outputs.pullRequestNumber }}>" >> $GITHUB_STEP_SUMMARY
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,8 @@ tests/                 # Build verification tests
 
 - `pnpm-workspace.yaml` defines workspace packages and a `catalog:` section for shared dependency versions
 - Example apps use `workspace:*` to reference local TinaCMS packages
+- Published packages must use `workspace:^` for internal refs in `dependencies`/`peerDependencies` (`devDependencies` are exempt). pnpm publishes it as a caret range so npm can dedupe; `workspace:*` publishes an exact pin that nests duplicate dependency trees (#7207). Enforced by `tests/workspace-protocol.test.ts`.
+- Because published dependents float across caret ranges, internal APIs consumed by sibling published packages are compatibility contracts within a major: an already-published `@tinacms/cli`/`@tinacms/app` may run against a newer `tinacms`. Breaking such an API requires a major bump.
 - `turbo.json` defines build/test/types task dependencies
 
 ## Coding Standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,6 +100,14 @@ Build your changes with `pnpm build`
 
 Run `pnpm version:snapshot`
 
+Re-pin internal deps so the snapshot publishes exact versions (pnpm would otherwise expand `workspace:^` to a caret prerelease range, which npm can resolve to a different snapshot batch):
+
+```sh
+for f in packages/*/package.json packages/@tinacms/*/package.json; do
+  sed 's/"workspace:\^"/"workspace:*"/g' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+done
+```
+
 Run `pnpm publish:dev`
 
 If you have 2FA, this will prompt you to enter you one-time code for each package you publish.

--- a/tests/workspace-protocol.test.ts
+++ b/tests/workspace-protocol.test.ts
@@ -1,0 +1,69 @@
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const ROOT = path.resolve(__dirname, '..')
+
+// pnpm publishes `workspace:^` as a caret range (`^1.2.3`), which lets npm
+// dedupe internal packages against the consumer's copy. Any other workspace
+// spec (`workspace:*`, `workspace:~`, `workspace:1.2.3`) publishes a pin that
+// nests duplicate dependency trees — ~320 MB in a stock consumer app (#7207).
+// devDependencies never ship, so they are exempt.
+const SHIPPED_SECTIONS = [
+  'dependencies',
+  'peerDependencies',
+  'optionalDependencies',
+] as const
+
+interface PkgRef {
+  name: string
+  pkgJsonPath: string
+  pkg: Record<string, Record<string, string> | undefined>
+}
+
+function collectPackagesFromDir(dir: string, skipAt = false): PkgRef[] {
+  const results: PkgRef[] = []
+
+  for (const entry of fs.readdirSync(dir)) {
+    if (skipAt && entry.startsWith('@')) continue
+
+    const pkgJsonPath = path.join(dir, entry, 'package.json')
+    if (!fs.existsSync(pkgJsonPath)) continue
+
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf-8'))
+    if (pkg.private === true) continue
+
+    results.push({ name: pkg.name, pkgJsonPath, pkg })
+  }
+
+  return results
+}
+
+function discoverPackages(): PkgRef[] {
+  return [
+    ...collectPackagesFromDir(path.join(ROOT, 'packages/@tinacms')),
+    ...collectPackagesFromDir(path.join(ROOT, 'packages'), true),
+  ]
+}
+
+describe('workspace protocol in published packages', () => {
+  it('uses workspace:^ for every internal ref in shipped dependency sections', () => {
+    const violations: string[] = []
+
+    for (const { name, pkgJsonPath, pkg } of discoverPackages()) {
+      for (const section of SHIPPED_SECTIONS) {
+        for (const [dep, spec] of Object.entries(pkg[section] ?? {})) {
+          if (spec.startsWith('workspace:') && spec !== 'workspace:^') {
+            violations.push(
+              `${name} ${section}.${dep} = "${spec}" (${path.relative(ROOT, pkgJsonPath)})`
+            )
+          }
+        }
+      }
+    }
+
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
Follow-up to #7213 

pnpm expands `workspace:^` to `^0.0.0-<sha>-<ts>` on snapshots, which npm can resolve to a different snapshot batch. Re-pin to `workspace:*` before snapshot publishes (CI + manual flow), and add a test guarding `workspace:^` in shipped dep sections. Real releases unaffected.
