### PR TITLE
🐛 Keep the rich-text link popover anchored while scrolling

### DIFF
--- a/.changeset/link-popover-detaches-on-scroll.md
+++ b/.changeset/link-popover-detaches-on-scroll.md
@@ -1,0 +1,7 @@
+---
+"tinacms": patch
+---
+
+Fix the rich-text link popover staying in place when you scroll the form.
+
+The popover is rendered in a portal on `document.body`, and its floating-ui reference is a virtual element with no `contextElement`. That left `autoUpdate` with nothing to attach scroll listeners to except the window, so scrolling the form body never repositioned it and the popover drifted away from the text it was anchored to. It now tracks the editor's scroll container.

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/link-floating-toolbar.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/components/plate-ui/link-floating-toolbar.tsx
@@ -5,7 +5,9 @@ import * as React from 'react';
 import { PortalBody } from '@udecode/cn';
 import {
   type UseVirtualFloatingOptions,
+  autoUpdate,
   flip,
+  getRangeBoundingClientRect,
   limitShift,
   offset,
   shift,
@@ -81,14 +83,26 @@ export function LinkFloatingToolbar({
       ],
       placement:
         activeSuggestionId || activeCommentId ? 'top-start' : 'bottom-start',
+      whileElementsMounted: (reference, floating, update) =>
+        autoUpdate(
+          { ...reference, contextElement: editor.api.toDOMNode(editor) },
+          floating,
+          update
+        ),
     };
-  }, [activeCommentId, activeSuggestionId]);
+  }, [activeCommentId, activeSuggestionId, editor]);
+
+  const getSelectionRect = React.useCallback(
+    () => getRangeBoundingClientRect(editor, editor.selection),
+    [editor]
+  );
 
   //when adding a new link
   const insertState = useFloatingLinkInsertState({
     ...state,
     floatingOptions: {
       ...floatingOptions,
+      getBoundingClientRect: getSelectionRect,
       ...state?.floatingOptions,
     },
   });


### PR DESCRIPTION
## TL;DR

Opening the link popover (Cmd+K) and then scrolling the form left the popover frozen in place while the text it was anchored to scrolled away. It now tracks the anchor, verified at a constant 50px gap across four scroll positions.

## Evidence

Same clip both times: open the popover on "Vote For Pedro", then scroll the form from 550 to 790.

| Before | After |
|---|---|
|  <img width="545" height="700" alt="pr7350-before-broken" src="https://github.com/user-attachments/assets/0f38034a-eefd-4039-a540-e1fce7bdf543" />  |   <img width="545" height="700" alt="pr7350-after-fixed" src="https://github.com/user-attachments/assets/09ad2256-f060-42f9-886e-f0b6f962727c" />   |


At the final scroll position the heading has moved to y=215. Before, the popover is still at y=485, stranded over an unrelated code block. After, it sits at y=245, still 50px under its anchor.

## Why

Two defects stacked, which is the part worth knowing before reading the diff.

`useVirtualFloating` passes `whileElementsMounted: autoUpdate`, but its reference is a virtual element with no `contextElement`. floating-ui then builds its scroll-listener list from the floating element's ancestors only, and since #7131 that element is portaled onto `document.body`, whose sole overflow ancestor is the window. The real scroller is the form body (`form-builder.tsx:419`), so `update()` never fired.

Attaching the editor as `contextElement` alone makes it worse. The insert popover's rect comes from `getDOMSelectionBoundingClientRect`, which reads the live DOM selection; once the popover opens, focus sits in the URL input and that selection is collapsed outside the editor, rect `{0,0,0,0}`. Live updates then snap the popover to the top of the viewport. The frozen position was masking this.

## Reviewer notes

- **Insert only.** The rect override is scoped to `useFloatingLinkInsertState`. The edit popover already derives its rect from the link node's path, so it keeps that.
- **`getRangeBoundingClientRect` reads the Slate model.** It resolves `editor.selection` through `toDOMRange`, so it survives focus leaving the editor and handles collapsed carets, unlike the DOM-selection version.

## Tests

Verified manually in the kitchen-sink admin. Insert popover held a 50px gap across scroll +200 / +400 / back to 0; edit popover held 27px. Inserting a link still wraps exactly the selected word.

## Links

- Follows #7251 and #7131, which introduced the portal this regressed from