### PR TITLE
fix(mdx): parse image field with list:true instead of crashing on .split

### DIFF
--- a/.changeset/fix-image-list-rich-text-parse.md
+++ b/.changeset/fix-image-list-rich-text-parse.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/mdx": patch
+---
+
+Fix a crash when parsing rich-text containing an `image` field with `list: true`. The image-list branch called `.split(',')` on the array returned by `extractScalar`, throwing `TypeError: values.split is not a function`; the error was wrapped as a parse failure, so the block became an `invalid_markdown` node (content dropped in the editor) or failed `tinacms build`. It now maps over the array like the other list field types.

--- a/packages/@tinacms/mdx/src/parse/acorn.ts
+++ b/packages/@tinacms/mdx/src/parse/acorn.ts
@@ -65,8 +65,8 @@ const extractAttribute = (
         const values = extractScalar(
           extractExpression(attribute),
           field
-        ) as string;
-        return values.split(',').map((value) => imageCallback(value));
+        ) as string[];
+        return values.map((value) => imageCallback(value));
       } else {
         const value = extractString(attribute, field);
         return imageCallback(value);

--- a/packages/@tinacms/mdx/src/parse/index.test.ts
+++ b/packages/@tinacms/mdx/src/parse/index.test.ts
@@ -157,4 +157,34 @@ describe('parseMDX', () => {
       expect(mdxTree.children[0]?.type).toBe('invalid_markdown');
     });
   });
+
+  describe('image list props', () => {
+    it('parses an image field with list: true as an array', () => {
+      // Regression: the image-list branch called `.split(',')` on the array
+      // returned by extractScalar, throwing a TypeError that turned the whole
+      // node into invalid_markdown (content silently lost).
+      const imageListField: RichTextField = {
+        name: 'body',
+        type: 'rich-text',
+        parser: { type: 'mdx' },
+        templates: [
+          {
+            name: 'Gallery',
+            label: 'Gallery',
+            fields: [{ name: 'images', type: 'image', list: true }],
+          },
+        ],
+      };
+      const tree = parseMDX(
+        '<Gallery images={["/a.png", "/b.png"]} />',
+        imageListField,
+        passthrough
+      );
+      expect(tree.children[0]?.type).toBe('mdxJsxFlowElement');
+      expect((tree.children[0] as any).props.images).toEqual([
+        '/a.png',
+        '/b.png',
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
### What

Parsing a rich-text field whose template embeds an `image` field with `list: true` crashes.

```
<Gallery images={["/a.png", "/b.png"]} />
```

`parseMDX` (legacy `parser: { type: 'mdx' }` path) throws `TypeError: values.split is not a function`. The error is caught and wrapped as a parse failure, so the block is replaced with an `invalid_markdown` node (content silently lost in the editor); in audit build mode it surfaces as a `GraphQLError` that fails `tinacms build`.

### Why

In `packages/@tinacms/mdx/src/parse/acorn.ts`, `extractAttribute`'s `image` + `list` branch does:

```ts
const values = extractScalar(extractExpression(attribute), field) as string;
return values.split(',').map((value) => imageCallback(value));
```

But `extractScalar` returns an **array** for list fields (it maps over the `ArrayExpression` elements). Casting that array to `string` and calling `.split(',')` throws. Every sibling list type (`string`, `datetime`, `reference`) already returns the array from `extractScalar` directly — only `image` tried to `.split` it. The paired serializer writes image lists as an array literal, so this breaks round-trips too. There was no test covering image lists.

### How

Map over the array directly, matching the sibling list types:

```ts
const values = extractScalar(extractExpression(attribute), field) as string[];
return values.map((value) => imageCallback(value));
```

Added a `parseMDX` regression test in `parse/index.test.ts` and a changeset (`@tinacms/mdx` patch).
