### PR TITLE
fix(@tinacms/graphql): retry datalayer connection instead of hanging forever at "Indexing local files"

### DIFF
--- a/.changeset/tidy-eyes-refuse.md
+++ b/.changeset/tidy-eyes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Fix an intermittent, silent hang at "Indexing local files" in `tinacms dev`/`build`/`audit`. `TinaLevelClient.openConnection` connected to the in-process datalayer server without waiting for the server's `listen()` to complete; when the connection lost that race, `many-level` queued every database operation forever with no error. The connection is now retried (100 ms × 50), and if it ultimately fails the RPC stream is destroyed so queued operations reject with `LEVEL_CONNECTION_LOST` instead of hanging. The race is timing-sensitive: on Node 25 it was lost almost every run, on Node 22 occasionally.

--- a/packages/@tinacms/graphql/src/level/tinaLevel.ts
+++ b/packages/@tinacms/graphql/src/level/tinaLevel.ts
@@ -2,6 +2,9 @@ import { ManyLevelGuest } from 'many-level';
 import { pipeline } from 'readable-stream';
 import { connect } from 'net';
 
+const CONNECT_RETRIES = 50;
+const CONNECT_RETRY_DELAY_MS = 100;
+
 export class TinaLevelClient extends ManyLevelGuest<
   string,
   Record<string, any>
@@ -14,11 +17,40 @@ export class TinaLevelClient extends ManyLevelGuest<
   }
   public openConnection() {
     if (this._connected) return;
-    const socket = connect(this.port);
-    pipeline(socket, this.createRpcStream(), socket, () => {
-      // Disconnected
-      this._connected = false;
-    });
+    // The datalayer server may not be listening yet when this runs — the CLI
+    // calls `createServer().listen()` and connects this client without
+    // waiting for `listen()` to complete. If the connection fails,
+    // ManyLevelGuest silently queues every operation forever, which presents
+    // as an indefinite "Indexing local files" hang. Retry the connection,
+    // and if it truly can't be established, destroy the RPC stream so queued
+    // operations reject (LEVEL_CONNECTION_LOST) instead of hanging.
+    const rpcStream = this.createRpcStream();
+    const tryConnect = (attempt: number) => {
+      const socket = connect(this.port);
+      const onConnectError = (err: Error) => {
+        socket.destroy();
+        if (attempt < CONNECT_RETRIES) {
+          setTimeout(() => tryConnect(attempt + 1), CONNECT_RETRY_DELAY_MS);
+        } else {
+          console.error(
+            `TinaLevelClient: could not connect to the datalayer server on port ${this.port} after ${
+              attempt + 1
+            } attempts (${err.message}).`
+          );
+          rpcStream.destroy(err);
+          this._connected = false;
+        }
+      };
+      socket.once('error', onConnectError);
+      socket.once('connect', () => {
+        socket.removeListener('error', onConnectError);
+        pipeline(socket, rpcStream, socket, () => {
+          // Disconnected
+          this._connected = false;
+        });
+      });
+    };
+    tryConnect(0);
     this._connected = true;
   }
 }


### PR DESCRIPTION
Fixes #7294

`TinaLevelClient.openConnection()` connected to the in-process datalayer server with no error handling: the CLI's `dbServer.listen()` is asynchronous and nothing coordinates the client connect with it. A lost race (`ECONNREFUSED`) left `many-level` silently queuing every DB operation forever — the indefinite "Indexing local files" spinner. Node 25's faster connection setup loses the race almost every run; Node 22 loses it occasionally. Full root-cause analysis in #7294.

This change:

- retries the connection (100 ms × 50 ≈ 5 s worst case) before giving up;
- on exhaustion, logs a clear error and destroys the RPC stream, so queued operations reject with `LEVEL_CONNECTION_LOST` ("Connection to leader lost") instead of hanging — a loud failure instead of a silent one;
- leaves the established-connection behavior unchanged (same `pipeline` wiring once connected).

Verified:

- **Retry-win path:** with the server deliberately listening 350 ms late, the client connects on attempt 4 and `put`/`get` complete normally.
- **Exhaustion path:** with nothing listening on the port, queued operations reject with `LEVEL_CONNECTION_LOST` after retries are exhausted.
- **Real-world:** applied to `@tinacms/graphql` 2.4.5 via patch-package in an Astro + Tina project where Node 25 hung nearly every build — 3/3 full builds now pass on Node 25.9.0 and Node 22.22.2.

Includes a changeset (`patch` bump for `@tinacms/graphql`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)