### PR TITLE
fix(graphql): stop stale datetime index rows surfacing documents twice (#7053)

### DIFF
--- a/.changeset/stale-datetime-index-rows.md
+++ b/.changeset/stale-datetime-index-rows.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/graphql": patch
+---
+
+Fix stale datetime index rows from the pre-2.4.3 key encoding surfacing documents twice in datetime-sorted queries

--- a/packages/@tinacms/graphql/src/database/database.test.ts
+++ b/packages/@tinacms/graphql/src/database/database.test.ts
@@ -21,6 +21,7 @@ import { buildSchema, createDatabaseInternal } from '..';
 import type { Bridge } from './bridge';
 import type { Schema } from '@tinacms/schema-tools';
 import { atob } from '../util';
+import { INDEX_KEY_FIELD_SEPARATOR, SUBLEVEL_OPTIONS } from './level';
 
 // ─── InMemoryBridge ──────────────────────────────────────────────────────────
 
@@ -598,5 +599,97 @@ describe('Database.indexContent()', () => {
       hydrate
     );
     expect(result.edges).toHaveLength(2);
+  });
+});
+
+// ─── Regression: stale pre-2.4.3 datetime index rows (#7053) ───────────────
+//
+// @tinacms/graphql@2.4.3 (5c216dd, PR #6941) changed datetime index keys
+// from Unix-millisecond strings to ISO 8601 strings. On a persistent data
+// layer (TinaCloud, self-hosted Mongo/DynamoDB/SQLite level), a row indexed
+// under the old encoding is never cleaned up by a later put()/re-index,
+// because those paths delete a document's previous index rows by
+// *recomputing* the keys with the current encoder rather than deleting the
+// keys that were actually written. The stale row and the fresh row then
+// both point at the same document, so it appears twice in datetime-sorted
+// connection queries and the admin collection list.
+
+const datetimeSchema: Schema = {
+  collections: [
+    {
+      name: 'post',
+      label: 'Post',
+      path: 'content/posts',
+      format: 'json',
+      fields: [
+        { name: 'title', label: 'Title', type: 'string' },
+        { name: 'date', label: 'Date', type: 'datetime' },
+      ],
+    },
+  ],
+};
+
+async function setupDatetimeDatabase() {
+  const bridge = new InMemoryBridge();
+  bridge.seed(
+    'content/posts/a.json',
+    jsonDoc({ title: 'Post A', date: '2020-01-01T00:00:00.000Z' })
+  );
+
+  const level = new MemoryLevel<string, Record<string, any>>({
+    valueEncoding: 'json',
+  });
+  const database = createDatabaseInternal({
+    bridge,
+    level,
+    tinaDirectory: 'tina',
+  });
+
+  const builtSchema = await buildSchema({ schema: datetimeSchema });
+  await database.indexContent(builtSchema);
+
+  const hydrate = async (path: string, value: Record<string, any>) => ({
+    path,
+    ...value,
+  });
+
+  return { database, hydrate };
+}
+
+describe('Database — stale datetime index rows across an index key encoding change (#7053)', () => {
+  it('does not surface a document twice when a pre-2.4.3 (millisecond-keyed) datetime index row survives alongside the current (ISO-keyed) row after a re-index', async () => {
+    const { database, hydrate } = await setupDatetimeDatabase();
+    const filepath = 'content/posts/a.json';
+    const dateValue = '2020-01-01T00:00:00.000Z';
+
+    // Simulate a row left behind by @tinacms/graphql@2.4.2: the sort key for
+    // a datetime field used to be `String(new Date(value).getTime())`
+    // (Unix milliseconds) rather than the ISO 8601 string 2.4.3 uses. This
+    // is written directly into the same on-disk sublevel a pre-2.4.3
+    // deployment would have used, independent of whatever encoding the
+    // current code happens to write to.
+    const legacyMillisKey = `${String(
+      new Date(dateValue).getTime()
+    )}${INDEX_KEY_FIELD_SEPARATOR}${filepath}`;
+    await database.contentLevel
+      .sublevel('post', SUBLEVEL_OPTIONS)
+      .sublevel('date', SUBLEVEL_OPTIONS)
+      .put(legacyMillisKey, {});
+
+    // Reproduce the reported trigger: edit the document without changing
+    // its datetime value, which forces Database.put() to re-index it.
+    await database.put(
+      filepath,
+      { title: 'Post A (edited)', date: dateValue },
+      'post'
+    );
+
+    const result = await database.query(
+      { collection: 'post', sort: 'date', filterChain: [] },
+      hydrate
+    );
+
+    expect(result.edges).toHaveLength(1);
+    expect((result.edges[0].node as any).path).toBe(filepath);
   });
 });

--- a/packages/@tinacms/graphql/src/database/datalayer.ts
+++ b/packages/@tinacms/graphql/src/database/datalayer.ts
@@ -740,9 +740,9 @@ export const makeFolderOpsForCollection = <T extends object>(
     );
     let folderSortingIdx = 0;
     for (const path of Array.from(folder).sort()) {
-      for (const [sort] of Object.entries(indexDefinitions)) {
+      for (const [sort, definition] of Object.entries(indexDefinitions)) {
         const indexSublevel = folderCollectionSublevel.sublevel(
-          sort,
+          indexSublevelName(sort, definition),
           SUBLEVEL_OPTIONS
         );
         const subFolderKey = sha.hex(path);
@@ -789,6 +789,37 @@ export const makeFolderOpsForCollection = <T extends object>(
   return result;
 };
 
+/**
+ * @tinacms/graphql@2.4.3 (#6941) changed how datetime index keys are
+ * encoded, from Unix-millisecond strings to ISO 8601 strings (see
+ * parseDatetimeUTC above). On a persistent data layer, index rows written
+ * under the old encoding are never comparable to keys the new encoder
+ * computes, so a later put()/re-index — which deletes a document's stale
+ * rows by *recomputing* their keys with the current encoder — can never
+ * find and remove them. The old row lingers forever alongside the new one,
+ * surfacing as a duplicate document (#7053).
+ *
+ * Routing any index whose key includes a datetime field into its own
+ * sublevel, versioned by encoding, sidesteps that: rows written under a
+ * previous encoding simply live in a sublevel nothing reads from anymore,
+ * instead of colliding with fresh rows in the same keyspace. Bump this
+ * suffix again if the datetime key encoding ever changes in a
+ * non-backwards-compatible way.
+ */
+const DATETIME_INDEX_ENCODING_SUFFIX = '@dtv2';
+
+const usesDatetimeEncoding = (definition: IndexDefinition): boolean =>
+  definition.fields.some((field) => field.type === 'datetime');
+
+/** The sublevel name to use for a given sort key / index definition. */
+export const indexSublevelName = (
+  sort: string,
+  definition: IndexDefinition
+): string =>
+  usesDatetimeEncoding(definition)
+    ? `${sort}${DATETIME_INDEX_ENCODING_SUFFIX}`
+    : sort;
+
 export const makeIndexOpsForDocument = <T extends object>(
   filepath: string,
   collection: string | undefined,
@@ -804,7 +835,10 @@ export const makeIndexOpsForDocument = <T extends object>(
     const collectionSublevel = level.sublevel(collection, SUBLEVEL_OPTIONS);
     for (const [sort, definition] of Object.entries(indexDefinitions)) {
       const indexedValue = makeKeyForField<T>(definition, data, escapeStr);
-      const indexSublevel = collectionSublevel.sublevel(sort, SUBLEVEL_OPTIONS);
+      const indexSublevel = collectionSublevel.sublevel(
+        indexSublevelName(sort, definition),
+        SUBLEVEL_OPTIONS
+      );
       if (sort === DEFAULT_COLLECTION_SORT_KEY) {
         result.push({
           type: opType,

--- a/packages/@tinacms/graphql/src/database/index.ts
+++ b/packages/@tinacms/graphql/src/database/index.ts
@@ -34,6 +34,7 @@ import {
   REFS_REFERENCE_FIELD,
   type TernaryFilter,
   coerceFilterChainOperands,
+  indexSublevelName,
   makeFilter,
   makeFilterSuffixes,
   makeFolderOpsForCollection,
@@ -1092,7 +1093,7 @@ export class Database {
             }`,
             SUBLEVEL_OPTIONS
           )
-          .sublevel(sort, SUBLEVEL_OPTIONS)
+          .sublevel(indexSublevelName(sort, indexDefinition), SUBLEVEL_OPTIONS)
       : rootLevel;
 
     if (!query.gt && !query.gte) {
@@ -1121,6 +1122,10 @@ export class Database {
       ? new RegExp(`^${fieldsPattern}(?<_filepath_>.+)`)
       : new RegExp(`^(?<_filepath_>.+)`);
     const itemFilter = makeFilter({ filterChain });
+    // Defense in depth against duplicate index rows for the same document
+    // (e.g. a stale row left behind by an index key encoding change, see
+    // #7053) so a document can never surface twice in a single result page.
+    const seenPaths = new Set<string>();
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
@@ -1160,6 +1165,11 @@ export class Database {
       if (!itemFilter(itemRecord)) {
         continue;
       }
+
+      if (seenPaths.has(filepath)) {
+        continue;
+      }
+      seenPaths.add(filepath);
 
       if (limit !== -1 && edges.length >= limit) {
         if (query.reverse) {


### PR DESCRIPTION
<!-- PR title: fix(graphql): stop stale datetime index rows surfacing documents twice (#7053) -->

**You set the work.** #7053: after upgrading `@tinacms/graphql` from 2.4.2 to 2.4.3, datetime-sorted queries return some documents twice.

**It's done.** #6941 changed how datetime index keys are encoded but never invalidated rows written under the old encoding, so both survive and collide. The fix keeps them from ever colliding — no version detection or forced rebuild needed. One regression test written before the fix, reproducing the exact upgrade scenario from your report.

**Here's the evidence.**

- Fresh clone at `5112e60b`, patch applied, dependencies installed, then the network was disconnected.
- Full `@tinacms/graphql` suite in a clean `node:22-bookworm` container: **524/524 pass**, including the new test.
- `tsc` clean for the package.
- The new test fails on unpatched main with exactly your symptom (`expected length 1, got 2`).

<details>
<summary><b>Audit trail</b> — an independently checkable record that these checks ran, in this order, before this PR existed</summary>

| | |
|---|---|
| Base commit | `5112e60bd0c98f6de36f63dbf068d252993e586f` |
| Container | `node:22-bookworm@sha256:5647be70…` (linux/arm64), network off during tests |
| The patch, content-addressed | [record](https://gateway.autonolas.tech/ipfs/f015512206bb86b536a99d008667a575423b9b6f45a977eb24b54436746d4d4a9f457fe5f) |
| The verification result, signed by a second key | [record](https://gateway.autonolas.tech/ipfs/f01551220e25bca4a90b6b11e7f12fe4e0a7d3e7112d1375b2e6befc6d472111e0691d631) |
| Timestamped sequence | [work assigned](https://sepolia.basescan.org/tx/0xaf2b3f6e3a815d1cbf77d9dda7a843161dbfb73a9a9a63c3c6ff0c534a27efc0) → [work delivered](https://sepolia.basescan.org/tx/0x3dd13e5ac239084d91e5e229dd33eac71d384acb20e713b529d71edcf7d3d85c) → [checks passed](https://sepolia.basescan.org/tx/0x610faf9c66e183c1642724b3afa92261487de87260ec7d1de3434bf5e554da7b) |

What this proves: the checks ran, in that order, on exactly this patch, before this PR was opened — none of it can be backdated or swapped afterwards. What it doesn't prove: that the fix is *right*. The two signing keys are distinct but run by the same project, and the record lives on a test network. Correctness is your judgement, which is the point.

</details>

Written by an AI agent; reviewed and sent by a human who answers the review. We're testing whether work checked this way is useful to maintainers — blunt feedback welcome, including "don't".

---

## Everything below is written by Claude

Fixes #7053.

Indexes whose definition includes a `datetime` field now live in a versioned sublevel (`${sort}@dtv2`). Rows written under the previous encoding stay in the old keyspace, which nothing reads from anymore, so they can never collide with fresh rows. The query path also dedupes edges by filepath as defence in depth. Applied to both document and folder-scoped index paths (the folder path had the same latent bug).

### Two scope notes for the reviewer

- The issue's first bullet suggests storing a key-format version and failing loudly or rebuilding on mismatch. This patch achieves the same practical outcome (stale rows permanently invisible) by namespacing instead — smaller, and no operator action needed — but orphaned pre-2.4.3 rows remain in the store as dead weight rather than being reclaimed. If you'd rather have the explicit version-check/rebuild UX, happy to rework.
- #6941 also added number padding to composite indexes, which has the same stale-row bug class for `number` fields. Deliberately out of scope here; can file a follow-up issue if useful.
