### PR TITLE
refactor(v4): polish the extracted Plate editor

### DIFF
--- a/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
@@ -12,10 +12,11 @@ import { helpers, unsupportedItemsInTable } from '../plugins/core/common';
 import {
   CONTAINER_MD_BREAKPOINT,
   EMBED_ICON_WIDTH,
-  FLOAT_BUTTON_WIDTH,
   HEADING_ICON_ONLY,
   HEADING_ICON_WITH_TEXT,
   HEADING_LABEL,
+  HIGHLIGHT_ICON_WIDTH,
+  OVERFLOW_MENU_WIDTH,
   STANDARD_ICON_WIDTH,
   type ToolbarOverrideType,
 } from '../toolbar/toolbar-overrides';
@@ -100,7 +101,7 @@ const toolbarItems: { [key in ToolbarOverrideType]: ToolbarItem } = {
   },
   highlight: {
     label: 'Highlight',
-    width: () => STANDARD_ICON_WIDTH,
+    width: () => HIGHLIGHT_ICON_WIDTH,
     Component: <HighlightToolbarButton />,
   },
   italic: {
@@ -146,23 +147,15 @@ export default function FixedToolbarButtons() {
   const { overrides, templates } = useToolbarContext();
   const showEmbedButton = templates.length > 0;
 
-  let items = [];
-
-  if (Array.isArray(overrides)) {
-    items =
-      overrides === undefined
-        ? Object.values(toolbarItems)
-        : overrides
-            .map((item) => toolbarItems[item])
-            .filter((item) => item !== undefined);
-  } else {
-    items =
-      overrides?.toolbar === undefined
-        ? Object.values(toolbarItems)
-        : overrides.toolbar
-            .map((item) => toolbarItems[item])
-            .filter((item) => item !== undefined);
-  }
+  // The buttons the schema asks for, in the order it asks for them. Without a
+  // `toolbar` list, the toolbar holds every button. An empty list holds none, and
+  // the filter drops a name that no button answers to.
+  let items: ToolbarItem[] =
+    overrides?.toolbar === undefined
+      ? Object.values(toolbarItems)
+      : overrides.toolbar
+          .map((item) => toolbarItems[item])
+          .filter((item) => item !== undefined);
 
   if (!showEmbedButton) {
     items = items.filter((item) => item.label !== toolbarItems.embed.label);
@@ -178,35 +171,45 @@ export default function FixedToolbarButtons() {
   const userInCodeBlock = helpers.isNodeActive(editorState, CodeBlockPlugin);
 
   useResize(toolbarRef, (entry) => {
-    const width = entry.target.getBoundingClientRect().width - 8;
+    const width = entry.target.getBoundingClientRect().width;
     const headingButton = items.find((item) => item.label === HEADING_LABEL);
+    // This element carries `@container/toolbar`, so its own width is what the
+    // `@md/toolbar` query on the heading label resolves against.
     const headingWidth = headingButton
-      ? //some discrepancy here between the md breakpoint here and in practice, but it works
-        headingButton.width(width > CONTAINER_MD_BREAKPOINT - 9)
+      ? headingButton.width(width >= CONTAINER_MD_BREAKPOINT)
       : 0;
 
     // Calculate the available width excluding the heading button
     const availableWidth = width - headingWidth;
 
     // Count numbers of buttons can fit into the available width
-    const { itemFitCount } = items.reduce(
-      (acc, item) => {
-        if (
-          item.label !== HEADING_LABEL &&
-          acc.totalItemsWidth + item.width() <= availableWidth
-        ) {
-          return {
-            //add 4px to account for additional padding on toolbar buttons
-            totalItemsWidth: acc.totalItemsWidth + item.width() + 4,
-            itemFitCount: acc.itemFitCount + 1,
-          };
-        }
-        return acc;
-      },
-      { totalItemsWidth: 0, itemFitCount: 1 }
-    ); // Initial values fit count set as 1 becasue heading is always exist
+    const countItemsFitting = (budget: number) => {
+      // The heading is measured above, so it starts the count already spent —
+      // but only when it is actually in the list.
+      let count = headingButton ? 1 : 0;
+      let used = 0;
+      for (const item of items) {
+        if (item.label === HEADING_LABEL) continue;
+        // The row renders a contiguous prefix of `items`, so the first item that
+        // does not fit ends the count. A narrower item further down the list
+        // cannot take its place, and counting one that way overfills the row.
+        if (used + item.width() > budget) break;
+        used += item.width();
+        count += 1;
+      }
+      return count;
+    };
 
-    setItemsShown(itemFitCount);
+    // Reserve room for the overflow menu itself, but only once we know it will
+    // be rendered — otherwise a toolbar that fits exactly loses a button to a
+    // menu that never appears.
+    const fitCount = countItemsFitting(availableWidth);
+
+    setItemsShown(
+      fitCount >= items.length
+        ? items.length
+        : countItemsFitting(availableWidth - OVERFLOW_MENU_WIDTH)
+    );
   });
 
   const getOpacity = (item: ToolbarItem) => {
@@ -228,23 +231,24 @@ export default function FixedToolbarButtons() {
         }}
       >
         <>
-          {items
-            .slice(0, items.length > itemsShown ? itemsShown - 1 : itemsShown)
-            .map((item) => (
-              <div
-                className={cn(
-                  'transition duration-500 ease-in-out',
-                  getOpacity(item)
-                )}
-                key={item.label}
-              >
-                {item.Component}
-              </div>
-            ))}
+          {items.slice(0, itemsShown).map((item) => (
+            <div
+              className={cn(
+                'transition duration-500 ease-in-out',
+                getOpacity(item)
+              )}
+              key={item.label}
+            >
+              {item.Component}
+            </div>
+          ))}
+          {/* The menu follows the last button rather than sitting against the far
+              edge. Pushed right, the leftover width opens as a gap mid-row, which
+              reads as a button that failed to render. */}
           {items.length > itemsShown && (
-            <div className='w-fit ml-auto'>
+            <div className='w-fit'>
               <OverflowMenu>
-                {items.slice(itemsShown - 1).flatMap((c) => (
+                {items.slice(itemsShown).flatMap((c) => (
                   <div
                     className={cn(
                       'transition duration-500 ease-in-out',

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/code-block-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/code-block-element.tsx
@@ -60,7 +60,7 @@ export const CodeBlockElement = withRef<typeof PlateElement>(
         } catch (err) {
           if (!isCancelled) {
             setCodeBlockError(
-              String(err.message) ||
+              (err instanceof Error && err.message) ||
                 'An error occurred while parsing the diagram.'
             );
           }

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-element.tsx
@@ -5,15 +5,14 @@ export const MermaidElementWithRef = ({ config }) => {
   const mermaidRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (mermaidRef.current) {
-      const renderMermaid = async () => {
-        await mermaid.run({
-          nodes: [mermaidRef.current.querySelector('.mermaid')],
-        });
-      };
+    const node = mermaidRef.current?.querySelector<HTMLElement>('.mermaid');
+    if (!node) return;
 
-      renderMermaid();
-    }
+    // mermaid.run rejects for a diagram it cannot parse, and the author types one
+    // character at a time, so most intermediate states do not parse. Reporting that is
+    // the code block's job — code-block-element.tsx validates and shows the message.
+    // Here the rejection only has to stop being an unhandled one.
+    mermaid.run({ nodes: [node] }).catch(() => {});
   }, [config]);
 
   return (

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/templates-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/templates-toolbar-button.tsx
@@ -24,18 +24,16 @@ interface EmbedButtonProps {
   templates: MdxTemplate[];
 }
 
+// Below this many, the list is short enough to scan and the input is just noise.
+const TEMPLATE_COUNT_NEEDING_FILTER = 10;
+
 const EmbedButton: React.FC<EmbedButtonProps> = ({ editor, templates }) => {
   const { open, onOpenChange } = useOpenState();
-  const [filteredTemplates, setFilteredTemplates] = useState(templates);
+  const [filterText, setFilterText] = useState('');
 
-  const filterChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const filterText = e.target.value.toLowerCase();
-    setFilteredTemplates(
-      templates.filter((template) =>
-        template.name.toLowerCase().includes(filterText)
-      )
-    );
-  };
+  const filteredTemplates = templates.filter((template) =>
+    template.name.toLowerCase().includes(filterText.toLowerCase())
+  );
 
   return (
     <DropdownMenu modal={false} open={open} onOpenChange={onOpenChange}>
@@ -48,12 +46,13 @@ const EmbedButton: React.FC<EmbedButtonProps> = ({ editor, templates }) => {
         align='start'
         className='max-h-72 overflow-y-auto border-border rounded-none rounded-bl rounded-br'
       >
-        {templates.length > 10 && (
+        {templates.length > TEMPLATE_COUNT_NEEDING_FILTER && (
           <input
             type='text'
             placeholder='Filter templates...'
             className='w-full p-2 border border-gray-300 rounded'
-            onChange={filterChange}
+            value={filterText}
+            onChange={(event) => setFilterText(event.target.value)}
           />
         )}
         {filteredTemplates.map((template) => (
@@ -64,7 +63,6 @@ const EmbedButton: React.FC<EmbedButtonProps> = ({ editor, templates }) => {
               onOpenChange(false);
               insertMDX(editor, template);
             }}
-            className={''}
           >
             {template.label || template.name}
           </DropdownMenuItem>

--- a/packages/v4/@tinacms/rich-text/src/plate/editor-field.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/editor-field.ts
@@ -1,7 +1,4 @@
-import type {
-  ToolbarOverrideType,
-  ToolbarOverrides,
-} from './toolbar/toolbar-overrides';
+import type { ToolbarOverrides } from './toolbar/toolbar-overrides';
 import type { MdxTemplate } from './types';
 
 // The slice of a field's schema the editor actually reads: which embeds exist
@@ -11,5 +8,4 @@ import type { MdxTemplate } from './types';
 export interface RichEditorField {
   templates?: MdxTemplate[];
   overrides?: ToolbarOverrides;
-  toolbarOverride?: ToolbarOverrideType[];
 }

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/embed-hooks.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/embed-hooks.ts
@@ -35,19 +35,23 @@ const handleRemoveBase = (editor, element) => {
 export const useHotkey = (key, callback) => {
   const selected = useSelected();
 
-  React.useEffect(() => {
-    const handleEnter = (e) => {
-      if (selected) {
-        if (isHotkey(key, e)) {
-          e.preventDefault();
-          callback();
-        }
-      }
-    };
-    document.addEventListener('keydown', handleEnter);
+  /**
+   * Bound once, for the life of the node. `selected`, `key`, and the callback are all
+   * read when the key is pressed, so the listener never churns on a selection change
+   * and never fires a callback from an earlier render — the callbacks here close over
+   * the editor and the element, and only `selected` used to re-create them.
+   */
+  const onKeyDown = React.useEffectEvent((e) => {
+    if (!selected || !isHotkey(key, e)) return;
+    e.preventDefault();
+    callback();
+  });
 
-    return () => document.removeEventListener('keydown', handleEnter);
-  }, [selected]);
+  React.useEffect(() => {
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
 };
 
 export const useEmbedHandles = (editor, element, baseFieldName: string) => {

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/use-resize.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/use-resize.ts
@@ -1,16 +1,28 @@
 import React from 'react';
 
-export const useResize = (ref, callback) => {
+export const useResize = (
+  ref: React.RefObject<HTMLElement | null>,
+  callback: (entry: ResizeObserverEntry) => void
+) => {
+  /**
+   * The callback closes over render values — the toolbar's caller rebuilds its item
+   * list every render — so it is read at each resize rather than captured when the
+   * observer is created. `ref.current` was the previous dependency, which a ref never
+   * makes reactive: the effect saw null on the first render and the node on the second,
+   * then never re-ran, leaving the observer holding the second render's closure.
+   */
+  const onResize = React.useEffectEvent(callback);
+
   React.useEffect(() => {
+    if (!ref.current) return;
+
     const resizeObserver = new ResizeObserver((entries) => {
       for (const entry of entries) {
-        callback(entry);
+        onResize(entry);
       }
     });
-    if (ref.current) {
-      resizeObserver.observe(ref.current);
-    }
+    resizeObserver.observe(ref.current);
 
     return () => resizeObserver.disconnect();
-  }, [ref.current]);
+  }, [ref]);
 };

--- a/packages/v4/@tinacms/rich-text/src/plate/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/index.tsx
@@ -29,14 +29,22 @@ export interface RichEditorProps {
 export const RichEditor = ({ input, field, ariaLabel }: RichEditorProps) => {
   // Seeded once: Plate owns the value after mount. Remounting on a document
   // switch is the field component's job (it keys this on the form id).
-  const initialValue = React.useMemo(() => {
+  // A lazy useState initialiser, and not a useMemo with an empty dependency list:
+  // the seed reads `input.value`, so an empty list claims a narrower dependency
+  // than the body has. That is the one memo the React Compiler cannot preserve, and
+  // it skips the whole component over it. useState says "once at mount" outright.
+  const [initialValue] = React.useState(() => {
     if (input.value?.children?.length) {
-      return input.value.children.map(helpers.normalize);
+      return helpers.withRootNodeIds(
+        input.value.children.map(helpers.normalize)
+      );
     }
     return [{ type: 'p', children: [{ type: 'text', text: '' }] }];
-  }, []);
+  });
   // Filter out FloatingToolbarPlugin if showFloatingToolbar is false
   const showFloatingToolbar = field?.overrides?.showFloatingToolbar !== false;
+  // Held: this package is not built with the React Compiler, and usePlateEditor reads
+  // the list at mount only, so rebuilding it on every keystroke buys nothing.
   const builtPlugins = React.useMemo(
     () =>
       createEditorPlugins({
@@ -77,9 +85,7 @@ export const RichEditor = ({ input, field, ariaLabel }: RichEditorProps) => {
           <TooltipProvider>
             <ToolbarProvider
               templates={field.templates ?? []}
-              overrides={
-                field?.toolbarOverride ? field.toolbarOverride : field.overrides
-              }
+              overrides={field?.overrides}
             >
               <FixedToolbar>
                 <FixedToolbarButtons />

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/common.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/common.tsx
@@ -32,6 +32,19 @@ const isListActive = (editor, type) => {
   return !!res && res.list[0].type === type;
 };
 
+// NodeIdPlugin normalizes the initial value by walking every node, one editor
+// operation each, so the walk grows with the document — it was most of the editor's
+// build time on a long body. The plugin skips the whole walk when the first and the
+// last root nodes already carry an id: partial ids are a state Plate supports, and
+// its insert overrides id new nodes as they arrive. Seeding the root ids here turns
+// the walk into that skip. Plain object copies, because at this point the value is
+// data, and not yet an editor.
+let seededNodeIds = 0;
+const withRootNodeIds = (nodes: any[]) =>
+  nodes.map((node) =>
+    node.id ? node : { ...node, id: `seed-${++seededNodeIds}` }
+  );
+
 const normalize = (node: any) => {
   if (
     [ELEMENT_MDX_BLOCK, ELEMENT_MDX_INLINE, ELEMENT_IMG].includes(node.type)
@@ -39,7 +52,6 @@ const normalize = (node: any) => {
     return {
       ...node,
       children: [{ type: 'text', text: '' }],
-      id: Date.now(),
     };
   }
   if (node.children) {
@@ -47,14 +59,12 @@ const normalize = (node: any) => {
       return {
         ...node,
         children: node.children.map(normalize),
-        id: Date.now(),
       };
     }
     // Always supply an empty text leaf
     return {
       ...node,
       children: [{ text: '' }],
-      id: Date.now(),
     };
   }
   return node;
@@ -85,8 +95,7 @@ const isCurrentBlockEmpty = (editor) => {
   const blockAbove = editor.api.block();
   const isEmpty =
     !NodeApi.string(node) &&
-    // @ts-ignore bad type from slate
-    !node.children?.some((n) => Editor.isInline(editor, n)) &&
+    !node.children?.some((child) => editor.api.isInline(child)) &&
     // Only do this if we're at the start of a block
     editor.api.isStart(cursor, blockAbove[1]);
 
@@ -137,4 +146,5 @@ export const helpers = {
   currentNodeSupportsMDX,
   normalize,
   normalizeLinksInCodeBlocks,
+  withRootNodeIds,
 };

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/autocomplete.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/autocomplete.tsx
@@ -6,7 +6,7 @@ import {
   ComboboxOptions,
   Transition,
 } from '@headlessui/react';
-import { ChevronDownIcon } from '@heroicons/react/solid';
+import { ChevronDownIcon } from 'lucide-react';
 import React, { Fragment } from 'react';
 import { classNames } from './helpers';
 
@@ -25,6 +25,20 @@ interface AutocompleteProps {
   items: AutocompleteItem[];
 }
 
+const filterItems = (
+  items: AutocompleteItem[],
+  query: string
+): AutocompleteItem[] => {
+  try {
+    const reFilter = new RegExp(query, 'i');
+    const matched = items.filter((item) => reFilter.test(item.label));
+    if (matched.length === 0) return items;
+    return matched;
+  } catch {
+    return items;
+  }
+};
+
 export const Autocomplete: React.FC<AutocompleteProps> = ({
   value,
   onChange,
@@ -32,16 +46,7 @@ export const Autocomplete: React.FC<AutocompleteProps> = ({
   items,
 }) => {
   const [query, setQuery] = React.useState(defaultQuery ?? '');
-  const filteredItems = React.useMemo(() => {
-    try {
-      const reFilter = new RegExp(query, 'i');
-      const _items = items.filter((item) => reFilter.test(item.label));
-      if (_items.length === 0) return items;
-      return _items;
-    } catch (err) {
-      return items;
-    }
-  }, [items, query]);
+  const filteredItems = filterItems(items, query);
 
   return (
     <Combobox

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/dropdown.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/dropdown.tsx
@@ -5,7 +5,7 @@ import {
   MenuItems,
   Transition,
 } from '@headlessui/react';
-import { ChevronDownIcon } from '@heroicons/react/solid';
+import { ChevronDownIcon } from 'lucide-react';
 import React from 'react';
 import { classNames } from './helpers';
 

--- a/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-overrides.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-overrides.tsx
@@ -1,12 +1,18 @@
 import type { HeadingLevel, ToolbarOverrideType } from '@tinacms/schema-tools';
 export type { HeadingLevel, ToolbarOverrideType };
 
-export const STANDARD_ICON_WIDTH = 32;
-export const HEADING_ICON_WITH_TEXT = 127;
-export const HEADING_ICON_ONLY = 58;
-export const EMBED_ICON_WIDTH = 78;
+// Measured off the rendered toolbar in Chromium, not derived from the classes: a
+// button is `h-9 px-2` around a `size-5` icon, and the row that holds the buttons
+// sets no gap, so each of these is the whole horizontal cost of one item.
+export const STANDARD_ICON_WIDTH = 36;
+export const HEADING_ICON_WITH_TEXT = 130;
+export const HEADING_ICON_ONLY = 62;
+export const EMBED_ICON_WIDTH = 54;
+// Highlight opens a colour swatch, so it carries a dropdown arrow that the plain
+// icon buttons do not.
+export const HIGHLIGHT_ICON_WIDTH = 54;
 export const CONTAINER_MD_BREAKPOINT = 448; // Tailwind's 'md' breakpoint for container with default `max-width` scale https://tailwindcss.com/blog/tailwindcss-v3-2
-export const FLOAT_BUTTON_WIDTH = 25;
+export const OVERFLOW_MENU_WIDTH = 36;
 
 export const HEADING_LABEL = 'Headings';
 

--- a/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-provider.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-provider.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { type ReactNode, createContext, useContext, useMemo } from 'react';
+import { type ReactNode, createContext, useContext } from 'react';
 
 import {
   ALL_HEADING_LEVELS,
@@ -7,14 +7,11 @@ import {
   normalizeHeadingLevels,
 } from '@tinacms/schema-tools';
 import type { MdxTemplate } from '../types';
-import type {
-  ToolbarOverrideType,
-  ToolbarOverrides,
-} from './toolbar-overrides';
+import type { ToolbarOverrides } from './toolbar-overrides';
 
 interface ToolbarContextProps {
   templates: MdxTemplate[];
-  overrides: ToolbarOverrideType[] | ToolbarOverrides;
+  overrides: ToolbarOverrides | undefined;
   headingLevels: readonly HeadingLevel[];
   /**
    * True when the schema explicitly sets `overrides.headingLevels`
@@ -42,16 +39,12 @@ export const ToolbarProvider: React.FC<ToolbarProviderProps> = ({
   overrides,
   children,
 }) => {
-  const configured = !Array.isArray(overrides)
-    ? overrides?.headingLevels
-    : undefined;
+  const configured = overrides?.headingLevels;
   const headingLevelsConfigured = Array.isArray(configured);
 
-  const headingLevels = useMemo<readonly HeadingLevel[]>(
-    () =>
-      configured ? normalizeHeadingLevels(configured) : ALL_HEADING_LEVELS,
-    [configured]
-  );
+  const headingLevels: readonly HeadingLevel[] = configured
+    ? normalizeHeadingLevels(configured)
+    : ALL_HEADING_LEVELS;
 
   return (
     <ToolbarContext.Provider

--- a/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.ts
@@ -10,20 +10,20 @@ const nonLocalhostDomainRE = /^[^\s.]+\.\S{2,}$/;
 const localUrlRE = /^\/\S+/; // Regular expression for local URLs
 
 /** Loosely validate a URL `string`. */
-export const isUrl = (string: any) => {
-  if (typeof string !== 'string') {
+export const isUrl = (value: unknown) => {
+  if (typeof value !== 'string') {
     return false;
   }
 
   // Check if the string is a bare hash link
-  if (string.startsWith('#')) {
+  if (value.startsWith('#')) {
     return true;
   }
 
-  const generalMatch = string.match(protocolAndDomainRE);
-  const emailLinkMatch = string.match(emailLintRE);
-  const telLinkMatch = string.match(telLintRE); // Check for tel: link match
-  const localUrlMatch = string.match(localUrlRE); // Check for local URL match
+  const generalMatch = value.match(protocolAndDomainRE);
+  const emailLinkMatch = value.match(emailLintRE);
+  const telLinkMatch = value.match(telLintRE); // Check for tel: link match
+  const localUrlMatch = value.match(localUrlRE); // Check for local URL match
 
   // Check if any of the specific link types or the general pattern match
   if (emailLinkMatch || telLinkMatch || localUrlMatch) {
@@ -41,7 +41,7 @@ export const isUrl = (string: any) => {
 
     // Fallback to URL constructor for stricter validation of complex URLs
     try {
-      new URL(string);
+      new URL(value);
     } catch {
       return false;
     }

--- a/packages/v4/@tinacms/rich-text/src/plate/types.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/types.ts
@@ -6,6 +6,11 @@ export interface TemplateField {
   name: string;
   label?: string;
   type?: string;
+  // The field whose value labels the embed in the editor, as `Template: value`. Refer
+  // to getLabel in create-mdx-plugins/component.tsx, which reads this. Templates are
+  // author-written config, so the key reaches here even though v4's own FieldSchema
+  // does not model it yet.
+  isTitle?: boolean;
 }
 
 export type MdxTemplate = {

--- a/packages/v4/@tinacms/tinacms/_docs/rich-text-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/rich-text-field.md
@@ -36,7 +36,11 @@ The config (`RichTextFieldSchema`, which extends `BaseFieldSchema`):
 | `isBody` | `boolean` | This field is the markdown body of the file, and not a frontmatter key. |
 | `templates` | `MdxTemplate[]` | The MDX components that an author can embed in the text. |
 | `overrides` | `ToolbarOverrides` | The toolbar buttons and the heading levels that the editor shows. |
-| `toolbarOverride` | `ToolbarOverrideType[]` | The older list form of `overrides.toolbar`. |
+
+v3 also took a bare list of buttons under `toolbarOverride`. v4 drops it:
+`overrides.toolbar` takes the same list, and it is the only shape the editor
+reads. A v3 schema with `toolbarOverride: ['bold', 'italic']` becomes
+`overrides: { toolbar: ['bold', 'italic'] }`.
 
 There is no `parser` option. Both of v3's values lose content through this
 field. `slatejson` makes `serializeMDX` return the AST, and this field writes

--- a/packages/v4/@tinacms/tinacms/e2e/rich-text-field.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/rich-text-field.spec.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { expect, test } from '@playwright/test';
+import { setColumnWidth, toolbar } from './form-column';
 
 // Two rich-text guarantees that only a real browser can check. Both of these
 // shipped broken and were caught by hand; this is what stops that recurring.
@@ -63,6 +64,41 @@ test.describe('rich-text layout', () => {
     });
     expect(fits).toBe(true);
   });
+
+  // The toolbar decides how many tools to show from a table of pixel widths, one entry
+  // per control. Nothing derives that table from the buttons, so it drifts the moment a
+  // button changes. When it does, the row runs past its container and `overflow-hidden`
+  // takes the last control off screen — silently, because a clipped button still reports
+  // as rendered and still answers a click that lands where it used to be. This asserts
+  // the property the table exists to hold, at the widths the column can take.
+  test('the toolbar fits its column at every width the column can take', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await openDocument(page, 'second-post.mdx');
+
+    for (const columnWidth of [352, 420, 480, 560, 700, 900, 1200]) {
+      await setColumnWidth(page, columnWidth);
+
+      const row = await toolbar(page).evaluate((container) => {
+        const controls = Array.from(
+          (container.firstElementChild as HTMLElement).children
+        );
+        return {
+          container: container.getBoundingClientRect().width,
+          controls: controls.reduce(
+            (total, control) => total + control.getBoundingClientRect().width,
+            0
+          ),
+        };
+      });
+
+      expect(
+        row.controls,
+        `toolbar controls overflow a ${columnWidth}px column`
+      ).toBeLessThanOrEqual(row.container);
+    }
+  });
 });
 
 test.describe('rich-text save lifecycle', () => {
@@ -89,6 +125,26 @@ test.describe('rich-text save lifecycle', () => {
 
     await page.getByRole('button', { name: 'Save' }).click();
     await expect(status(page)).toHaveText('clean');
+  });
+
+  // Typing and then deleting what was typed leaves the file it would write unchanged,
+  // so the document is not edited any more. The tree Plate holds is not the tree the
+  // document was parsed from — Plate adds node ids and a trailing block — so a compare
+  // of the two trees answers "edited" for a document that has returned to its contents
+  // on disk, and the badge then never leaves "Unsaved".
+  test('typing and then deleting it returns the document to clean', async ({
+    page,
+  }) => {
+    await expect(status(page)).toHaveText('No changes');
+
+    await body(page).click();
+    await body(page).pressSequentially('Edited.');
+    await expect(status(page)).toHaveText('Unsaved');
+
+    // "Saved", and not "No changes": the form has been edited, and its values match the
+    // file again. Only a form that was never edited is pristine.
+    for (const _ of 'Edited.') await page.keyboard.press('Backspace');
+    await expect(status(page)).toHaveText('Saved');
   });
 
   test('a second edit after saving can also reach clean', async ({ page }) => {


### PR DESCRIPTION
**TLDR:** A polish pass over the extracted Plate editor: named constants, derived state, and safe error paths.

**Feats:**
- Toolbar override widths get real constants; the override list is computed declaratively
- Mermaid render failures stop being unhandled rejections
- The template filter becomes derived state; embed hotkeys bind once
- The dead toolbarOverride escape hatch is deleted

**How to test:** No behaviour changes beyond the error paths.
- Go to `packages/v4/@tinacms/rich-text`.
- Run `pnpm test`.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test:e2e`.
