### PR TITLE
feat(v4): tinacms codegen — the CLI that writes tina-lock.json

### DIFF
--- a/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
+++ b/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// The bin is JavaScript and the CLI it runs is TypeScript, loaded through Vite
+// rather than node's own type stripping: node can strip the types but not follow
+// this package's extensionless relative imports, since `exports` still points at
+// raw src (ADR-001 leaves the dist build undecided).
+//
+// No cost either way — the CLI needs a Vite server regardless, because that is how
+// a user's tina/config.ts gets read. This boots it once and lends it downstream.
+
+import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
+
+const server = await createServer({
+  configFile: false,
+  logLevel: 'warn',
+  server: { middlewareMode: true, hmr: false, watch: null },
+});
+
+try {
+  const { runCli } = await server.ssrLoadModule(
+    fileURLToPath(new URL('../src/cli/index.ts', import.meta.url))
+  );
+  process.exitCode = await runCli(process.argv.slice(2), { loader: server });
+} finally {
+  await server.close();
+}

--- a/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
+++ b/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
-// The bin is JavaScript and the CLI it runs is TypeScript, loaded through Vite
-// rather than node's own type stripping: node can strip the types but not follow
-// this package's extensionless relative imports, since `exports` still points at
-// raw src (ADR-001 leaves the dist build undecided).
+// The bin is JavaScript, and the CLI that it runs is TypeScript. Vite loads that
+// TypeScript, and node does not strip the types. Node can strip the types, but it cannot
+// follow the relative imports of this package, which have no extension. The `exports`
+// field still points at the raw source, because ADR-001 has not decided the dist build.
 //
-// No cost either way — the CLI needs a Vite server regardless, because that is how
-// a user's tina/config.ts gets read. This boots it once and lends it downstream.
+// This costs nothing. The CLI needs a Vite server in any case, because that is how it
+// reads the tina/config.ts of a user. This file starts one server, and lends it to the
+// code below.
 
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
@@ -13,7 +14,11 @@ import { createServer } from 'vite';
 const server = await createServer({
   configFile: false,
   logLevel: 'warn',
-  server: { middlewareMode: true, hmr: false, watch: null },
+  // `ws: false` is required, and `hmr: false` alone is not enough. In middleware mode
+  // Vite has no HTTP server for the HMR socket, falls through, and binds its default
+  // port 24678 on every interface — so running the CLI would claim a fixed global
+  // port and two runs at once would race. load-config.ts guards the same way.
+  server: { middlewareMode: true, hmr: false, ws: false, watch: null },
 });
 
 try {

--- a/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
+++ b/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
@@ -4,9 +4,10 @@
 // follow the relative imports of this package, which have no extension. The `exports`
 // field still points at the raw source, because ADR-001 has not decided the dist build.
 //
-// This costs nothing. The CLI needs a Vite server in any case, because that is how it
-// reads the tina/config.ts of a user. This file starts one server, and lends it to the
-// code below.
+// This server loads the CLI, and only the CLI. It is rooted at this package, so it must
+// not also read the user's tina/config.ts: that config resolves its relative imports and
+// tsconfig paths against the project, which `--root` can put anywhere. The CLI therefore
+// opens its own server for the config, rooted at the directory the config sits in.
 
 import { fileURLToPath } from 'node:url';
 import { createServer } from 'vite';
@@ -25,7 +26,7 @@ try {
   const { runCli } = await server.ssrLoadModule(
     fileURLToPath(new URL('../src/cli/index.ts', import.meta.url))
   );
-  process.exitCode = await runCli(process.argv.slice(2), { loader: server });
+  process.exitCode = await runCli(process.argv.slice(2));
 } finally {
   await server.close();
 }

--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -83,6 +83,7 @@
     "prism-react-renderer": "catalog:",
     "react-hook-form": "^7.80.0",
     "sqlite-level": "catalog:",
+    "vite": "^5.4.0",
     "zod": "catalog:",
     "zustand": "^5.0.14"
   },
@@ -106,7 +107,6 @@
     "react-dom": "^19.2.7",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.7.3",
-    "vite": "^5.4.0",
     "vitest": "^2.1.9"
   }
 }

--- a/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
+++ b/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
@@ -1,0 +1,38 @@
+{
+  "version": 1,
+  "schema": {
+    "collections": [
+      {
+        "name": "post",
+        "label": "Posts",
+        "path": "content/posts",
+        "format": "mdx",
+        "fields": [
+          {
+            "name": "title",
+            "label": "Title",
+            "required": true,
+            "min": 3,
+            "type": "string"
+          },
+          {
+            "name": "featured",
+            "label": "Featured",
+            "type": "boolean"
+          },
+          {
+            "name": "body",
+            "label": "Body",
+            "isBody": true,
+            "type": "rich-text"
+          }
+        ]
+      }
+    ]
+  },
+  "primitives": {
+    "boolean": 1,
+    "rich-text": 1,
+    "string": 1
+  }
+}

--- a/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
+++ b/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 4,
   "schema": {
     "collections": [
       {

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.test.ts
@@ -1,0 +1,115 @@
+import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { ResolvedConfig } from '../../config';
+import { definePlugin } from '../../core/plugin';
+import { LOCK_FILENAME, TINA_DIRECTORY, runCodegen } from './codegen';
+
+// Against a real temp directory rather than a mocked fs: the behaviour under test is
+// what lands on disk — that an unchanged lock is not rewritten, and that a failed run
+// leaves the committed file alone.
+let rootDir: string;
+let lockPath: string;
+
+const config = (fields: { name: string; type: string }[]): ResolvedConfig => ({
+  plugins: [
+    definePlugin({ name: 'test:content', provides: ['content'] }),
+    definePlugin({
+      name: 'test:field:string',
+      provides: ['field'],
+      field: { type: 'string', contractVersion: 1 },
+    }),
+  ],
+  schema: {
+    collections: [
+      { name: 'post', path: 'content/posts', format: 'md', fields },
+    ],
+  },
+});
+
+// Stands in for the Vite server the bin lends the CLI, so these tests exercise
+// runCodegen's disk behaviour without booting one per case.
+const loaderFor = (resolved: ResolvedConfig) => ({
+  ssrLoadModule: async () => ({ default: resolved }),
+});
+
+const codegen = (resolved: ResolvedConfig) =>
+  runCodegen({
+    rootDir,
+    configPath: path.join(rootDir, TINA_DIRECTORY, 'config.ts'),
+    load: { loader: loaderFor(resolved) },
+  });
+
+const readLock = async () => JSON.parse(await readFile(lockPath, 'utf8'));
+
+beforeEach(async () => {
+  rootDir = await mkdtemp(path.join(tmpdir(), 'tina-codegen-'));
+  await mkdir(path.join(rootDir, TINA_DIRECTORY), { recursive: true });
+  lockPath = path.join(rootDir, TINA_DIRECTORY, LOCK_FILENAME);
+});
+
+describe('runCodegen', () => {
+  it('writes the lock on a first run', async () => {
+    const result = await codegen(config([{ name: 'title', type: 'string' }]));
+    expect(result.outcome).toBe('created');
+    expect((await readLock()).primitives).toEqual({ string: 1 });
+  });
+
+  // The lock is committed: rewriting an identical file would put it in `git status`
+  // after every build.
+  it('leaves an already-current lock untouched', async () => {
+    const schema = config([{ name: 'title', type: 'string' }]);
+    await codegen(schema);
+    const written = await readFile(lockPath, 'utf8');
+    const result = await codegen(schema);
+    expect(result.outcome).toBe('unchanged');
+    expect(await readFile(lockPath, 'utf8')).toBe(written);
+  });
+
+  it('regenerates a lock that lags the schema, and says why', async () => {
+    await codegen(config([{ name: 'title', type: 'string' }]));
+    const result = await codegen(
+      config([
+        { name: 'title', type: 'string' },
+        { name: 'subtitle', type: 'string' },
+      ])
+    );
+    expect(result.outcome).toBe('updated');
+    expect(result.warning).toMatch(/out of date/);
+    expect((await readLock()).schema.collections[0].fields).toHaveLength(2);
+  });
+
+  it('stops on a contract-version mismatch without touching the lock', async () => {
+    await codegen(config([{ name: 'title', type: 'string' }]));
+    const committed = await readFile(lockPath, 'utf8');
+    const bumped: ResolvedConfig = {
+      ...config([{ name: 'title', type: 'string' }]),
+      plugins: [
+        definePlugin({ name: 'test:content', provides: ['content'] }),
+        definePlugin({
+          name: 'test:field:string',
+          provides: ['field'],
+          field: { type: 'string', contractVersion: 2 },
+        }),
+      ],
+    };
+    await expect(codegen(bumped)).rejects.toThrow(/tina migrate/);
+    expect(await readFile(lockPath, 'utf8')).toBe(committed);
+  });
+
+  // A hand-edit or a bad merge leaves nothing trustworthy to compare against, so it
+  // recompiles rather than failing on JSON.parse.
+  it('recompiles over an unparseable lock', async () => {
+    await writeFile(lockPath, '{ not json');
+    const result = await codegen(config([{ name: 'title', type: 'string' }]));
+    expect(result.outcome).toBe('created');
+    expect((await readLock()).primitives).toEqual({ string: 1 });
+  });
+
+  it('reports a project with no config rather than guessing', async () => {
+    await expect(
+      runCodegen({ rootDir, load: { loader: loaderFor(config([])) } })
+    ).rejects.toThrow(/No Tina config found/);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.test.ts
@@ -1,35 +1,36 @@
-import { mkdtemp, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import type { ResolvedConfig } from '../../config';
+import { type ResolvedConfig, asResolvedConfig } from '../../config';
 import { definePlugin } from '../../core/plugin';
 import { LOCK_FILENAME, TINA_DIRECTORY, runCodegen } from './codegen';
 
-// Against a real temp directory rather than a mocked fs: the behaviour under test is
-// what lands on disk — that an unchanged lock is not rewritten, and that a failed run
-// leaves the committed file alone.
+// These tests use a real temporary directory, and not a mock file system. The behaviour
+// under test is what reaches the disk. An unchanged lock is not written again, and a
+// failed run leaves the committed file as it is.
 let rootDir: string;
 let lockPath: string;
 
-const config = (fields: { name: string; type: string }[]): ResolvedConfig => ({
-  plugins: [
-    definePlugin({ name: 'test:content', provides: ['content'] }),
-    definePlugin({
-      name: 'test:field:string',
-      provides: ['field'],
-      field: { type: 'string', contractVersion: 1 },
-    }),
-  ],
-  schema: {
-    collections: [
-      { name: 'post', path: 'content/posts', format: 'md', fields },
+const config = (fields: { name: string; type: string }[]): ResolvedConfig =>
+  asResolvedConfig({
+    plugins: [
+      definePlugin({ name: 'test:content', provides: ['content'] }),
+      definePlugin({
+        name: 'test:field:string',
+        provides: ['field'],
+        field: { type: 'string', contractVersion: 1 },
+      }),
     ],
-  },
-});
+    schema: {
+      collections: [
+        { name: 'post', path: 'content/posts', format: 'md', fields },
+      ],
+    },
+  });
 
-// Stands in for the Vite server the bin lends the CLI, so these tests exercise
-// runCodegen's disk behaviour without booting one per case.
+// This stands in for the Vite server that the bin lends to the CLI. These tests then
+// cover the disk behaviour of runCodegen, and start no server for each case.
 const loaderFor = (resolved: ResolvedConfig) => ({
   ssrLoadModule: async () => ({ default: resolved }),
 });
@@ -42,6 +43,10 @@ const codegen = (resolved: ResolvedConfig) =>
   });
 
 const readLock = async () => JSON.parse(await readFile(lockPath, 'utf8'));
+
+afterEach(async () => {
+  await rm(rootDir, { recursive: true, force: true });
+});
 
 beforeEach(async () => {
   rootDir = await mkdtemp(path.join(tmpdir(), 'tina-codegen-'));
@@ -56,7 +61,7 @@ describe('runCodegen', () => {
     expect((await readLock()).primitives).toEqual({ string: 1 });
   });
 
-  // The lock is committed: rewriting an identical file would put it in `git status`
+  // The lock is committed. A write of an identical file would put it in `git status`
   // after every build.
   it('leaves an already-current lock untouched', async () => {
     const schema = config([{ name: 'title', type: 'string' }]);
@@ -83,7 +88,7 @@ describe('runCodegen', () => {
   it('stops on a contract-version mismatch without touching the lock', async () => {
     await codegen(config([{ name: 'title', type: 'string' }]));
     const committed = await readFile(lockPath, 'utf8');
-    const bumped: ResolvedConfig = {
+    const bumped = asResolvedConfig({
       ...config([{ name: 'title', type: 'string' }]),
       plugins: [
         definePlugin({ name: 'test:content', provides: ['content'] }),
@@ -93,13 +98,13 @@ describe('runCodegen', () => {
           field: { type: 'string', contractVersion: 2 },
         }),
       ],
-    };
-    await expect(codegen(bumped)).rejects.toThrow(/tina migrate/);
+    });
+    await expect(codegen(bumped)).rejects.toThrow(/tinacms migrate/);
     expect(await readFile(lockPath, 'utf8')).toBe(committed);
   });
 
-  // A hand-edit or a bad merge leaves nothing trustworthy to compare against, so it
-  // recompiles rather than failing on JSON.parse.
+  // A hand edit, or a bad merge, leaves nothing to compare against. The command
+  // therefore compiles again, and does not fail in JSON.parse.
   it('recompiles over an unparseable lock', async () => {
     await writeFile(lockPath, '{ not json');
     const result = await codegen(config([{ name: 'title', type: 'string' }]));
@@ -111,5 +116,46 @@ describe('runCodegen', () => {
     await expect(
       runCodegen({ rootDir, load: { loader: loaderFor(config([])) } })
     ).rejects.toThrow(/No Tina config found/);
+  });
+});
+
+describe('runCodegen on a lock it cannot trust', () => {
+  // These parse but are not a lock. The cast alone let them reach checkLock, which
+  // then threw a TypeError on `lock.primitives[type]` instead of recompiling.
+  it.each([
+    ['an array', '[]'],
+    ['a number', '3'],
+    ['no primitives', '{"version":1}'],
+  ])('recompiles over %s', async (_label, contents) => {
+    await writeFile(lockPath, contents);
+    const result = await codegen(config([{ name: 'title', type: 'string' }]));
+    expect(result.outcome).toBe('created');
+    expect((await readLock()).primitives).toEqual({ string: 1 });
+  });
+
+  it('stops rather than downgrading a lock from a newer tinacms', async () => {
+    await codegen(config([{ name: 'title', type: 'string' }]));
+    const current = JSON.parse(await readFile(lockPath, 'utf8'));
+    await writeFile(
+      lockPath,
+      JSON.stringify({ ...current, version: current.version + 1 }, null, 2)
+    );
+    const committed = await readFile(lockPath, 'utf8');
+
+    await expect(
+      codegen(config([{ name: 'title', type: 'string' }]))
+    ).rejects.toThrow(/Upgrade tinacms/);
+    expect(await readFile(lockPath, 'utf8')).toBe(committed);
+  });
+
+  // --config can point outside tina/, so the lock's directory is not a given.
+  it('creates the lock directory when it does not exist', async () => {
+    await rm(path.join(rootDir, TINA_DIRECTORY), {
+      recursive: true,
+      force: true,
+    });
+    const result = await codegen(config([{ name: 'title', type: 'string' }]));
+    expect(result.outcome).toBe('created');
+    expect((await readLock()).primitives).toEqual({ string: 1 });
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -1,9 +1,10 @@
-// `tinacms codegen` — read the project's config, compile its schema, and write
-// tina-lock.json (ADR-016). The lock is committed, so the write is deliberately
-// conservative: an unchanged lock is left alone rather than rewritten, and a
-// contract-version mismatch stops rather than resolving itself.
+// The `tinacms codegen` command. It reads the config of the project, compiles its
+// schema, and writes tina-lock.json (ADR-016). The lock is committed, so the write is
+// careful. An unchanged lock stays as it is, and a contract version that does not match
+// stops the command.
 
-import { readFile, writeFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   type LoadTinaConfigOptions,
@@ -19,13 +20,14 @@ import { invariant } from '../../core/invariant';
 export const TINA_DIRECTORY = 'tina';
 export const LOCK_FILENAME = 'tina-lock.json';
 
-// In config-file order. `.tsx` earns its place: a collection holding a custom field
-// component is JSX, which is why the v3 examples name their config config.tsx.
+// In the order of the config files. The list holds `.tsx`, because a collection with a
+// custom field component holds JSX. The v3 examples name their config config.tsx for
+// that reason.
 const CONFIG_FILENAMES = ['config.ts', 'config.tsx', 'config.js', 'config.mjs'];
 
 export interface CodegenOptions {
   rootDir: string;
-  // Explicit path to the config, for a project that keeps it somewhere else.
+  // An explicit path to the config, for a project that keeps it in another place.
   configPath?: string;
   load?: LoadTinaConfigOptions;
 }
@@ -33,8 +35,8 @@ export interface CodegenOptions {
 export type CodegenOutcome =
   | 'created'
   | 'updated'
-  // Byte-identical to what is already committed, so nothing was written — the lock
-  // must not show up in `git status` on every build.
+  // The output holds the same bytes as the committed file, so this command wrote
+  // nothing. The lock must not appear in `git status` after each build.
   | 'unchanged';
 
 export interface CodegenResult {
@@ -42,17 +44,20 @@ export interface CodegenResult {
   lockPath: string;
   outcome: CodegenOutcome;
   lock: TinaLock;
-  // Set when an existing lock lagged the schema; the lock has been regenerated.
+  // Set when the committed lock was older than the schema. The command wrote it again.
   warning?: string;
 }
 
 const firstExisting = async (candidates: string[]): Promise<string | null> => {
   for (const candidate of candidates) {
     try {
-      await readFile(candidate);
+      // access, not readFile: slurping the file reported an unreadable or
+      // directory-shaped config as a missing one, and anything that is not ENOENT is
+      // a real fault the developer needs to see.
+      await access(candidate, constants.R_OK);
       return candidate;
     } catch {
-      // Next candidate — a missing file here is the question being asked, not a fault.
+      // Try the next candidate. A missing file here is the question, and not a fault.
     }
   }
   return null;
@@ -74,16 +79,26 @@ export const findConfigPath = async (rootDir: string): Promise<string> => {
 
 const readExistingLock = async (lockPath: string): Promise<TinaLock | null> => {
   try {
-    return JSON.parse(await readFile(lockPath, 'utf8')) as TinaLock;
+    const parsed: unknown = JSON.parse(await readFile(lockPath, 'utf8'));
+    // A lock that parses to `[]`, `3`, or `{}` after a bad merge is as untrustworthy
+    // as one that does not parse at all; the cast alone let it reach checkLock and
+    // throw a TypeError on `lock.primitives[type]`.
+    const lock = parsed as TinaLock | null;
+    if (!lock || typeof lock !== 'object' || Array.isArray(lock)) return null;
+    if (typeof lock.primitives !== 'object' || lock.primitives === null) {
+      return null;
+    }
+    return lock;
   } catch {
-    // Absent (first run) or unparseable (hand-edited, bad merge) are the same
-    // situation: there is nothing trustworthy to compare against, so recompile.
+    // A lock that is absent, on the first run, and a lock that does not parse, after
+    // a hand edit or a bad merge, are one situation. There is nothing to compare
+    // against, so compile again.
     return null;
   }
 };
 
-// Pretty-printed with a trailing newline because it is a committed file that people
-// read in diffs, not a build output.
+// The file is formatted, and it ends with a newline, because it is a committed file that
+// people read in a diff. It is not a build output.
 const serializeLock = (lock: TinaLock): string =>
   `${JSON.stringify(lock, null, 2)}\n`;
 
@@ -99,6 +114,7 @@ export const runCodegen = async (
   const existing = await readExistingLock(lockPath);
 
   if (!existing) {
+    await mkdir(path.dirname(lockPath), { recursive: true });
     await writeFile(lockPath, serializeLock(lock));
     return { configPath, lockPath, outcome: 'created', lock };
   }
@@ -107,9 +123,13 @@ export const runCodegen = async (
   if (check.status === 'current') {
     return { configPath, lockPath, outcome: 'unchanged', lock };
   }
-  // The one failure this command has: a field type changed shape under a committed
-  // lock. Rewriting it here is exactly the silent break ADR-016 exists to prevent.
-  invariant(check.status === 'stale', 'lock-incompatible', check.message);
+  // This is the one failure of the command. A field type changed its shape under a
+  // committed lock. A write here would be the silent break that ADR-016 prevents.
+  invariant(
+    check.status === 'stale',
+    check.status === 'unreadable' ? 'lock-unreadable' : 'lock-incompatible',
+    check.message
+  );
   await writeFile(lockPath, serializeLock(lock));
   return {
     configPath,

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -1,0 +1,121 @@
+// `tinacms codegen` — read the project's config, compile its schema, and write
+// tina-lock.json (ADR-016). The lock is committed, so the write is deliberately
+// conservative: an unchanged lock is left alone rather than rewritten, and a
+// contract-version mismatch stops rather than resolving itself.
+
+import { readFile, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import {
+  type LoadTinaConfigOptions,
+  loadTinaConfig,
+} from '../../codegen/load-config';
+import {
+  type TinaLock,
+  checkLock,
+  compileSchema,
+} from '../../codegen/compile-schema';
+import { invariant } from '../../core/invariant';
+
+export const TINA_DIRECTORY = 'tina';
+export const LOCK_FILENAME = 'tina-lock.json';
+
+// In config-file order. `.tsx` earns its place: a collection holding a custom field
+// component is JSX, which is why the v3 examples name their config config.tsx.
+const CONFIG_FILENAMES = ['config.ts', 'config.tsx', 'config.js', 'config.mjs'];
+
+export interface CodegenOptions {
+  rootDir: string;
+  // Explicit path to the config, for a project that keeps it somewhere else.
+  configPath?: string;
+  load?: LoadTinaConfigOptions;
+}
+
+export type CodegenOutcome =
+  | 'created'
+  | 'updated'
+  // Byte-identical to what is already committed, so nothing was written — the lock
+  // must not show up in `git status` on every build.
+  | 'unchanged';
+
+export interface CodegenResult {
+  configPath: string;
+  lockPath: string;
+  outcome: CodegenOutcome;
+  lock: TinaLock;
+  // Set when an existing lock lagged the schema; the lock has been regenerated.
+  warning?: string;
+}
+
+const firstExisting = async (candidates: string[]): Promise<string | null> => {
+  for (const candidate of candidates) {
+    try {
+      await readFile(candidate);
+      return candidate;
+    } catch {
+      // Next candidate — a missing file here is the question being asked, not a fault.
+    }
+  }
+  return null;
+};
+
+export const findConfigPath = async (rootDir: string): Promise<string> => {
+  const found = await firstExisting(
+    CONFIG_FILENAMES.map((name) => path.join(rootDir, TINA_DIRECTORY, name))
+  );
+  invariant(
+    found,
+    'config-not-found',
+    `No Tina config found. Expected one of ${CONFIG_FILENAMES.map(
+      (name) => `${TINA_DIRECTORY}/${name}`
+    ).join(', ')} under ${rootDir}.`
+  );
+  return found;
+};
+
+const readExistingLock = async (lockPath: string): Promise<TinaLock | null> => {
+  try {
+    return JSON.parse(await readFile(lockPath, 'utf8')) as TinaLock;
+  } catch {
+    // Absent (first run) or unparseable (hand-edited, bad merge) are the same
+    // situation: there is nothing trustworthy to compare against, so recompile.
+    return null;
+  }
+};
+
+// Pretty-printed with a trailing newline because it is a committed file that people
+// read in diffs, not a build output.
+const serializeLock = (lock: TinaLock): string =>
+  `${JSON.stringify(lock, null, 2)}\n`;
+
+export const runCodegen = async (
+  options: CodegenOptions
+): Promise<CodegenResult> => {
+  const configPath =
+    options.configPath ?? (await findConfigPath(options.rootDir));
+  const lockPath = path.join(options.rootDir, TINA_DIRECTORY, LOCK_FILENAME);
+
+  const config = await loadTinaConfig(configPath, options.load);
+  const lock = compileSchema(config);
+  const existing = await readExistingLock(lockPath);
+
+  if (!existing) {
+    await writeFile(lockPath, serializeLock(lock));
+    return { configPath, lockPath, outcome: 'created', lock };
+  }
+
+  const check = checkLock(existing, config);
+  if (check.status === 'current') {
+    return { configPath, lockPath, outcome: 'unchanged', lock };
+  }
+  // The one failure this command has: a field type changed shape under a committed
+  // lock. Rewriting it here is exactly the silent break ADR-016 exists to prevent.
+  invariant(check.status === 'stale', 'lock-incompatible', check.message);
+  await writeFile(lockPath, serializeLock(lock));
+  return {
+    configPath,
+    lockPath,
+    outcome: 'updated',
+    lock,
+    warning: check.message,
+  };
+};

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -56,8 +56,10 @@ const firstExisting = async (candidates: string[]): Promise<string | null> => {
       // a real fault the developer needs to see.
       await access(candidate, constants.R_OK);
       return candidate;
-    } catch {
+    } catch (cause) {
       // Try the next candidate. A missing file here is the question, and not a fault.
+      // An unreadable one is, so it surfaces rather than reading as "no config".
+      if ((cause as NodeJS.ErrnoException).code !== 'ENOENT') throw cause;
     }
   }
   return null;

--- a/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
@@ -1,14 +1,14 @@
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { beforeEach, describe, expect, it } from 'vitest';
-import type { ResolvedConfig } from '../config';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { asResolvedConfig } from '../config';
 import { definePlugin } from '../core/plugin';
 import { runCli } from './index';
 
 let rootDir: string;
 
-const resolved: ResolvedConfig = {
+const resolved = asResolvedConfig({
   plugins: [
     definePlugin({ name: 'test:content', provides: ['content'] }),
     definePlugin({
@@ -27,9 +27,9 @@ const resolved: ResolvedConfig = {
       },
     ],
   },
-};
+});
 
-// Captures what a developer actually sees, and keeps it off the test runner's output.
+// This captures what a developer sees, and keeps it out of the test runner output.
 const capture = () => {
   const out: string[] = [];
   const err: string[] = [];
@@ -45,6 +45,10 @@ const capture = () => {
   };
 };
 
+afterEach(async () => {
+  await rm(rootDir, { recursive: true, force: true });
+});
+
 beforeEach(async () => {
   rootDir = await mkdtemp(path.join(tmpdir(), 'tina-cli-'));
   await mkdir(path.join(rootDir, 'tina'), { recursive: true });
@@ -53,8 +57,8 @@ beforeEach(async () => {
 describe('runCli', () => {
   it('runs codegen against the working directory', async () => {
     const { out, context } = capture();
-    // The config-file lookup reads the directory rather than trusting the loader,
-    // so the file has to actually be there.
+    // The lookup for the config file reads the directory, and does not trust the
+    // loader. The file must therefore exist.
     await writeFile(path.join(rootDir, 'tina', 'config.ts'), 'export default {}');
 
     expect(await runCli(['codegen'], context)).toBe(0);
@@ -75,8 +79,8 @@ describe('runCli', () => {
     expect(out.join('\n')).toContain(path.join(nested, 'tina', 'tina-lock.json'));
   });
 
-  // Every throw on this path carries a written explanation, so the developer gets
-  // that rather than a stack trace.
+  // Every throw on this path carries an explanation, so the developer reads that and
+  // not a stack trace.
   it('reports a missing config as a message, not a crash', async () => {
     const { err, context } = capture();
     expect(await runCli(['codegen'], context)).toBe(1);
@@ -95,10 +99,54 @@ describe('runCli', () => {
     expect(out.join('\n')).toContain('tinacms <command>');
   });
 
-  // A bare invocation is a mistake, not a request for help: usage, but non-zero.
+  // A call with no command is a mistake, and not a request for help. Print the usage,
+  // and exit with a non-zero code.
   it('exits non-zero when given no command', async () => {
     const { out, context } = capture();
     expect(await runCli([], context)).toBe(1);
     expect(out.join('\n')).toContain('tinacms <command>');
+  });
+});
+
+describe('runCli argument handling', () => {
+  // parseArgs sat outside the try/catch, so a bad flag escaped as a stack trace —
+  // against this file's own "a message, not a crash" contract.
+  it('reports an unknown flag as a message rather than throwing', async () => {
+    const { err, context } = capture();
+    await writeFile(
+      path.join(rootDir, 'tina', 'config.ts'),
+      'export default {}'
+    );
+    await expect(runCli(['codegen', '--bogus'], context)).resolves.toBe(1);
+    expect(err.join('\n')).not.toBe('');
+  });
+
+  it('reports a flag given without its value', async () => {
+    const { context } = capture();
+    await expect(runCli(['codegen', '--root'], context)).resolves.toBe(1);
+  });
+
+  // A typo'd command used to exit 0 whenever --help was also passed.
+  it('exits non-zero for an unknown command even with --help', async () => {
+    const { err, context } = capture();
+    expect(await runCli(['publish', '--help'], context)).toBe(1);
+    expect(err.join('\n')).toMatch(/Unknown command "publish"/);
+  });
+
+  // startsWith('/') called C:\site relative and concatenated it onto cwd.
+  it('treats an absolute --root as absolute', async () => {
+    const { out, context } = capture();
+    const elsewhere = await mkdtemp(path.join(tmpdir(), 'tina-abs-'));
+    await mkdir(path.join(elsewhere, 'tina'), { recursive: true });
+    await writeFile(
+      path.join(elsewhere, 'tina', 'config.ts'),
+      'export default {}'
+    );
+
+    expect(await runCli(['codegen', '--root', elsewhere], context)).toBe(0);
+    expect(out.join('\n')).toContain(
+      path.join(elsewhere, 'tina', 'tina-lock.json')
+    );
+    await rm(elsewhere, { recursive: true, force: true });
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
@@ -1,0 +1,104 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { ResolvedConfig } from '../config';
+import { definePlugin } from '../core/plugin';
+import { runCli } from './index';
+
+let rootDir: string;
+
+const resolved: ResolvedConfig = {
+  plugins: [
+    definePlugin({ name: 'test:content', provides: ['content'] }),
+    definePlugin({
+      name: 'test:field:string',
+      provides: ['field'],
+      field: { type: 'string', contractVersion: 1 },
+    }),
+  ],
+  schema: {
+    collections: [
+      {
+        name: 'post',
+        path: 'content/posts',
+        format: 'md',
+        fields: [{ name: 'title', type: 'string' }],
+      },
+    ],
+  },
+};
+
+// Captures what a developer actually sees, and keeps it off the test runner's output.
+const capture = () => {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    context: {
+      cwd: rootDir,
+      log: (message: string) => out.push(message),
+      logError: (message: string) => err.push(message),
+      loader: { ssrLoadModule: async () => ({ default: resolved }) },
+    },
+  };
+};
+
+beforeEach(async () => {
+  rootDir = await mkdtemp(path.join(tmpdir(), 'tina-cli-'));
+  await mkdir(path.join(rootDir, 'tina'), { recursive: true });
+});
+
+describe('runCli', () => {
+  it('runs codegen against the working directory', async () => {
+    const { out, context } = capture();
+    // The config-file lookup reads the directory rather than trusting the loader,
+    // so the file has to actually be there.
+    await writeFile(path.join(rootDir, 'tina', 'config.ts'), 'export default {}');
+
+    expect(await runCli(['codegen'], context)).toBe(0);
+    expect(out.join('\n')).toMatch(/Wrote .*tina-lock\.json/);
+    const lock = JSON.parse(
+      await readFile(path.join(rootDir, 'tina', 'tina-lock.json'), 'utf8')
+    );
+    expect(lock.primitives).toEqual({ string: 1 });
+  });
+
+  it('resolves --root relative to the working directory', async () => {
+    const { out, context } = capture();
+    const nested = path.join(rootDir, 'site');
+    await mkdir(path.join(nested, 'tina'), { recursive: true });
+    await writeFile(path.join(nested, 'tina', 'config.ts'), 'export default {}');
+
+    expect(await runCli(['codegen', '--root', 'site'], context)).toBe(0);
+    expect(out.join('\n')).toContain(path.join(nested, 'tina', 'tina-lock.json'));
+  });
+
+  // Every throw on this path carries a written explanation, so the developer gets
+  // that rather than a stack trace.
+  it('reports a missing config as a message, not a crash', async () => {
+    const { err, context } = capture();
+    expect(await runCli(['codegen'], context)).toBe(1);
+    expect(err.join('\n')).toMatch(/No Tina config found/);
+  });
+
+  it('rejects an unknown command with the usage text', async () => {
+    const { err, context } = capture();
+    expect(await runCli(['publish'], context)).toBe(1);
+    expect(err.join('\n')).toMatch(/Unknown command "publish"/);
+  });
+
+  it('prints usage for --help', async () => {
+    const { out, context } = capture();
+    expect(await runCli(['--help'], context)).toBe(0);
+    expect(out.join('\n')).toContain('tinacms <command>');
+  });
+
+  // A bare invocation is a mistake, not a request for help: usage, but non-zero.
+  it('exits non-zero when given no command', async () => {
+    const { out, context } = capture();
+    expect(await runCli([], context)).toBe(1);
+    expect(out.join('\n')).toContain('tinacms <command>');
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/cli/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.ts
@@ -1,0 +1,101 @@
+// The `tinacms` bin's command dispatch. v4 folds the CLI into the runtime package
+// (ADR-001), so this lives beside the code it drives rather than in a separate
+// @tinacms/cli.
+//
+// Arguments are parsed with node:util's parseArgs — the command surface is four
+// flags wide, which is not worth a dependency.
+
+import { parseArgs } from 'node:util';
+import type { ModuleLoader } from '../codegen/load-config';
+import { type CodegenResult, runCodegen } from './commands/codegen';
+
+export interface CliContext {
+  // The Vite server the bin used to load this module. Handed down so the config
+  // read reuses it instead of booting a second one.
+  loader?: ModuleLoader;
+  cwd?: string;
+  log?: (message: string) => void;
+  logError?: (message: string) => void;
+}
+
+const USAGE = `tinacms <command> [options]
+
+Commands:
+  codegen     Compile the schema in tina/config.ts to tina/tina-lock.json
+
+Options:
+  --root <dir>      Project root (default: the working directory)
+  --config <path>   Path to the config, when it is not under tina/
+  -h, --help        Show this message
+`;
+
+const describe = (result: CodegenResult): string => {
+  const target = `${result.lockPath}`;
+  if (result.outcome === 'created') return `Wrote ${target}`;
+  if (result.outcome === 'updated') return `Updated ${target}`;
+  return `${target} is up to date`;
+};
+
+const codegenCommand = async (
+  values: { root?: string; config?: string },
+  context: Required<Pick<CliContext, 'cwd' | 'log'>> & CliContext
+): Promise<number> => {
+  const result = await runCodegen({
+    rootDir: values.root ? resolveFrom(context.cwd, values.root) : context.cwd,
+    configPath: values.config
+      ? resolveFrom(context.cwd, values.config)
+      : undefined,
+    load: { loader: context.loader },
+  });
+  // The stale path regenerates rather than failing, so the reason is worth saying
+  // out loud — an unexplained lock diff in a commit is how drift gets normalised.
+  if (result.warning) context.log(result.warning);
+  context.log(describe(result));
+  return 0;
+};
+
+const resolveFrom = (cwd: string, target: string): string =>
+  target.startsWith('/') ? target : `${cwd}/${target}`;
+
+export const runCli = async (
+  argv: string[],
+  context: CliContext = {}
+): Promise<number> => {
+  const cwd = context.cwd ?? process.cwd();
+  const log = context.log ?? ((message: string) => console.log(message));
+  const logError =
+    context.logError ?? ((message: string) => console.error(message));
+
+  const [command, ...rest] = argv;
+  if (!command || command === '-h' || command === '--help') {
+    log(USAGE);
+    return command ? 0 : 1;
+  }
+
+  const { values } = parseArgs({
+    args: rest,
+    options: {
+      root: { type: 'string' },
+      config: { type: 'string' },
+      help: { type: 'boolean', short: 'h' },
+    },
+    allowPositionals: true,
+  });
+  if (values.help) {
+    log(USAGE);
+    return 0;
+  }
+
+  try {
+    if (command === 'codegen') {
+      return await codegenCommand(values, { ...context, cwd, log });
+    }
+    logError(`Unknown command "${command}".\n\n${USAGE}`);
+    return 1;
+  } catch (cause) {
+    // A config or lock failure is a message for the developer, not a stack trace:
+    // every throw on this path carries a written explanation.
+    logError(cause instanceof Error ? cause.message : String(cause));
+    return 1;
+  }
+};

--- a/packages/v4/@tinacms/tinacms/src/cli/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.ts
@@ -1,17 +1,18 @@
-// The `tinacms` bin's command dispatch. v4 folds the CLI into the runtime package
-// (ADR-001), so this lives beside the code it drives rather than in a separate
-// @tinacms/cli.
+// The command dispatch of the `tinacms` bin. v4 puts the CLI in the runtime package
+// (ADR-001), so this file sits beside the code that it drives. There is no separate
+// @tinacms/cli package.
 //
-// Arguments are parsed with node:util's parseArgs — the command surface is four
-// flags wide, which is not worth a dependency.
+// parseArgs from node:util reads the arguments. The command surface is four flags wide,
+// which does not need a dependency.
 
+import path from 'node:path';
 import { parseArgs } from 'node:util';
 import type { ModuleLoader } from '../codegen/load-config';
 import { type CodegenResult, runCodegen } from './commands/codegen';
 
 export interface CliContext {
-  // The Vite server the bin used to load this module. Handed down so the config
-  // read reuses it instead of booting a second one.
+  // The Vite server that the bin used to load this module. The bin passes it down, so
+  // the config read uses it and does not start a second one.
   loader?: ModuleLoader;
   cwd?: string;
   log?: (message: string) => void;
@@ -47,15 +48,17 @@ const codegenCommand = async (
       : undefined,
     load: { loader: context.loader },
   });
-  // The stale path regenerates rather than failing, so the reason is worth saying
-  // out loud — an unexplained lock diff in a commit is how drift gets normalised.
+  // A stale lock is written again, and does not fail the build, so this states the
+  // reason. A change to the lock with no explanation in a commit hides the drift.
   if (result.warning) context.log(result.warning);
   context.log(describe(result));
   return 0;
 };
 
+// path.resolve, not a `/` test: `C:\\site` is absolute and `startsWith('/')` says it
+// is not, so it was concatenated onto cwd and reported as a missing config.
 const resolveFrom = (cwd: string, target: string): string =>
-  target.startsWith('/') ? target : `${cwd}/${target}`;
+  path.resolve(cwd, target);
 
 export const runCli = async (
   argv: string[],
@@ -72,29 +75,33 @@ export const runCli = async (
     return command ? 0 : 1;
   }
 
-  const { values } = parseArgs({
-    args: rest,
-    options: {
-      root: { type: 'string' },
-      config: { type: 'string' },
-      help: { type: 'boolean', short: 'h' },
-    },
-    allowPositionals: true,
-  });
-  if (values.help) {
-    log(USAGE);
-    return 0;
-  }
-
   try {
-    if (command === 'codegen') {
-      return await codegenCommand(values, { ...context, cwd, log });
+    // Inside the try. An unknown flag, or `--root` with no value, makes parseArgs
+    // throw, and outside this block that reached the caller as a stack trace — which
+    // is what the comment below promises it never does.
+    const { values } = parseArgs({
+      args: rest,
+      options: {
+        root: { type: 'string' },
+        config: { type: 'string' },
+        help: { type: 'boolean', short: 'h' },
+      },
+      allowPositionals: true,
+    });
+    // The command is checked before --help, so a typo does not exit 0 just because
+    // the user also asked for usage.
+    if (command !== 'codegen') {
+      logError(`Unknown command "${command}".\n\n${USAGE}`);
+      return 1;
     }
-    logError(`Unknown command "${command}".\n\n${USAGE}`);
-    return 1;
+    if (values.help) {
+      log(USAGE);
+      return 0;
+    }
+    return await codegenCommand(values, { ...context, cwd, log });
   } catch (cause) {
-    // A config or lock failure is a message for the developer, not a stack trace:
-    // every throw on this path carries a written explanation.
+    // A failure of the config or of the lock is a message for the developer, and not
+    // a stack trace. Every throw on this path carries an explanation.
     logError(cause instanceof Error ? cause.message : String(cause));
     return 1;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2793,6 +2793,9 @@ importers:
       sqlite-level:
         specifier: 'catalog:'
         version: 2.1.0
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -2845,9 +2848,6 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
-      vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@25.1.0)(happy-dom@15.10.2)(jsdom@15.2.1(bufferutil@4.1.0))(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)


### PR DESCRIPTION
**TLDR:** The `tinacms` bin arrives with one command: codegen compiles the schema to tina-lock.json, conservatively, in the runtime package (ADR-001).

**Feats:**
- An already-current lock is left untouched; a stale lock regenerates and says why
- A contract-version mismatch stops without touching the disk
- Bad flags exit 1 with a message instead of a stack trace; Windows-style --root paths resolve
- An unreadable config surfaces as an error instead of reading as "no config"
- The bin boots one Vite server and lends it to the config loader

**How to test:** Run codegen against the playground.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
- Run `node bin/tinacms.mjs codegen --root playground`.
- Confirm it reports the lock as up to date.
