### PR TITLE
feat(v4): local data layer — content capability, fs provider, hosted GraphQL pipeline

### DIFF
--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -41,6 +41,10 @@
       "types": "./src/server/index.ts",
       "default": "./src/server/index.ts"
     },
+    "./local-data-layer": {
+      "types": "./src/plugins/content/local/local-data-layer.ts",
+      "default": "./src/plugins/content/local/local-data-layer.ts"
+    },
     "./adapters/next": {
       "types": "./src/adapters/next/index.ts",
       "default": "./src/adapters/next/index.ts"
@@ -60,6 +64,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
+    "gray-matter": "catalog:",
     "@tinacms/ui": "workspace:*",
     "react-hook-form": "^7.80.0",
     "zod": "catalog:",

--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -45,6 +45,10 @@
       "types": "./src/plugins/content/local/local-data-layer.ts",
       "default": "./src/plugins/content/local/local-data-layer.ts"
     },
+    "./local-data-layer/vite": {
+      "types": "./src/plugins/content/local/local-data-layer.vite.ts",
+      "default": "./src/plugins/content/local/local-data-layer.vite.ts"
+    },
     "./adapters/next": {
       "types": "./src/adapters/next/index.ts",
       "default": "./src/adapters/next/index.ts"
@@ -64,12 +68,12 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
-    "abstract-level": "catalog:",
-    "gray-matter": "catalog:",
     "@tinacms/graphql": "workspace:*",
     "@tinacms/ui": "workspace:*",
-    "sqlite-level": "catalog:",
+    "abstract-level": "catalog:",
+    "gray-matter": "catalog:",
     "react-hook-form": "^7.80.0",
+    "sqlite-level": "catalog:",
     "zod": "catalog:",
     "zustand": "^5.0.14"
   },

--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -64,8 +64,11 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.4.0",
+    "abstract-level": "catalog:",
     "gray-matter": "catalog:",
+    "@tinacms/graphql": "workspace:*",
     "@tinacms/ui": "workspace:*",
+    "sqlite-level": "catalog:",
     "react-hook-form": "^7.80.0",
     "zod": "catalog:",
     "zustand": "^5.0.14"

--- a/packages/v4/@tinacms/tinacms/playground/content/posts/hello-world.mdx
+++ b/packages/v4/@tinacms/tinacms/playground/content/posts/hello-world.mdx
@@ -1,5 +1,5 @@
 ---
-title: Hello World
+title: Hello World....
 featured: false
 category: not-in-schema-yet
 ---

--- a/packages/v4/@tinacms/tinacms/playground/content/posts/hello-world.mdx
+++ b/packages/v4/@tinacms/tinacms/playground/content/posts/hello-world.mdx
@@ -1,0 +1,9 @@
+---
+title: Hello World
+featured: false
+category: not-in-schema-yet
+---
+
+This body prose and the `category` frontmatter key above are unknown to the
+schema — the local data layer must round-trip both verbatim on every save
+(CONTEXT.md Unknown field).

--- a/packages/v4/@tinacms/tinacms/playground/content/posts/second-post.mdx
+++ b/packages/v4/@tinacms/tinacms/playground/content/posts/second-post.mdx
@@ -1,5 +1,5 @@
 ---
-title: Second Post
+title: Second Post!
 featured: true
 ---
 

--- a/packages/v4/@tinacms/tinacms/playground/content/posts/second-post.mdx
+++ b/packages/v4/@tinacms/tinacms/playground/content/posts/second-post.mdx
@@ -1,0 +1,7 @@
+---
+title: Second Post
+featured: true
+---
+
+A second document, so form continuity (kept edits across a switch) has
+something to switch between.

--- a/packages/v4/@tinacms/tinacms/playground/src/app.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/app.tsx
@@ -1,9 +1,7 @@
 import {
-  type ContentSlice,
   type DocumentEntry,
   type FieldSchema,
   type TinaDocument,
-  corePlugins,
   localContentPlugin,
 } from '@tinacms/tinacms';
 import {
@@ -13,6 +11,8 @@ import {
   TinaProvider,
   toFieldAddress,
   toFormId,
+  useCollectionDocuments,
+  useContentSlice,
   useFormErrors,
   useFormId,
   useFormSave,
@@ -20,19 +20,10 @@ import {
   useIsFieldDirty,
   useIsFormDirty,
   usePreviewConnection,
-  useTinaStore,
 } from '@tinacms/tinacms/react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { postCollection } from './content';
 import { PluginsPanel } from './plugins-panel';
-
-const plugins = [...corePlugins, localContentPlugin()];
-
-// The `content` namespace is typed as an open SliceState until codegen produces
-// typed capability reads; the one cast lives here.
-function useContentSlice(): ContentSlice {
-  return useTinaStore((state) => state.content) as unknown as ContentSlice;
-}
 
 const STATUS_COLORS: Record<FormStatus, string> = {
   pristine: '#6b7280',
@@ -161,14 +152,7 @@ function Workspace() {
   const content = useContentSlice();
   const [savedDocument, setSavedDocument] = useState<TinaDocument | null>(null);
   const [activePath, setActivePath] = useState<string | null>(null);
-  // Action refs are stable across slice updates; depending on the function (not
-  // the slice object) keeps this a boot-time load, not a loop.
-  const { loadDocuments } = content;
-  useEffect(() => {
-    void loadDocuments(postCollection.name);
-  }, [loadDocuments]);
-
-  const { documents } = content;
+  const documents = useCollectionDocuments(postCollection.name);
   const active =
     documents.find(({ path }) => path === activePath) ?? documents[0];
   // Pin the hosted entry per form instance: live cache updates (e.g. the
@@ -240,7 +224,7 @@ function Workspace() {
 
 export function App() {
   return (
-    <TinaProvider plugins={plugins}>
+    <TinaProvider plugins={[localContentPlugin()]}>
       <Workspace />
     </TinaProvider>
   );

--- a/packages/v4/@tinacms/tinacms/playground/src/app.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/app.tsx
@@ -1,7 +1,10 @@
 import {
+  type ContentSlice,
+  type DocumentEntry,
   type FieldSchema,
   type TinaDocument,
   corePlugins,
+  localContentPlugin,
 } from '@tinacms/tinacms';
 import {
   Field,
@@ -17,10 +20,19 @@ import {
   useIsFieldDirty,
   useIsFormDirty,
   usePreviewConnection,
+  useTinaStore,
 } from '@tinacms/tinacms/react';
-import { useRef, useState } from 'react';
-import { documents, postCollection } from './content';
+import { useEffect, useRef, useState } from 'react';
+import { postCollection } from './content';
 import { PluginsPanel } from './plugins-panel';
+
+const plugins = [...corePlugins, localContentPlugin()];
+
+// The `content` namespace is typed as an open SliceState until codegen produces
+// typed capability reads; the one cast lives here.
+function useContentSlice(): ContentSlice {
+  return useTinaStore((state) => state.content) as unknown as ContentSlice;
+}
 
 const STATUS_COLORS: Record<FormStatus, string> = {
   pristine: '#6b7280',
@@ -62,9 +74,11 @@ function FieldRow({ node }: { node: FieldSchema }) {
 // mirror — a dirty dot and an error dot stay live for BOTH documents no matter
 // which form is hosted (useIsFormDirty/useFormErrors read any open form).
 function DocumentTabs({
+  documents,
   activePath,
   onSelect,
 }: {
+  documents: DocumentEntry[];
   activePath: string;
   onSelect: (path: string) => void;
 }) {
@@ -140,55 +154,84 @@ function SaveButton() {
   );
 }
 
-export function App() {
+// Loads the collection through the content capability and hosts one document's
+// form at a time. Saves flow back through the same slice — the local data layer
+// writes the real file (ADR-018).
+function Workspace() {
+  const content = useContentSlice();
   const [savedDocument, setSavedDocument] = useState<TinaDocument | null>(null);
-  const [activePath, setActivePath] = useState(documents[0].path);
+  const [activePath, setActivePath] = useState<string | null>(null);
+  // Action refs are stable across slice updates; depending on the function (not
+  // the slice object) keeps this a boot-time load, not a loop.
+  const { loadDocuments } = content;
+  useEffect(() => {
+    void loadDocuments(postCollection.name);
+  }, [loadDocuments]);
+
+  const { documents } = content;
   const active =
     documents.find(({ path }) => path === activePath) ?? documents[0];
+  if (!active) return <p style={{ padding: '1rem' }}>Loading content…</p>;
+
+  const saveActiveDocument = async (document: TinaDocument) => {
+    await content.saveDocument(postCollection.name, active.path, document);
+    setSavedDocument(document);
+  };
+
   return (
-    <TinaProvider plugins={corePlugins}>
-      {/* Keyed remount per document: a switch tears the form down (the store
-          keeps its edits, ADR-012) and hosts the other one. */}
-      <FormProvider
-        key={active.path}
-        collection={postCollection}
-        path={active.path}
-        document={active.document}
-        onSave={setSavedDocument}
-      >
-        <div style={{ display: 'flex', height: '100vh' }}>
-          <aside
+    // Keyed remount per document: a switch tears the form down (the store
+    // keeps its edits, ADR-012) and hosts the other one.
+    <FormProvider
+      key={active.path}
+      collection={postCollection}
+      path={active.path}
+      document={active.document}
+      onSave={saveActiveDocument}
+    >
+      <div style={{ display: 'flex', height: '100vh' }}>
+        <aside
+          style={{
+            width: '22rem',
+            flexShrink: 0,
+            borderRight: '1px solid #e5e7eb',
+            padding: '1rem',
+            overflowY: 'auto',
+          }}
+        >
+          <DocumentTabs
+            documents={documents}
+            activePath={active.path}
+            onSelect={setActivePath}
+          />
+          <header
             style={{
-              width: '22rem',
-              flexShrink: 0,
-              borderRight: '1px solid #e5e7eb',
-              padding: '1rem',
-              overflowY: 'auto',
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              marginBottom: '1rem',
             }}
           >
-            <DocumentTabs activePath={activePath} onSelect={setActivePath} />
-            <header
-              style={{
-                display: 'flex',
-                justifyContent: 'space-between',
-                alignItems: 'center',
-                marginBottom: '1rem',
-              }}
-            >
-              <strong>{active.path}</strong>
-              <StatusBadge />
-            </header>
-            {postCollection.fields.map((node) => (
-              <FieldRow key={node.name} node={node} />
-            ))}
-            <SaveButton />
-            <PluginsPanel savedDocument={savedDocument} />
-          </aside>
-          <main style={{ flex: 1 }}>
-            <PreviewPane />
-          </main>
-        </div>
-      </FormProvider>
+            <strong>{active.path}</strong>
+            <StatusBadge />
+          </header>
+          {postCollection.fields.map((node) => (
+            <FieldRow key={node.name} node={node} />
+          ))}
+          <SaveButton />
+          <PluginsPanel savedDocument={savedDocument} />
+        </aside>
+        <main style={{ flex: 1 }}>
+          <PreviewPane />
+        </main>
+      </div>
+    </FormProvider>
+  );
+}
+
+export function App() {
+  return (
+    <TinaProvider plugins={plugins}>
+      <Workspace />
     </TinaProvider>
   );
 }

--- a/packages/v4/@tinacms/tinacms/playground/src/app.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/app.tsx
@@ -22,7 +22,7 @@ import {
   usePreviewConnection,
   useTinaStore,
 } from '@tinacms/tinacms/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { postCollection } from './content';
 import { PluginsPanel } from './plugins-panel';
 
@@ -171,22 +171,32 @@ function Workspace() {
   const { documents } = content;
   const active =
     documents.find(({ path }) => path === activePath) ?? documents[0];
-  if (!active) return <p style={{ padding: '1rem' }}>Loading content…</p>;
+  // Pin the hosted entry per form instance: live cache updates (e.g. the
+  // persisted entry a save feeds back) keep the tab badges fresh but must not
+  // re-seed the mounted form — that would reset RHF and wipe keystrokes typed
+  // while the save was in flight.
+  const hosted = useMemo(() => active, [active?.path]);
+  if (!hosted) return <p style={{ padding: '1rem' }}>Loading content…</p>;
 
-  const saveActiveDocument = async (document: TinaDocument) => {
-    await content.saveDocument(postCollection.name, active.path, document);
-    setSavedDocument(document);
+  const saveHostedDocument = async (document: TinaDocument) => {
+    const saved = await content.saveDocument(
+      postCollection.name,
+      hosted.path,
+      document
+    );
+    // Show what was persisted (unknown fields merged), not the raw form value.
+    setSavedDocument(saved.document);
   };
 
   return (
     // Keyed remount per document: a switch tears the form down (the store
     // keeps its edits, ADR-012) and hosts the other one.
     <FormProvider
-      key={active.path}
+      key={hosted.path}
       collection={postCollection}
-      path={active.path}
-      document={active.document}
-      onSave={saveActiveDocument}
+      path={hosted.path}
+      document={hosted.document}
+      onSave={saveHostedDocument}
     >
       <div style={{ display: 'flex', height: '100vh' }}>
         <aside
@@ -200,7 +210,7 @@ function Workspace() {
         >
           <DocumentTabs
             documents={documents}
-            activePath={active.path}
+            activePath={hosted.path}
             onSelect={setActivePath}
           />
           <header
@@ -211,7 +221,7 @@ function Workspace() {
               marginBottom: '1rem',
             }}
           >
-            <strong>{active.path}</strong>
+            <strong>{hosted.path}</strong>
             <StatusBadge />
           </header>
           {postCollection.fields.map((node) => (

--- a/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
@@ -10,5 +10,7 @@ export const postCollectionMeta = {
   fields: [
     { name: 'title', type: 'string', required: true },
     { name: 'featured', type: 'boolean' },
+    // v3 content model: the markdown body, served by GraphQL as the mdx AST.
+    { name: 'body', type: 'rich-text', isBody: true },
   ],
 } as const;

--- a/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
@@ -1,6 +1,9 @@
 // The collection's file mapping, shared between the app (content.ts) and
-// vite.config.ts's data-layer middleware. Kept import-free so the Vite config
-// loader can bundle it without dragging app code into node.
+// vite.config.ts's data-layer plugin. The type import is erased, keeping the
+// module import-free so the Vite config loader can bundle it without dragging
+// app code into node.
+import type { CollectionSchema } from '@tinacms/tinacms';
+
 export const postCollectionMeta = {
   name: 'post',
   path: 'content/posts',
@@ -13,4 +16,4 @@ export const postCollectionMeta = {
     // v3 content model: the markdown body, served by GraphQL as the mdx AST.
     { name: 'body', type: 'rich-text', isBody: true },
   ],
-} as const;
+} satisfies CollectionSchema;

--- a/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
@@ -5,4 +5,10 @@ export const postCollectionMeta = {
   name: 'post',
   path: 'content/posts',
   format: 'mdx',
+  // Wire-level field shapes — enough for the data layer's GraphQL schema. The
+  // app's form fields (content.ts) override these with richer t.* definitions.
+  fields: [
+    { name: 'title', type: 'string', required: true },
+    { name: 'featured', type: 'boolean' },
+  ],
 } as const;

--- a/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/collection-meta.ts
@@ -1,0 +1,8 @@
+// The collection's file mapping, shared between the app (content.ts) and
+// vite.config.ts's data-layer middleware. Kept import-free so the Vite config
+// loader can bundle it without dragging app code into node.
+export const postCollectionMeta = {
+  name: 'post',
+  path: 'content/posts',
+  format: 'mdx',
+} as const;

--- a/packages/v4/@tinacms/tinacms/playground/src/content.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/content.ts
@@ -2,7 +2,7 @@ import { type CollectionSchema, type TinaDocument, t } from '@tinacms/tinacms';
 import { postCollectionMeta } from './collection-meta';
 
 // Real documents live in playground/content/posts/ and arrive through the
-// content slice (localContentPlugin → vite.config.ts middleware).
+// content slice (localContentPlugin → tinaLocalDataLayerVitePlugin's endpoint).
 
 export const postCollection: CollectionSchema = {
   ...postCollectionMeta,

--- a/packages/v4/@tinacms/tinacms/playground/src/content.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/content.ts
@@ -1,12 +1,11 @@
 import { type CollectionSchema, type TinaDocument, t } from '@tinacms/tinacms';
+import { postCollectionMeta } from './collection-meta';
 
-// The hardcoded documents this playground edits — two of them, so form
-// continuity (kept edits across a switch) and the collection-level dirty/error
-// dots have something to switch between. The data layer (ADR-019) replaces
-// this with real content once it lands.
+// Real documents live in playground/content/posts/ and arrive through the
+// content slice (localContentPlugin → vite.config.ts middleware).
 
 export const postCollection: CollectionSchema = {
-  name: 'post',
+  ...postCollectionMeta,
   label: 'Posts',
   fields: [
     t.string({ name: 'title', label: 'Title', required: true, min: 3 }),
@@ -14,21 +13,8 @@ export const postCollection: CollectionSchema = {
   ],
 };
 
-export interface PlaygroundDocument {
-  path: string;
-  document: TinaDocument;
-}
-
-export const documents: PlaygroundDocument[] = [
-  {
-    path: 'content/posts/hello-world.mdx',
-    document: { title: 'Hello World', featured: false },
-  },
-  {
-    path: 'content/posts/second-post.mdx',
-    document: { title: 'Second Post', featured: true },
-  },
-];
-
-// The standalone preview's static seed (/preview.html opened directly).
-export const sampleDocument: TinaDocument = documents[0].document;
+// Static seed for /preview.html opened standalone (outside the editor iframe).
+export const sampleDocument: TinaDocument = {
+  title: 'Hello World',
+  featured: false,
+};

--- a/packages/v4/@tinacms/tinacms/playground/tsconfig.json
+++ b/packages/v4/@tinacms/tinacms/playground/tsconfig.json
@@ -9,7 +9,8 @@
     "paths": {
       "@tinacms/tinacms/react": ["../src/editor/index.ts"],
       "@tinacms/tinacms/adapters/react": ["../src/adapters/react/index.ts"],
-      "@tinacms/tinacms": ["../src/index.ts"]
+      "@tinacms/tinacms": ["../src/index.ts"],
+      "@tinacms/graphql": ["../src/plugins/content/local/tinacms-graphql.d.ts"]
     }
   },
   "include": ["src", "vite.config.ts"]

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -58,6 +58,14 @@ const localDataLayerPlugin = (): Plugin => {
 // Array form: the more specific subpath must come first.
 export default defineConfig({
   plugins: [react(), tailwindcss(), localDataLayerPlugin()],
+  server: {
+    watch: {
+      // Content documents are data, not app source — a save must reach the
+      // editor through the content slice, not as an HMR full page reload
+      // (tailwind's content scan otherwise promotes the .mdx write to one).
+      ignored: [fileURLToPath(new URL('./content/**', import.meta.url))],
+    },
+  },
   resolve: {
     alias: [
       {

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { type Connect, type Plugin, defineConfig } from 'vite';
+import { DEFAULT_CONTENT_URL } from '../src/plugins/content/local/local-content.plugin';
 import {
   createLocalDataLayer,
   handleContentRequest,
@@ -18,7 +19,16 @@ const localDataLayerPlugin = (): Plugin => {
     collections: [{ ...postCollectionMeta, fields: [] }],
   });
   const handle: Connect.NextHandleFunction = (req, res) => {
+    // CSRF guard: browsers send Origin on cross-site POSTs — reject anything
+    // that isn't the dev server itself (no Origin = curl and friends, allowed).
+    const { origin, host } = req.headers;
+    if (origin && origin !== `http://${host}`) {
+      res.statusCode = 403;
+      res.end('Cross-origin request rejected');
+      return;
+    }
     let body = '';
+    req.setEncoding('utf8');
     req.on('data', (chunk) => {
       body += chunk;
     });
@@ -36,7 +46,7 @@ const localDataLayerPlugin = (): Plugin => {
   return {
     name: 'tina-local-data-layer',
     configureServer(server) {
-      server.middlewares.use('/api/tina/content', handle);
+      server.middlewares.use(DEFAULT_CONTENT_URL, handle);
     },
   };
 };

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -16,7 +16,9 @@ import { postCollectionMeta } from './src/collection-meta';
 const localDataLayerPlugin = (): Plugin => {
   const dataLayer = createLocalDataLayer({
     rootDir: fileURLToPath(new URL('.', import.meta.url)),
-    collections: [{ ...postCollectionMeta, fields: [] }],
+    collections: [
+      { ...postCollectionMeta, fields: [...postCollectionMeta.fields] },
+    ],
   });
   const handle: Connect.NextHandleFunction = (req, res) => {
     // CSRF guard: browsers send Origin on cross-site POSTs — reject anything

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -1,71 +1,22 @@
 import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { type Connect, type Plugin, defineConfig } from 'vite';
-import { DEFAULT_CONTENT_URL } from '../src/plugins/content/local/local-content.plugin';
-import {
-  createLocalDataLayer,
-  handleContentRequest,
-} from '../src/plugins/content/local/local-data-layer';
+import { defineConfig } from 'vite';
+import { tinaLocalDataLayerVitePlugin } from '../src/plugins/content/local/local-data-layer.vite';
 import { postCollectionMeta } from './src/collection-meta';
-
-// The Local Data Layer (ADR-018): the dev server hosts the content endpoint the
-// localContentPlugin slice talks to; saves write the real files under
-// playground/content/. Only the file mapping matters here, so the middleware
-// takes the import-free collection-meta module, not the app's full schema.
-const localDataLayerPlugin = (): Plugin => {
-  const dataLayer = createLocalDataLayer({
-    rootDir: fileURLToPath(new URL('.', import.meta.url)),
-    collections: [
-      { ...postCollectionMeta, fields: [...postCollectionMeta.fields] },
-    ],
-  });
-  const handle: Connect.NextHandleFunction = (req, res) => {
-    // CSRF guard: browsers send Origin on cross-site POSTs — reject anything
-    // that isn't the dev server itself (no Origin = curl and friends, allowed).
-    const { origin, host } = req.headers;
-    if (origin && origin !== `http://${host}` && origin !== `https://${host}`) {
-      res.statusCode = 403;
-      res.end('Cross-origin request rejected');
-      return;
-    }
-    let body = '';
-    req.setEncoding('utf8');
-    req.on('data', (chunk) => {
-      body += chunk;
-    });
-    req.on('end', async () => {
-      try {
-        const result = await handleContentRequest(dataLayer, JSON.parse(body));
-        res.setHeader('content-type', 'application/json');
-        res.end(JSON.stringify(result));
-      } catch (cause) {
-        res.statusCode = 400;
-        res.end(cause instanceof Error ? cause.message : String(cause));
-      }
-    });
-  };
-  return {
-    name: 'tina-local-data-layer',
-    configureServer(server) {
-      server.middlewares.use(DEFAULT_CONTENT_URL, handle);
-    },
-  };
-};
 
 // Aliases point the public import strings at the package source, so the playground
 // exercises the same specifiers a real app will use (not relative paths into src/).
 // Array form: the more specific subpath must come first.
 export default defineConfig({
-  plugins: [react(), tailwindcss(), localDataLayerPlugin()],
-  server: {
-    watch: {
-      // Content documents are data, not app source — a save must reach the
-      // editor through the content slice, not as an HMR full page reload
-      // (tailwind's content scan otherwise promotes the .mdx write to one).
-      ignored: [fileURLToPath(new URL('./content/**', import.meta.url))],
-    },
-  },
+  plugins: [
+    react(),
+    tailwindcss(),
+    tinaLocalDataLayerVitePlugin({
+      rootDir: fileURLToPath(new URL('.', import.meta.url)),
+      collections: [postCollectionMeta],
+    }),
+  ],
   resolve: {
     alias: [
       {

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -24,7 +24,7 @@ const localDataLayerPlugin = (): Plugin => {
     // CSRF guard: browsers send Origin on cross-site POSTs — reject anything
     // that isn't the dev server itself (no Origin = curl and friends, allowed).
     const { origin, host } = req.headers;
-    if (origin && origin !== `http://${host}`) {
+    if (origin && origin !== `http://${host}` && origin !== `https://${host}`) {
       res.statusCode = 403;
       res.end('Cross-origin request rejected');
       return;

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -1,13 +1,51 @@
 import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { type Connect, type Plugin, defineConfig } from 'vite';
+import {
+  createLocalDataLayer,
+  handleContentRequest,
+} from '../src/plugins/content/local/local-data-layer';
+import { postCollectionMeta } from './src/collection-meta';
+
+// The Local Data Layer (ADR-018): the dev server hosts the content endpoint the
+// localContentPlugin slice talks to; saves write the real files under
+// playground/content/. Only the file mapping matters here, so the middleware
+// takes the import-free collection-meta module, not the app's full schema.
+const localDataLayerPlugin = (): Plugin => {
+  const dataLayer = createLocalDataLayer({
+    rootDir: fileURLToPath(new URL('.', import.meta.url)),
+    collections: [{ ...postCollectionMeta, fields: [] }],
+  });
+  const handle: Connect.NextHandleFunction = (req, res) => {
+    let body = '';
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', async () => {
+      try {
+        const result = await handleContentRequest(dataLayer, JSON.parse(body));
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(result));
+      } catch (cause) {
+        res.statusCode = 400;
+        res.end(cause instanceof Error ? cause.message : String(cause));
+      }
+    });
+  };
+  return {
+    name: 'tina-local-data-layer',
+    configureServer(server) {
+      server.middlewares.use('/api/tina/content', handle);
+    },
+  };
+};
 
 // Aliases point the public import strings at the package source, so the playground
 // exercises the same specifiers a real app will use (not relative paths into src/).
 // Array form: the more specific subpath must come first.
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), localDataLayerPlugin()],
   resolve: {
     alias: [
       {

--- a/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
@@ -21,6 +21,11 @@ export interface ContentProvider {
   list(collection: string): Promise<DocumentEntry[]>;
   // The save: writes the JSON content value. Also writes when the file is missing —
   // a document deleted out-of-band must not swallow the editor's pending save
-  // (never lose the edit, ADR-018).
-  update(collection: string, path: string, value: TinaDocument): Promise<void>;
+  // (never lose the edit, ADR-018). Returns what was persisted, which may carry
+  // more than `value` (unknown fields merged from the stored document).
+  update(
+    collection: string,
+    path: string,
+    value: TinaDocument
+  ): Promise<DocumentEntry>;
 }

--- a/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
@@ -1,0 +1,26 @@
+import type { TinaDocument } from '../schema/types';
+
+// A document paired with its identity — the path IS the id (ADR-017); paths are
+// project-root-relative ('content/posts/hello.mdx').
+export interface DocumentEntry {
+  path: string;
+  document: TinaDocument;
+}
+
+// The abstract level of the `content` capability (ADR-019): the operation set every
+// Data Layer implements — Local (fs, this package), TinaCloud, self-hosted, or a
+// v3-compat provider translating these ops onto the v3 GraphQL client. The client
+// side talks only to this interface, so swapping providers never touches the editor.
+//
+// Deliberately the slice-sized subset: get/list/update (the save, ADR-018). Absent
+// until a consumer exists: create/delete/rename, cursor pagination, filter/sort on
+// indexed fields, system metadata, and the GraphQL wire format + generated typed
+// client (lands with codegen, ADR-019 §2).
+export interface ContentProvider {
+  get(collection: string, path: string): Promise<DocumentEntry | null>;
+  list(collection: string): Promise<DocumentEntry[]>;
+  // The save: writes the JSON content value. Also writes when the file is missing —
+  // a document deleted out-of-band must not swallow the editor's pending save
+  // (never lose the edit, ADR-018).
+  update(collection: string, path: string, value: TinaDocument): Promise<void>;
+}

--- a/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
@@ -29,3 +29,22 @@ export interface ContentProvider {
     value: TinaDocument
   ): Promise<DocumentEntry>;
 }
+
+// What `get().content` holds: the ContentProvider ops (above) plus the
+// list cache collection views render from, keyed by collection name.
+// saveDocument's rejection propagates so useFormSave leaves the form dirty
+// (context.ts SaveHandler contract).
+export interface ContentSlice {
+  documents: Record<string, DocumentEntry[]>;
+  loadDocuments(collection: string): Promise<DocumentEntry[]>;
+  getDocument(collection: string, path: string): Promise<DocumentEntry | null>;
+  saveDocument(
+    collection: string,
+    path: string,
+    value: TinaDocument
+  ): Promise<DocumentEntry>;
+}
+
+// Where the content capability's wire endpoint mounts by default — shared by
+// the client slice and whatever dev server hosts the data layer.
+export const DEFAULT_CONTENT_URL = '/api/tina/content';

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
@@ -6,6 +6,9 @@ export interface BaseFieldSchema {
 
 export interface FieldSchema extends BaseFieldSchema {
   type: string;
+  // Marks the field that owns the markdown body (v3 content model). The local
+  // GraphQL pipeline serves it as the v3 mdx AST; the form doesn't edit it yet.
+  isBody?: boolean;
 }
 
 export interface CollectionSchema {

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
@@ -15,7 +15,7 @@ export interface CollectionSchema {
   name: string;
   label?: string;
   path?: string;
-  format?: 'md' | 'mdx' | 'json' | 'yaml';
+  format: 'md' | 'mdx' | 'json' | 'yaml';
   fields: FieldSchema[];
 }
 

--- a/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
@@ -1,6 +1,7 @@
 import { use, useCallback, useEffect, useRef } from 'react';
 import { useController, useFormContext, useFormState } from 'react-hook-form';
 import { useStore } from 'zustand';
+import type { ContentSlice, DocumentEntry } from '../core/content/contract';
 import type { FieldAddress } from '../core/field/address';
 import type { FieldRegistry } from '../core/field/registry';
 import { digestDocument } from '../core/form/ingest';
@@ -37,6 +38,38 @@ export function useTinaStore<Selected>(
     'useTinaStore must be used within a TinaProvider'
   );
   return useStore(runtime.store, selector);
+}
+
+// The `content` namespace is typed as an open SliceState until codegen produces
+// typed capability reads; the one cast lives here.
+export function useContentSlice(): ContentSlice {
+  const slice = useTinaStore((state) => state.content);
+  invariant(
+    slice,
+    'content-capability-missing',
+    'No content capability is mounted — pass a content plugin (e.g. localContentPlugin()) to <TinaProvider plugins>'
+  );
+  return slice as unknown as ContentSlice;
+}
+
+// Stable fallback so the selector below never returns a fresh [] per render.
+const EMPTY_DOCUMENTS: DocumentEntry[] = [];
+
+// Loads the collection through the content capability on mount (and when the
+// collection changes) and returns the slice's list cache for that collection.
+// The effect depends on the loadDocuments function (stable action ref), not the
+// slice object, so the load runs once per collection — not per slice update.
+export function useCollectionDocuments(collection: string): DocumentEntry[] {
+  const { documents, loadDocuments } = useContentSlice();
+  useEffect(() => {
+    loadDocuments(collection).catch((cause) =>
+      console.error(
+        `[tinacms] Failed to load collection "${collection}":`,
+        cause
+      )
+    );
+  }, [loadDocuments, collection]);
+  return documents[collection] ?? EMPTY_DOCUMENTS;
 }
 
 function useFormScope(hookCode: string, hookName: string): FormScope {

--- a/packages/v4/@tinacms/tinacms/src/editor/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/index.ts
@@ -40,6 +40,8 @@ export {
 export {
   type ActiveField,
   useActiveField,
+  useCollectionDocuments,
+  useContentSlice,
   useFieldActivation,
   useFieldAddress,
   useFieldErrors,

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
@@ -1,7 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { definePlugin } from '../core/plugin';
-import { corePlugins } from '../index';
 import { useFieldRegistry, useTinaStore } from './hooks';
 import { TinaProvider } from './provider';
 
@@ -21,9 +20,9 @@ function BootProbe() {
 }
 
 describe('TinaProvider boot', () => {
-  it('provides the resolved field registry and the composed boot store', async () => {
+  it('mounts corePlugins by default: resolved field registry, composed boot store', async () => {
     render(
-      <TinaProvider plugins={corePlugins}>
+      <TinaProvider>
         <BootProbe />
       </TinaProvider>
     );
@@ -40,7 +39,7 @@ describe('TinaProvider boot', () => {
     const onDestroy = vi.fn();
     const lifecycle = definePlugin({ name: 'lifecycle', onInit, onDestroy });
     const { unmount } = render(
-      <TinaProvider plugins={[...corePlugins, lifecycle]}>
+      <TinaProvider plugins={[lifecycle]}>
         <BootProbe />
       </TinaProvider>
     );

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
@@ -21,6 +21,7 @@ import {
   toFormValues,
   useFormStore,
 } from '../form/form-store';
+import { corePlugins } from '../plugins/fields';
 import { createTinaStore } from '../store/create-store';
 import {
   FormScopeContext,
@@ -36,7 +37,9 @@ import {
 import { buildFormResolver } from './resolver';
 
 export interface TinaProviderProps {
-  plugins: PluginManifest[];
+  // Additional plugins on top of the built-in corePlugins; a passed plugin with
+  // a built-in's name replaces it (user override wins).
+  plugins?: PluginManifest[];
   children: ReactNode;
 }
 
@@ -47,12 +50,17 @@ export interface TinaProviderProps {
 // are module singletons, so their lifecycle is global state.
 let lifecycleTurn: Promise<unknown> = Promise.resolve();
 
-export function TinaProvider({ plugins, children }: TinaProviderProps) {
+export function TinaProvider({ plugins = [], children }: TinaProviderProps) {
   // One resolveClientSegments pass feeds both runtime halves (ADR-003), held as a
   // single state object so registry and store always appear together (no tearing).
   const [runtime, setRuntime] = useState<TinaRuntime | null>(null);
   const [error, setError] = useState<Error | null>(null);
-  const pluginsKey = plugins.map((plugin) => plugin.name).join('|');
+  const passedNames = new Set(plugins.map((plugin) => plugin.name));
+  const composedPlugins = [
+    ...corePlugins.filter((plugin) => !passedNames.has(plugin.name)),
+    ...plugins,
+  ];
+  const pluginsKey = composedPlugins.map((plugin) => plugin.name).join('|');
 
   useEffect(() => {
     let mounted = true;
@@ -63,13 +71,13 @@ export function TinaProvider({ plugins, children }: TinaProviderProps) {
     // onInit runs last, before the runtime is exposed, so no consumer sees a
     // half-initialized plugin set.
     const boot = lifecycleTurn.then(async () => {
-      validateCapabilityGraph(plugins);
-      const resolved = await resolveClientSegments(plugins);
+      validateCapabilityGraph(composedPlugins);
+      const resolved = await resolveClientSegments(composedPlugins);
       const runtime: TinaRuntime = {
         registry: createFieldRegistry(resolved),
         store: createTinaStore(resolved),
       };
-      const destroyPlugins = await initializePlugins(plugins);
+      const destroyPlugins = await initializePlugins(composedPlugins);
       if (mounted) setRuntime(runtime);
       return destroyPlugins;
     });

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
@@ -48,7 +48,7 @@ export interface TinaProviderProps {
 // onInit waits for the previous instance's teardown, so an outgoing onDestroy
 // can never land after a successor's onInit. Module-level on purpose: manifests
 // are module singletons, so their lifecycle is global state.
-let lifecycleTurn: Promise<unknown> = Promise.resolve();
+let lifecycleTurn: Promise<void> = Promise.resolve();
 
 export function TinaProvider({ plugins = [], children }: TinaProviderProps) {
   // One resolveClientSegments pass feeds both runtime halves (ADR-003), held as a
@@ -81,10 +81,19 @@ export function TinaProvider({ plugins = [], children }: TinaProviderProps) {
       if (mounted) setRuntime(runtime);
       return destroyPlugins;
     });
+    // Advance the shared turn at mount, not just at teardown: a second provider
+    // mounting in the same commit then chains its onInit after this boot instead
+    // of racing it on the module-singleton manifests. Teardown replaces the turn
+    // again with the destroy.
+    lifecycleTurn = boot.then(
+      () => undefined,
+      () => undefined
+    );
     boot.catch((cause) => {
-      if (mounted) {
-        setError(cause instanceof Error ? cause : new Error(String(cause)));
-      }
+      if (!mounted) return;
+      const bootError =
+        cause instanceof Error ? cause : new Error(String(cause));
+      setError(bootError);
     });
     return () => {
       mounted = false;

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
@@ -91,9 +91,11 @@ export function TinaProvider({ plugins = [], children }: TinaProviderProps) {
     );
     boot.catch((cause) => {
       if (!mounted) return;
-      const bootError =
-        cause instanceof Error ? cause : new Error(String(cause));
-      setError(bootError);
+      if (cause instanceof Error) {
+        setError(cause);
+      } else {
+        setError(new Error(String(cause)));
+      }
     });
     return () => {
       mounted = false;

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -5,6 +5,10 @@
 // helpers, and the public contract types. Each field type contributes its own
 // `t.<type>` builder from its plugin; this entry is the composition root.
 
+export type {
+  ContentProvider,
+  DocumentEntry,
+} from './core/content/contract';
 export {
   type Capability,
   definePlugin,
@@ -15,6 +19,10 @@ export type {
   FieldSchema,
   TinaDocument,
 } from './core/schema/types';
+export {
+  type ContentSlice,
+  localContentPlugin,
+} from './plugins/content/local/local-content.plugin';
 export { corePlugins, t } from './plugins/fields';
 export type {
   BooleanFieldSchema,

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -7,6 +7,7 @@
 
 export type {
   ContentProvider,
+  ContentSlice,
   DocumentEntry,
 } from './core/content/contract';
 export {
@@ -19,10 +20,7 @@ export type {
   FieldSchema,
   TinaDocument,
 } from './core/schema/types';
-export {
-  type ContentSlice,
-  localContentPlugin,
-} from './plugins/content/local/local-content.plugin';
+export { localContentPlugin } from './plugins/content/local/local-content.plugin';
 export { corePlugins, t } from './plugins/fields';
 export type {
   BooleanFieldSchema,

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/content-request.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/content-request.ts
@@ -1,0 +1,46 @@
+// The wire protocol: one JSON request per operation, validated at the trust
+// boundary. Transport-agnostic — the host (Vite middleware, express, a Next
+// route) parses the HTTP body and JSONs the result back.
+
+import { z } from 'zod';
+import type { DocumentEntry } from '../../../core/content/contract';
+import type { GraphQLResult } from './graphql-pipeline';
+import type { LocalDataLayer } from './local-data-layer';
+
+const contentRequestSchema = z.discriminatedUnion('op', [
+  z.object({ op: z.literal('list'), collection: z.string() }),
+  z.object({ op: z.literal('get'), collection: z.string(), path: z.string() }),
+  z.object({
+    op: z.literal('update'),
+    collection: z.string(),
+    path: z.string(),
+    value: z.record(z.string(), z.unknown()),
+  }),
+  // The v3 read surface: a raw GraphQL request, answered by graphql-pipeline.ts.
+  z.object({
+    op: z.literal('graphql'),
+    query: z.string(),
+    variables: z.record(z.string(), z.unknown()).optional(),
+  }),
+]);
+
+export type ContentRequest = z.infer<typeof contentRequestSchema>;
+
+// Returns DocumentEntry shapes for the provider ops, or the GraphQL
+// { data, errors } envelope for `graphql` — the host JSONs it either way.
+export const dispatchContentRequest = async (
+  provider: LocalDataLayer,
+  request: unknown
+): Promise<DocumentEntry[] | DocumentEntry | null | GraphQLResult> => {
+  const parsed = contentRequestSchema.parse(request);
+  switch (parsed.op) {
+    case 'list':
+      return provider.list(parsed.collection);
+    case 'get':
+      return provider.get(parsed.collection, parsed.path);
+    case 'update':
+      return provider.update(parsed.collection, parsed.path, parsed.value);
+    case 'graphql':
+      return provider.graphql(parsed.query, parsed.variables);
+  }
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/content-request.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/content-request.ts
@@ -1,6 +1,7 @@
-// The wire protocol: one JSON request per operation, validated at the trust
-// boundary. Transport-agnostic — the host (Vite middleware, express, a Next
-// route) parses the HTTP body and JSONs the result back.
+// The wire protocol. Each operation is one JSON request, and this file validates it at
+// the trust boundary. It knows no transport. The host parses the HTTP body, and writes
+// the result back as JSON. That host is a Vite middleware, an express server, or a
+// Next.js route.
 
 import { z } from 'zod';
 import type { DocumentEntry } from '../../../core/content/contract';
@@ -16,7 +17,7 @@ const contentRequestSchema = z.discriminatedUnion('op', [
     path: z.string(),
     value: z.record(z.string(), z.unknown()),
   }),
-  // The v3 read surface: a raw GraphQL request, answered by graphql-pipeline.ts.
+  // The v3 read interface. It is a GraphQL request, and graphql-pipeline.ts answers it.
   z.object({
     op: z.literal('graphql'),
     query: z.string(),
@@ -26,8 +27,8 @@ const contentRequestSchema = z.discriminatedUnion('op', [
 
 export type ContentRequest = z.infer<typeof contentRequestSchema>;
 
-// Returns DocumentEntry shapes for the provider ops, or the GraphQL
-// { data, errors } envelope for `graphql` — the host JSONs it either way.
+// This returns a DocumentEntry for a provider operation, and the GraphQL
+// { data, errors } object for `graphql`. The host writes either one as JSON.
 export const dispatchContentRequest = async (
   provider: LocalDataLayer,
   request: unknown

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { formatAdapterFor } from './format-adapters';
+
+const MDX_RAW = `---
+title: Hello World
+featured: false
+category: not-in-schema
+---
+
+Body prose the schema does not know about.
+`;
+
+describe('markdown adapter', () => {
+  const adapter = formatAdapterFor('mdx');
+
+  it('parses frontmatter as the document', () => {
+    expect(adapter.parse(MDX_RAW)).toEqual({
+      title: 'Hello World',
+      featured: false,
+      category: 'not-in-schema',
+    });
+  });
+
+  it('preserves unknown frontmatter keys and the body across a save', () => {
+    const saved = adapter.serialize(
+      { title: 'Renamed', featured: true },
+      MDX_RAW
+    );
+    expect(adapter.parse(saved)).toEqual({
+      title: 'Renamed',
+      featured: true,
+      category: 'not-in-schema',
+    });
+    expect(saved).toContain('Body prose the schema does not know about.');
+  });
+
+  it('serializes a fresh document without a previous file', () => {
+    const saved = adapter.serialize({ title: 'New' });
+    expect(adapter.parse(saved)).toEqual({ title: 'New' });
+  });
+});
+
+describe('json adapter', () => {
+  const adapter = formatAdapterFor('json');
+
+  it('round-trips and preserves unknown keys', () => {
+    const previous = JSON.stringify({ title: 'Old', extra: 'kept' });
+    const saved = adapter.serialize({ title: 'New' }, previous);
+    expect(adapter.parse(saved)).toEqual({ title: 'New', extra: 'kept' });
+    expect(saved.endsWith('\n')).toBe(true);
+  });
+});
+
+it('throws on an unsupported format', () => {
+  expect(() => formatAdapterFor('yaml')).toThrow(/No format adapter/);
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.ts
@@ -1,8 +1,9 @@
-import matter from 'gray-matter';
 import type {
   CollectionSchema,
   TinaDocument,
 } from '../../../core/schema/types';
+import { jsonAdapter } from './json.adapter';
+import { markdownAdapter } from './markdown.adapter';
 
 export type CollectionFormat = NonNullable<CollectionSchema['format']>;
 
@@ -17,29 +18,6 @@ export interface FormatAdapter {
   parse(raw: string): TinaDocument;
   serialize(document: TinaDocument, previousRaw?: string): string;
 }
-
-// Frontmatter is the document; the body stays out of it until a rich-text `isBody`
-// field exists to own it — preserved via previousRaw meanwhile.
-const markdownAdapter = (extension: string): FormatAdapter => ({
-  extension,
-  parse: (raw) => matter(raw).data,
-  serialize: (document, previousRaw) => {
-    const previous = matter(previousRaw ?? '');
-    return matter.stringify(previous.content, {
-      ...previous.data,
-      ...document,
-    });
-  },
-});
-
-const jsonAdapter: FormatAdapter = {
-  extension: '.json',
-  parse: (raw) => JSON.parse(raw),
-  serialize: (document, previousRaw) => {
-    const previous = previousRaw ? JSON.parse(previousRaw) : {};
-    return `${JSON.stringify({ ...previous, ...document }, null, 2)}\n`;
-  },
-};
 
 const adapters: Partial<Record<CollectionFormat, FormatAdapter>> = {
   md: markdownAdapter('.md'),

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.ts
@@ -1,0 +1,53 @@
+import matter from 'gray-matter';
+import type { TinaDocument } from '../../../core/schema/types';
+
+// Format adapters (ADR-017 §5): the only serialization layer — document JSON ↔ file.
+// `serialize` takes the file's previous raw contents and merges the saved value OVER
+// what's already there, so frontmatter keys the schema doesn't know about and the
+// markdown body survive every save verbatim (CONTEXT.md Unknown field). That
+// round-trip guarantee is what makes pointing v4 at an existing v3 content folder
+// safe — same gray-matter format v3 writes, nothing gets dropped.
+export interface FormatAdapter {
+  extension: string;
+  parse(raw: string): TinaDocument;
+  serialize(document: TinaDocument, previousRaw?: string): string;
+}
+
+// Frontmatter is the document; the body stays out of it until a rich-text `isBody`
+// field exists to own it — preserved via previousRaw meanwhile.
+const markdownAdapter = (extension: string): FormatAdapter => ({
+  extension,
+  parse: (raw) => matter(raw).data,
+  serialize: (document, previousRaw) => {
+    const previous = matter(previousRaw ?? '');
+    return matter.stringify(previous.content, {
+      ...previous.data,
+      ...document,
+    });
+  },
+});
+
+const jsonAdapter: FormatAdapter = {
+  extension: '.json',
+  parse: (raw) => JSON.parse(raw),
+  serialize: (document, previousRaw) => {
+    const previous = previousRaw ? JSON.parse(previousRaw) : {};
+    return `${JSON.stringify({ ...previous, ...document }, null, 2)}\n`;
+  },
+};
+
+const adapters: Record<string, FormatAdapter> = {
+  md: markdownAdapter('.md'),
+  mdx: markdownAdapter('.mdx'),
+  json: jsonAdapter,
+};
+
+export const formatAdapterFor = (format: string): FormatAdapter => {
+  const adapter = adapters[format];
+  if (!adapter) {
+    throw new Error(
+      `No format adapter for "${format}" — supported: ${Object.keys(adapters).join(', ')}.`
+    );
+  }
+  return adapter;
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/format-adapters.ts
@@ -1,5 +1,10 @@
 import matter from 'gray-matter';
-import type { TinaDocument } from '../../../core/schema/types';
+import type {
+  CollectionSchema,
+  TinaDocument,
+} from '../../../core/schema/types';
+
+export type CollectionFormat = NonNullable<CollectionSchema['format']>;
 
 // Format adapters (ADR-017 §5): the only serialization layer — document JSON ↔ file.
 // `serialize` takes the file's previous raw contents and merges the saved value OVER
@@ -36,17 +41,21 @@ const jsonAdapter: FormatAdapter = {
   },
 };
 
-const adapters: Record<string, FormatAdapter> = {
+const adapters: Partial<Record<CollectionFormat, FormatAdapter>> = {
   md: markdownAdapter('.md'),
   mdx: markdownAdapter('.mdx'),
   json: jsonAdapter,
 };
 
-export const formatAdapterFor = (format: string): FormatAdapter => {
-  const adapter = adapters[format];
+export const formatAdapterFor = (
+  format: CollectionFormat,
+  overrides?: Partial<Record<CollectionFormat, FormatAdapter>>
+): FormatAdapter => {
+  const registry = { ...adapters, ...overrides };
+  const adapter = registry[format];
   if (!adapter) {
     throw new Error(
-      `No format adapter for "${format}" — supported: ${Object.keys(adapters).join(', ')}.`
+      `No format adapter for "${format}" — supported: ${Object.keys(registry).join(', ')}.`
     );
   }
   return adapter;

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
@@ -1,0 +1,91 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  type LocalDataLayer,
+  createLocalDataLayer,
+  handleContentRequest,
+} from './local-data-layer';
+
+const HELLO_RAW = `---
+title: Hello World
+featured: false
+---
+
+Body prose.
+`;
+
+let rootDir: string;
+let dataLayer: LocalDataLayer;
+
+beforeEach(async () => {
+  rootDir = await fs.mkdtemp(path.join(tmpdir(), 'tina-graphql-'));
+  await fs.mkdir(path.join(rootDir, 'content/posts'), { recursive: true });
+  await fs.writeFile(path.join(rootDir, 'content/posts/hello.mdx'), HELLO_RAW);
+  dataLayer = createLocalDataLayer({
+    rootDir,
+    collections: [
+      {
+        name: 'post',
+        path: 'content/posts',
+        format: 'mdx',
+        fields: [
+          { name: 'title', type: 'string', required: true },
+          { name: 'featured', type: 'boolean' },
+        ],
+      },
+    ],
+  });
+});
+
+afterEach(() => fs.rm(rootDir, { recursive: true, force: true }));
+
+type GraphQLResult = {
+  data?: Record<string, any>;
+  errors?: { message: string }[];
+};
+
+describe('graphql (the v3 pipeline)', () => {
+  it('answers a v3 single-document query', async () => {
+    const result = (await dataLayer.graphql(
+      'query($relativePath: String!) { post(relativePath: $relativePath) { title featured } }',
+      { relativePath: 'hello.mdx' }
+    )) as GraphQLResult;
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.post).toMatchObject({
+      title: 'Hello World',
+      featured: false,
+    });
+  });
+
+  it('answers a v3 connection (list) query', async () => {
+    const result = (await dataLayer.graphql(
+      'query { postConnection { edges { node { title } } } }'
+    )) as GraphQLResult;
+    expect(result.errors).toBeUndefined();
+    expect(
+      result.data?.postConnection.edges.map((edge: any) => edge.node.title)
+    ).toEqual(['Hello World']);
+  });
+
+  it('sees a save made after the pipeline booted (reindex-on-save)', async () => {
+    await dataLayer.graphql('query { postConnection { totalCount } }');
+    await dataLayer.update('post', 'content/posts/hello.mdx', {
+      title: 'Renamed',
+      featured: true,
+    });
+    const result = (await dataLayer.graphql(
+      'query { post(relativePath: "hello.mdx") { title } }'
+    )) as GraphQLResult;
+    expect(result.data?.post.title).toBe('Renamed');
+  });
+
+  it('dispatches over the wire protocol', async () => {
+    const result = (await handleContentRequest(dataLayer, {
+      op: 'graphql',
+      query: 'query { post(relativePath: "hello.mdx") { title } }',
+    })) as GraphQLResult;
+    expect(result.data?.post.title).toBe('Hello World');
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
@@ -2,11 +2,8 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import {
-  type LocalDataLayer,
-  createLocalDataLayer,
-  handleContentRequest,
-} from './local-data-layer';
+import { dispatchContentRequest } from './content-request';
+import { type LocalDataLayer, createLocalDataLayer } from './local-data-layer';
 
 const HELLO_RAW = `---
 title: Hello World
@@ -42,17 +39,12 @@ beforeEach(async () => {
 
 afterEach(() => fs.rm(rootDir, { recursive: true, force: true }));
 
-type GraphQLResult = {
-  data?: Record<string, any>;
-  errors?: { message: string }[];
-};
-
 describe('graphql (the v3 pipeline)', () => {
   it('answers a v3 single-document query', async () => {
-    const result = (await dataLayer.graphql(
+    const result = await dataLayer.graphql(
       'query($relativePath: String!) { post(relativePath: $relativePath) { title featured } }',
       { relativePath: 'hello.mdx' }
-    )) as GraphQLResult;
+    );
     expect(result.errors).toBeUndefined();
     expect(result.data?.post).toMatchObject({
       title: 'Hello World',
@@ -61,13 +53,13 @@ describe('graphql (the v3 pipeline)', () => {
   });
 
   it('answers a v3 connection (list) query', async () => {
-    const result = (await dataLayer.graphql(
+    const result = await dataLayer.graphql(
       'query { postConnection { edges { node { title } } } }'
-    )) as GraphQLResult;
+    );
     expect(result.errors).toBeUndefined();
-    expect(
-      result.data?.postConnection.edges.map((edge: any) => edge.node.title)
-    ).toEqual(['Hello World']);
+    expect(result.data?.postConnection).toMatchObject({
+      edges: [{ node: { title: 'Hello World' } }],
+    });
   });
 
   it('sees a save made after the pipeline booted (reindex-on-save)', async () => {
@@ -76,35 +68,40 @@ describe('graphql (the v3 pipeline)', () => {
       title: 'Renamed',
       featured: true,
     });
-    const result = (await dataLayer.graphql(
+    const result = await dataLayer.graphql(
       'query { post(relativePath: "hello.mdx") { title } }'
-    )) as GraphQLResult;
-    expect(result.data?.post.title).toBe('Renamed');
+    );
+    expect(result.data?.post).toMatchObject({ title: 'Renamed' });
   });
 
   it('serves the markdown body as the v3 mdx AST, surviving a frontmatter save', async () => {
     const query = 'query { post(relativePath: "hello.mdx") { body } }';
-    const before = (await dataLayer.graphql(query)) as GraphQLResult;
+    const before = await dataLayer.graphql(query);
     expect(before.errors).toBeUndefined();
-    expect(before.data?.post.body).toMatchObject({
-      type: 'root',
-      children: [
-        { type: 'p', children: [{ type: 'text', text: 'Body prose.' }] },
-      ],
+    expect(before.data?.post).toMatchObject({
+      body: {
+        type: 'root',
+        children: [
+          { type: 'p', children: [{ type: 'text', text: 'Body prose.' }] },
+        ],
+      },
     });
     await dataLayer.update('post', 'content/posts/hello.mdx', {
       title: 'Renamed',
       featured: true,
     });
-    const after = (await dataLayer.graphql(query)) as GraphQLResult;
-    expect(after.data?.post.body).toEqual(before.data?.post.body);
+    // The query selects only the body, so the whole envelope must round-trip.
+    const after = await dataLayer.graphql(query);
+    expect(after.data).toEqual(before.data);
   });
 
   it('dispatches over the wire protocol', async () => {
-    const result = (await handleContentRequest(dataLayer, {
+    const result = await dispatchContentRequest(dataLayer, {
       op: 'graphql',
       query: 'query { post(relativePath: "hello.mdx") { title } }',
-    })) as GraphQLResult;
-    expect(result.data?.post.title).toBe('Hello World');
+    });
+    expect(result).toMatchObject({
+      data: { post: { title: 'Hello World' } },
+    });
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
@@ -33,6 +33,7 @@ beforeEach(async () => {
         fields: [
           { name: 'title', type: 'string', required: true },
           { name: 'featured', type: 'boolean' },
+          { name: 'body', type: 'rich-text', isBody: true },
         ],
       },
     ],
@@ -79,6 +80,24 @@ describe('graphql (the v3 pipeline)', () => {
       'query { post(relativePath: "hello.mdx") { title } }'
     )) as GraphQLResult;
     expect(result.data?.post.title).toBe('Renamed');
+  });
+
+  it('serves the markdown body as the v3 mdx AST, surviving a frontmatter save', async () => {
+    const query = 'query { post(relativePath: "hello.mdx") { body } }';
+    const before = (await dataLayer.graphql(query)) as GraphQLResult;
+    expect(before.errors).toBeUndefined();
+    expect(before.data?.post.body).toMatchObject({
+      type: 'root',
+      children: [
+        { type: 'p', children: [{ type: 'text', text: 'Body prose.' }] },
+      ],
+    });
+    await dataLayer.update('post', 'content/posts/hello.mdx', {
+      title: 'Renamed',
+      featured: true,
+    });
+    const after = (await dataLayer.graphql(query)) as GraphQLResult;
+    expect(after.data?.post.body).toEqual(before.data?.post.body);
   });
 
   it('dispatches over the wire protocol', async () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
@@ -36,6 +36,7 @@ const toV3Field = (field: FieldSchema) => ({
   name: field.name,
   label: field.label,
   required: field.required,
+  isBody: field.isBody,
 });
 
 const toV3Collection = (collection: CollectionSchema) => ({

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
@@ -67,9 +67,18 @@ export const createGraphQLPipeline = async (
     buildSDK: false,
   });
   await database.indexContent({ graphQLSchema, tinaSchema, lookup });
+  // Reindexes run one at a time — concurrent saves must not interleave
+  // read-modify-write on the shared index. A failed run doesn't block the next.
+  let indexing: Promise<unknown> = Promise.resolve();
   return {
     execute: (query, variables = {}) =>
       resolve({ database, query, variables, verbose: false }),
-    reindexPaths: (paths) => database.indexContentByPaths(paths),
+    reindexPaths: async (paths) => {
+      const run = indexing
+        .catch(() => {})
+        .then(() => database.indexContentByPaths(paths));
+      indexing = run;
+      await run;
+    },
   };
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
@@ -1,0 +1,75 @@
+// Node-only — the v3 content pipeline, hosted by the Local Data Layer: the same
+// @tinacms/graphql Database/resolve stack the v3 CLI ran, indexing local files
+// into an abstract-level store (sqlite-level, the adapter we maintain). Keeps
+// every v3 GraphQL query working against v4-managed content.
+
+import {
+  FilesystemBridge,
+  type Level,
+  buildDotTinaFiles,
+  createDatabaseInternal,
+  resolve,
+} from '@tinacms/graphql';
+import { SqliteLevel } from 'sqlite-level';
+import type { CollectionSchema, FieldSchema } from '../../../core/schema/types';
+
+export interface GraphQLPipelineOptions {
+  rootDir: string;
+  collections: CollectionSchema[];
+  // Any abstract-level store; defaults to an in-memory sqlite-level. Pass a
+  // file-backed one to persist the index across restarts.
+  level?: Level;
+}
+
+export interface GraphQLPipeline {
+  // Runs one v3 GraphQL request; returns the standard { data, errors } envelope.
+  execute(query: string, variables?: Record<string, unknown>): Promise<unknown>;
+  // Re-index saved documents (root-relative posix paths) so the next execute
+  // sees them.
+  reindexPaths(paths: string[]): Promise<void>;
+}
+
+// v3's schema validation rejects unknown keys, so only the props both models
+// share cross over; v4-only field props (validation rules, ui config) stay out.
+const toV3Field = (field: FieldSchema) => ({
+  type: field.type,
+  name: field.name,
+  label: field.label,
+  required: field.required,
+});
+
+const toV3Collection = (collection: CollectionSchema) => ({
+  name: collection.name,
+  label: collection.label,
+  path: collection.path,
+  format: collection.format,
+  fields: collection.fields.map(toV3Field),
+});
+
+export const createGraphQLPipeline = async (
+  options: GraphQLPipelineOptions
+): Promise<GraphQLPipeline> => {
+  const database = createDatabaseInternal({
+    bridge: new FilesystemBridge(options.rootDir),
+    level:
+      options.level ??
+      (new SqliteLevel({
+        filename: ':memory:',
+        valueEncoding: 'json',
+      }) as unknown as Level),
+    tinaDirectory: 'tina',
+  });
+  const schema = { collections: options.collections.map(toV3Collection) };
+  const { graphQLSchema, tinaSchema, lookup } = await buildDotTinaFiles({
+    // buildDotTinaFiles only reads config.schema; the full v3 Config surface
+    // (branch, clientId, media…) has no local equivalent.
+    config: { schema } as Parameters<typeof buildDotTinaFiles>[0]['config'],
+    buildSDK: false,
+  });
+  await database.indexContent({ graphQLSchema, tinaSchema, lookup });
+  return {
+    execute: (query, variables = {}) =>
+      resolve({ database, query, variables, verbose: false }),
+    reindexPaths: (paths) => database.indexContentByPaths(paths),
+  };
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
@@ -5,6 +5,7 @@
 
 import {
   FilesystemBridge,
+  type GraphQLResult,
   type Level,
   buildDotTinaFiles,
   createDatabaseInternal,
@@ -12,6 +13,9 @@ import {
 } from '@tinacms/graphql';
 import { SqliteLevel } from 'sqlite-level';
 import type { CollectionSchema, FieldSchema } from '../../../core/schema/types';
+
+export type { GraphQLResult } from '@tinacms/graphql';
+export type GraphQLVariables = Record<string, unknown>;
 
 export interface GraphQLPipelineOptions {
   rootDir: string;
@@ -23,7 +27,7 @@ export interface GraphQLPipelineOptions {
 
 export interface GraphQLPipeline {
   // Runs one v3 GraphQL request; returns the standard { data, errors } envelope.
-  execute(query: string, variables?: Record<string, unknown>): Promise<unknown>;
+  execute(query: string, variables?: GraphQLVariables): Promise<GraphQLResult>;
   // Re-index saved documents (root-relative posix paths) so the next execute
   // sees them.
   reindexPaths(paths: string[]): Promise<void>;
@@ -47,6 +51,8 @@ const toV3Collection = (collection: CollectionSchema) => ({
   fields: collection.fields.map(toV3Field),
 });
 
+type IndexedDocument = Record<string, unknown>;
+
 export const createGraphQLPipeline = async (
   options: GraphQLPipelineOptions
 ): Promise<GraphQLPipeline> => {
@@ -54,7 +60,7 @@ export const createGraphQLPipeline = async (
     bridge: new FilesystemBridge(options.rootDir),
     level:
       options.level ??
-      new SqliteLevel<string, Record<string, unknown>>({
+      new SqliteLevel<string, IndexedDocument>({
         filename: ':memory:',
         valueEncoding: 'json',
       }),
@@ -70,7 +76,7 @@ export const createGraphQLPipeline = async (
   await database.indexContent({ graphQLSchema, tinaSchema, lookup });
   // Reindexes run one at a time — concurrent saves must not interleave
   // read-modify-write on the shared index. A failed run doesn't block the next.
-  let indexing: Promise<unknown> = Promise.resolve();
+  let indexing: Promise<void> = Promise.resolve();
   return {
     execute: (query, variables = {}) =>
       resolve({ database, query, variables, verbose: false }),

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
@@ -53,17 +53,17 @@ export const createGraphQLPipeline = async (
     bridge: new FilesystemBridge(options.rootDir),
     level:
       options.level ??
-      (new SqliteLevel({
+      new SqliteLevel<string, Record<string, unknown>>({
         filename: ':memory:',
         valueEncoding: 'json',
-      }) as unknown as Level),
+      }),
     tinaDirectory: 'tina',
   });
   const schema = { collections: options.collections.map(toV3Collection) };
   const { graphQLSchema, tinaSchema, lookup } = await buildDotTinaFiles({
     // buildDotTinaFiles only reads config.schema; the full v3 Config surface
     // (branch, clientId, media…) has no local equivalent.
-    config: { schema } as Parameters<typeof buildDotTinaFiles>[0]['config'],
+    config: { schema },
     buildSDK: false,
   });
   await database.indexContent({ graphQLSchema, tinaSchema, lookup });

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/json.adapter.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/json.adapter.ts
@@ -1,0 +1,10 @@
+import type { FormatAdapter } from './format-adapters';
+
+export const jsonAdapter: FormatAdapter = {
+  extension: '.json',
+  parse: (raw) => JSON.parse(raw),
+  serialize: (document, previousRaw) => {
+    const previous = previousRaw ? JSON.parse(previousRaw) : {};
+    return `${JSON.stringify({ ...previous, ...document }, null, 2)}\n`;
+  },
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
@@ -29,10 +29,13 @@ const postContentRequest = async <Result>(
 const upsertByPath = (
   entries: DocumentEntry[],
   entry: DocumentEntry
-): DocumentEntry[] =>
-  entries.some((cached) => cached.path === entry.path)
-    ? entries.map((cached) => (cached.path === entry.path ? entry : cached))
-    : [...entries, entry];
+): DocumentEntry[] => {
+  const index = entries.findIndex((cached) => cached.path === entry.path);
+  if (index === -1) return [...entries, entry];
+  const next = [...entries];
+  next[index] = entry;
+  return next;
+};
 
 // The store composes many slices, so the setter hands back the generic SliceState
 // (Record<string, unknown>). This is the one place that reads our own `documents`

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
@@ -6,7 +6,7 @@
 // Refer to ContentSlice.
 
 import type {
-  ContentSlice,
+  ContentProvider,
   DocumentEntry,
 } from '../../../core/content/contract';
 import type { ClientSlice } from '../../../core/plugin';
@@ -30,7 +30,7 @@ const postContentRequest = async <Result>(
 };
 
 export const createContentSlice = (url: string): ClientSlice => {
-  const slice: ContentSlice = {
+  const slice: ContentProvider = {
     list: (collection) =>
       postContentRequest<DocumentEntry[]>(url, { op: 'list', collection }),
     get: (collection, path) =>

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
@@ -34,6 +34,14 @@ const upsertByPath = (
     ? entries.map((cached) => (cached.path === entry.path ? entry : cached))
     : [...entries, entry];
 
+// The store composes many slices, so the setter hands back the generic SliceState
+// (Record<string, unknown>). This is the one place that reads our own `documents`
+// field back out as its concrete type — the single boundary cast.
+const documentsOf = (state: {
+  documents?: unknown;
+}): ContentSlice['documents'] =>
+  (state.documents as ContentSlice['documents']) ?? {};
+
 export const createContentSlice =
   (url: string): ClientSlice =>
   (set) => {
@@ -44,9 +52,9 @@ export const createContentSlice =
           op: 'list',
           collection,
         });
-        set(({ documents }) => ({
+        set((state) => ({
           documents: {
-            ...(documents as ContentSlice['documents']),
+            ...documentsOf(state),
             [collection]: response,
           },
         }));
@@ -70,8 +78,8 @@ export const createContentSlice =
         });
         // Keep the list cache honest so collection views reflect the save —
         // replace the cached entry, or append when the path is not cached yet.
-        set(({ documents }) => {
-          const cache = documents as ContentSlice['documents'];
+        set((state) => {
+          const cache = documentsOf(state);
           return {
             documents: {
               ...cache,

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
@@ -1,0 +1,86 @@
+// Client segment of the localContentPlugin: the ContentSlice (contract.ts)
+// speaking the content-request.ts wire protocol over plain fetch — content goes
+// Client → Data Layer directly, not through Capability RPC (ADR-018 §1).
+
+import type {
+  ContentSlice,
+  DocumentEntry,
+} from '../../../core/content/contract';
+import type { ClientSlice } from '../../../core/plugin';
+import type { ContentRequest } from './content-request';
+
+const postContentRequest = async <Result>(
+  url: string,
+  request: ContentRequest
+): Promise<Result> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Content request ${request.op} failed (${response.status}): ${await response.text()}`
+    );
+  }
+  return response.json();
+};
+
+const upsertByPath = (
+  entries: DocumentEntry[],
+  entry: DocumentEntry
+): DocumentEntry[] =>
+  entries.some((cached) => cached.path === entry.path)
+    ? entries.map((cached) => (cached.path === entry.path ? entry : cached))
+    : [...entries, entry];
+
+export const createContentSlice =
+  (url: string): ClientSlice =>
+  (set) => {
+    const slice: ContentSlice = {
+      documents: {},
+      async loadDocuments(collection) {
+        const response = await postContentRequest<DocumentEntry[]>(url, {
+          op: 'list',
+          collection,
+        });
+        set(({ documents }) => ({
+          documents: {
+            ...(documents as ContentSlice['documents']),
+            [collection]: response,
+          },
+        }));
+        return response;
+      },
+      async getDocument(collection, path) {
+        return postContentRequest<DocumentEntry | null>(url, {
+          op: 'get',
+          collection,
+          path,
+        });
+      },
+      async saveDocument(collection, path, value) {
+        // update returns the persisted entry, which may carry more than the
+        // form value (unknown fields merged from the stored document).
+        const saved = await postContentRequest<DocumentEntry>(url, {
+          op: 'update',
+          collection,
+          path,
+          value,
+        });
+        // Keep the list cache honest so collection views reflect the save —
+        // replace the cached entry, or append when the path is not cached yet.
+        set(({ documents }) => {
+          const cache = documents as ContentSlice['documents'];
+          return {
+            documents: {
+              ...cache,
+              [collection]: upsertByPath(cache[collection] ?? [], saved),
+            },
+          };
+        });
+        return saved;
+      },
+    };
+    return { ...slice };
+  };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
@@ -1,6 +1,9 @@
-// Client segment of the localContentPlugin: the ContentSlice (contract.ts)
-// speaking the content-request.ts wire protocol over plain fetch — content goes
-// Client → Data Layer directly, not through Capability RPC (ADR-018 §1).
+// The client segment of the localContentPlugin. It is the ContentSlice from contract.ts,
+// and it speaks the wire protocol of content-request.ts over fetch. The content goes from
+// the client to the data layer directly, and not through the capability RPC (ADR-018 §1).
+//
+// It is a transport, and holds no cache. The admin's query client caches these reads.
+// Refer to ContentSlice.
 
 import type {
   ContentSlice,
@@ -26,72 +29,27 @@ const postContentRequest = async <Result>(
   return response.json();
 };
 
-const upsertByPath = (
-  entries: DocumentEntry[],
-  entry: DocumentEntry
-): DocumentEntry[] => {
-  const index = entries.findIndex((cached) => cached.path === entry.path);
-  if (index === -1) return [...entries, entry];
-  const next = [...entries];
-  next[index] = entry;
-  return next;
-};
-
-// The store composes many slices, so the setter hands back the generic SliceState
-// (Record<string, unknown>). This is the one place that reads our own `documents`
-// field back out as its concrete type — the single boundary cast.
-const documentsOf = (state: {
-  documents?: unknown;
-}): ContentSlice['documents'] =>
-  (state.documents as ContentSlice['documents']) ?? {};
-
-export const createContentSlice =
-  (url: string): ClientSlice =>
-  (set) => {
-    const slice: ContentSlice = {
-      documents: {},
-      async loadDocuments(collection) {
-        const response = await postContentRequest<DocumentEntry[]>(url, {
-          op: 'list',
-          collection,
-        });
-        set((state) => ({
-          documents: {
-            ...documentsOf(state),
-            [collection]: response,
-          },
-        }));
-        return response;
-      },
-      async getDocument(collection, path) {
-        return postContentRequest<DocumentEntry | null>(url, {
-          op: 'get',
-          collection,
-          path,
-        });
-      },
-      async saveDocument(collection, path, value) {
-        // update returns the persisted entry, which may carry more than the
-        // form value (unknown fields merged from the stored document).
-        const saved = await postContentRequest<DocumentEntry>(url, {
-          op: 'update',
-          collection,
-          path,
-          value,
-        });
-        // Keep the list cache honest so collection views reflect the save —
-        // replace the cached entry, or append when the path is not cached yet.
-        set((state) => {
-          const cache = documentsOf(state);
-          return {
-            documents: {
-              ...cache,
-              [collection]: upsertByPath(cache[collection] ?? [], saved),
-            },
-          };
-        });
-        return saved;
-      },
-    };
-    return { ...slice };
+export const createContentSlice = (url: string): ClientSlice => {
+  const slice: ContentSlice = {
+    list: (collection) =>
+      postContentRequest<DocumentEntry[]>(url, { op: 'list', collection }),
+    get: (collection, path) =>
+      postContentRequest<DocumentEntry | null>(url, {
+        op: 'get',
+        collection,
+        path,
+      }),
+    // The update returns the stored entry, which can hold more than the value that was
+    // sent. The unknown fields of the stored document merge into it.
+    update: (collection, path, value) =>
+      postContentRequest<DocumentEntry>(url, {
+        op: 'update',
+        collection,
+        path,
+        value,
+      }),
   };
+  // The slice takes no `set`. It writes no state, so it ignores both arguments and
+  // returns the same operations at each boot.
+  return () => ({ ...slice });
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
@@ -52,8 +52,14 @@ describe('content slice', () => {
     expect(harness.slice().documents).toEqual(ENTRIES);
   });
 
-  it('saveDocument posts an update op and refreshes the cache entry', async () => {
-    const harness = await createSliceHarness(null);
+  it('saveDocument posts an update op and caches the persisted entry', async () => {
+    // The server merges unknown fields into the persisted document — the cache
+    // must hold what came back, not the raw form value.
+    const persisted: DocumentEntry = {
+      path: 'content/posts/hello.mdx',
+      document: { title: 'Renamed', category: 'not-in-schema' },
+    };
+    const harness = await createSliceHarness(persisted);
     // Seed the cache as if a list had run.
     harness.slice().documents.push(...ENTRIES);
     await harness
@@ -67,10 +73,7 @@ describe('content slice', () => {
         value: { title: 'Renamed' },
       },
     ]);
-    expect(harness.slice().documents).toEqual([
-      { path: 'content/posts/hello.mdx', document: { title: 'Renamed' } },
-      ENTRIES[1],
-    ]);
+    expect(harness.slice().documents).toEqual([persisted, ENTRIES[1]]);
   });
 
   it('surfaces a failed request as a rejection (form stays dirty)', async () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { DocumentEntry } from '../../../core/content/contract';
+import type { SliceSet, SliceState } from '../../../core/plugin';
+import { type ContentSlice, localContentPlugin } from './local-content.plugin';
+
+const ENTRIES: DocumentEntry[] = [
+  { path: 'content/posts/hello.mdx', document: { title: 'Hello' } },
+  { path: 'content/posts/second.mdx', document: { title: 'Second' } },
+];
+
+// Minimal slice harness: the namespace-scoped `set` the store hands a slice.
+const createSliceHarness = async (responseBody: unknown, ok = true) => {
+  const requests: unknown[] = [];
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init: RequestInit) => {
+      requests.push(JSON.parse(init.body as string));
+      return {
+        ok,
+        status: ok ? 200 : 500,
+        text: async () => 'boom',
+        json: async () => responseBody,
+      };
+    })
+  );
+  const manifest = localContentPlugin({ url: '/test/content' });
+  const clientModule = await manifest.client?.();
+  const sliceCreator = clientModule?.default.slice;
+  if (!sliceCreator) throw new Error('local-content plugin has no slice');
+  let state: SliceState = {};
+  const set: SliceSet = (partial) => {
+    state = {
+      ...state,
+      ...(typeof partial === 'function' ? partial(state) : partial),
+    };
+  };
+  state = sliceCreator(set, () => ({ content: state }));
+  return {
+    requests,
+    slice: () => state as unknown as ContentSlice,
+  };
+};
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('content slice', () => {
+  it('loadDocuments posts a list op and caches the result', async () => {
+    const harness = await createSliceHarness(ENTRIES);
+    const loaded = await harness.slice().loadDocuments('post');
+    expect(harness.requests).toEqual([{ op: 'list', collection: 'post' }]);
+    expect(loaded).toEqual(ENTRIES);
+    expect(harness.slice().documents).toEqual(ENTRIES);
+  });
+
+  it('saveDocument posts an update op and refreshes the cache entry', async () => {
+    const harness = await createSliceHarness(null);
+    // Seed the cache as if a list had run.
+    harness.slice().documents.push(...ENTRIES);
+    await harness
+      .slice()
+      .saveDocument('post', 'content/posts/hello.mdx', { title: 'Renamed' });
+    expect(harness.requests).toEqual([
+      {
+        op: 'update',
+        collection: 'post',
+        path: 'content/posts/hello.mdx',
+        value: { title: 'Renamed' },
+      },
+    ]);
+    expect(harness.slice().documents).toEqual([
+      { path: 'content/posts/hello.mdx', document: { title: 'Renamed' } },
+      ENTRIES[1],
+    ]);
+  });
+
+  it('surfaces a failed request as a rejection (form stays dirty)', async () => {
+    const harness = await createSliceHarness(null, false);
+    await expect(
+      harness.slice().saveDocument('post', 'content/posts/hello.mdx', {})
+    ).rejects.toThrow(/update failed \(500\): boom/);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
@@ -11,7 +11,7 @@ const ENTRIES: DocumentEntry[] = [
   { path: 'content/posts/second.mdx', document: { title: 'Second' } },
 ];
 
-// Minimal slice harness: the namespace-scoped `set` the store hands a slice.
+// A small harness for a slice. It is the scoped `set` that the store gives to a slice.
 const createSliceHarness = async (responseBody: unknown, ok = true) => {
   const requests: unknown[] = [];
   vi.stubGlobal(
@@ -46,28 +46,38 @@ const createSliceHarness = async (responseBody: unknown, ok = true) => {
 
 afterEach(() => vi.unstubAllGlobals());
 
+// The slice is a transport. It maps the ContentProvider operations onto the wire
+// protocol and returns what came back. The caching that used to live here belongs to the
+// query client now, and editor/content-queries.test.tsx covers it.
 describe('content slice', () => {
-  it('loadDocuments posts a list op and caches the result', async () => {
+  it('posts a list op and returns the entries', async () => {
     const harness = await createSliceHarness(ENTRIES);
-    const loaded = await harness.slice().loadDocuments('post');
+    const listed = await harness.slice().list('post');
     expect(harness.requests).toEqual([{ op: 'list', collection: 'post' }]);
-    expect(loaded).toEqual(ENTRIES);
-    expect(harness.slice().documents).toEqual({ post: ENTRIES });
+    expect(listed).toEqual(ENTRIES);
   });
 
-  it('saveDocument posts an update op and caches the persisted entry', async () => {
-    // The server merges unknown fields into the persisted document — the cache
-    // must hold what came back, not the raw form value.
+  it('posts a get op for one document', async () => {
+    const harness = await createSliceHarness(ENTRIES[0]);
+    const entry = await harness.slice().get('post', 'content/posts/hello.mdx');
+    expect(harness.requests).toEqual([
+      { op: 'get', collection: 'post', path: 'content/posts/hello.mdx' },
+    ]);
+    expect(entry).toEqual(ENTRIES[0]);
+  });
+
+  it('posts an update op and returns the persisted entry', async () => {
+    // The server merges the unknown fields into the stored document, so the result
+    // holds more than the value that was sent. The caller gets that result, and not
+    // the raw form value.
     const persisted: DocumentEntry = {
       path: 'content/posts/hello.mdx',
       document: { title: 'Renamed', category: 'not-in-schema' },
     };
     const harness = await createSliceHarness(persisted);
-    // Seed the cache as if a list had run.
-    harness.slice().documents.post = [...ENTRIES];
     const saved = await harness
       .slice()
-      .saveDocument('post', 'content/posts/hello.mdx', { title: 'Renamed' });
+      .update('post', 'content/posts/hello.mdx', { title: 'Renamed' });
     expect(harness.requests).toEqual([
       {
         op: 'update',
@@ -77,31 +87,18 @@ describe('content slice', () => {
       },
     ]);
     expect(saved).toEqual(persisted);
-    expect(harness.slice().documents).toEqual({
-      post: [persisted, ENTRIES[1]],
-    });
-  });
-
-  it('saveDocument appends the persisted entry when the path is not cached', async () => {
-    const persisted: DocumentEntry = {
-      path: 'content/posts/new.mdx',
-      document: { title: 'New' },
-    };
-    const harness = await createSliceHarness(persisted);
-    harness.slice().documents.post = [...ENTRIES];
-    const saved = await harness
-      .slice()
-      .saveDocument('post', 'content/posts/new.mdx', { title: 'New' });
-    expect(saved).toEqual(persisted);
-    expect(harness.slice().documents).toEqual({
-      post: [...ENTRIES, persisted],
-    });
   });
 
   it('surfaces a failed request as a rejection (form stays dirty)', async () => {
     const harness = await createSliceHarness(null, false);
     await expect(
-      harness.slice().saveDocument('post', 'content/posts/hello.mdx', {})
+      harness.slice().update('post', 'content/posts/hello.mdx', {})
     ).rejects.toThrow(/update failed \(500\): boom/);
+  });
+
+  it('writes no store state, because it holds no cache', async () => {
+    const harness = await createSliceHarness(ENTRIES);
+    await harness.slice().list('post');
+    expect(Object.keys(harness.slice())).toEqual(['list', 'get', 'update']);
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
@@ -62,7 +62,7 @@ describe('content slice', () => {
     const harness = await createSliceHarness(persisted);
     // Seed the cache as if a list had run.
     harness.slice().documents.push(...ENTRIES);
-    await harness
+    const saved = await harness
       .slice()
       .saveDocument('post', 'content/posts/hello.mdx', { title: 'Renamed' });
     expect(harness.requests).toEqual([
@@ -73,7 +73,22 @@ describe('content slice', () => {
         value: { title: 'Renamed' },
       },
     ]);
+    expect(saved).toEqual(persisted);
     expect(harness.slice().documents).toEqual([persisted, ENTRIES[1]]);
+  });
+
+  it('saveDocument appends the persisted entry when the path is not cached', async () => {
+    const persisted: DocumentEntry = {
+      path: 'content/posts/new.mdx',
+      document: { title: 'New' },
+    };
+    const harness = await createSliceHarness(persisted);
+    harness.slice().documents.push(...ENTRIES);
+    const saved = await harness
+      .slice()
+      .saveDocument('post', 'content/posts/new.mdx', { title: 'New' });
+    expect(saved).toEqual(persisted);
+    expect(harness.slice().documents).toEqual([...ENTRIES, persisted]);
   });
 
   it('surfaces a failed request as a rejection (form stays dirty)', async () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { DocumentEntry } from '../../../core/content/contract';
+import type {
+  ContentSlice,
+  DocumentEntry,
+} from '../../../core/content/contract';
 import type { SliceSet, SliceState } from '../../../core/plugin';
-import { type ContentSlice, localContentPlugin } from './local-content.plugin';
+import { localContentPlugin } from './local-content.plugin';
 
 const ENTRIES: DocumentEntry[] = [
   { path: 'content/posts/hello.mdx', document: { title: 'Hello' } },
@@ -49,7 +52,7 @@ describe('content slice', () => {
     const loaded = await harness.slice().loadDocuments('post');
     expect(harness.requests).toEqual([{ op: 'list', collection: 'post' }]);
     expect(loaded).toEqual(ENTRIES);
-    expect(harness.slice().documents).toEqual(ENTRIES);
+    expect(harness.slice().documents).toEqual({ post: ENTRIES });
   });
 
   it('saveDocument posts an update op and caches the persisted entry', async () => {
@@ -61,7 +64,7 @@ describe('content slice', () => {
     };
     const harness = await createSliceHarness(persisted);
     // Seed the cache as if a list had run.
-    harness.slice().documents.push(...ENTRIES);
+    harness.slice().documents.post = [...ENTRIES];
     const saved = await harness
       .slice()
       .saveDocument('post', 'content/posts/hello.mdx', { title: 'Renamed' });
@@ -74,7 +77,9 @@ describe('content slice', () => {
       },
     ]);
     expect(saved).toEqual(persisted);
-    expect(harness.slice().documents).toEqual([persisted, ENTRIES[1]]);
+    expect(harness.slice().documents).toEqual({
+      post: [persisted, ENTRIES[1]],
+    });
   });
 
   it('saveDocument appends the persisted entry when the path is not cached', async () => {
@@ -83,12 +88,14 @@ describe('content slice', () => {
       document: { title: 'New' },
     };
     const harness = await createSliceHarness(persisted);
-    harness.slice().documents.push(...ENTRIES);
+    harness.slice().documents.post = [...ENTRIES];
     const saved = await harness
       .slice()
       .saveDocument('post', 'content/posts/new.mdx', { title: 'New' });
     expect(saved).toEqual(persisted);
-    expect(harness.slice().documents).toEqual([...ENTRIES, persisted]);
+    expect(harness.slice().documents).toEqual({
+      post: [...ENTRIES, persisted],
+    });
   });
 
   it('surfaces a failed request as a rejection (form stays dirty)', async () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
@@ -1,0 +1,99 @@
+// Client half of the Local Data Layer: the plugin providing the `content`
+// capability during local dev. Its slice mounts at the `content` namespace
+// (SINGLETON_SLICE_CAPABILITIES) and speaks the local-data-layer.ts wire
+// protocol over plain fetch — content goes Client → Data Layer directly, not
+// through Capability RPC (ADR-018 §1). A TinaCloud or v3-compat provider
+// replaces this plugin and mounts the same-shaped slice.
+
+import type { DocumentEntry } from '../../../core/content/contract';
+import {
+  type ClientSlice,
+  type PluginManifest,
+  definePlugin,
+} from '../../../core/plugin';
+import type { TinaDocument } from '../../../core/schema/types';
+import type { ContentRequest } from './local-data-layer';
+
+// What `get().content` holds: the ContentProvider ops (contract.ts) plus the
+// list cache collection views render from. saveDocument's rejection propagates
+// so useFormSave leaves the form dirty (context.ts SaveHandler contract).
+export interface ContentSlice {
+  documents: DocumentEntry[];
+  loadDocuments(collection: string): Promise<DocumentEntry[]>;
+  getDocument(collection: string, path: string): Promise<DocumentEntry | null>;
+  saveDocument(
+    collection: string,
+    path: string,
+    value: TinaDocument
+  ): Promise<void>;
+}
+
+const postContentRequest = async (
+  url: string,
+  request: ContentRequest
+): Promise<unknown> => {
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(request),
+  });
+  if (!response.ok) {
+    throw new Error(
+      `Content request ${request.op} failed (${response.status}): ${await response.text()}`
+    );
+  }
+  return response.json();
+};
+
+const createContentSlice =
+  (url: string): ClientSlice =>
+  (set) => {
+    const slice: ContentSlice = {
+      documents: [],
+      async loadDocuments(collection) {
+        const documents = (await postContentRequest(url, {
+          op: 'list',
+          collection,
+        })) as DocumentEntry[];
+        set({ documents });
+        return documents;
+      },
+      async getDocument(collection, path) {
+        return (await postContentRequest(url, {
+          op: 'get',
+          collection,
+          path,
+        })) as DocumentEntry | null;
+      },
+      async saveDocument(collection, path, value) {
+        await postContentRequest(url, {
+          op: 'update',
+          collection,
+          path,
+          value,
+        });
+        // Keep the list cache honest so collection views reflect the save.
+        set(({ documents }) => ({
+          documents: (documents as DocumentEntry[]).map((entry) =>
+            entry.path === path ? { path, document: value } : entry
+          ),
+        }));
+      },
+    };
+    return { ...slice };
+  };
+
+export const DEFAULT_CONTENT_URL = '/api/tina/content';
+
+export const localContentPlugin = (options?: {
+  url?: string;
+}): PluginManifest =>
+  definePlugin({
+    name: 'tina:content:local',
+    provides: ['content'],
+    client: async () => ({
+      default: {
+        slice: createContentSlice(options?.url ?? DEFAULT_CONTENT_URL),
+      },
+    }),
+  });

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
@@ -66,16 +66,18 @@ const createContentSlice =
         })) as DocumentEntry | null;
       },
       async saveDocument(collection, path, value) {
-        await postContentRequest(url, {
+        // update returns the persisted entry, which may carry more than the
+        // form value (unknown fields merged from the stored document).
+        const saved = (await postContentRequest(url, {
           op: 'update',
           collection,
           path,
           value,
-        });
+        })) as DocumentEntry;
         // Keep the list cache honest so collection views reflect the save.
         set(({ documents }) => ({
           documents: (documents as DocumentEntry[]).map((entry) =>
-            entry.path === path ? { path, document: value } : entry
+            entry.path === path ? saved : entry
           ),
         }));
       },

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
@@ -1,8 +1,8 @@
-// Client half of the Local Data Layer: the plugin providing the `content`
-// capability during local dev. Its slice mounts at the `content` namespace
-// (SINGLETON_SLICE_CAPABILITIES) and speaks the content-request.ts wire
-// protocol (local-content.client.ts). A TinaCloud or v3-compat provider
-// replaces this plugin and mounts the same-shaped slice.
+// The client half of the local data layer. This plugin provides the `content` capability
+// during local development. Its slice mounts at the `content` namespace, from
+// SINGLETON_SLICE_CAPABILITIES, and it speaks the wire protocol of content-request.ts.
+// Refer to local-content.client.ts. A TinaCloud provider, or a v3 provider, replaces this
+// plugin and mounts a slice of the same shape.
 
 import { DEFAULT_CONTENT_URL } from '../../../core/content/contract';
 import { type PluginManifest, definePlugin } from '../../../core/plugin';

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
@@ -25,7 +25,7 @@ export interface ContentSlice {
     collection: string,
     path: string,
     value: TinaDocument
-  ): Promise<void>;
+  ): Promise<DocumentEntry>;
 }
 
 const postContentRequest = async (
@@ -74,12 +74,17 @@ const createContentSlice =
           path,
           value,
         })) as DocumentEntry;
-        // Keep the list cache honest so collection views reflect the save.
-        set(({ documents }) => ({
-          documents: (documents as DocumentEntry[]).map((entry) =>
-            entry.path === path ? saved : entry
-          ),
-        }));
+        // Keep the list cache honest so collection views reflect the save —
+        // replace the cached entry, or append when the path is not cached yet.
+        set(({ documents }) => {
+          const entries = documents as DocumentEntry[];
+          return {
+            documents: entries.some((entry) => entry.path === path)
+              ? entries.map((entry) => (entry.path === path ? saved : entry))
+              : [...entries, saved],
+          };
+        });
+        return saved;
       },
     };
     return { ...slice };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
@@ -1,96 +1,11 @@
 // Client half of the Local Data Layer: the plugin providing the `content`
 // capability during local dev. Its slice mounts at the `content` namespace
-// (SINGLETON_SLICE_CAPABILITIES) and speaks the local-data-layer.ts wire
-// protocol over plain fetch — content goes Client → Data Layer directly, not
-// through Capability RPC (ADR-018 §1). A TinaCloud or v3-compat provider
+// (SINGLETON_SLICE_CAPABILITIES) and speaks the content-request.ts wire
+// protocol (local-content.client.ts). A TinaCloud or v3-compat provider
 // replaces this plugin and mounts the same-shaped slice.
 
-import type { DocumentEntry } from '../../../core/content/contract';
-import {
-  type ClientSlice,
-  type PluginManifest,
-  definePlugin,
-} from '../../../core/plugin';
-import type { TinaDocument } from '../../../core/schema/types';
-import type { ContentRequest } from './local-data-layer';
-
-// What `get().content` holds: the ContentProvider ops (contract.ts) plus the
-// list cache collection views render from. saveDocument's rejection propagates
-// so useFormSave leaves the form dirty (context.ts SaveHandler contract).
-export interface ContentSlice {
-  documents: DocumentEntry[];
-  loadDocuments(collection: string): Promise<DocumentEntry[]>;
-  getDocument(collection: string, path: string): Promise<DocumentEntry | null>;
-  saveDocument(
-    collection: string,
-    path: string,
-    value: TinaDocument
-  ): Promise<DocumentEntry>;
-}
-
-const postContentRequest = async (
-  url: string,
-  request: ContentRequest
-): Promise<unknown> => {
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(request),
-  });
-  if (!response.ok) {
-    throw new Error(
-      `Content request ${request.op} failed (${response.status}): ${await response.text()}`
-    );
-  }
-  return response.json();
-};
-
-const createContentSlice =
-  (url: string): ClientSlice =>
-  (set) => {
-    const slice: ContentSlice = {
-      documents: [],
-      async loadDocuments(collection) {
-        const documents = (await postContentRequest(url, {
-          op: 'list',
-          collection,
-        })) as DocumentEntry[];
-        set({ documents });
-        return documents;
-      },
-      async getDocument(collection, path) {
-        return (await postContentRequest(url, {
-          op: 'get',
-          collection,
-          path,
-        })) as DocumentEntry | null;
-      },
-      async saveDocument(collection, path, value) {
-        // update returns the persisted entry, which may carry more than the
-        // form value (unknown fields merged from the stored document).
-        const saved = (await postContentRequest(url, {
-          op: 'update',
-          collection,
-          path,
-          value,
-        })) as DocumentEntry;
-        // Keep the list cache honest so collection views reflect the save —
-        // replace the cached entry, or append when the path is not cached yet.
-        set(({ documents }) => {
-          const entries = documents as DocumentEntry[];
-          return {
-            documents: entries.some((entry) => entry.path === path)
-              ? entries.map((entry) => (entry.path === path ? saved : entry))
-              : [...entries, saved],
-          };
-        });
-        return saved;
-      },
-    };
-    return { ...slice };
-  };
-
-export const DEFAULT_CONTENT_URL = '/api/tina/content';
+import { DEFAULT_CONTENT_URL } from '../../../core/content/contract';
+import { type PluginManifest, definePlugin } from '../../../core/plugin';
 
 export const localContentPlugin = (options?: {
   url?: string;
@@ -98,9 +13,12 @@ export const localContentPlugin = (options?: {
   definePlugin({
     name: 'tina:content:local',
     provides: ['content'],
-    client: async () => ({
-      default: {
-        slice: createContentSlice(options?.url ?? DEFAULT_CONTENT_URL),
-      },
-    }),
+    client: async () => {
+      const { createContentSlice } = await import('./local-content.client');
+      return {
+        default: {
+          slice: createContentSlice(options?.url ?? DEFAULT_CONTENT_URL),
+        },
+      };
+    },
   });

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ContentProvider } from '../../../core/content/contract';
 import { createLocalDataLayer, handleContentRequest } from './local-data-layer';
 
@@ -32,6 +32,8 @@ beforeEach(async () => {
     rootDir,
     collections: [
       { name: 'post', path: 'content/posts', format: 'mdx', fields: [] },
+      // Folder intentionally never created.
+      { name: 'page', path: 'content/pages', format: 'mdx', fields: [] },
     ],
   });
 });
@@ -47,6 +49,25 @@ describe('list', () => {
     ]);
     expect(entries[0].document.title).toBe('Hello World');
   });
+
+  it('returns [] when the collection folder does not exist yet', async () => {
+    expect(await dataLayer.list('page')).toEqual([]);
+  });
+
+  it('skips (and warns on) an unparsable file instead of rejecting', async () => {
+    await fs.writeFile(
+      path.join(rootDir, 'content/posts/broken.mdx'),
+      '---\ntitle: [unclosed\n---\n'
+    );
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const entries = await dataLayer.list('post');
+    expect(entries.map((entry) => entry.path)).toEqual([
+      'content/posts/hello.mdx',
+      'content/posts/nested/deep.mdx',
+    ]);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
 });
 
 describe('get', () => {
@@ -61,8 +82,8 @@ describe('get', () => {
 });
 
 describe('update', () => {
-  it('writes the save and preserves unknown fields and the body', async () => {
-    await dataLayer.update('post', 'content/posts/hello.mdx', {
+  it('writes the save, preserves unknown fields and the body, and returns the persisted entry', async () => {
+    const saved = await dataLayer.update('post', 'content/posts/hello.mdx', {
       title: 'Renamed',
       featured: true,
     });
@@ -72,18 +93,33 @@ describe('update', () => {
     );
     expect(raw).toContain('category: not-in-schema');
     expect(raw).toContain('Body prose.');
-    const entry = await dataLayer.get('post', 'content/posts/hello.mdx');
-    expect(entry?.document).toEqual({
-      title: 'Renamed',
-      featured: true,
-      category: 'not-in-schema',
+    expect(saved).toEqual({
+      path: 'content/posts/hello.mdx',
+      document: {
+        title: 'Renamed',
+        featured: true,
+        category: 'not-in-schema',
+      },
     });
+    const entry = await dataLayer.get('post', 'content/posts/hello.mdx');
+    expect(entry?.document).toEqual(saved.document);
   });
 
   it('writes fresh when the file is missing (never lose the edit)', async () => {
     await dataLayer.update('post', 'content/posts/new.mdx', { title: 'New' });
     const entry = await dataLayer.get('post', 'content/posts/new.mdx');
     expect(entry?.document).toEqual({ title: 'New' });
+  });
+
+  it('recreates a parent folder deleted out-of-band (never lose the edit)', async () => {
+    await fs.rm(path.join(rootDir, 'content/posts/nested'), {
+      recursive: true,
+    });
+    await dataLayer.update('post', 'content/posts/nested/deep.mdx', {
+      title: 'Restored',
+    });
+    const entry = await dataLayer.get('post', 'content/posts/nested/deep.mdx');
+    expect(entry?.document).toEqual({ title: 'Restored' });
   });
 });
 
@@ -121,7 +157,10 @@ describe('handleContentRequest', () => {
       path: 'content/posts/hello.mdx',
       value: { title: 'Via wire' },
     });
-    expect(updated).toBeNull();
+    expect(updated).toMatchObject({
+      path: 'content/posts/hello.mdx',
+      document: { title: 'Via wire' },
+    });
     const fetched = await handleContentRequest(dataLayer, {
       op: 'get',
       collection: 'post',

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
@@ -2,12 +2,9 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { dispatchContentRequest } from './content-request';
 import { createGraphQLPipeline } from './graphql-pipeline';
-import {
-  type LocalDataLayer,
-  createLocalDataLayer,
-  handleContentRequest,
-} from './local-data-layer';
+import { type LocalDataLayer, createLocalDataLayer } from './local-data-layer';
 
 // The real pipeline boots the whole v3 stack; these tests only care about the
 // memoization around it.
@@ -39,7 +36,12 @@ beforeEach(async () => {
   dataLayer = createLocalDataLayer({
     rootDir,
     collections: [
-      { name: 'post', path: 'content/posts', format: 'mdx', fields: [] },
+      {
+        name: 'post',
+        path: 'content/posts',
+        format: 'mdx',
+        fields: [{ name: 'body', type: 'rich-text', isBody: true }],
+      },
       // Folder intentionally never created.
       { name: 'page', path: 'content/pages', format: 'mdx', fields: [] },
     ],
@@ -125,6 +127,19 @@ describe('update', () => {
     expect(entry?.document).toEqual(saved.document);
   });
 
+  it('keeps an isBody field out of the frontmatter (the raw body owns it)', async () => {
+    await dataLayer.update('post', 'content/posts/hello.mdx', {
+      title: 'Renamed',
+      body: { type: 'root', children: [] },
+    });
+    const raw = await fs.readFile(
+      path.join(rootDir, 'content/posts/hello.mdx'),
+      'utf8'
+    );
+    expect(raw).not.toContain('body:');
+    expect(raw).toContain('Body prose.');
+  });
+
   it('writes fresh when the file is missing (never lose the edit)', async () => {
     await dataLayer.update('post', 'content/posts/new.mdx', { title: 'New' });
     const entry = await dataLayer.get('post', 'content/posts/new.mdx');
@@ -156,7 +171,16 @@ describe('trust boundary', () => {
   it('rejects paths with the wrong extension', async () => {
     await expect(
       dataLayer.get('post', 'content/posts/ignored.txt')
-    ).rejects.toThrow(/outside collection/);
+    ).rejects.toThrow(/not a \.mdx file/);
+  });
+
+  it('canonicalizes a non-canonical path in the returned entry', async () => {
+    const saved = await dataLayer.update(
+      'post',
+      'content/posts/nested/../hello.mdx',
+      { title: 'Canonical' }
+    );
+    expect(saved.path).toBe('content/posts/hello.mdx');
   });
 
   it('rejects an unknown collection', async () => {
@@ -169,17 +193,17 @@ describe('graphql pipeline', () => {
     vi.mocked(createGraphQLPipeline)
       .mockRejectedValueOnce(new Error('boot failed'))
       .mockResolvedValueOnce({
-        execute: async () => 'ok',
+        execute: async () => ({ data: {} }),
         reindexPaths: async () => {},
       });
     await expect(dataLayer.graphql('{}')).rejects.toThrow('boot failed');
-    await expect(dataLayer.graphql('{}')).resolves.toBe('ok');
+    await expect(dataLayer.graphql('{}')).resolves.toEqual({ data: {} });
     expect(createGraphQLPipeline).toHaveBeenCalledTimes(2);
   });
 
   it('a reindex failure warns but does not fail the written save', async () => {
     vi.mocked(createGraphQLPipeline).mockResolvedValueOnce({
-      execute: async () => 'ok',
+      execute: async () => ({ data: {} }),
       reindexPaths: async () => {
         throw new Error('index broke');
       },
@@ -195,14 +219,14 @@ describe('graphql pipeline', () => {
   });
 });
 
-describe('handleContentRequest', () => {
+describe('dispatchContentRequest', () => {
   it('dispatches ops', async () => {
-    const listed = await handleContentRequest(dataLayer, {
+    const listed = await dispatchContentRequest(dataLayer, {
       op: 'list',
       collection: 'post',
     });
     expect(Array.isArray(listed)).toBe(true);
-    const updated = await handleContentRequest(dataLayer, {
+    const updated = await dispatchContentRequest(dataLayer, {
       op: 'update',
       collection: 'post',
       path: 'content/posts/hello.mdx',
@@ -212,7 +236,7 @@ describe('handleContentRequest', () => {
       path: 'content/posts/hello.mdx',
       document: { title: 'Via wire' },
     });
-    const fetched = await handleContentRequest(dataLayer, {
+    const fetched = await dispatchContentRequest(dataLayer, {
       op: 'get',
       collection: 'post',
       path: 'content/posts/hello.mdx',
@@ -222,10 +246,10 @@ describe('handleContentRequest', () => {
 
   it('rejects a malformed request at the boundary', async () => {
     await expect(
-      handleContentRequest(dataLayer, { op: 'drop-tables' })
+      dispatchContentRequest(dataLayer, { op: 'drop-tables' })
     ).rejects.toThrow();
     await expect(
-      handleContentRequest(dataLayer, { op: 'get', collection: 'post' })
+      dispatchContentRequest(dataLayer, { op: 'get', collection: 'post' })
     ).rejects.toThrow();
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ContentProvider } from '../../../core/content/contract';
+import { createLocalDataLayer, handleContentRequest } from './local-data-layer';
+
+const HELLO_RAW = `---
+title: Hello World
+featured: false
+category: not-in-schema
+---
+
+Body prose.
+`;
+
+let rootDir: string;
+let dataLayer: ContentProvider;
+
+beforeEach(async () => {
+  rootDir = await fs.mkdtemp(path.join(tmpdir(), 'tina-local-'));
+  await fs.mkdir(path.join(rootDir, 'content/posts/nested'), {
+    recursive: true,
+  });
+  await fs.writeFile(path.join(rootDir, 'content/posts/hello.mdx'), HELLO_RAW);
+  await fs.writeFile(
+    path.join(rootDir, 'content/posts/nested/deep.mdx'),
+    '---\ntitle: Deep\n---\n'
+  );
+  await fs.writeFile(path.join(rootDir, 'content/posts/ignored.txt'), 'nope');
+  dataLayer = createLocalDataLayer({
+    rootDir,
+    collections: [
+      { name: 'post', path: 'content/posts', format: 'mdx', fields: [] },
+    ],
+  });
+});
+
+afterEach(() => fs.rm(rootDir, { recursive: true, force: true }));
+
+describe('list', () => {
+  it('returns matching files (recursively) with root-relative paths', async () => {
+    const entries = await dataLayer.list('post');
+    expect(entries.map((entry) => entry.path)).toEqual([
+      'content/posts/hello.mdx',
+      'content/posts/nested/deep.mdx',
+    ]);
+    expect(entries[0].document.title).toBe('Hello World');
+  });
+});
+
+describe('get', () => {
+  it('returns the parsed document', async () => {
+    const entry = await dataLayer.get('post', 'content/posts/hello.mdx');
+    expect(entry?.document).toMatchObject({ title: 'Hello World' });
+  });
+
+  it('returns null for a missing file', async () => {
+    expect(await dataLayer.get('post', 'content/posts/gone.mdx')).toBeNull();
+  });
+});
+
+describe('update', () => {
+  it('writes the save and preserves unknown fields and the body', async () => {
+    await dataLayer.update('post', 'content/posts/hello.mdx', {
+      title: 'Renamed',
+      featured: true,
+    });
+    const raw = await fs.readFile(
+      path.join(rootDir, 'content/posts/hello.mdx'),
+      'utf8'
+    );
+    expect(raw).toContain('category: not-in-schema');
+    expect(raw).toContain('Body prose.');
+    const entry = await dataLayer.get('post', 'content/posts/hello.mdx');
+    expect(entry?.document).toEqual({
+      title: 'Renamed',
+      featured: true,
+      category: 'not-in-schema',
+    });
+  });
+
+  it('writes fresh when the file is missing (never lose the edit)', async () => {
+    await dataLayer.update('post', 'content/posts/new.mdx', { title: 'New' });
+    const entry = await dataLayer.get('post', 'content/posts/new.mdx');
+    expect(entry?.document).toEqual({ title: 'New' });
+  });
+});
+
+describe('trust boundary', () => {
+  it('rejects paths outside the collection folder', async () => {
+    await expect(dataLayer.get('post', '../outside.mdx')).rejects.toThrow(
+      /outside collection/
+    );
+    await expect(
+      dataLayer.update('post', 'content/posts/../../escape.mdx', {})
+    ).rejects.toThrow(/outside collection/);
+  });
+
+  it('rejects paths with the wrong extension', async () => {
+    await expect(
+      dataLayer.get('post', 'content/posts/ignored.txt')
+    ).rejects.toThrow(/outside collection/);
+  });
+
+  it('rejects an unknown collection', async () => {
+    await expect(dataLayer.list('nope')).rejects.toThrow(/Unknown collection/);
+  });
+});
+
+describe('handleContentRequest', () => {
+  it('dispatches ops', async () => {
+    const listed = await handleContentRequest(dataLayer, {
+      op: 'list',
+      collection: 'post',
+    });
+    expect(Array.isArray(listed)).toBe(true);
+    const updated = await handleContentRequest(dataLayer, {
+      op: 'update',
+      collection: 'post',
+      path: 'content/posts/hello.mdx',
+      value: { title: 'Via wire' },
+    });
+    expect(updated).toBeNull();
+    const fetched = await handleContentRequest(dataLayer, {
+      op: 'get',
+      collection: 'post',
+      path: 'content/posts/hello.mdx',
+    });
+    expect(fetched).toMatchObject({ document: { title: 'Via wire' } });
+  });
+
+  it('rejects a malformed request at the boundary', async () => {
+    await expect(
+      handleContentRequest(dataLayer, { op: 'drop-tables' })
+    ).rejects.toThrow();
+    await expect(
+      handleContentRequest(dataLayer, { op: 'get', collection: 'post' })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
@@ -2,8 +2,16 @@ import { promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { ContentProvider } from '../../../core/content/contract';
-import { createLocalDataLayer, handleContentRequest } from './local-data-layer';
+import { createGraphQLPipeline } from './graphql-pipeline';
+import {
+  type LocalDataLayer,
+  createLocalDataLayer,
+  handleContentRequest,
+} from './local-data-layer';
+
+// The real pipeline boots the whole v3 stack; these tests only care about the
+// memoization around it.
+vi.mock('./graphql-pipeline', () => ({ createGraphQLPipeline: vi.fn() }));
 
 const HELLO_RAW = `---
 title: Hello World
@@ -15,7 +23,7 @@ Body prose.
 `;
 
 let rootDir: string;
-let dataLayer: ContentProvider;
+let dataLayer: LocalDataLayer;
 
 beforeEach(async () => {
   rootDir = await fs.mkdtemp(path.join(tmpdir(), 'tina-local-'));
@@ -153,6 +161,37 @@ describe('trust boundary', () => {
 
   it('rejects an unknown collection', async () => {
     await expect(dataLayer.list('nope')).rejects.toThrow(/Unknown collection/);
+  });
+});
+
+describe('graphql pipeline', () => {
+  it('retries the boot after a failure instead of caching the rejection', async () => {
+    vi.mocked(createGraphQLPipeline)
+      .mockRejectedValueOnce(new Error('boot failed'))
+      .mockResolvedValueOnce({
+        execute: async () => 'ok',
+        reindexPaths: async () => {},
+      });
+    await expect(dataLayer.graphql('{}')).rejects.toThrow('boot failed');
+    await expect(dataLayer.graphql('{}')).resolves.toBe('ok');
+    expect(createGraphQLPipeline).toHaveBeenCalledTimes(2);
+  });
+
+  it('a reindex failure warns but does not fail the written save', async () => {
+    vi.mocked(createGraphQLPipeline).mockResolvedValueOnce({
+      execute: async () => 'ok',
+      reindexPaths: async () => {
+        throw new Error('index broke');
+      },
+    });
+    await dataLayer.graphql('{}');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const saved = await dataLayer.update('post', 'content/posts/hello.mdx', {
+      title: 'Still saved',
+    });
+    expect(saved.document.title).toBe('Still saved');
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
   });
 });
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.test.ts
@@ -68,6 +68,18 @@ describe('list', () => {
     expect(warn).toHaveBeenCalledOnce();
     warn.mockRestore();
   });
+
+  it('skips (and warns on) an unreadable entry, e.g. a directory named *.mdx', async () => {
+    await fs.mkdir(path.join(rootDir, 'content/posts/folder.mdx'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const entries = await dataLayer.list('post');
+    expect(entries.map((entry) => entry.path)).toEqual([
+      'content/posts/hello.mdx',
+      'content/posts/nested/deep.mdx',
+    ]);
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
 });
 
 describe('get', () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -93,17 +93,31 @@ export const createLocalDataLayer = (
 
     async list(collectionName) {
       const collection = collectionFor(collectionName);
-      const names = await fs.readdir(collection.folder, { recursive: true });
+      let names: string[];
+      try {
+        names = (await fs.readdir(collection.folder, { recursive: true })).map(
+          String
+        );
+      } catch (cause) {
+        // A not-yet-created collection folder is an empty collection.
+        if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        throw cause;
+      }
       const entries: DocumentEntry[] = [];
-      for (const name of names.map(String).sort()) {
+      for (const name of names.sort()) {
         if (!name.endsWith(collection.adapter.extension)) continue;
         const absolute = path.join(collection.folder, name);
-        entries.push({
-          path: path.relative(rootDir, absolute),
-          document: collection.adapter.parse(
-            await fs.readFile(absolute, 'utf8')
-          ),
-        });
+        const raw = await fs.readFile(absolute, 'utf8');
+        try {
+          entries.push({
+            // Paths are the document id: root-relative posix (ADR-017).
+            path: path.relative(rootDir, absolute).split(path.sep).join('/'),
+            document: collection.adapter.parse(raw),
+          });
+        } catch (cause) {
+          // One malformed file must not take down the whole collection.
+          console.warn(`Skipping unparsable document "${absolute}":`, cause);
+        }
       }
       return entries;
     },
@@ -114,13 +128,17 @@ export const createLocalDataLayer = (
       // Merge over the file's current contents so unknown fields and the body
       // survive (format-adapters.ts); a missing file is written fresh — never
       // lose the edit (ADR-018).
-      const previousRaw = await fs
-        .readFile(absolute, 'utf8')
-        .catch(() => undefined);
-      await fs.writeFile(
-        absolute,
-        collection.adapter.serialize(value, previousRaw)
-      );
+      let previousRaw: string | undefined;
+      try {
+        previousRaw = await fs.readFile(absolute, 'utf8');
+      } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code !== 'ENOENT') throw cause;
+      }
+      const raw = collection.adapter.serialize(value, previousRaw);
+      // The parent folder may have been deleted out-of-band — same promise.
+      await fs.mkdir(path.dirname(absolute), { recursive: true });
+      await fs.writeFile(absolute, raw);
+      return { path: documentPath, document: collection.adapter.parse(raw) };
     },
   };
 };
@@ -152,7 +170,6 @@ export const handleContentRequest = async (
     case 'get':
       return provider.get(parsed.collection, parsed.path);
     case 'update':
-      await provider.update(parsed.collection, parsed.path, parsed.value);
-      return null;
+      return provider.update(parsed.collection, parsed.path, parsed.value);
   }
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -12,12 +12,22 @@ import type {
 } from '../../../core/content/contract';
 import type { CollectionSchema } from '../../../core/schema/types';
 import { type FormatAdapter, formatAdapterFor } from './format-adapters';
+import {
+  type GraphQLPipeline,
+  createGraphQLPipeline,
+} from './graphql-pipeline';
 
 export interface LocalDataLayerOptions {
   // The project root document paths are relative to; collection `path`s resolve
   // against it.
   rootDir: string;
   collections: CollectionSchema[];
+}
+
+// ContentProvider plus the v3 GraphQL read surface (graphql-pipeline.ts) —
+// serving the website render path the same queries v3 served.
+export interface LocalDataLayer extends ContentProvider {
+  graphql(query: string, variables?: Record<string, unknown>): Promise<unknown>;
 }
 
 interface ResolvedCollection {
@@ -49,9 +59,19 @@ const resolveCollections = ({
 
 export const createLocalDataLayer = (
   options: LocalDataLayerOptions
-): ContentProvider => {
+): LocalDataLayer => {
   const rootDir = path.resolve(options.rootDir);
   const collections = resolveCollections(options);
+
+  // The v3 pipeline indexes every file at first use, so it boots lazily — a
+  // session that never queries GraphQL never pays for it. Files stay the source
+  // of truth: saves land on disk first, then refresh the index.
+  let pipeline: Promise<GraphQLPipeline> | undefined;
+  const graphQLPipeline = () =>
+    (pipeline ??= createGraphQLPipeline({
+      rootDir,
+      collections: options.collections,
+    }));
 
   const collectionFor = (name: string): ResolvedCollection => {
     const collection = collections.get(name);
@@ -139,8 +159,16 @@ export const createLocalDataLayer = (
       // The parent folder may have been deleted out-of-band — same promise.
       await fs.mkdir(path.dirname(absolute), { recursive: true });
       await fs.writeFile(absolute, raw);
+      // Keep the GraphQL index in step with the save — only once it exists;
+      // a not-yet-booted pipeline indexes everything fresh on first query.
+      // ponytail: no fs watcher, out-of-band edits go stale until the next
+      // save; add chokidar when that bites.
+      if (pipeline) await (await pipeline).reindexPaths([documentPath]);
       return { path: documentPath, document: collection.adapter.parse(raw) };
     },
+
+    graphql: async (query, variables) =>
+      (await graphQLPipeline()).execute(query, variables),
   };
 };
 
@@ -156,14 +184,22 @@ const contentRequestSchema = z.discriminatedUnion('op', [
     path: z.string(),
     value: z.record(z.string(), z.unknown()),
   }),
+  // The v3 read surface: a raw GraphQL request, answered by graphql-pipeline.ts.
+  z.object({
+    op: z.literal('graphql'),
+    query: z.string(),
+    variables: z.record(z.string(), z.unknown()).optional(),
+  }),
 ]);
 
 export type ContentRequest = z.infer<typeof contentRequestSchema>;
 
+// Returns DocumentEntry shapes for the provider ops, or the GraphQL
+// { data, errors } envelope for `graphql` — the host JSONs it either way.
 export const handleContentRequest = async (
-  provider: ContentProvider,
+  provider: LocalDataLayer,
   request: unknown
-): Promise<DocumentEntry[] | DocumentEntry | null> => {
+): Promise<unknown> => {
   const parsed = contentRequestSchema.parse(request);
   switch (parsed.op) {
     case 'list':
@@ -172,5 +208,7 @@ export const handleContentRequest = async (
       return provider.get(parsed.collection, parsed.path);
     case 'update':
       return provider.update(parsed.collection, parsed.path, parsed.value);
+    case 'graphql':
+      return provider.graphql(parsed.query, parsed.variables);
   }
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -64,7 +64,7 @@ const resolveCollections = ({
     );
     resolved.set(schema.name, {
       schema,
-      adapter: formatAdapterFor(schema.format ?? 'md', formatAdapters),
+      adapter: formatAdapterFor(schema.format, formatAdapters),
       absoluteFolder: path.resolve(rootDir, schema.path),
     });
   }

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -5,57 +5,74 @@
 
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
-import { z } from 'zod';
 import type {
   ContentProvider,
   DocumentEntry,
 } from '../../../core/content/contract';
+import { invariant } from '../../../core/invariant';
 import type { CollectionSchema } from '../../../core/schema/types';
-import { type FormatAdapter, formatAdapterFor } from './format-adapters';
+import {
+  type CollectionFormat,
+  type FormatAdapter,
+  formatAdapterFor,
+} from './format-adapters';
 import {
   type GraphQLPipeline,
+  type GraphQLResult,
+  type GraphQLVariables,
   createGraphQLPipeline,
 } from './graphql-pipeline';
+
+// The wire dispatch a host (express, a Next route) pairs with createLocalDataLayer.
+export {
+  type ContentRequest,
+  dispatchContentRequest,
+} from './content-request';
 
 export interface LocalDataLayerOptions {
   // The project root document paths are relative to; collection `path`s resolve
   // against it.
   rootDir: string;
   collections: CollectionSchema[];
+  // Per-format adapter overrides, merged over the built-ins (format-adapters.ts).
+  formatAdapters?: Partial<Record<CollectionFormat, FormatAdapter>>;
 }
 
 // ContentProvider plus the v3 GraphQL read surface (graphql-pipeline.ts) —
 // serving the website render path the same queries v3 served.
 export interface LocalDataLayer extends ContentProvider {
-  graphql(query: string, variables?: Record<string, unknown>): Promise<unknown>;
+  graphql(query: string, variables?: GraphQLVariables): Promise<GraphQLResult>;
 }
 
 interface ResolvedCollection {
   schema: CollectionSchema;
   adapter: FormatAdapter;
-  // Absolute folder holding the collection's files.
-  folder: string;
+  absoluteFolder: string;
 }
 
 const resolveCollections = ({
   rootDir,
   collections,
+  formatAdapters,
 }: LocalDataLayerOptions): Map<string, ResolvedCollection> => {
   const resolved = new Map<string, ResolvedCollection>();
   for (const schema of collections) {
-    if (!schema.path) {
-      throw new Error(
-        `Collection "${schema.name}" has no \`path\` — the local data layer needs one to locate its files.`
-      );
-    }
+    invariant(
+      schema.path,
+      'content-collection-no-path',
+      `Collection "${schema.name}" has no \`path\` — the local data layer needs one to locate its files.`
+    );
     resolved.set(schema.name, {
       schema,
-      adapter: formatAdapterFor(schema.format ?? 'md'),
-      folder: path.resolve(rootDir, schema.path),
+      adapter: formatAdapterFor(schema.format ?? 'md', formatAdapters),
+      absoluteFolder: path.resolve(rootDir, schema.path),
     });
   }
   return resolved;
 };
+
+const isMissingFileError = (cause: unknown): boolean =>
+  cause instanceof Error && (cause as NodeJS.ErrnoException).code === 'ENOENT';
 
 export const createLocalDataLayer = (
   options: LocalDataLayerOptions
@@ -67,19 +84,27 @@ export const createLocalDataLayer = (
   // session that never queries GraphQL never pays for it. Files stay the source
   // of truth: saves land on disk first, then refresh the index.
   let pipeline: Promise<GraphQLPipeline> | undefined;
-  const graphQLPipeline = () =>
-    (pipeline ??= createGraphQLPipeline({
-      rootDir,
-      collections: options.collections,
-    }).catch((cause) => {
-      // A failed boot must not be memoized forever — the next call retries.
-      pipeline = undefined;
-      throw cause;
-    }));
+  const graphQLPipeline = () => {
+    if (!pipeline) {
+      pipeline = createGraphQLPipeline({
+        rootDir,
+        collections: options.collections,
+      }).catch((cause) => {
+        // A failed boot must not be memoized forever — the next call retries.
+        pipeline = undefined;
+        throw cause;
+      });
+    }
+    return pipeline;
+  };
 
   const collectionFor = (name: string): ResolvedCollection => {
     const collection = collections.get(name);
-    if (!collection) throw new Error(`Unknown collection "${name}".`);
+    invariant(
+      collection,
+      'content-unknown-collection',
+      `Unknown collection "${name}".`
+    );
     return collection;
   };
 
@@ -90,16 +115,24 @@ export const createLocalDataLayer = (
     documentPath: string
   ): string => {
     const absolute = path.resolve(rootDir, documentPath);
-    if (
-      !absolute.startsWith(collection.folder + path.sep) ||
-      !absolute.endsWith(collection.adapter.extension)
-    ) {
+    if (!absolute.startsWith(collection.absoluteFolder + path.sep)) {
       throw new Error(
         `Path "${documentPath}" is outside collection "${collection.schema.name}".`
       );
     }
+    if (!absolute.endsWith(collection.adapter.extension)) {
+      throw new Error(
+        `Path "${documentPath}" is not a ${collection.adapter.extension} file in collection "${collection.schema.name}".`
+      );
+    }
     return absolute;
   };
+
+  // The document id is the root-relative posix path (ADR-017) — derived from the
+  // resolved absolute so a non-canonical client path (…/nested/../x.mdx) can't
+  // leak into the index or the echoed entry.
+  const documentIdFor = (absolute: string): string =>
+    path.relative(rootDir, absolute).split(path.sep).join('/');
 
   return {
     async get(collectionName, documentPath) {
@@ -109,33 +142,35 @@ export const createLocalDataLayer = (
       try {
         raw = await fs.readFile(absolute, 'utf8');
       } catch (cause) {
-        if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        if (isMissingFileError(cause)) return null;
         throw cause;
       }
-      return { path: documentPath, document: collection.adapter.parse(raw) };
+      return {
+        path: documentIdFor(absolute),
+        document: collection.adapter.parse(raw),
+      };
     },
 
     async list(collectionName) {
       const collection = collectionFor(collectionName);
       let names: string[];
       try {
-        names = (await fs.readdir(collection.folder, { recursive: true })).map(
-          String
-        );
+        names = await fs.readdir(collection.absoluteFolder, {
+          recursive: true,
+        });
       } catch (cause) {
         // A not-yet-created collection folder is an empty collection.
-        if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return [];
+        if (isMissingFileError(cause)) return [];
         throw cause;
       }
       const entries: DocumentEntry[] = [];
       for (const name of names.sort()) {
         if (!name.endsWith(collection.adapter.extension)) continue;
-        const absolute = path.join(collection.folder, name);
+        const absolute = path.join(collection.absoluteFolder, name);
         try {
           const raw = await fs.readFile(absolute, 'utf8');
           entries.push({
-            // Paths are the document id: root-relative posix (ADR-017).
-            path: path.relative(rootDir, absolute).split(path.sep).join('/'),
+            path: documentIdFor(absolute),
             document: collection.adapter.parse(raw),
           });
         } catch (cause) {
@@ -150,6 +185,7 @@ export const createLocalDataLayer = (
     async update(collectionName, documentPath, value) {
       const collection = collectionFor(collectionName);
       const absolute = resolveDocumentPath(collection, documentPath);
+      const canonicalPath = documentIdFor(absolute);
       // Merge over the file's current contents so unknown fields and the body
       // survive (format-adapters.ts); a missing file is written fresh — never
       // lose the edit (ADR-018).
@@ -157,70 +193,43 @@ export const createLocalDataLayer = (
       try {
         previousRaw = await fs.readFile(absolute, 'utf8');
       } catch (cause) {
-        if ((cause as NodeJS.ErrnoException).code !== 'ENOENT') throw cause;
+        if (!isMissingFileError(cause)) throw cause;
       }
-      const raw = collection.adapter.serialize(value, previousRaw);
+      // An isBody field is the markdown body, not frontmatter — a client
+      // echoing it back must not land the rich-text AST in the YAML merge
+      // (previousRaw still owns the real body).
+      const bodyFields = new Set(
+        collection.schema.fields
+          .filter((field) => field.isBody)
+          .map((field) => field.name)
+      );
+      const frontmatter = Object.fromEntries(
+        Object.entries(value).filter(([key]) => !bodyFields.has(key))
+      );
+      const raw = collection.adapter.serialize(frontmatter, previousRaw);
       // The parent folder may have been deleted out-of-band — same promise.
       await fs.mkdir(path.dirname(absolute), { recursive: true });
       await fs.writeFile(absolute, raw);
       // Keep the GraphQL index in step with the save — only once it exists;
       // a not-yet-booted pipeline indexes everything fresh on first query.
-      // ponytail: no fs watcher, out-of-band edits go stale until the next
-      // save; add chokidar when that bites.
+      // Deliberately no fs watcher: out-of-band edits go stale until the
+      // next save; add chokidar when that bites.
       if (pipeline) {
+        const readyPipeline = await pipeline;
         try {
-          await (await pipeline).reindexPaths([documentPath]);
+          await readyPipeline.reindexPaths([canonicalPath]);
         } catch (cause) {
           // The file is already written — a reindex failure must not fail the
           // save; the index self-heals on the next successful reindex/boot.
-          console.warn(`Reindex failed for "${documentPath}":`, cause);
+          console.warn(`Reindex failed for "${canonicalPath}":`, cause);
         }
       }
-      return { path: documentPath, document: collection.adapter.parse(raw) };
+      return { path: canonicalPath, document: collection.adapter.parse(raw) };
     },
 
-    graphql: async (query, variables) =>
-      (await graphQLPipeline()).execute(query, variables),
+    graphql: async (query, variables) => {
+      const readyPipeline = await graphQLPipeline();
+      return readyPipeline.execute(query, variables);
+    },
   };
-};
-
-// The wire protocol: one JSON request per operation, validated at the trust
-// boundary. Transport-agnostic — the host (Vite middleware, express, a Next
-// route) parses the HTTP body and JSONs the result back.
-const contentRequestSchema = z.discriminatedUnion('op', [
-  z.object({ op: z.literal('list'), collection: z.string() }),
-  z.object({ op: z.literal('get'), collection: z.string(), path: z.string() }),
-  z.object({
-    op: z.literal('update'),
-    collection: z.string(),
-    path: z.string(),
-    value: z.record(z.string(), z.unknown()),
-  }),
-  // The v3 read surface: a raw GraphQL request, answered by graphql-pipeline.ts.
-  z.object({
-    op: z.literal('graphql'),
-    query: z.string(),
-    variables: z.record(z.string(), z.unknown()).optional(),
-  }),
-]);
-
-export type ContentRequest = z.infer<typeof contentRequestSchema>;
-
-// Returns DocumentEntry shapes for the provider ops, or the GraphQL
-// { data, errors } envelope for `graphql` — the host JSONs it either way.
-export const handleContentRequest = async (
-  provider: LocalDataLayer,
-  request: unknown
-): Promise<unknown> => {
-  const parsed = contentRequestSchema.parse(request);
-  switch (parsed.op) {
-    case 'list':
-      return provider.list(parsed.collection);
-    case 'get':
-      return provider.get(parsed.collection, parsed.path);
-    case 'update':
-      return provider.update(parsed.collection, parsed.path, parsed.value);
-    case 'graphql':
-      return provider.graphql(parsed.query, parsed.variables);
-  }
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -1,0 +1,158 @@
+// Node-only — the Local Data Layer (ADR-018 §3): an fs-backed ContentProvider.
+// A save writes the file and leaves it uncommitted; Tina runs no git locally.
+// Hosted by whatever dev server is around (the playground mounts it as a Vite
+// middleware; the CLI will mount the same handler).
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { z } from 'zod';
+import type {
+  ContentProvider,
+  DocumentEntry,
+} from '../../../core/content/contract';
+import type { CollectionSchema } from '../../../core/schema/types';
+import { type FormatAdapter, formatAdapterFor } from './format-adapters';
+
+export interface LocalDataLayerOptions {
+  // The project root document paths are relative to; collection `path`s resolve
+  // against it.
+  rootDir: string;
+  collections: CollectionSchema[];
+}
+
+interface ResolvedCollection {
+  schema: CollectionSchema;
+  adapter: FormatAdapter;
+  // Absolute folder holding the collection's files.
+  folder: string;
+}
+
+const resolveCollections = ({
+  rootDir,
+  collections,
+}: LocalDataLayerOptions): Map<string, ResolvedCollection> => {
+  const resolved = new Map<string, ResolvedCollection>();
+  for (const schema of collections) {
+    if (!schema.path) {
+      throw new Error(
+        `Collection "${schema.name}" has no \`path\` — the local data layer needs one to locate its files.`
+      );
+    }
+    resolved.set(schema.name, {
+      schema,
+      adapter: formatAdapterFor(schema.format ?? 'md'),
+      folder: path.resolve(rootDir, schema.path),
+    });
+  }
+  return resolved;
+};
+
+export const createLocalDataLayer = (
+  options: LocalDataLayerOptions
+): ContentProvider => {
+  const rootDir = path.resolve(options.rootDir);
+  const collections = resolveCollections(options);
+
+  const collectionFor = (name: string): ResolvedCollection => {
+    const collection = collections.get(name);
+    if (!collection) throw new Error(`Unknown collection "${name}".`);
+    return collection;
+  };
+
+  // Document paths come from the client — resolve and pin them inside the
+  // collection's folder before any fs call (trust boundary).
+  const resolveDocumentPath = (
+    collection: ResolvedCollection,
+    documentPath: string
+  ): string => {
+    const absolute = path.resolve(rootDir, documentPath);
+    if (
+      !absolute.startsWith(collection.folder + path.sep) ||
+      !absolute.endsWith(collection.adapter.extension)
+    ) {
+      throw new Error(
+        `Path "${documentPath}" is outside collection "${collection.schema.name}".`
+      );
+    }
+    return absolute;
+  };
+
+  return {
+    async get(collectionName, documentPath) {
+      const collection = collectionFor(collectionName);
+      const absolute = resolveDocumentPath(collection, documentPath);
+      let raw: string;
+      try {
+        raw = await fs.readFile(absolute, 'utf8');
+      } catch (cause) {
+        if ((cause as NodeJS.ErrnoException).code === 'ENOENT') return null;
+        throw cause;
+      }
+      return { path: documentPath, document: collection.adapter.parse(raw) };
+    },
+
+    async list(collectionName) {
+      const collection = collectionFor(collectionName);
+      const names = await fs.readdir(collection.folder, { recursive: true });
+      const entries: DocumentEntry[] = [];
+      for (const name of names.map(String).sort()) {
+        if (!name.endsWith(collection.adapter.extension)) continue;
+        const absolute = path.join(collection.folder, name);
+        entries.push({
+          path: path.relative(rootDir, absolute),
+          document: collection.adapter.parse(
+            await fs.readFile(absolute, 'utf8')
+          ),
+        });
+      }
+      return entries;
+    },
+
+    async update(collectionName, documentPath, value) {
+      const collection = collectionFor(collectionName);
+      const absolute = resolveDocumentPath(collection, documentPath);
+      // Merge over the file's current contents so unknown fields and the body
+      // survive (format-adapters.ts); a missing file is written fresh — never
+      // lose the edit (ADR-018).
+      const previousRaw = await fs
+        .readFile(absolute, 'utf8')
+        .catch(() => undefined);
+      await fs.writeFile(
+        absolute,
+        collection.adapter.serialize(value, previousRaw)
+      );
+    },
+  };
+};
+
+// The wire protocol: one JSON request per operation, validated at the trust
+// boundary. Transport-agnostic — the host (Vite middleware, express, a Next
+// route) parses the HTTP body and JSONs the result back.
+const contentRequestSchema = z.discriminatedUnion('op', [
+  z.object({ op: z.literal('list'), collection: z.string() }),
+  z.object({ op: z.literal('get'), collection: z.string(), path: z.string() }),
+  z.object({
+    op: z.literal('update'),
+    collection: z.string(),
+    path: z.string(),
+    value: z.record(z.string(), z.unknown()),
+  }),
+]);
+
+export type ContentRequest = z.infer<typeof contentRequestSchema>;
+
+export const handleContentRequest = async (
+  provider: ContentProvider,
+  request: unknown
+): Promise<DocumentEntry[] | DocumentEntry | null> => {
+  const parsed = contentRequestSchema.parse(request);
+  switch (parsed.op) {
+    case 'list':
+      return provider.list(parsed.collection);
+    case 'get':
+      return provider.get(parsed.collection, parsed.path);
+    case 'update':
+      await provider.update(parsed.collection, parsed.path, parsed.value);
+      return null;
+  }
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -71,6 +71,10 @@ export const createLocalDataLayer = (
     (pipeline ??= createGraphQLPipeline({
       rootDir,
       collections: options.collections,
+    }).catch((cause) => {
+      // A failed boot must not be memoized forever — the next call retries.
+      pipeline = undefined;
+      throw cause;
     }));
 
   const collectionFor = (name: string): ResolvedCollection => {
@@ -163,7 +167,15 @@ export const createLocalDataLayer = (
       // a not-yet-booted pipeline indexes everything fresh on first query.
       // ponytail: no fs watcher, out-of-band edits go stale until the next
       // save; add chokidar when that bites.
-      if (pipeline) await (await pipeline).reindexPaths([documentPath]);
+      if (pipeline) {
+        try {
+          await (await pipeline).reindexPaths([documentPath]);
+        } catch (cause) {
+          // The file is already written — a reindex failure must not fail the
+          // save; the index self-heals on the next successful reindex/boot.
+          console.warn(`Reindex failed for "${documentPath}":`, cause);
+        }
+      }
       return { path: documentPath, document: collection.adapter.parse(raw) };
     },
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.ts
@@ -107,16 +107,17 @@ export const createLocalDataLayer = (
       for (const name of names.sort()) {
         if (!name.endsWith(collection.adapter.extension)) continue;
         const absolute = path.join(collection.folder, name);
-        const raw = await fs.readFile(absolute, 'utf8');
         try {
+          const raw = await fs.readFile(absolute, 'utf8');
           entries.push({
             // Paths are the document id: root-relative posix (ADR-017).
             path: path.relative(rootDir, absolute).split(path.sep).join('/'),
             document: collection.adapter.parse(raw),
           });
         } catch (cause) {
-          // One malformed file must not take down the whole collection.
-          console.warn(`Skipping unparsable document "${absolute}":`, cause);
+          // One malformed or unreadable file must not take down the whole
+          // collection.
+          console.warn(`Skipping unreadable document "${absolute}":`, cause);
         }
       }
       return entries;

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.test.ts
@@ -1,0 +1,194 @@
+// The Vite host is a published subpath (`./local-data-layer/vite`), so its guards and
+// its watch config are a contract. The Connect handler is a plain function of (req, res),
+// which means none of this needs a dev server: the tests call it with a request double
+// and read what it wrote back.
+
+import { EventEmitter } from 'node:events';
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CollectionSchema } from '../../../core/schema/types';
+import { tinaLocalDataLayerVitePlugin } from './local-data-layer.vite';
+
+vi.mock('./graphql-pipeline', () => ({ createGraphQLPipeline: vi.fn() }));
+
+const POSTS: CollectionSchema = {
+  name: 'posts',
+  label: 'Posts',
+  path: 'content/posts',
+  format: 'mdx',
+  fields: [{ type: 'string', name: 'title', label: 'Title' }],
+};
+
+let rootDir: string;
+
+beforeEach(async () => {
+  rootDir = await fs.mkdtemp(path.join(tmpdir(), 'tina-vite-'));
+  await fs.mkdir(path.join(rootDir, 'content/posts'), { recursive: true });
+  await fs.writeFile(
+    path.join(rootDir, 'content/posts/hello.mdx'),
+    '---\ntitle: Hello\n---\n'
+  );
+});
+
+// Connect hands the middleware a Node IncomingMessage. Only the headers, the encoding
+// and the data/end/error events are read, so an EventEmitter carries all of it.
+const requestDouble = (headers: Record<string, string>, body?: string) => {
+  const req = Object.assign(new EventEmitter(), {
+    headers,
+    setEncoding: () => {},
+  });
+  if (body !== undefined) {
+    queueMicrotask(() => {
+      req.emit('data', body);
+      req.emit('end');
+    });
+  }
+  return req as never;
+};
+
+const responseDouble = () => {
+  const chunks: string[] = [];
+  return {
+    statusCode: 200,
+    destroyed: false,
+    headers: {} as Record<string, string>,
+    setHeader(name: string, value: string) {
+      this.headers[name] = value;
+    },
+    end(chunk?: string) {
+      if (chunk !== undefined) chunks.push(chunk);
+    },
+    get body() {
+      return chunks.join('');
+    },
+  };
+};
+
+const middlewareOf = (url?: string) => {
+  const plugin = tinaLocalDataLayerVitePlugin({
+    rootDir,
+    collections: [POSTS],
+    ...(url ? { url } : {}),
+  });
+  let mounted: { route: string; handler: Function } | null = null;
+  const server = {
+    middlewares: {
+      use: (route: string, handler: Function) => {
+        mounted = { route, handler };
+      },
+    },
+  };
+  (plugin.configureServer as (s: unknown) => void)(server);
+  if (!mounted) throw new Error('The plugin mounted no middleware.');
+  return mounted;
+};
+
+const JSON_HEADERS = {
+  'content-type': 'application/json',
+  host: 'localhost:5173',
+  origin: 'http://localhost:5173',
+};
+
+describe('tinaLocalDataLayerVitePlugin middleware', () => {
+  it('serves a same-origin JSON content request', async () => {
+    const { handler } = middlewareOf();
+    const res = responseDouble();
+    await handler(
+      requestDouble(
+        JSON_HEADERS,
+        JSON.stringify({ op: 'list', collection: 'posts' })
+      ),
+      res
+    );
+    expect(res.statusCode).toBe(200);
+    expect(res.headers['content-type']).toBe('application/json');
+    expect(res.body).toContain('hello.mdx');
+  });
+
+  it('serves a request with no Origin header, which is what curl sends', async () => {
+    const { handler } = middlewareOf();
+    const res = responseDouble();
+    await handler(
+      requestDouble(
+        { 'content-type': 'application/json', host: 'localhost:5173' },
+        JSON.stringify({ op: 'list', collection: 'posts' })
+      ),
+      res
+    );
+    expect(res.statusCode).toBe(200);
+  });
+
+  it('403s a cross-origin request', async () => {
+    const { handler } = middlewareOf();
+    const res = responseDouble();
+    await handler(
+      requestDouble(
+        { ...JSON_HEADERS, origin: 'http://evil.example' },
+        JSON.stringify({ op: 'list', collection: 'posts' })
+      ),
+      res
+    );
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('415s a request that is not JSON', async () => {
+    const { handler } = middlewareOf();
+    const res = responseDouble();
+    await handler(
+      requestDouble({ ...JSON_HEADERS, 'content-type': 'text/plain' }, '{}'),
+      res
+    );
+    expect(res.statusCode).toBe(415);
+  });
+
+  it('400s a damaged body', async () => {
+    const { handler } = middlewareOf();
+    const res = responseDouble();
+    await handler(requestDouble(JSON_HEADERS, '{ not json'), res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('writes nothing when the socket is already destroyed', async () => {
+    const { handler } = middlewareOf();
+    const res = responseDouble();
+    res.destroyed = true;
+    await handler(requestDouble(JSON_HEADERS, '{ not json'), res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toBe('');
+  });
+
+  it('mounts at the configured url', () => {
+    expect(middlewareOf('/__tina/content').route).toBe('/__tina/content');
+  });
+});
+
+describe('tinaLocalDataLayerVitePlugin watch config', () => {
+  it('ignores the collection folders, in posix form', () => {
+    const plugin = tinaLocalDataLayerVitePlugin({
+      rootDir,
+      collections: [POSTS],
+    });
+    const config = (plugin.config as () => Record<string, never>)();
+    const ignored = (
+      config as unknown as {
+        server: { watch: { ignored: string[] } };
+      }
+    ).server.watch.ignored;
+    expect(ignored).toHaveLength(1);
+    expect(ignored[0].endsWith('content/posts/**')).toBe(true);
+    expect(ignored[0]).not.toContain('\\');
+  });
+
+  // The watch config keeps a `folder ? … : []` branch that this can never reach: the
+  // data layer is built first, and it refuses a collection with no path outright.
+  it('refuses a collection with no path before it configures anything', () => {
+    expect(() =>
+      tinaLocalDataLayerVitePlugin({
+        rootDir,
+        collections: [{ ...POSTS, path: undefined as unknown as string }],
+      })
+    ).toThrow(/content-collection-no-path/);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
@@ -1,8 +1,8 @@
-// Vite host for the Local Data Layer (ADR-018): mounts the content endpoint
-// the localContentPlugin slice talks to, and keeps the content folders out of
-// the dev watcher — a save must reach the editor through the content slice,
-// not as an HMR full page reload (tailwind's content scan otherwise promotes
-// the file write to one).
+// The Vite host for the local data layer (ADR-018). It mounts the content endpoint that
+// the localContentPlugin slice calls. It also keeps the content folders out of the dev
+// watcher. A save must reach the editor through the content slice, and not as a full page
+// reload from HMR. Without that, the content scan of Tailwind turns the file write into a
+// reload.
 
 import path from 'node:path';
 import type { Connect, Plugin } from 'vite';
@@ -13,12 +13,12 @@ import {
   createLocalDataLayer,
 } from './local-data-layer';
 
-// Same origin as the dev server, or no Origin at all (curl and friends).
+// The same origin as the dev server, or no Origin header, which is what curl sends.
 const isSameOrigin = (origin: string | undefined, host?: string): boolean =>
   !origin || origin === `http://${host}` || origin === `https://${host}`;
 
-// Collect the request body as a UTF-8 string; a client abort mid-stream rejects
-// rather than hanging or crashing the dev server.
+// Collect the request body as a UTF-8 string. A client that aborts the stream makes this
+// reject. It does not hang, and it does not stop the dev server.
 const readRequestBody = (req: Connect.IncomingMessage): Promise<string> =>
   new Promise((resolve, reject) => {
     let body = '';
@@ -36,8 +36,9 @@ export const tinaLocalDataLayerVitePlugin = (
   const dataLayer = createLocalDataLayer(options);
   const serveContentRequest: Connect.NextHandleFunction = async (req, res) => {
     const { origin, host } = req.headers;
-    // CSRF guard: reject a cross-site POST, and require a JSON content-type — a
-    // cross-origin fetch with it always preflights, closing the remaining gap.
+    // The CSRF guard. It rejects a cross-site POST, and it requires a JSON content
+    // type. A cross-origin fetch with that type always sends a preflight, which
+    // closes the gap.
     if (!isSameOrigin(origin, host)) {
       res.statusCode = 403;
       res.end('Cross-origin request rejected');
@@ -54,9 +55,10 @@ export const tinaLocalDataLayerVitePlugin = (
       res.setHeader('content-type', 'application/json');
       res.end(JSON.stringify(result));
     } catch (cause) {
-      // A malformed body or a mid-stream abort lands here — 400 rather than a
-      // crashed dev server. Skip the write if the socket is already gone (an
-      // abort destroys it, so `destroyed` is the live check, not `writableEnded`).
+      // A damaged body, and an abort during the stream, both arrive here. The reply
+      // is a 400, and the dev server keeps running. Do not write when the socket has
+      // gone. An abort destroys the socket, so `destroyed` is the correct check, and
+      // `writableEnded` is not.
       if (res.destroyed) return;
       res.statusCode = 400;
       res.end(cause instanceof Error ? cause.message : String(cause));
@@ -67,16 +69,14 @@ export const tinaLocalDataLayerVitePlugin = (
     config: () => ({
       server: {
         watch: {
-          // Globs must be posix even on Windows (picomatch).
-          ignored: options.collections.flatMap(({ path: folder }) =>
-            folder
-              ? [
-                  path
-                    .resolve(options.rootDir, folder, '**')
-                    .split(path.sep)
-                    .join('/'),
-                ]
-              : []
+          // A glob must use posix separators, and Windows is no exception. This is
+          // a picomatch rule. Every collection has a folder: createLocalDataLayer
+          // above throws for one that declares no `path`.
+          ignored: options.collections.map(({ path: folder }) =>
+            path
+              .resolve(options.rootDir, folder, '**')
+              .split(path.sep)
+              .join('/')
           ),
         },
       },

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
@@ -55,8 +55,9 @@ export const tinaLocalDataLayerVitePlugin = (
       res.end(JSON.stringify(result));
     } catch (cause) {
       // A malformed body or a mid-stream abort lands here — 400 rather than a
-      // crashed dev server. Skip the write if the socket is already gone.
-      if (res.writableEnded) return;
+      // crashed dev server. Skip the write if the socket is already gone (an
+      // abort destroys it, so `destroyed` is the live check, not `writableEnded`).
+      if (res.destroyed) return;
       res.statusCode = 400;
       res.end(cause instanceof Error ? cause.message : String(cause));
     }

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
@@ -1,0 +1,83 @@
+// Vite host for the Local Data Layer (ADR-018): mounts the content endpoint
+// the localContentPlugin slice talks to, and keeps the content folders out of
+// the dev watcher — a save must reach the editor through the content slice,
+// not as an HMR full page reload (tailwind's content scan otherwise promotes
+// the file write to one).
+
+import path from 'node:path';
+import type { Connect, Plugin } from 'vite';
+import { DEFAULT_CONTENT_URL } from '../../../core/content/contract';
+import { dispatchContentRequest } from './content-request';
+import {
+  type LocalDataLayerOptions,
+  createLocalDataLayer,
+} from './local-data-layer';
+
+export const tinaLocalDataLayerVitePlugin = (
+  options: LocalDataLayerOptions & { url?: string }
+): Plugin => {
+  const dataLayer = createLocalDataLayer(options);
+  const serveContentRequest: Connect.NextHandleFunction = (req, res) => {
+    // CSRF guard: browsers send Origin on cross-site POSTs — reject anything
+    // that isn't the dev server itself (no Origin = curl and friends, allowed).
+    const { origin, host } = req.headers;
+    if (origin && origin !== `http://${host}` && origin !== `https://${host}`) {
+      res.statusCode = 403;
+      res.end('Cross-origin request rejected');
+      return;
+    }
+    // Only JSON bodies: a cross-origin fetch with this content-type always
+    // preflights, closing the remaining CSRF gap.
+    if (req.headers['content-type']?.includes('application/json') !== true) {
+      res.statusCode = 415;
+      res.end('Expected application/json');
+      return;
+    }
+    let body = '';
+    req.setEncoding('utf8');
+    // A client abort mid-body must not crash the dev server.
+    req.on('error', () => res.destroy());
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', async () => {
+      try {
+        const result = await dispatchContentRequest(
+          dataLayer,
+          JSON.parse(body)
+        );
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(result));
+      } catch (cause) {
+        res.statusCode = 400;
+        res.end(cause instanceof Error ? cause.message : String(cause));
+      }
+    });
+  };
+  return {
+    name: 'tina-local-data-layer',
+    config: () => ({
+      server: {
+        watch: {
+          // Globs must be posix even on Windows (picomatch).
+          ignored: options.collections.flatMap(({ path: folder }) =>
+            folder
+              ? [
+                  path
+                    .resolve(options.rootDir, folder, '**')
+                    .split(path.sep)
+                    .join('/'),
+                ]
+              : []
+          ),
+        },
+      },
+    }),
+    configureServer(server) {
+      server.middlewares.use(
+        options.url ?? DEFAULT_CONTENT_URL,
+        serveContentRequest
+      );
+    },
+  };
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-data-layer.vite.ts
@@ -13,46 +13,53 @@ import {
   createLocalDataLayer,
 } from './local-data-layer';
 
+// Same origin as the dev server, or no Origin at all (curl and friends).
+const isSameOrigin = (origin: string | undefined, host?: string): boolean =>
+  !origin || origin === `http://${host}` || origin === `https://${host}`;
+
+// Collect the request body as a UTF-8 string; a client abort mid-stream rejects
+// rather than hanging or crashing the dev server.
+const readRequestBody = (req: Connect.IncomingMessage): Promise<string> =>
+  new Promise((resolve, reject) => {
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+    });
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+
 export const tinaLocalDataLayerVitePlugin = (
   options: LocalDataLayerOptions & { url?: string }
 ): Plugin => {
   const dataLayer = createLocalDataLayer(options);
-  const serveContentRequest: Connect.NextHandleFunction = (req, res) => {
-    // CSRF guard: browsers send Origin on cross-site POSTs — reject anything
-    // that isn't the dev server itself (no Origin = curl and friends, allowed).
+  const serveContentRequest: Connect.NextHandleFunction = async (req, res) => {
     const { origin, host } = req.headers;
-    if (origin && origin !== `http://${host}` && origin !== `https://${host}`) {
+    // CSRF guard: reject a cross-site POST, and require a JSON content-type — a
+    // cross-origin fetch with it always preflights, closing the remaining gap.
+    if (!isSameOrigin(origin, host)) {
       res.statusCode = 403;
       res.end('Cross-origin request rejected');
       return;
     }
-    // Only JSON bodies: a cross-origin fetch with this content-type always
-    // preflights, closing the remaining CSRF gap.
     if (req.headers['content-type']?.includes('application/json') !== true) {
       res.statusCode = 415;
       res.end('Expected application/json');
       return;
     }
-    let body = '';
-    req.setEncoding('utf8');
-    // A client abort mid-body must not crash the dev server.
-    req.on('error', () => res.destroy());
-    req.on('data', (chunk) => {
-      body += chunk;
-    });
-    req.on('end', async () => {
-      try {
-        const result = await dispatchContentRequest(
-          dataLayer,
-          JSON.parse(body)
-        );
-        res.setHeader('content-type', 'application/json');
-        res.end(JSON.stringify(result));
-      } catch (cause) {
-        res.statusCode = 400;
-        res.end(cause instanceof Error ? cause.message : String(cause));
-      }
-    });
+    try {
+      const body = await readRequestBody(req);
+      const result = await dispatchContentRequest(dataLayer, JSON.parse(body));
+      res.setHeader('content-type', 'application/json');
+      res.end(JSON.stringify(result));
+    } catch (cause) {
+      // A malformed body or a mid-stream abort lands here — 400 rather than a
+      // crashed dev server. Skip the write if the socket is already gone.
+      if (res.writableEnded) return;
+      res.statusCode = 400;
+      res.end(cause instanceof Error ? cause.message : String(cause));
+    }
   };
   return {
     name: 'tina-local-data-layer',

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/markdown.adapter.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/markdown.adapter.ts
@@ -1,0 +1,16 @@
+import matter from 'gray-matter';
+import type { FormatAdapter } from './format-adapters';
+
+// Frontmatter is the document; the body stays out of it until a rich-text `isBody`
+// field exists to own it — preserved via previousRaw meanwhile.
+export const markdownAdapter = (extension: string): FormatAdapter => ({
+  extension,
+  parse: (raw) => matter(raw).data,
+  serialize: (document, previousRaw) => {
+    const previous = matter(previousRaw ?? '');
+    return matter.stringify(previous.content, {
+      ...previous.data,
+      ...document,
+    });
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
@@ -1,10 +1,10 @@
-// Local typings for @tinacms/graphql, mapped in via tsconfig `paths`. The
-// published d.ts is a passthrough into v3 source (tinacms-scripts emits
-// `export * from "../src/index"`), which drags the whole v3 graphql+mdx source
-// — and its ~150 pre-existing type errors — into this package's tsc. Typing
-// just the members graphql-pipeline.ts consumes keeps the boundary typed
-// without checking v3 source. Runtime behaviour is covered by
-// graphql-pipeline.test.ts against the real package.
+// The local types for @tinacms/graphql. The tsconfig `paths` field maps them in. The
+// published d.ts file points into the v3 source, because tinacms-scripts emits
+// `export * from "../src/index"`. That pulls the whole v3 graphql and mdx source into
+// the tsc run of this package, with about 150 type errors that were already there. These
+// types cover the members that graphql-pipeline.ts uses, so the boundary has types and
+// tsc does not check the v3 source. graphql-pipeline.test.ts covers the runtime behaviour
+// against the real package.
 declare module '@tinacms/graphql' {
   import type { AbstractLevel } from 'abstract-level';
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
@@ -1,0 +1,52 @@
+// Local typings for @tinacms/graphql, mapped in via tsconfig `paths`. The
+// published d.ts is a passthrough into v3 source (tinacms-scripts emits
+// `export * from "../src/index"`), which drags the whole v3 graphql+mdx source
+// — and its ~150 pre-existing type errors — into this package's tsc. Typing
+// just the members graphql-pipeline.ts consumes keeps the boundary typed
+// without checking v3 source. Runtime behaviour is covered by
+// graphql-pipeline.test.ts against the real package.
+declare module '@tinacms/graphql' {
+  import type { AbstractLevel } from 'abstract-level';
+
+  export type Level = AbstractLevel<
+    Buffer | Uint8Array | string,
+    string,
+    Record<string, unknown>
+  >;
+
+  export class FilesystemBridge {
+    constructor(rootPath: string, outputPath?: string);
+  }
+
+  export interface Database {
+    indexContent(args: {
+      graphQLSchema: unknown;
+      tinaSchema: unknown;
+      lookup?: object;
+    }): Promise<unknown>;
+    indexContentByPaths(documentPaths: string[]): Promise<void>;
+  }
+
+  export function createDatabaseInternal(config: {
+    bridge: FilesystemBridge;
+    level: Level;
+    tinaDirectory?: string;
+  }): Database;
+
+  export function buildDotTinaFiles(args: {
+    config: { schema: { collections: unknown[] } };
+    flags?: string[];
+    buildSDK?: boolean;
+  }): Promise<{
+    graphQLSchema: unknown;
+    tinaSchema: unknown;
+    lookup: object;
+  }>;
+
+  export function resolve(args: {
+    database: Database;
+    query: string;
+    variables: object;
+    verbose?: boolean;
+  }): Promise<unknown>;
+}

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
@@ -43,10 +43,15 @@ declare module '@tinacms/graphql' {
     lookup: object;
   }>;
 
+  export interface GraphQLResult {
+    data?: Record<string, unknown> | null;
+    errors?: Array<{ message: string }>;
+  }
+
   export function resolve(args: {
     database: Database;
     query: string;
     variables: object;
     verbose?: boolean;
-  }): Promise<unknown>;
+  }): Promise<GraphQLResult>;
 }

--- a/packages/v4/@tinacms/tinacms/src/test/setup.ts
+++ b/packages/v4/@tinacms/tinacms/src/test/setup.ts
@@ -7,24 +7,6 @@ import { useFormStore } from '../form/form-store';
 // (plugin graph + lazy segment imports) on loaded CI runners.
 configure({ asyncUtilTimeout: 5000 });
 
-// node ≥23 ships its own globalThis.localStorage that shadows happy-dom's and is
-// non-functional without --localstorage-file, so tests bring their own in-memory
-// Storage — deterministic on every node version.
-const entries = new Map<string, string>();
-Object.defineProperty(globalThis, 'localStorage', {
-  configurable: true,
-  value: {
-    getItem: (key: string) => entries.get(key) ?? null,
-    setItem: (key: string, value: string) => entries.set(key, String(value)),
-    removeItem: (key: string) => entries.delete(key),
-    clear: () => entries.clear(),
-    key: (index: number) => [...entries.keys()][index] ?? null,
-    get length() {
-      return entries.size;
-    },
-  },
-});
-
 // The form-store is a module-level singleton, so its state bleeds across tests.
 // Reset it here for every test file rather than mandating a beforeEach per file.
 // localStorage too: every createTinaStore persists/rehydrates the shared

--- a/packages/v4/@tinacms/tinacms/src/test/setup.ts
+++ b/packages/v4/@tinacms/tinacms/src/test/setup.ts
@@ -7,6 +7,24 @@ import { useFormStore } from '../form/form-store';
 // (plugin graph + lazy segment imports) on loaded CI runners.
 configure({ asyncUtilTimeout: 5000 });
 
+// node ≥23 ships its own globalThis.localStorage that shadows happy-dom's and is
+// non-functional without --localstorage-file, so tests bring their own in-memory
+// Storage — deterministic on every node version.
+const entries = new Map<string, string>();
+Object.defineProperty(globalThis, 'localStorage', {
+  configurable: true,
+  value: {
+    getItem: (key: string) => entries.get(key) ?? null,
+    setItem: (key: string, value: string) => entries.set(key, String(value)),
+    removeItem: (key: string) => entries.delete(key),
+    clear: () => entries.clear(),
+    key: (index: number) => [...entries.keys()][index] ?? null,
+    get length() {
+      return entries.size;
+    },
+  },
+});
+
 // The form-store is a module-level singleton, so its state bleeds across tests.
 // Reset it here for every test file rather than mandating a beforeEach per file.
 // localStorage too: every createTinaStore persists/rehydrates the shared

--- a/packages/v4/@tinacms/tinacms/test-results/.last-run.json
+++ b/packages/v4/@tinacms/tinacms/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}

--- a/packages/v4/@tinacms/tinacms/tsconfig.json
+++ b/packages/v4/@tinacms/tinacms/tsconfig.json
@@ -3,7 +3,12 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": "src",
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": {
+      "@tinacms/graphql": [
+        "./src/plugins/content/local/tinacms-graphql.d.ts"
+      ]
+    }
   },
   "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"],
   "include": ["src"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,13 +1278,13 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+        version: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       next:
         specifier: 14.2.35
         version: 14.2.35(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.97.3)
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -25276,13 +25276,13 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  create-jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -25291,13 +25291,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -27724,6 +27724,25 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-cli@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
   jest-cli@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
@@ -27734,25 +27753,6 @@ snapshots:
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  jest-cli@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -27920,37 +27920,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       ts-node: 10.9.2(@types/node@22.19.3)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.28.5
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.28.5)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 25.1.0
-      ts-node: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -28497,24 +28466,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -32826,26 +32795,6 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-jest@29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3):
-    dependencies:
-      bs-logger: 0.2.6
-      fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
-      jest: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      json5: 2.2.3
-      lodash.memoize: 4.1.2
-      make-error: 1.3.6
-      semver: 7.7.3
-      type-fest: 4.41.0
-      typescript: 5.9.3
-      yargs-parser: 21.1.1
-    optionalDependencies:
-      '@babel/core': 7.28.5
-      '@jest/transform': 30.2.0
-      '@jest/types': 30.2.0
-      babel-jest: 30.2.0(@babel/core@7.29.7)
-      jest-util: 30.2.0
-
   ts-jest@29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@29.7.0(@babel/core@7.29.7))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -32855,7 +32804,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.7.3
+      semver: 7.8.1
       type-fest: 4.41.0
       typescript: 5.9.3
       yargs-parser: 21.1.1
@@ -32867,6 +32816,26 @@ snapshots:
       esbuild: 0.25.12
       jest-util: 30.2.0
 
+  ts-jest@29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3):
+    dependencies:
+      bs-logger: 0.2.6
+      fast-json-stable-stringify: 2.1.0
+      handlebars: 4.7.8
+      jest: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.8.1
+      type-fest: 4.41.0
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.29.7
+      '@jest/transform': 30.2.0
+      '@jest/types': 30.2.0
+      babel-jest: 30.2.0(@babel/core@7.29.7)
+      jest-util: 30.2.0
+
   ts-jest@29.4.6(@babel/core@7.29.7)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7))(jest-util@30.2.0)(jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@25.1.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
@@ -32876,7 +32845,7 @@ snapshots:
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
-      semver: 7.7.3
+      semver: 7.8.1
       type-fest: 4.41.0
       typescript: 5.9.3
       yargs-parser: 21.1.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,13 +1278,13 @@ importers:
         version: 29.5.14
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+        version: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       next:
         specifier: 14.2.35
         version: 14.2.35(@babel/core@7.29.7)(@opentelemetry/api@1.9.0)(@playwright/test@1.61.1)(babel-plugin-macros@3.1.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(sass@1.97.3)
       ts-jest:
         specifier: 'catalog:'
-        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.7))(jest-util@30.2.0)(jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(jest-util@30.2.0)(jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)))(typescript@5.9.3)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -2600,15 +2600,24 @@ importers:
       '@hookform/resolvers':
         specifier: ^5.4.0
         version: 5.4.0(react-hook-form@7.80.0(react@19.2.7))
+      '@tinacms/graphql':
+        specifier: workspace:*
+        version: link:../../../@tinacms/graphql
       '@tinacms/ui':
         specifier: workspace:*
         version: link:../ui
+      abstract-level:
+        specifier: 'catalog:'
+        version: 1.0.4
       gray-matter:
         specifier: 'catalog:'
         version: 4.0.3
       react-hook-form:
         specifier: ^7.80.0
         version: 7.80.0(react@19.2.7)
+      sqlite-level:
+        specifier: 'catalog:'
+        version: 2.1.0
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -25267,13 +25276,13 @@ snapshots:
 
   crc-32@1.2.2: {}
 
-  create-jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -25282,13 +25291,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -27715,25 +27724,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      '@jest/test-result': 29.7.0
-      '@jest/types': 29.6.3
-      chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      exit: 0.1.2
-      import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      yargs: 17.7.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest-cli@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
@@ -27744,6 +27734,25 @@ snapshots:
       exit: 0.1.2
       import-local: 3.2.0
       jest-config: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-cli@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -27911,6 +27920,37 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       ts-node: 10.9.2(@types/node@22.19.3)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.28.5
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.28.5)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0(babel-plugin-macros@3.1.0)
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.1.0
+      ts-node: 10.9.2(@types/node@22.19.17)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -28457,24 +28497,24 @@ snapshots:
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
-    dependencies:
-      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-      '@jest/types': 29.6.3
-      import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.19.17)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
   jest@29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3)):
     dependencies:
       '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
       jest-cli: 29.7.0(@types/node@22.19.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.3)(typescript@5.9.3))
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3)):
+    dependencies:
+      '@jest/core': 29.7.0(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@25.1.0)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@22.19.17)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2603,6 +2603,9 @@ importers:
       '@tinacms/ui':
         specifier: workspace:*
         version: link:../ui
+      gray-matter:
+        specifier: 'catalog:'
+        version: 4.0.3
       react-hook-form:
         specifier: ^7.80.0
         version: 7.80.0(react@19.2.7)


### PR DESCRIPTION
**TLDR:** The content capability contract, with the fs-backed Local Data Layer as its first provider and the v3 GraphQL pipeline hosted inside it.

**Feats:**
- ContentProvider contract (get/list/update) with a zod-validated wire dispatcher and a path-traversal guard
- Format adapters (md/mdx/json) that round-trip unknown frontmatter and the body verbatim
- The v3 GraphQL pipeline over sqlite-level, indexed from local files, reindex-on-save
- Vite middleware with an origin check and abort-safe error writes
- Plugin lifecycle serialised across simultaneous provider mounts

**How to test:** The suite covers the data layer; the playground writes real files.
- Run `pnpm install`.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
- Run `pnpm dev` and open the playground.
- Edit a document and save it.
- Confirm the file under `playground/content/posts/` changed.
