### PR TITLE
🔧 Point media manager listing at the v2 assets-api endpoint

### DIFF
--- a/.changeset/media-list-v2-endpoint.md
+++ b/.changeset/media-list-v2-endpoint.md
@@ -1,0 +1,5 @@
+---
+"tinacms": patch
+---
+
+The media manager now lists assets from the v2 assets-api endpoint. Uploads and deletes are unchanged and stay on v1. Listing behaviour is identical — this is a transport-only move that sets up media search.

--- a/packages/tinacms/src/toolkit/core/media-store.default.test.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.test.ts
@@ -155,6 +155,108 @@ const buildStore = ({
   };
 };
 
+describe('TinaMediaStore — endpoint version (v1 vs v2)', () => {
+  it('lists media from the v2 endpoint', async () => {
+    const { store, fetchWithToken } = buildStore({ branch: 'main' });
+    fetchWithToken.mockResolvedValueOnce(
+      makeJsonResponse(200, { files: [], directories: [], cursor: 0 })
+    );
+
+    await store.list({ directory: '', thumbnailSizes: [] });
+
+    const calledUrl = fetchWithToken.mock.calls[0][0];
+    expect(calledUrl).toContain('/v2/test-client/list');
+    expect(calledUrl).not.toContain('/v1/');
+  });
+
+  it('lists a subdirectory from the v2 endpoint', async () => {
+    const { store, fetchWithToken } = buildStore({ branch: 'main' });
+    fetchWithToken.mockResolvedValueOnce(
+      makeJsonResponse(200, { files: [], directories: [], cursor: 0 })
+    );
+
+    await store.list({ directory: 'uploads', thumbnailSizes: [] });
+
+    const calledUrl = fetchWithToken.mock.calls[0][0];
+    expect(calledUrl).toContain('/v2/test-client/list/uploads');
+    expect(calledUrl).not.toContain('/v1/');
+  });
+
+  describe('mutating operations stay on v1', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+      vi.unstubAllGlobals();
+    });
+
+    it('deletes via the v1 endpoint', async () => {
+      const { store, fetchWithToken } = buildStore({ branch: 'main' });
+      fetchWithToken.mockResolvedValueOnce(
+        makeJsonResponse(200, { requestId: 'req-1' })
+      );
+
+      const deletePromise = store.delete({
+        directory: 'images',
+        filename: 'a.png',
+      } as Media);
+      await vi.advanceTimersByTimeAsync(1100);
+      await deletePromise;
+
+      const calledUrl = fetchWithToken.mock.calls[0][0];
+      expect(calledUrl).toContain('/v1/test-client/');
+      expect(calledUrl).not.toContain('/v2/');
+    });
+
+    it('requests the upload URL via v1 but resolves uploaded entries via v2', async () => {
+      const { store, fetchWithToken } = buildStore({ branch: 'feat%2Fx' });
+      fetchWithToken.mockResolvedValueOnce(
+        makeJsonResponse(200, {
+          signedUrl: 'https://s3.example/signed',
+          requestId: 'req-1',
+        })
+      );
+      fetchWithToken.mockResolvedValueOnce(
+        makeJsonResponse(200, {
+          files: [
+            {
+              filename: 'llama.png',
+              src: 'https://assets.tina.io/test-client/__file/uploads/llama.png',
+            },
+          ],
+          directories: [],
+          cursor: 0,
+        })
+      );
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(''),
+        json: vi.fn().mockResolvedValue({}),
+      });
+      vi.stubGlobal('fetch', fetchMock);
+
+      const uploads: MediaUploadOptions[] = [
+        {
+          directory: 'uploads',
+          file: new File(['x'], 'llama.png', { type: 'image/png' }),
+        },
+      ];
+
+      const persistPromise = store.persist(uploads);
+      await vi.advanceTimersByTimeAsync(1100);
+      await persistPromise;
+
+      const uploadUrl = fetchWithToken.mock.calls[0][0];
+      const listUrl = fetchWithToken.mock.calls[1][0];
+      expect(uploadUrl).toContain('/v1/test-client/upload_url/');
+      expect(listUrl).toContain('/v2/test-client/list');
+    });
+  });
+});
+
 describe('TinaMediaStore — branch query param', () => {
   describe('list()', () => {
     it('appends single-encoded branch for a simple branch', async () => {

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -803,7 +803,7 @@ export class TinaMediaStore implements MediaStore {
     if (!this.isLocal) {
       const encodedBranch = this.encodedBranchParam();
       res = await this.api.authProvider.fetchWithToken(
-        `${this.listUrl || this.url}/list/${options.directory || ''}?limit=${
+        `${this.listUrl}/list/${options.directory || ''}?limit=${
           options.limit || 20
         }${options.offset ? `&cursor=${options.offset}` : ''}${
           encodedBranch ? `&branch=${encodedBranch}` : ''

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -106,6 +106,7 @@ export class TinaMediaStore implements MediaStore {
   private cms: TinaCMS;
   private isLocal: boolean;
   private url: string;
+  private listUrl: string;
   private staticMedia: StaticMedia;
   isStatic?: boolean;
 
@@ -161,6 +162,7 @@ export class TinaMediaStore implements MediaStore {
               'assets'
             )}/v1/${this.api.clientId}`;
           }
+          this.listUrl = this.url.replace('/v1/', '/v2/');
         }
       }
     }
@@ -801,7 +803,7 @@ export class TinaMediaStore implements MediaStore {
     if (!this.isLocal) {
       const encodedBranch = this.encodedBranchParam();
       res = await this.api.authProvider.fetchWithToken(
-        `${this.url}/list/${options.directory || ''}?limit=${
+        `${this.listUrl || this.url}/list/${options.directory || ''}?limit=${
           options.limit || 20
         }${options.offset ? `&cursor=${options.offset}` : ''}${
           encodedBranch ? `&branch=${encodedBranch}` : ''


### PR DESCRIPTION
## TL;DR

Media **listing** now calls the `/v2` assets-api endpoint. **Uploads and deletes stay on `/v1`** (v2 is list-only). v2 runs the same handler as v1, so listing behaviour is unchanged — this is a transport-only move that unblocks media search (the `?search=` param already lives on v2).

## What changed

- `TinaMediaStore` derives a `listUrl` (`…/v2/<clientId>`) and uses it only in `list()`. `url` (v1) still drives `upload_url` and `delete`.
- Local/self-hosted (`/media` on content-api) is untouched.
- Tests lock in the contract: list + subdir → v2, delete + upload_url → v1, post-upload `list()` → v2.

## The one thing to verify before release

**CORS on `/v2` has never been exercised by a real browser.** The server derives the allowed origin from the request path, so `/v2` needed its own matchers (added backend-side). Personal stages bypass that check, so this PR is the first real browser request carrying an `Origin` to `/v2`. Confirm the media manager loads against a TinaCloud project (prod has v2 as of `2026.07.1`) before this ships in a release.

## Links

- Parent: tinacms/tinacloud#2051
- Backend v2 endpoint: tinacms/tinacloud#3862 · search param: tinacms/tinacloud#3867