### PR TITLE
✨ Add media manager search and folder/file filter

### DIFF
--- a/.changeset/local-media-server-search.md
+++ b/.changeset/local-media-server-search.md
@@ -1,5 +1,0 @@
----
-"@tinacms/cli": minor
----
-
-The local dev-server media endpoint now supports a `search` query param, so media-manager search works in `tinacms dev`. Matching filenames are found recursively within the requested folder (case-insensitive substring), mirroring the cloud behaviour. The recursive walk stays within the media root — entries whose real path escapes it (via symlink) are skipped.

--- a/.changeset/local-media-server-search.md
+++ b/.changeset/local-media-server-search.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/cli": minor
+---
+
+The local dev-server media endpoint now supports a `search` query param, so media-manager search works in `tinacms dev`. Matching filenames are found recursively within the requested folder (case-insensitive substring), mirroring the cloud behaviour. The recursive walk stays within the media root — entries whose real path escapes it (via symlink) are skipped.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -8,3 +8,5 @@ Add media-manager search and a folder/file filter, and refresh the grid.
 Search filters the library by filename (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and videos show a play overlay.
 
 Search works against both TinaCloud media and local dev media — the local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching filenames recursively within the requested folder (case-insensitive) and staying within the media root.
+
+The search box is opt-in per media store via a new `searchable` flag on the `MediaStore` interface. The default (TinaCloud/local) store sets it; a custom or self-hosted store shows the box only once it sets `searchable` and reads `options.search` in its `list()`, so stores that don't support search don't get a box that returns unfiltered results.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -1,0 +1,5 @@
+---
+"tinacms": minor
+---
+
+Add a search box and a folder/file filter to the media manager. Typing in the search box filters the library by filename (debounced, recursive across folders) via the v2 assets-api `search` param; the `All | Folders | Files` toggle narrows what's shown. Search is available for TinaCloud-backed media.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -2,4 +2,4 @@
 "tinacms": minor
 ---
 
-Add a search box and a folder/file filter to the media manager. Typing in the search box filters the library by filename (debounced, recursive across folders) via the v2 assets-api `search` param; the `All | Folders | Files` toggle narrows what's shown. Search is available for TinaCloud-backed media.
+Add a search box and a folder/file filter to the media manager. Typing in the search box filters the library by filename (debounced, recursive across folders) via the assets-api `search` param; the `All | Folders | Files` toggle narrows what's shown. Works against both TinaCloud-backed media and local dev media.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -7,7 +7,7 @@ Add media-manager search and a folder/file filter, and refresh the grid.
 
 Search filters the library by file path (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and videos show a play overlay.
 
-Search works against both TinaCloud media and local dev media. The local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching paths recursively within the requested folder (case-insensitive) and staying within the media root. Matching is on the folder-relative path, so a folder name matches the files beneath it. Results are paginated with the same `limit`/`cursor` contract as an unfiltered listing.
+Search works against both TinaCloud media and local dev media. The local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching paths recursively within the requested folder (case-insensitive) and staying within the media root. Matching is on the folder-relative path, so a folder name matches the files beneath it, and matching folders surface as their own folder results (local dev media; TinaCloud parity to follow). Results are paginated with the same `limit`/`cursor` contract as an unfiltered listing.
 
 The search box is opt-in per media store via a new `searchable` flag on the `MediaStore` interface. The default (TinaCloud/local) store sets it; a custom or self-hosted store shows the box only once it sets `searchable` and reads `options.search` in its `list()`, so stores that don't support search don't get a box that returns unfiltered results.
 

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -10,3 +10,5 @@ Search filters the library by file path (debounced, recursive across folders); t
 Search works against both TinaCloud media and local dev media. The local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching paths recursively within the requested folder (case-insensitive) and staying within the media root. Matching is on the folder-relative path, so a folder name matches the files beneath it. Results are paginated with the same `limit`/`cursor` contract as an unfiltered listing.
 
 The search box is opt-in per media store via a new `searchable` flag on the `MediaStore` interface. The default (TinaCloud/local) store sets it; a custom or self-hosted store shows the box only once it sets `searchable` and reads `options.search` in its `list()`, so stores that don't support search don't get a box that returns unfiltered results.
+
+Also fixes the breadcrumb rendering a duplicate root crumb — and Back not returning to the root — for folder names that carry a trailing slash.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -5,8 +5,8 @@
 
 Add media-manager search and a folder/file filter, and refresh the grid.
 
-Search filters the library by filename (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and videos show a play overlay.
+Search filters the library by file path (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and videos show a play overlay.
 
-Search works against both TinaCloud media and local dev media — the local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching filenames recursively within the requested folder (case-insensitive) and staying within the media root.
+Search works against both TinaCloud media and local dev media. The local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching paths recursively within the requested folder (case-insensitive) and staying within the media root. Matching is on the folder-relative path, so a folder name matches the files beneath it. Results are paginated with the same `limit`/`cursor` contract as an unfiltered listing.
 
 The search box is opt-in per media store via a new `searchable` flag on the `MediaStore` interface. The default (TinaCloud/local) store sets it; a custom or self-hosted store shows the box only once it sets `searchable` and reads `options.search` in its `list()`, so stores that don't support search don't get a box that returns unfiltered results.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -2,4 +2,4 @@
 "tinacms": minor
 ---
 
-Add a search box and a folder/file filter to the media manager. Typing in the search box filters the library by filename (debounced, recursive across folders) via the assets-api `search` param; the `All | Folders | Files` toggle narrows what's shown. Works against both TinaCloud-backed media and local dev media.
+Refresh the media manager: a search box, a folder/file filter, and a redesigned grid. Search filters the library by filename (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and video files show a play overlay. Search works against both TinaCloud-backed media and local dev media.

--- a/.changeset/media-manager-search-filter.md
+++ b/.changeset/media-manager-search-filter.md
@@ -1,5 +1,10 @@
 ---
 "tinacms": minor
+"@tinacms/cli": minor
 ---
 
-Refresh the media manager: a search box, a folder/file filter, and a redesigned grid. Search filters the library by filename (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and video files show a play overlay. Search works against both TinaCloud-backed media and local dev media.
+Add media-manager search and a folder/file filter, and refresh the grid.
+
+Search filters the library by filename (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Folders and files render in labelled sections, files show a type badge (JPEG/PNG/MP4…), and videos show a play overlay.
+
+Search works against both TinaCloud media and local dev media — the local dev-server media endpoint (`@tinacms/cli`) now honours a `search` query param, matching filenames recursively within the requested folder (case-insensitive) and staying within the media root.

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -118,6 +118,41 @@ describe('MediaModel (Vite dev server)', () => {
       expect(names).toEqual(['nested/deep/LLAMA.jpg']);
     });
 
+    it('returns matching directories as results, not only files', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'deep' });
+      expect(result.directories).toEqual(['/nested/deep']);
+    });
+
+    it('returns matching directories only on the first page', async () => {
+      const base = path.join(tmpDir, 'public', 'uploads');
+      await fs.mkdirp(path.join(base, 'match-dir'));
+      for (let i = 0; i < 15; i++) {
+        await fs.writeFile(
+          path.join(base, `match-${String(i).padStart(2, '0')}.png`),
+          'x'
+        );
+      }
+      const model = new MediaModel(config);
+
+      const page1 = await model.listMedia({
+        searchPath: '',
+        search: 'match',
+        limit: '10',
+      });
+      expect(page1.directories).toEqual(['/match-dir']);
+      expect(page1.files).toHaveLength(10);
+
+      const page2 = await model.listMedia({
+        searchPath: '',
+        search: 'match',
+        limit: '10',
+        cursor: '10',
+      });
+      expect(page2.directories).toEqual([]);
+    });
+
     it('paginates results with limit and cursor', async () => {
       const base = path.join(tmpDir, 'public', 'uploads');
       for (let i = 0; i < 25; i++) {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -60,6 +60,63 @@ describe('MediaModel (Vite dev server)', () => {
     });
   });
 
+  describe('listMedia search', () => {
+    const seed = async () => {
+      const base = path.join(tmpDir, 'public', 'uploads');
+      await fs.mkdirp(path.join(base, 'nested', 'deep'));
+      await fs.writeFile(path.join(base, 'llama.png'), 'x');
+      await fs.writeFile(path.join(base, 'cat.png'), 'x');
+      await fs.writeFile(path.join(base, 'nested', 'llama-baby.png'), 'x');
+      await fs.writeFile(path.join(base, 'nested', 'deep', 'LLAMA.jpg'), 'x');
+    };
+
+    it('matches filenames recursively and suppresses directories', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'llama' });
+      const names = result.files.map((f) => f.filename).sort();
+      expect(names).toEqual([
+        'llama.png',
+        'nested/deep/LLAMA.jpg',
+        'nested/llama-baby.png',
+      ]);
+      expect(result.directories).toEqual([]);
+    });
+
+    it('is case-insensitive', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'LLAMA' });
+      expect(result.files).toHaveLength(3);
+    });
+
+    it('scopes to the requested directory with dir-relative filenames', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({
+        searchPath: 'nested',
+        search: 'llama',
+      });
+      const names = result.files.map((f) => f.filename).sort();
+      expect(names).toEqual(['deep/LLAMA.jpg', 'llama-baby.png']);
+    });
+
+    it('prefixes src with the media root', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'cat' });
+      expect(result.files[0].src).toBe('/uploads/cat.png');
+    });
+
+    it('returns empty when nothing matches', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'zzz' });
+      expect(result.files).toEqual([]);
+      expect(result.directories).toEqual([]);
+    });
+  });
+
   describe('symlink traversal', () => {
     let outsideDir: string;
 
@@ -90,6 +147,15 @@ describe('MediaModel (Vite dev server)', () => {
       await expect(
         model.deleteMedia({ searchPath: 'escape/secret.txt' })
       ).rejects.toThrow(PathTraversalError);
+    });
+
+    it('search does not follow a symlink escaping the media root', async () => {
+      const model = new MediaModel(config);
+      const result = await model.listMedia({
+        searchPath: '',
+        search: 'secret',
+      });
+      expect(result.files).toEqual([]);
     });
   });
 

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -70,7 +70,7 @@ describe('MediaModel (Vite dev server)', () => {
       await fs.writeFile(path.join(base, 'nested', 'deep', 'LLAMA.jpg'), 'x');
     };
 
-    it('matches filenames recursively and suppresses directories', async () => {
+    it('matches file paths recursively and suppresses directories', async () => {
       await seed();
       const model = new MediaModel(config);
       const result = await model.listMedia({ searchPath: '', search: 'llama' });
@@ -81,6 +81,69 @@ describe('MediaModel (Vite dev server)', () => {
         'nested/llama-baby.png',
       ]);
       expect(result.directories).toEqual([]);
+    });
+
+    it('matches a directory name against the files beneath it', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'deep' });
+      const names = result.files.map((f) => f.filename);
+      expect(names).toEqual(['nested/deep/LLAMA.jpg']);
+    });
+
+    it('paginates results with limit and cursor', async () => {
+      const base = path.join(tmpDir, 'public', 'uploads');
+      for (let i = 0; i < 25; i++) {
+        await fs.writeFile(
+          path.join(base, `match-${String(i).padStart(2, '0')}.png`),
+          'x'
+        );
+      }
+      const model = new MediaModel(config);
+
+      const page1 = await model.listMedia({
+        searchPath: '',
+        search: 'match',
+        limit: '10',
+      });
+      expect(page1.files).toHaveLength(10);
+      expect(page1.files[0].filename).toBe('match-00.png');
+      expect(page1.cursor).toBe('10');
+
+      const page3 = await model.listMedia({
+        searchPath: '',
+        search: 'match',
+        limit: '10',
+        cursor: page1.cursor as string,
+      });
+      expect(page3.files[0].filename).toBe('match-10.png');
+
+      const last = await model.listMedia({
+        searchPath: '',
+        search: 'match',
+        limit: '10',
+        cursor: '20',
+      });
+      expect(last.files).toHaveLength(5);
+      expect(last.cursor).toBeNull();
+    });
+
+    it('returns a structured result instead of throwing on a broken symlink', async () => {
+      await seed();
+      const base = path.join(tmpDir, 'public', 'uploads');
+      await fs.symlink(path.join(tmpDir, 'gone'), path.join(base, 'dangling'));
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'llama' });
+      expect(result.files).toHaveLength(3);
+    });
+
+    it('terminates on a symlink cycle inside the media root', async () => {
+      await seed();
+      const base = path.join(tmpDir, 'public', 'uploads');
+      await fs.symlink(base, path.join(base, 'loop'), 'dir');
+      const model = new MediaModel(config);
+      const result = await model.listMedia({ searchPath: '', search: 'llama' });
+      expect(result.files).toHaveLength(3);
     });
 
     it('is case-insensitive', async () => {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -58,6 +58,33 @@ describe('MediaModel (Vite dev server)', () => {
         model.listMedia({ searchPath: '%2e%2e/%2e%2e/%2e%2e/etc' })
       ).rejects.toThrow(PathTraversalError);
     });
+
+    it('returns all directories on the first page and paginates files', async () => {
+      const base = path.join(tmpDir, 'public', 'uploads');
+      for (let i = 0; i < 5; i++) {
+        await fs.mkdirp(path.join(base, `dir-${i}`));
+      }
+      for (let i = 0; i < 10; i++) {
+        await fs.writeFile(
+          path.join(base, `file-${String(i).padStart(2, '0')}.png`),
+          'x'
+        );
+      }
+      const model = new MediaModel(config);
+
+      const page1 = await model.listMedia({ searchPath: '', limit: '4' });
+      expect(page1.directories).toHaveLength(5);
+      expect(page1.files).toHaveLength(4);
+      expect(page1.cursor).toBe('4');
+
+      const page2 = await model.listMedia({
+        searchPath: '',
+        limit: '4',
+        cursor: '4',
+      });
+      expect(page2.directories).toEqual([]);
+      expect(page2.files).toHaveLength(4);
+    });
   });
 
   describe('listMedia search', () => {
@@ -144,6 +171,28 @@ describe('MediaModel (Vite dev server)', () => {
       const model = new MediaModel(config);
       const result = await model.listMedia({ searchPath: '', search: 'llama' });
       expect(result.files).toHaveLength(3);
+    });
+
+    it('keeps matches from readable folders when a nested folder cannot be read', async () => {
+      await seed();
+      const realReaddir = fs.readdir;
+      const spy = jest
+        .spyOn(fs, 'readdir')
+        .mockImplementation((dirPath: any, ...rest: any[]) =>
+          typeof dirPath === 'string' && dirPath.endsWith('nested')
+            ? Promise.reject(new Error('EACCES: permission denied'))
+            : (realReaddir as any).call(fs, dirPath, ...rest)
+        );
+      try {
+        const result = await new MediaModel(config).listMedia({
+          searchPath: '',
+          search: 'llama',
+        });
+        expect(result.files.map((f) => f.filename)).toEqual(['llama.png']);
+        expect(result.error).toBeUndefined();
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it('is case-insensitive', async () => {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -125,6 +125,16 @@ describe('MediaModel (Vite dev server)', () => {
       expect(result.directories).toEqual(['/nested/deep']);
     });
 
+    it('a parent-folder match does not include its descendants', async () => {
+      await seed();
+      const model = new MediaModel(config);
+      const result = await model.listMedia({
+        searchPath: '',
+        search: 'nested',
+      });
+      expect(result.directories).toEqual(['/nested']);
+    });
+
     it('returns matching directories only on the first page', async () => {
       const base = path.join(tmpDir, 'public', 'uploads');
       await fs.mkdirp(path.join(base, 'match-dir'));

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -24,10 +24,12 @@ export const createMediaRouter = (config: PathConfig) => {
       );
       const limit = requestURL.searchParams.get('limit');
       const cursor = requestURL.searchParams.get('cursor');
+      const search = requestURL.searchParams.get('search');
       const media = await mediaModel.listMedia({
         searchPath: folder,
         cursor,
         limit,
+        search,
       });
       res.end(JSON.stringify(media));
     } catch (error) {
@@ -122,6 +124,7 @@ interface MediaArgs {
   searchPath: string;
   cursor?: string;
   limit?: string;
+  search?: string;
 }
 
 interface File {
@@ -321,6 +324,17 @@ export class MediaModel {
           directories: [],
         };
       }
+
+      const search = args.search?.trim().toLowerCase();
+      if (search) {
+        return this.searchMedia({
+          mediaBase,
+          validatedPath,
+          searchPath,
+          search,
+        });
+      }
+
       const filesStr = await fs.readdir(validatedPath);
       const filesProm: Promise<FileRes>[] = filesStr.map(async (file) => {
         const filePath = join(validatedPath, file);
@@ -393,6 +407,51 @@ export class MediaModel {
       };
     }
   }
+  private async searchMedia({
+    mediaBase,
+    validatedPath,
+    searchPath,
+    search,
+  }: {
+    mediaBase: string;
+    validatedPath: string;
+    searchPath: string;
+    search: string;
+  }): Promise<ListMediaRes> {
+    const resolvedBase = path.resolve(mediaBase);
+    const files: File[] = [];
+
+    const walk = async (dir: string, relPrefix: string) => {
+      const entries = await fs.readdir(dir);
+      for (const entry of entries) {
+        const absPath = join(dir, entry);
+        // @security Skip entries whose real path escapes the media root
+        // (symlink/junction), matching resolveWithinBase for the recursive walk.
+        try {
+          assertSymlinkWithinBase(absPath, resolvedBase, absPath);
+        } catch {
+          continue;
+        }
+        const relPath = relPrefix ? `${relPrefix}/${entry}` : entry;
+        const stat = await fs.stat(absPath);
+        if (stat.isDirectory()) {
+          await walk(absPath, relPath);
+          continue;
+        }
+        if (!relPath.toLowerCase().includes(search)) continue;
+
+        let src = `/${relPath}`;
+        if (searchPath) src = `/${searchPath}${src}`;
+        if (this.mediaRoot) src = `/${this.mediaRoot}${src}`;
+        files.push({ src, filename: relPath, size: stat.size });
+      }
+    };
+
+    await walk(validatedPath, '');
+
+    return { files, directories: [] };
+  }
+
   async deleteMedia(args: MediaArgs): Promise<SuccessRecord> {
     try {
       const mediaBase = join(this.rootPath, this.publicFolder, this.mediaRoot);

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -384,12 +384,15 @@ export class MediaModel {
         }
         return 0;
       });
-      const limitItems = sortedItems.slice(offset, offset + limit);
-      const files = limitItems.filter((x) => x.isFile);
-      const directories = limitItems.filter((x) => !x.isFile).map((x) => x.src);
+      const allDirectories = sortedItems
+        .filter((x) => !x.isFile)
+        .map((x) => x.src);
+      const allFiles = sortedItems.filter((x) => x.isFile);
 
+      const directories = offset === 0 ? allDirectories : [];
+      const files = allFiles.slice(offset, offset + limit);
       const cursor =
-        rawItems.length > offset + limit ? String(offset + limit) : null;
+        allFiles.length > offset + limit ? String(offset + limit) : null;
 
       return {
         files,
@@ -429,7 +432,12 @@ export class MediaModel {
     const visitedDirs = new Set<string>([resolveRealPath(validatedPath)]);
 
     const walk = async (dir: string, relPrefix: string) => {
-      const entries = await fs.readdir(dir);
+      let entries: string[];
+      try {
+        entries = await fs.readdir(dir);
+      } catch {
+        return;
+      }
       const stats = await Promise.all(
         entries.map(async (entry) => {
           const absPath = join(dir, entry);

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -327,11 +327,13 @@ export class MediaModel {
 
       const search = args.search?.trim().toLowerCase();
       if (search) {
-        return this.searchMedia({
+        return await this.searchMedia({
           mediaBase,
           validatedPath,
           searchPath,
           search,
+          cursor: args.cursor,
+          limit: args.limit,
         });
       }
 
@@ -412,29 +414,50 @@ export class MediaModel {
     validatedPath,
     searchPath,
     search,
+    cursor,
+    limit,
   }: {
     mediaBase: string;
     validatedPath: string;
     searchPath: string;
     search: string;
+    cursor?: string;
+    limit?: string;
   }): Promise<ListMediaRes> {
     const resolvedBase = path.resolve(mediaBase);
     const files: File[] = [];
+    const visitedDirs = new Set<string>([resolveRealPath(validatedPath)]);
 
     const walk = async (dir: string, relPrefix: string) => {
       const entries = await fs.readdir(dir);
-      for (const entry of entries) {
-        const absPath = join(dir, entry);
-        // @security Skip entries whose real path escapes the media root
-        // (symlink/junction), matching resolveWithinBase for the recursive walk.
-        try {
-          assertSymlinkWithinBase(absPath, resolvedBase, absPath);
-        } catch {
-          continue;
-        }
+      const stats = await Promise.all(
+        entries.map(async (entry) => {
+          const absPath = join(dir, entry);
+          // @security Skip entries whose real path escapes the media root
+          // (symlink/junction), matching resolveWithinBase for the recursive walk.
+          try {
+            assertSymlinkWithinBase(absPath, resolvedBase, absPath);
+          } catch {
+            return null;
+          }
+          try {
+            return { entry, absPath, stat: await fs.stat(absPath) };
+          } catch {
+            return null;
+          }
+        })
+      );
+
+      for (const entryStat of stats) {
+        if (!entryStat) continue;
+        const { entry, absPath, stat } = entryStat;
         const relPath = relPrefix ? `${relPrefix}/${entry}` : entry;
-        const stat = await fs.stat(absPath);
         if (stat.isDirectory()) {
+          // @security Symlinked directories inside the media root pass the
+          // containment check, so track real paths to break traversal cycles.
+          const realDir = resolveRealPath(absPath);
+          if (visitedDirs.has(realDir)) continue;
+          visitedDirs.add(realDir);
           await walk(absPath, relPath);
           continue;
         }
@@ -448,8 +471,17 @@ export class MediaModel {
     };
 
     await walk(validatedPath, '');
+    files.sort((a, b) => a.filename.localeCompare(b.filename));
 
-    return { files, directories: [] };
+    const offset = Number(cursor) || 0;
+    const pageSize = Number(limit) || 20;
+
+    return {
+      files: files.slice(offset, offset + pageSize),
+      directories: [],
+      cursor:
+        files.length > offset + pageSize ? String(offset + pageSize) : null,
+    };
   }
 
   async deleteMedia(args: MediaArgs): Promise<SuccessRecord> {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -467,7 +467,7 @@ export class MediaModel {
           const realDir = resolveRealPath(absPath);
           if (visitedDirs.has(realDir)) continue;
           visitedDirs.add(realDir);
-          if (relPath.toLowerCase().includes(search)) {
+          if (entry.toLowerCase().includes(search)) {
             directories.push(`/${relPath}`);
           }
           await walk(absPath, relPath);

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -429,6 +429,7 @@ export class MediaModel {
   }): Promise<ListMediaRes> {
     const resolvedBase = path.resolve(mediaBase);
     const files: File[] = [];
+    const directories: string[] = [];
     const visitedDirs = new Set<string>([resolveRealPath(validatedPath)]);
 
     const walk = async (dir: string, relPrefix: string) => {
@@ -466,6 +467,9 @@ export class MediaModel {
           const realDir = resolveRealPath(absPath);
           if (visitedDirs.has(realDir)) continue;
           visitedDirs.add(realDir);
+          if (relPath.toLowerCase().includes(search)) {
+            directories.push(`/${relPath}`);
+          }
           await walk(absPath, relPath);
           continue;
         }
@@ -480,13 +484,14 @@ export class MediaModel {
 
     await walk(validatedPath, '');
     files.sort((a, b) => a.filename.localeCompare(b.filename));
+    directories.sort();
 
     const offset = Number(cursor) || 0;
     const pageSize = Number(limit) || 20;
 
     return {
       files: files.slice(offset, offset + pageSize),
-      directories: [],
+      directories: offset === 0 ? directories : [],
       cursor:
         files.length > offset + pageSize ? String(offset + pageSize) : null,
     };

--- a/packages/tinacms/src/toolkit/components/media/breadcrumb.test.tsx
+++ b/packages/tinacms/src/toolkit/components/media/breadcrumb.test.tsx
@@ -1,0 +1,43 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { Breadcrumb } from './breadcrumb';
+
+describe('Breadcrumb', () => {
+  // Cloud (v2) folder names arrive with a trailing slash (e.g. "uploads/").
+  it('renders a single Media root for a trailing-slash directory', () => {
+    const { getAllByText } = render(
+      <Breadcrumb directory='uploads/' setDirectory={() => {}} />
+    );
+    expect(getAllByText('Media')).toHaveLength(1);
+    expect(getAllByText('uploads')).toHaveLength(1);
+  });
+
+  it('renders a single Media root for a leading-slash directory', () => {
+    const { getAllByText } = render(
+      <Breadcrumb directory='/uploads' setDirectory={() => {}} />
+    );
+    expect(getAllByText('Media')).toHaveLength(1);
+    expect(getAllByText('uploads')).toHaveLength(1);
+  });
+
+  it('back navigates to the root from a top-level folder', () => {
+    const setDirectory = vi.fn();
+    const { container } = render(
+      <Breadcrumb directory='uploads/' setDirectory={setDirectory} />
+    );
+    const backButton = container.querySelector('button');
+    (backButton as HTMLButtonElement).click();
+    expect(setDirectory).toHaveBeenCalledWith('');
+  });
+
+  it('back navigates one level up from a nested folder', () => {
+    const setDirectory = vi.fn();
+    const { container, getAllByText } = render(
+      <Breadcrumb directory='uploads/nested/' setDirectory={setDirectory} />
+    );
+    expect(getAllByText('Media')).toHaveLength(1);
+    const backButton = container.querySelector('button');
+    (backButton as HTMLButtonElement).click();
+    expect(setDirectory).toHaveBeenCalledWith('/uploads');
+  });
+});

--- a/packages/tinacms/src/toolkit/components/media/breadcrumb.tsx
+++ b/packages/tinacms/src/toolkit/components/media/breadcrumb.tsx
@@ -29,10 +29,8 @@ const BreadcrumbItem = ({ className = '', ...props }) => (
 );
 
 export function Breadcrumb({ directory = '', setDirectory }: BreadcrumbProps) {
-  // Normalize: ensure non-root directories always have a leading slash so that
-  // split('/') produces '' as the first element, which renders as 'Media'.
-  const normalizedDir =
-    directory && !directory.startsWith('/') ? '/' + directory : directory;
+  const trimmed = directory.replace(/^\/+|\/+$/g, '');
+  const normalizedDir = trimmed ? '/' + trimmed : '';
   const directoryParts = normalizedDir.split('/');
 
   let prevDir: string = dirname(normalizedDir) || '';

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -76,8 +76,10 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
 }
 
 const typeBadge = (filename: string): string | null => {
-  const ext = filename.split('.').pop()?.toLowerCase();
-  if (!ext || ext === filename.toLowerCase()) return null;
+  const name = filename.split('/').pop() ?? filename;
+  if (name.startsWith('.')) return null;
+  const ext = name.split('.').pop()?.toLowerCase();
+  if (!ext || ext === name.toLowerCase() || ext.length > 5) return null;
   return ext === 'jpg' ? 'JPEG' : ext.toUpperCase();
 };
 

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -67,6 +67,7 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
         )}
       </div>
       <span
+        title={item.filename}
         className={'text-base flex-grow w-full break-words truncate px-3 py-2'}
       >
         {item.filename}
@@ -96,7 +97,10 @@ export function GridFolderItem({
         <div className='flex items-center justify-center h-24'>
           <BiFolder className='w-11 h-11 fill-tina-orange' />
         </div>
-        <div className='w-full px-3 py-2 border-t border-gray-100 bg-white/60 text-sm font-medium text-gray-700 truncate'>
+        <div
+          title={item.filename}
+          className='w-full px-3 py-2 border-t border-gray-100 bg-white/60 text-sm font-medium text-gray-700 truncate'
+        >
           {item.filename}
         </div>
       </button>
@@ -164,7 +168,10 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
             </span>
           )}
         </div>
-        <div className='w-full px-2.5 py-2 text-sm text-gray-700 truncate'>
+        <div
+          title={item.filename}
+          className='w-full px-2.5 py-2 text-sm text-gray-700 truncate'
+        >
           {item.filename}
         </div>
       </button>

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -126,7 +126,10 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
             NEW
           </span>
         )}
-        <div className='relative w-full aspect-square overflow-hidden bg-gray-50'>
+        <div
+          className='relative w-full overflow-hidden bg-gray-50'
+          style={{ aspectRatio: '1 / 1' }}
+        >
           {itemIsImage ? (
             <img
               className='block w-full h-full object-center object-cover'

--- a/packages/tinacms/src/toolkit/components/media/media-item.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-item.tsx
@@ -75,41 +75,58 @@ export function ListMediaItem({ item, onClick, active }: MediaItemProps) {
   );
 }
 
+const typeBadge = (filename: string): string | null => {
+  const ext = filename.split('.').pop()?.toLowerCase();
+  if (!ext || ext === filename.toLowerCase()) return null;
+  return ext === 'jpg' ? 'JPEG' : ext.toUpperCase();
+};
+
+export function GridFolderItem({
+  item,
+  onClick,
+}: Omit<MediaItemProps, 'active'>) {
+  return (
+    <li className='block shrink-0 w-full'>
+      <button
+        onClick={() => onClick(item)}
+        className='group flex flex-col w-full text-left rounded-xl overflow-hidden border border-gray-150 bg-gradient-to-b from-orange-50/60 to-white shadow-sm hover:shadow-md hover:border-tina-orange/40 transition outline-none focus-visible:ring-2 focus-visible:ring-tina-orange/40'
+      >
+        <div className='flex items-center justify-center h-24'>
+          <BiFolder className='w-11 h-11 fill-tina-orange' />
+        </div>
+        <div className='w-full px-3 py-2 border-t border-gray-100 bg-white/60 text-sm font-medium text-gray-700 truncate'>
+          {item.filename}
+        </div>
+      </button>
+    </li>
+  );
+}
+
 export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
-  let FileIcon = BiFile;
-  if (item.type === 'dir') {
-    FileIcon = BiFolder;
-  } else if (isVideo(item.src)) {
-    FileIcon = BiMovie;
-  }
   const thumbnail = (item.thumbnails || {})['400x400'];
   const itemIsImage = isImage(thumbnail);
+  const itemIsVideo = isVideo(item.src);
+  const badge = typeBadge(item.filename);
   return (
-    <li className='block flex justify-center shrink-0 w-full transition duration-150 ease-out'>
+    <li className='block shrink-0 w-full'>
       <button
         className={cn(
-          'relative flex flex-col gap-1 items-center w-full outline-none rounded-lg overflow-hidden border-2 transition',
+          'group relative flex flex-col w-full text-left outline-none rounded-xl overflow-hidden border bg-white shadow-sm transition',
           {
-            'border-black/10 hover:border-tina-orange/50 shadow-sm hover:shadow-md bg-white':
+            'border-gray-150 hover:border-tina-orange/40 hover:shadow-md':
               !active,
-            'border-tina-orange bg-tina-orange/10 shadow-md': active,
-            'cursor-pointer': item.type === 'dir',
+            'border-2 border-tina-orange ring-2 ring-tina-orange/20 shadow-md':
+              active,
           }
         )}
-        onClick={() => {
-          if (!active) {
-            onClick(item);
-          } else {
-            onClick(false);
-          }
-        }}
+        onClick={() => onClick(active ? false : item)}
       >
         {item.new && (
-          <span className='absolute top-1 right-1 rounded shadow bg-green-100 border border-green-200 text-[10px] tracking-wide font-bold text-green-600 px-1.5 py-0.5 z-10'>
+          <span className='absolute top-2 right-2 z-10 rounded bg-green-100 border border-green-200 text-[10px] tracking-wide font-bold text-green-600 px-1.5 py-0.5'>
             NEW
           </span>
         )}
-        <div className='w-full overflow-hidden aspect-[1/1]'>
+        <div className='relative w-full aspect-square overflow-hidden bg-gray-50'>
           {itemIsImage ? (
             <img
               className='block w-full h-full object-center object-cover'
@@ -117,16 +134,32 @@ export function GridMediaItem({ item, active, onClick }: MediaItemProps) {
               src={thumbnail}
               alt={item.filename}
             />
+          ) : itemIsVideo ? (
+            <div className='w-full h-full bg-gradient-to-br from-gray-700 to-gray-900' />
           ) : (
-            <div className='w-full h-full flex flex-col items-center justify-center'>
-              <FileIcon
-                className={`w-[40%] h-auto ${item.type === 'dir' ? 'fill-tina-orange' : 'fill-gray-300'}`}
-                size={40}
-              />
+            <div className='w-full h-full flex items-center justify-center'>
+              <BiFile className='w-2/5 h-auto fill-gray-300' />
             </div>
           )}
+          {itemIsVideo && (
+            <span className='absolute inset-0 flex items-center justify-center'>
+              <span className='w-10 h-10 rounded-full bg-white/90 shadow flex items-center justify-center'>
+                <svg
+                  className='w-4 h-4 ml-0.5 fill-gray-700'
+                  viewBox='0 0 24 24'
+                >
+                  <path d='M8 5v14l11-7z' />
+                </svg>
+              </span>
+            </span>
+          )}
+          {badge && (
+            <span className='absolute bottom-2 left-2 rounded bg-black/65 text-white text-[10px] font-semibold tracking-wide px-1.5 py-0.5'>
+              {badge}
+            </span>
+          )}
         </div>
-        <div className='mt-auto w-full px-2 py-1 text-sm truncate'>
+        <div className='w-full px-2.5 py-2 text-sm text-gray-700 truncate'>
           {item.filename}
         </div>
       </button>

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -402,7 +402,7 @@ export function MediaPicker({
   }, [list.nextOffset, loaderRef.current]);
 
   const isSearching = !!debouncedSearch;
-  const canSearch = !cms.media.store.isStatic && !cms.api?.tina?.isLocalMode;
+  const canSearch = !cms.media.store.isStatic;
   const visibleItems = list.items.filter((item) => {
     if (mediaFilter === 'folders') return item.type === 'dir';
     if (mediaFilter === 'files') return item.type === 'file';

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -33,7 +33,12 @@ import {
 import { captureEvent } from '../../../lib/posthog/posthogProvider';
 import { Breadcrumb } from './breadcrumb';
 import { CopyField } from './copy-field';
-import { GridMediaItem, ListMediaItem, checkerboardStyle } from './media-item';
+import {
+  GridFolderItem,
+  GridMediaItem,
+  ListMediaItem,
+  checkerboardStyle,
+} from './media-item';
 import { DeleteModal, NewFolderModal } from './modal';
 import {
   DEFAULT_MEDIA_UPLOAD_TYPES,
@@ -408,6 +413,8 @@ export function MediaPicker({
     if (mediaFilter === 'files') return item.type === 'file';
     return true;
   });
+  const folders = visibleItems.filter((item) => item.type === 'dir');
+  const files = visibleItems.filter((item) => item.type === 'file');
 
   if ((listState === 'loading' && !list?.items?.length) || uploading) {
     return <LoadingMediaList />;
@@ -526,17 +533,11 @@ export function MediaPicker({
 
           <div className='flex h-full overflow-hidden bg-white'>
             <div className='flex w-full flex-col h-full @container'>
-              <ul
+              <div
                 {...rootProps}
-                className={`h-full grow overflow-y-auto transition duration-150 ease-out bg-gradient-to-b from-gray-50/50 to-gray-50 ${
-                  visibleItems.length === 0 ||
-                  (viewMode === 'list' &&
-                    'w-full flex flex-1 flex-col justify-start -mb-px')
-                } ${
-                  visibleItems.length > 0 &&
-                  viewMode === 'grid' &&
-                  'w-full p-4 gap-4 grid grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3 @2xl:grid-cols-4 @4xl:grid-cols-6 @6xl:grid-cols-9 auto-rows-auto content-start justify-start'
-                } ${isDragActive ? `border-2 border-blue-500 rounded-lg` : ``}`}
+                className={`h-full grow overflow-y-auto p-4 transition duration-150 ease-out bg-gradient-to-b from-gray-50/50 to-gray-50 ${
+                  isDragActive ? `border-2 border-tina-orange rounded-lg` : ``
+                }`}
               >
                 <input {...getInputProps()} />
 
@@ -552,30 +553,59 @@ export function MediaPicker({
                   />
                 )}
 
-                {viewMode === 'list' &&
-                  visibleItems.map((item: Media) => (
-                    <ListMediaItem
-                      key={item.id}
-                      item={item}
-                      onClick={onClickMediaItem}
-                      active={activeItem && activeItem.id === item.id}
-                    />
-                  ))}
-
-                {viewMode === 'grid' &&
-                  visibleItems.map((item: Media) => (
-                    <GridMediaItem
-                      key={item.id}
-                      item={item}
-                      onClick={onClickMediaItem}
-                      active={activeItem && activeItem.id === item.id}
-                    />
-                  ))}
+                {viewMode === 'list' ? (
+                  <ul className='w-full flex flex-col -mb-px'>
+                    {visibleItems.map((item: Media) => (
+                      <ListMediaItem
+                        key={item.id}
+                        item={item}
+                        onClick={onClickMediaItem}
+                        active={activeItem && activeItem.id === item.id}
+                      />
+                    ))}
+                  </ul>
+                ) : (
+                  <>
+                    {folders.length > 0 && (
+                      <section className='mb-6'>
+                        <h3 className='text-xs font-semibold tracking-wider text-gray-400 mb-3'>
+                          FOLDERS
+                        </h3>
+                        <ul className='grid grid-cols-2 gap-4 @md:grid-cols-3 @2xl:grid-cols-4 @4xl:grid-cols-5'>
+                          {folders.map((item: Media) => (
+                            <GridFolderItem
+                              key={item.id}
+                              item={item}
+                              onClick={onClickMediaItem}
+                            />
+                          ))}
+                        </ul>
+                      </section>
+                    )}
+                    {files.length > 0 && (
+                      <section>
+                        <h3 className='text-xs font-semibold tracking-wider text-gray-400 mb-3'>
+                          FILES
+                        </h3>
+                        <ul className='grid grid-cols-2 gap-4 @sm:grid-cols-3 @lg:grid-cols-4 @2xl:grid-cols-6 @4xl:grid-cols-8'>
+                          {files.map((item: Media) => (
+                            <GridMediaItem
+                              key={item.id}
+                              item={item}
+                              onClick={onClickMediaItem}
+                              active={activeItem && activeItem.id === item.id}
+                            />
+                          ))}
+                        </ul>
+                      </section>
+                    )}
+                  </>
+                )}
 
                 {!!list.nextOffset && mediaFilter !== 'folders' && (
                   <LoadingMediaList ref={loaderRef} />
                 )}
-              </ul>
+              </div>
             </div>
 
             <ActiveItemPreview
@@ -830,7 +860,7 @@ const SearchInput = ({
         value={value}
         onChange={(e) => setValue(e.target.value)}
         placeholder='Search this library...'
-        className='w-full rounded border border-gray-150 bg-white py-2 pl-10 pr-9 text-base text-gray-700 shadow-inner placeholder:text-gray-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400'
+        className='w-full rounded-lg border border-gray-200 bg-white py-2 pl-10 pr-9 text-base text-gray-700 shadow-sm placeholder:text-gray-400 focus:border-tina-orange focus:outline-none focus:ring-1 focus:ring-tina-orange'
       />
       {value && (
         <button
@@ -854,31 +884,29 @@ const MediaFilterToggle = ({
   setValue: (value: 'all' | 'folders' | 'files') => void;
 }) => {
   const base =
-    'relative whitespace-nowrap flex items-center justify-center gap-1.5 font-medium text-base px-3 py-1 transition-all ease-out duration-150 border';
-  const active =
-    'bg-white text-blue-500 shadow-inner border-gray-50 border-t-gray-100';
-  const inactive =
-    'bg-gray-50 text-gray-400 shadow border-gray-100 border-t-white';
+    'relative whitespace-nowrap flex items-center justify-center gap-1.5 text-sm px-3 py-1.5 transition-colors ease-out duration-150';
+  const active = 'bg-white text-tina-orange font-medium';
+  const inactive = 'bg-gray-50 text-gray-500 hover:text-gray-700';
   const options: { key: 'all' | 'folders' | 'files'; label: string }[] = [
     { key: 'all', label: 'All' },
     { key: 'folders', label: 'Folders' },
     { key: 'files', label: 'Files' },
   ];
   return (
-    <div className='grow-0 flex justify-between rounded border border-gray-100'>
+    <div className='grow-0 flex rounded-lg border border-gray-200 overflow-hidden'>
       {options.map((option, index) => (
         <button
           key={option.key}
           type='button'
           onClick={() => setValue(option.key)}
-          className={`${base} ${index === 0 ? 'rounded-l' : ''} ${
-            index === options.length - 1 ? 'rounded-r' : ''
-          } ${value === option.key ? active : inactive}`}
+          className={`${base} ${index > 0 ? 'border-l border-gray-200' : ''} ${
+            value === option.key ? active : inactive
+          }`}
         >
           {option.key === 'folders' && (
-            <BiFolder className='w-5 h-5 opacity-70' />
+            <BiFolder className='w-4 h-4 opacity-80' />
           )}
-          {option.key === 'files' && <BiFile className='w-5 h-5 opacity-70' />}
+          {option.key === 'files' && <BiFile className='w-4 h-4 opacity-80' />}
           {option.label}
         </button>
       ))}
@@ -887,36 +915,30 @@ const MediaFilterToggle = ({
 };
 
 const ViewModeToggle = ({ viewMode, setViewMode }) => {
-  const toggleClasses = {
-    base: 'relative whitespace-nowrap flex items-center justify-center flex-1 block font-medium text-base py-1 transition-all ease-out duration-150 border',
-    active:
-      'bg-white text-blue-500 shadow-inner border-gray-50 border-t-gray-100',
-    inactive: 'bg-gray-50 text-gray-400 shadow border-gray-100 border-t-white',
-  };
+  const base =
+    'relative whitespace-nowrap flex items-center justify-center px-2.5 py-1.5 transition-colors ease-out duration-150';
+  const active = 'bg-white text-tina-orange';
+  const inactive = 'bg-gray-50 text-gray-400 hover:text-gray-600';
 
   return (
-    <div
-      className={`grow-0 flex justify-between rounded border border-gray-100`}
-    >
+    <div className='grow-0 flex rounded-lg border border-gray-200 overflow-hidden'>
       <button
-        className={`${toggleClasses.base} px-2.5 rounded-l ${
-          viewMode === 'grid' ? toggleClasses.active : toggleClasses.inactive
-        }`}
+        className={`${base} ${viewMode === 'grid' ? active : inactive}`}
         onClick={() => {
           setViewMode('grid');
         }}
       >
-        <BiGridAlt className='w-6 h-full opacity-70' />
+        <BiGridAlt className='w-5 h-5' />
       </button>
       <button
-        className={`${toggleClasses.base} px-2 rounded-r ${
-          viewMode === 'list' ? toggleClasses.active : toggleClasses.inactive
+        className={`${base} border-l border-gray-200 ${
+          viewMode === 'list' ? active : inactive
         }`}
         onClick={() => {
           setViewMode('list');
         }}
       >
-        <BiListUl className='w-8 h-full opacity-70' />
+        <BiListUl className='w-6 h-5' />
       </button>
     </div>
   );

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -216,6 +216,7 @@ export function MediaPicker({
       setDebouncedSearch(next);
       resetOffset();
       setLoadFolders(true);
+      setActiveItem(false);
     }, 300);
     return () => clearTimeout(timer);
   }, [search, debouncedSearch]);

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -148,11 +148,13 @@ export function MediaPicker({
     items: [],
     nextOffset: undefined,
   });
-  const resetList = () =>
+  const resetList = () => {
+    newMediaSrcsRef.current = new Set();
     setList({
       items: [],
       nextOffset: undefined,
     });
+  };
 
   const [viewMode, setViewMode] = useState<'grid' | 'list'>('grid');
   const [activeItem, setActiveItem] = useState<Media | false>(false);
@@ -174,6 +176,7 @@ export function MediaPicker({
   const resetOffset = () => setOffsetHistory([]);
 
   const listRequestRef = useRef(0);
+  const newMediaSrcsRef = useRef<Set<string>>(new Set());
 
   async function loadMedia(loadFolders = true) {
     const requestId = ++listRequestRef.current;
@@ -192,10 +195,19 @@ export function MediaPicker({
         search: debouncedSearch || undefined,
       });
       if (requestId !== listRequestRef.current) return;
-      setList((prev) => ({
-        items: offset ? [...prev.items, ..._list.items] : _list.items,
-        nextOffset: _list.nextOffset,
-      }));
+      setList((prev) => {
+        const items = offset ? [...prev.items, ..._list.items] : _list.items;
+        const newSrcs = newMediaSrcsRef.current;
+        return {
+          items:
+            newSrcs.size === 0
+              ? items
+              : items.map((item) =>
+                  newSrcs.has(item.src) ? { ...item, new: true } : item
+                ),
+          nextOffset: _list.nextOffset,
+        };
+      });
       setListState('loaded');
     } catch (e) {
       if (requestId !== listRequestRef.current) return;
@@ -359,6 +371,7 @@ export function MediaPicker({
             fileCount: mediaItems.length,
           });
           setActiveItem(mediaItems[0]);
+          newMediaSrcsRef.current = new Set(mediaItems.map((x) => x.src));
           if (mediaFilter === 'folders') {
             setMediaFilter('all');
           }

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -175,6 +175,16 @@ export function MediaPicker({
   const offset = offsetHistory[offsetHistory.length - 1];
   const resetOffset = () => setOffsetHistory([]);
 
+  const navigateToDirectory = (dir: string) => {
+    setDirectory(dir);
+    setSearch('');
+    setDebouncedSearch('');
+    setLoadFolders(true);
+    resetOffset();
+    resetList();
+    setActiveItem(false);
+  };
+
   const listRequestRef = useRef(0);
   const newMediaSrcsRef = useRef<Set<string>>(new Set());
 
@@ -261,17 +271,11 @@ export function MediaPicker({
       setActiveItem(false);
     } else if (item.type === 'dir') {
       // Only join when there is a directory to join to
-      setDirectory(
+      navigateToDirectory(
         item.directory === '.' || item.directory === ''
           ? item.filename
           : join(item.directory, item.filename)
       );
-      setSearch('');
-      setDebouncedSearch('');
-      setLoadFolders(true);
-      resetOffset();
-      resetList();
-      setActiveItem(false);
     } else {
       setActiveItem(item);
     }
@@ -498,18 +502,7 @@ export function MediaPicker({
       {newFolderModalOpen && (
         <NewFolderModal
           onSubmit={(name) => {
-            setDirectory((oldDir) => {
-              if (oldDir) {
-                return join(oldDir, name);
-              } else {
-                return name;
-              }
-            });
-            setSearch('');
-            setDebouncedSearch('');
-            resetOffset();
-            resetList();
-            setActiveItem(false);
+            navigateToDirectory(directory ? join(directory, name) : name);
           }}
           close={() => setNewFolderModalOpen(false)}
         />
@@ -523,11 +516,7 @@ export function MediaPicker({
               <Breadcrumb
                 directory={directory}
                 setDirectory={(dir: string) => {
-                  setDirectory(dir);
-                  setLoadFolders(true);
-                  resetOffset();
-                  resetList();
-                  setActiveItem(false);
+                  navigateToDirectory(dir);
                 }}
               />
             </div>

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -407,7 +407,7 @@ export function MediaPicker({
   }, [list.nextOffset, loaderRef.current]);
 
   const isSearching = !!debouncedSearch;
-  const canSearch = !cms.media.store.isStatic;
+  const canSearch = !cms.media.store.isStatic && !!cms.media.store.searchable;
   const visibleItems = list.items.filter((item) => {
     if (mediaFilter === 'folders') return item.type === 'dir';
     if (mediaFilter === 'files') return item.type === 'file';

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -173,7 +173,10 @@ export function MediaPicker({
   const offset = offsetHistory[offsetHistory.length - 1];
   const resetOffset = () => setOffsetHistory([]);
 
+  const listRequestRef = useRef(0);
+
   async function loadMedia(loadFolders = true) {
+    const requestId = ++listRequestRef.current;
     setListState('loading');
     try {
       const _list = await cms.media.list({
@@ -188,12 +191,14 @@ export function MediaPicker({
         filesOnly: !loadFolders,
         search: debouncedSearch || undefined,
       });
+      if (requestId !== listRequestRef.current) return;
       setList((prev) => ({
         items: offset ? [...prev.items, ..._list.items] : _list.items,
         nextOffset: _list.nextOffset,
       }));
       setListState('loaded');
     } catch (e) {
+      if (requestId !== listRequestRef.current) return;
       console.error(e);
       if (e.ERR_TYPE === 'MediaListError') {
         setListError(e);
@@ -415,8 +420,23 @@ export function MediaPicker({
   });
   const folders = visibleItems.filter((item) => item.type === 'dir');
   const files = visibleItems.filter((item) => item.type === 'file');
+  const showLoader = !!list.nextOffset && mediaFilter !== 'folders';
 
-  if ((listState === 'loading' && !list?.items?.length) || uploading) {
+  const emptyMessage = () => {
+    if (isSearching) {
+      return mediaFilter === 'folders'
+        ? "Folders aren't part of search results"
+        : `No media matches “${debouncedSearch}”`;
+    }
+    if (mediaFilter === 'folders') return 'No folders here';
+    if (mediaFilter === 'files') return 'No files here';
+    return undefined;
+  };
+
+  if (
+    (listState === 'loading' && !list?.items?.length && !isSearching) ||
+    uploading
+  ) {
     return <LoadingMediaList />;
   }
 
@@ -541,17 +561,9 @@ export function MediaPicker({
               >
                 <input {...getInputProps()} />
 
-                {listState === 'loaded' && visibleItems.length === 0 && (
-                  <EmptyMediaList
-                    message={
-                      mediaFilter === 'folders' && isSearching
-                        ? "Folders aren't part of search results"
-                        : isSearching
-                          ? `No media matches “${debouncedSearch}”`
-                          : undefined
-                    }
-                  />
-                )}
+                {listState === 'loaded' &&
+                  visibleItems.length === 0 &&
+                  !showLoader && <EmptyMediaList message={emptyMessage()} />}
 
                 {viewMode === 'list' ? (
                   <ul className='w-full flex flex-col -mb-px'>
@@ -602,9 +614,7 @@ export function MediaPicker({
                   </>
                 )}
 
-                {!!list.nextOffset && mediaFilter !== 'folders' && (
-                  <LoadingMediaList ref={loaderRef} />
-                )}
+                {showLoader && <LoadingMediaList ref={loaderRef} />}
               </div>
             </div>
 
@@ -859,6 +869,7 @@ const SearchInput = ({
         type='text'
         value={value}
         onChange={(e) => setValue(e.target.value)}
+        aria-label='Search media library'
         placeholder='Search this library...'
         className='w-full rounded-lg border border-gray-200 bg-white py-2 pl-10 pr-9 text-base text-gray-700 shadow-sm placeholder:text-gray-400 focus:border-tina-orange focus:outline-none focus:ring-1 focus:ring-tina-orange'
       />
@@ -899,6 +910,7 @@ const MediaFilterToggle = ({
           key={option.key}
           type='button'
           onClick={() => setValue(option.key)}
+          aria-pressed={value === option.key}
           className={`${base} ${index > 0 ? 'border-l border-gray-200' : ''} ${
             value === option.key ? active : inactive
           }`}
@@ -923,6 +935,8 @@ const ViewModeToggle = ({ viewMode, setViewMode }) => {
   return (
     <div className='grow-0 flex rounded-lg border border-gray-200 overflow-hidden'>
       <button
+        aria-label='Grid view'
+        aria-pressed={viewMode === 'grid'}
         className={`${base} ${viewMode === 'grid' ? active : inactive}`}
         onClick={() => {
           setViewMode('grid');
@@ -931,6 +945,8 @@ const ViewModeToggle = ({ viewMode, setViewMode }) => {
         <BiGridAlt className='w-5 h-5' />
       </button>
       <button
+        aria-label='List view'
+        aria-pressed={viewMode === 'list'}
         className={`${base} border-l border-gray-200 ${
           viewMode === 'list' ? active : inactive
         }`}

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -509,6 +509,7 @@ export function MediaPicker({
             setDebouncedSearch('');
             resetOffset();
             resetList();
+            setActiveItem(false);
           }}
           close={() => setNewFolderModalOpen(false)}
         />

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -358,16 +358,23 @@ export function MediaPicker({
             fileCount: mediaItems.length,
           });
           setActiveItem(mediaItems[0]);
-          setList((mediaList) => {
-            return {
-              items: [
-                // all the newly added items are new
-                ...mediaItems.map((x) => ({ ...x, new: true })),
-                ...mediaList.items,
-              ],
-              nextOffset: mediaList.nextOffset,
-            };
-          });
+          if (debouncedSearch) {
+            setSearch('');
+            setDebouncedSearch('');
+            resetOffset();
+            setLoadFolders(true);
+          } else {
+            setList((mediaList) => {
+              return {
+                items: [
+                  // all the newly added items are new
+                  ...mediaItems.map((x) => ({ ...x, new: true })),
+                  ...mediaList.items,
+                ],
+                nextOffset: mediaList.nextOffset,
+              };
+            });
+          }
         }
       } catch {
         // TODO: Events get dispatched already. Does anything else need to happen?

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -359,6 +359,9 @@ export function MediaPicker({
             fileCount: mediaItems.length,
           });
           setActiveItem(mediaItems[0]);
+          if (mediaFilter === 'folders') {
+            setMediaFilter('all');
+          }
           if (debouncedSearch) {
             setSearch('');
             setDebouncedSearch('');

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -505,6 +505,8 @@ export function MediaPicker({
                 return name;
               }
             });
+            setSearch('');
+            setDebouncedSearch('');
             resetOffset();
             resetList();
           }}

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -928,7 +928,7 @@ const MediaFilterToggle = ({
 
 const ViewModeToggle = ({ viewMode, setViewMode }) => {
   const base =
-    'relative whitespace-nowrap flex items-center justify-center px-2.5 py-1.5 transition-colors ease-out duration-150';
+    'relative flex items-center justify-center w-9 py-1.5 transition-colors ease-out duration-150';
   const active = 'bg-white text-tina-orange';
   const inactive = 'bg-gray-50 text-gray-400 hover:text-gray-600';
 
@@ -954,7 +954,7 @@ const ViewModeToggle = ({ viewMode, setViewMode }) => {
           setViewMode('list');
         }}
       >
-        <BiListUl className='w-6 h-5' />
+        <BiListUl className='w-5 h-5' />
       </button>
     </div>
   );

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -425,7 +425,7 @@ export function MediaPicker({
   const emptyMessage = () => {
     if (isSearching) {
       return mediaFilter === 'folders'
-        ? "Folders aren't part of search results"
+        ? 'No folders match'
         : `No media matches “${debouncedSearch}”`;
     }
     if (mediaFilter === 'folders') return 'No folders here';

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -253,6 +253,8 @@ export function MediaPicker({
           ? item.filename
           : join(item.directory, item.filename)
       );
+      setSearch('');
+      setDebouncedSearch('');
       setLoadFolders(true);
       resetOffset();
       resetList();

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -21,6 +21,7 @@ import {
   BiGridAlt,
   BiLinkExternal,
   BiListUl,
+  BiSearch,
   BiX,
 } from 'react-icons/bi';
 import { BiFile } from 'react-icons/bi';
@@ -153,6 +154,11 @@ export function MediaPicker({
   const closePreview = () => setActiveItem(false);
   const [refreshing, setRefreshing] = useState(false);
   const [loadFolders, setLoadFolders] = useState(true);
+  const [search, setSearch] = useState('');
+  const [debouncedSearch, setDebouncedSearch] = useState('');
+  const [mediaFilter, setMediaFilter] = useState<'all' | 'folders' | 'files'>(
+    'all'
+  );
 
   /**
    * current offset is last element in offsetHistory[]
@@ -175,11 +181,12 @@ export function MediaPicker({
           { w: 1000, h: 1000 },
         ],
         filesOnly: !loadFolders,
+        search: debouncedSearch || undefined,
       });
-      setList({
-        items: [...list.items, ..._list.items],
+      setList((prev) => ({
+        items: offset ? [...prev.items, ..._list.items] : _list.items,
         nextOffset: _list.nextOffset,
-      });
+      }));
       setListState('loaded');
     } catch (e) {
       console.error(e);
@@ -191,6 +198,17 @@ export function MediaPicker({
       setListState('error');
     }
   }
+
+  useEffect(() => {
+    const next = search.trim();
+    const timer = setTimeout(() => {
+      if (next === debouncedSearch) return;
+      setDebouncedSearch(next);
+      resetOffset();
+      setLoadFolders(true);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search, debouncedSearch]);
 
   useEffect(() => {
     if (!refreshing) return;
@@ -213,7 +231,7 @@ export function MediaPicker({
         resetList();
       }
     );
-  }, [offset, directory, cms.media.isConfigured]);
+  }, [offset, directory, debouncedSearch, cms.media.isConfigured]);
 
   const onClickMediaItem = (item: Media) => {
     if (!item) {
@@ -383,6 +401,14 @@ export function MediaPicker({
     };
   }, [list.nextOffset, loaderRef.current]);
 
+  const isSearching = !!debouncedSearch;
+  const canSearch = !cms.media.store.isStatic && !cms.api?.tina?.isLocalMode;
+  const visibleItems = list.items.filter((item) => {
+    if (mediaFilter === 'folders') return item.type === 'dir';
+    if (mediaFilter === 'files') return item.type === 'file';
+    return true;
+  });
+
   if ((listState === 'loading' && !list?.items?.length) || uploading) {
     return <LoadingMediaList />;
   }
@@ -482,28 +508,52 @@ export function MediaPicker({
             )}
           </div>
 
+          <div className='flex flex-wrap items-center gap-4 bg-gray-50 border-b border-gray-150 py-3 px-5 shadow-sm flex-shrink-0'>
+            {canSearch && (
+              <SearchInput
+                value={search}
+                setValue={setSearch}
+                clear={() => setSearch('')}
+              />
+            )}
+            <div className='ml-auto'>
+              <MediaFilterToggle
+                value={mediaFilter}
+                setValue={setMediaFilter}
+              />
+            </div>
+          </div>
+
           <div className='flex h-full overflow-hidden bg-white'>
             <div className='flex w-full flex-col h-full @container'>
               <ul
                 {...rootProps}
                 className={`h-full grow overflow-y-auto transition duration-150 ease-out bg-gradient-to-b from-gray-50/50 to-gray-50 ${
-                  list.items.length === 0 ||
+                  visibleItems.length === 0 ||
                   (viewMode === 'list' &&
                     'w-full flex flex-1 flex-col justify-start -mb-px')
                 } ${
-                  list.items.length > 0 &&
+                  visibleItems.length > 0 &&
                   viewMode === 'grid' &&
                   'w-full p-4 gap-4 grid grid-cols-1 @sm:grid-cols-2 @lg:grid-cols-3 @2xl:grid-cols-4 @4xl:grid-cols-6 @6xl:grid-cols-9 auto-rows-auto content-start justify-start'
                 } ${isDragActive ? `border-2 border-blue-500 rounded-lg` : ``}`}
               >
                 <input {...getInputProps()} />
 
-                {listState === 'loaded' && list.items.length === 0 && (
-                  <EmptyMediaList />
+                {listState === 'loaded' && visibleItems.length === 0 && (
+                  <EmptyMediaList
+                    message={
+                      mediaFilter === 'folders' && isSearching
+                        ? "Folders aren't part of search results"
+                        : isSearching
+                          ? `No media matches “${debouncedSearch}”`
+                          : undefined
+                    }
+                  />
                 )}
 
                 {viewMode === 'list' &&
-                  list.items.map((item: Media) => (
+                  visibleItems.map((item: Media) => (
                     <ListMediaItem
                       key={item.id}
                       item={item}
@@ -513,7 +563,7 @@ export function MediaPicker({
                   ))}
 
                 {viewMode === 'grid' &&
-                  list.items.map((item: Media) => (
+                  visibleItems.map((item: Media) => (
                     <GridMediaItem
                       key={item.id}
                       item={item}
@@ -522,7 +572,9 @@ export function MediaPicker({
                     />
                   ))}
 
-                {!!list.nextOffset && <LoadingMediaList ref={loaderRef} />}
+                {!!list.nextOffset && mediaFilter !== 'folders' && (
+                  <LoadingMediaList ref={loaderRef} />
+                )}
               </ul>
             </div>
 
@@ -734,11 +786,12 @@ const useSyncStatus = () => {
   return context;
 };
 
-const EmptyMediaList = () => {
+const EmptyMediaList = ({ message }: { message?: string }) => {
   const { syncStatus } = useSyncStatus();
   return (
     <div className={`p-12 text-xl opacity-50 text-center`}>
-      {syncStatus == 'synced' ? 'Drag and drop assets here' : 'Loading...'}
+      {message ??
+        (syncStatus == 'synced' ? 'Drag and drop assets here' : 'Loading...')}
     </div>
   );
 };
@@ -756,6 +809,79 @@ const DocsLink = ({ title, message, docsLink, ...props }) => {
       >
         Learn More
       </a>
+    </div>
+  );
+};
+
+const SearchInput = ({
+  value,
+  setValue,
+  clear,
+}: {
+  value: string;
+  setValue: (value: string) => void;
+  clear: () => void;
+}) => {
+  return (
+    <div className='relative flex flex-1 items-center min-w-[200px] max-w-md'>
+      <BiSearch className='absolute left-3 w-5 h-5 text-gray-400 pointer-events-none' />
+      <input
+        type='text'
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        placeholder='Search this library...'
+        className='w-full rounded border border-gray-150 bg-white py-2 pl-10 pr-9 text-base text-gray-700 shadow-inner placeholder:text-gray-400 focus:border-blue-400 focus:outline-none focus:ring-1 focus:ring-blue-400'
+      />
+      {value && (
+        <button
+          type='button'
+          onClick={clear}
+          aria-label='Clear search'
+          className='absolute right-2 flex items-center justify-center text-gray-400 hover:text-gray-600'
+        >
+          <BiX className='w-5 h-5' />
+        </button>
+      )}
+    </div>
+  );
+};
+
+const MediaFilterToggle = ({
+  value,
+  setValue,
+}: {
+  value: 'all' | 'folders' | 'files';
+  setValue: (value: 'all' | 'folders' | 'files') => void;
+}) => {
+  const base =
+    'relative whitespace-nowrap flex items-center justify-center gap-1.5 font-medium text-base px-3 py-1 transition-all ease-out duration-150 border';
+  const active =
+    'bg-white text-blue-500 shadow-inner border-gray-50 border-t-gray-100';
+  const inactive =
+    'bg-gray-50 text-gray-400 shadow border-gray-100 border-t-white';
+  const options: { key: 'all' | 'folders' | 'files'; label: string }[] = [
+    { key: 'all', label: 'All' },
+    { key: 'folders', label: 'Folders' },
+    { key: 'files', label: 'Files' },
+  ];
+  return (
+    <div className='grow-0 flex justify-between rounded border border-gray-100'>
+      {options.map((option, index) => (
+        <button
+          key={option.key}
+          type='button'
+          onClick={() => setValue(option.key)}
+          className={`${base} ${index === 0 ? 'rounded-l' : ''} ${
+            index === options.length - 1 ? 'rounded-r' : ''
+          } ${value === option.key ? active : inactive}`}
+        >
+          {option.key === 'folders' && (
+            <BiFolder className='w-5 h-5 opacity-70' />
+          )}
+          {option.key === 'files' && <BiFile className='w-5 h-5 opacity-70' />}
+          {option.label}
+        </button>
+      ))}
     </div>
   );
 };

--- a/packages/tinacms/src/toolkit/core/media-store.default.test.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.test.ts
@@ -155,6 +155,13 @@ const buildStore = ({
   };
 };
 
+describe('TinaMediaStore — capabilities', () => {
+  it('advertises searchable so the media manager shows the search box', () => {
+    const { store } = buildStore();
+    expect(store.searchable).toBe(true);
+  });
+});
+
 describe('TinaMediaStore — endpoint version (v1 vs v2)', () => {
   it('lists media from the v2 endpoint', async () => {
     const { store, fetchWithToken } = buildStore({ branch: 'main' });

--- a/packages/tinacms/src/toolkit/core/media-store.default.test.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.test.ts
@@ -257,6 +257,44 @@ describe('TinaMediaStore — endpoint version (v1 vs v2)', () => {
   });
 });
 
+describe('TinaMediaStore — search query param', () => {
+  it('appends the url-encoded search term', async () => {
+    const { store, fetchWithToken } = buildStore({ branch: 'main' });
+    fetchWithToken.mockResolvedValueOnce(
+      makeJsonResponse(200, { files: [], directories: [], cursor: 0 })
+    );
+
+    await store.list({ directory: '', thumbnailSizes: [], search: 'a b/c' });
+
+    const calledUrl = fetchWithToken.mock.calls[0][0];
+    expect(calledUrl).toContain('&search=a%20b%2Fc');
+  });
+
+  it('omits the search param when unset', async () => {
+    const { store, fetchWithToken } = buildStore({ branch: 'main' });
+    fetchWithToken.mockResolvedValueOnce(
+      makeJsonResponse(200, { files: [], directories: [], cursor: 0 })
+    );
+
+    await store.list({ directory: '', thumbnailSizes: [] });
+
+    const calledUrl = fetchWithToken.mock.calls[0][0];
+    expect(calledUrl).not.toContain('search=');
+  });
+
+  it('omits the search param when empty', async () => {
+    const { store, fetchWithToken } = buildStore({ branch: 'main' });
+    fetchWithToken.mockResolvedValueOnce(
+      makeJsonResponse(200, { files: [], directories: [], cursor: 0 })
+    );
+
+    await store.list({ directory: '', thumbnailSizes: [], search: '' });
+
+    const calledUrl = fetchWithToken.mock.calls[0][0];
+    expect(calledUrl).not.toContain('search=');
+  });
+});
+
 describe('TinaMediaStore — branch query param', () => {
   describe('list()', () => {
     it('appends single-encoded branch for a simple branch', async () => {

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -175,6 +175,8 @@ export class TinaMediaStore implements MediaStore {
 
   accept = DEFAULT_MEDIA_UPLOAD_TYPES;
 
+  searchable = true;
+
   // allow up to 100MB uploads
   maxSize = 100 * 1024 * 1024;
 

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -821,7 +821,9 @@ export class TinaMediaStore implements MediaStore {
       res = await this.fetchFunction(
         `${this.url}/list/${options.directory || ''}?limit=${
           options.limit || 20
-        }${options.offset ? `&cursor=${options.offset}` : ''}`
+        }${options.offset ? `&cursor=${options.offset}` : ''}${
+          options.search ? `&search=${encodeURIComponent(options.search)}` : ''
+        }`
       );
 
       if (res.status == 404) {

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -807,7 +807,7 @@ export class TinaMediaStore implements MediaStore {
           options.limit || 20
         }${options.offset ? `&cursor=${options.offset}` : ''}${
           encodedBranch ? `&branch=${encodedBranch}` : ''
-        }`
+        }${options.search ? `&search=${encodeURIComponent(options.search)}` : ''}`
       );
 
       if (res.status == 401) {

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -126,6 +126,7 @@ export interface MediaListOptions {
   offset?: MediaListOffset;
   thumbnailSizes?: { w: number; h: number }[];
   filesOnly?: boolean;
+  search?: string;
 }
 
 /**

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -108,6 +108,15 @@ export interface MediaStore {
   isStatic?: boolean;
 
   /**
+   * Indicates that `list` honours the `search` option, so the media manager
+   * may show a search box. Stores that ignore `search` should leave this
+   * unset to avoid a search box that returns unfiltered results.
+   *
+   * @default false
+   */
+  searchable?: boolean;
+
+  /**
    * Converts a Media object to the value stored in a form field.
    *
    * Typically returns `media.src`. If not implemented, the image field


### PR DESCRIPTION
Tagged: https://tina-io-git-jb-test-tagged-media-tinacms.vercel.app/admin/index.html#/~/

## TL;DR

Adds a **search box** and a **folder/file filter** to the media manager. Search filters the library by filename (debounced, recursive across folders); the `All | Folders | Files` toggle narrows the view. Works against **both TinaCloud media** (via the `?search=` param from tinacms/tinacloud#3867) **and local dev media** (a matching `search` param added to the CLI dev-server). Builds on the v2 listing switch from #7322.

## How

- **`?search=` plumbing** — `search?: string` on `MediaListOptions`, appended (URL-encoded) to both the cloud and local list requests.
- **Local parity (`@tinacms/cli`)** — the dev-server media endpoint now honours `search`, matching filenames recursively within the requested folder (case-insensitive, dir-relative names) to mirror cloud. The recursive walk skips entries whose real path escapes the media root (symlink guard).
- **Search box** — debounced 300ms. On commit it resets paging and refetches; results *replace* the list (page-1 loads now replace instead of append) so the input keeps focus and doesn't flash a full-screen loader.
- **Opt-in per store** — the box only shows when the store sets a new `searchable` flag on the `MediaStore` interface. `TinaMediaStore` (TinaCloud + local dev) opts in; custom/self-hosted stores stay hidden until they set it and read `options.search`, so no store gets a box that returns unfiltered results.
- **Folder/file filter** — client-side over loaded items (folders arrive on page 1, files paginate). "Folders" view suppresses infinite-scroll since extra pages are only files.
- **Folders + active search → empty message**, since search never returns folders.

## Tests

- **Client:** store tests — `search` is URL-encoded, omitted when unset/empty, and `TinaMediaStore` advertises `searchable` (45 pass). Mutation-checked.
- **CLI dev-server:** 6 tests — recursive match + directory suppression, case-insensitivity, dir-scoped relative filenames, src prefix, no-match; plus a security test that search does **not** follow a symlink escaping the media root (22 pass). The symlink guard is mutation-checked as load-bearing.
- `tsc` clean on touched files, biome lint/format clean, `pnpm --filter tinacms build` and `--filter @tinacms/cli build` pass.


## Screenshots

<img width="1387" height="1067" alt="Screenshot 2026-07-27 at 4 11 36 pm" src="https://github.com/user-attachments/assets/3be845c1-0eba-4b9e-a273-1b695f25f274" />

<img width="1382" height="1056" alt="Screenshot 2026-07-27 at 4 11 45 pm" src="https://github.com/user-attachments/assets/c8d8e09d-5f64-4a85-af02-3a815f45595d" />


https://github.com/user-attachments/assets/abd4f83a-5f06-4919-a5cd-9e6e7bfccc8f


## Links

- Parent: tinacms/tinacloud#2051
- Depends on: #7322 (v2 listing) · backend `?search=`: tinacms/tinacloud#3867

