### PR TITLE
Fix: NextJS blog starter cli template grammatical error

### DIFF
--- a/packages/@tinacms/cli/src/cmds/init/templates/next.ts
+++ b/packages/@tinacms/cli/src/cmds/init/templates/next.ts
@@ -64,7 +64,7 @@ const BlogPage = (props) => {
             {' '}
             Check out this guide
           </a>{' '}
-          to see how add TinaCMS to an existing Next.js site.
+          to see how to add TinaCMS to an existing Next.js site.
         </div>
       </div>
     </>


### PR DESCRIPTION
## TL;DR

The TinaCMS Next.js blog starter template generated by the Tina CLI contains a grammatical error.

## Evidence

<img width="1099" height="766" alt="image" src="https://github.com/user-attachments/assets/0113c3d0-8d9b-42ce-b6d6-0057580a9727" />

## Why

This improves the readability and professionalism of the generated template.

## Tests

- Verified the grammar change manually.
- Confirmed the project builds successfully.
- Confirmed the project lints successfully.

## Links

- Fixes #7359