### PR TITLE
Updated publish job to inertly bump the lockfile

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -308,6 +308,10 @@ jobs:
           # Re-pin to workspace:* so snapshots publish exact internal versions —
           # caret prerelease ranges can resolve to a different snapshot batch.
           git diff --name-only -- '*package.json' | xargs -r sed -i 's/"workspace:\^"/"workspace:*"/g'
+          # Sync the lockfile with the re-pinned manifests so the deps check
+          # in `pnpm run` passes. Offline: the sync must never resolve
+          # anything new — workspace re-pins don't need the registry.
+          pnpm install --lockfile-only --no-frozen-lockfile --offline
           pnpm run publish:beta
           echo "A release PR has been created: <https://github.com/tinacms/tinacms/pull/${{ steps.changesets.outputs.pullRequestNumber }}>" >> $GITHUB_STEP_SUMMARY
         env:


### PR DESCRIPTION
* Updates the publish job to bump the lock file inertly offline, so that the job doesn't fail on lockfile diff
