### PR TITLE
fix(v4): nothing in v4 claims a fixed port

### DIFF
--- a/packages/v4/@tinacms/tinacms/playwright.config.ts
+++ b/packages/v4/@tinacms/tinacms/playwright.config.ts
@@ -1,3 +1,4 @@
+import { createServer } from 'node:net';
 import { defineConfig, devices } from '@playwright/test';
 
 // A browser is the only place two of this package's guarantees can be observed:
@@ -6,7 +7,34 @@ import { defineConfig, devices } from '@playwright/test';
 // keystrokes don't produce). Everything else stays in the vitest suite.
 //
 // The harness is the playground — the same app `pnpm dev` serves.
-const PORT = 5174;
+//
+// The port is asked for rather than fixed, so a second run of this suite (another
+// checkout, a watch process, two CI shards on one box) doesn't collide with the
+// first. Pin it with TINA_E2E_PORT, which also restores `reuseExistingServer`.
+const freePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    // Port 0 asks the OS for an unused one, which is free at the moment it's read
+    // back — hence --strictPort below. If something claims it in the gap before
+    // vite binds, that has to fail loudly rather than drift to a port baseURL
+    // isn't pointing at.
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      probe.close(() => {
+        if (address && typeof address === 'object') resolve(address.port);
+        else reject(new Error('Probe server reported no port'));
+      });
+    });
+  });
+
+const pinned = process.env.TINA_E2E_PORT;
+const PORT = pinned ? Number(pinned) : await freePort();
+// Playwright evaluates this config once in the runner and again in each worker it
+// forks. Only the runner starts the server, so the port it picked has to reach the
+// workers — otherwise they each probe their own and navigate to a port nothing is
+// serving. Workers fork after this line, so they inherit it.
+process.env.TINA_E2E_PORT = String(PORT);
 
 export default defineConfig({
   testDir: './e2e',
@@ -24,7 +52,8 @@ export default defineConfig({
   webServer: {
     command: `npx vite playground --port ${PORT} --strictPort`,
     url: `http://localhost:${PORT}/`,
-    reuseExistingServer: !process.env.CI,
+    // Only a pinned port can be reused; a probed one is fresh every run by design.
+    reuseExistingServer: !process.env.CI && Boolean(pinned),
     timeout: 60000,
   },
 });

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { Server } from 'node:net';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, expect, it } from 'vitest';
+import { loadTinaConfig } from './load-config';
+
+// v4 mounts into the server that the host app already runs. The RPC handler goes through
+// a framework adapter, and the local data layer goes through a middleware. No code under
+// src/ therefore owns a port. A read of the config file is the easiest place to lose that
+// property, because it starts a Vite server. In middleware mode, Vite has no HTTP server
+// for the HMR socket, so it binds its default port, 24678, on every interface. The
+// `hmr: false` option does not stop that. Two loads at the same time then race for one
+// fixed global port, and one of them fails.
+//
+// This test asserts the property, and not the flag that gives it today.
+let rootDir: string;
+let listened: unknown[][];
+
+// http.Server inherits listen from net.Server, so a patch on the one prototype sees every
+// socket that either class would open.
+const realListen = Server.prototype.listen;
+
+beforeEach(async () => {
+  rootDir = await mkdtemp(path.join(tmpdir(), 'tina-load-config-'));
+  listened = [];
+  Server.prototype.listen = function (
+    this: Server,
+    ...args: Parameters<typeof realListen>
+  ) {
+    listened.push(args);
+    // Call the original. A regression must fail this assertion. The loader must not
+    // behave differently in a test and in production.
+    return realListen.apply(this, args);
+  } as typeof realListen;
+});
+
+afterEach(() => {
+  Server.prototype.listen = realListen;
+});
+
+it('loads a config without binding a port', async () => {
+  const configPath = path.join(rootDir, 'config.ts');
+  await writeFile(
+    configPath,
+    'export default { plugins: [], schema: { collections: [] } };\n'
+  );
+
+  const config = await loadTinaConfig(configPath);
+
+  // This assertion stops the port check below from passing because the loader stopped
+  // early and started nothing.
+  expect(config.schema.collections).toEqual([]);
+  expect(listened).toEqual([]);
+});

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import { Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, expect, it } from 'vitest';
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { loadTinaConfig } from './load-config';
 
 // v4 mounts into the server that the host app already runs. The RPC handler goes through
@@ -52,4 +52,49 @@ it('loads a config without binding a port', async () => {
   // early and started nothing.
   expect(config.schema.collections).toEqual([]);
   expect(listened).toEqual([]);
+});
+
+// The server this function opens is its own, and it closes it. A server the caller
+// passed belongs to the caller, who may still be using it for the rest of a command.
+it('leaves a caller-supplied loader open', async () => {
+  const configPath = path.join(rootDir, 'config.ts');
+  await writeFile(
+    configPath,
+    'export default { plugins: [], schema: { collections: [] } };\n'
+  );
+  const close = vi.fn(async () => {});
+  const loader = {
+    ssrLoadModule: async () => ({
+      default: { plugins: [], schema: { collections: [] } },
+    }),
+    close,
+  };
+
+  await loadTinaConfig(configPath, {
+    loader: loader as unknown as Parameters<typeof loadTinaConfig>[1]['loader'],
+  });
+
+  expect(close).not.toHaveBeenCalled();
+});
+
+// Without a root the server sits at process.cwd(), so a config loaded from anywhere
+// else resolves its relative imports against the caller's directory. `tinacms codegen
+// --root <dir>` is exactly that case.
+it('resolves a relative import against the config directory, not the cwd', async () => {
+  const projectDir = path.join(rootDir, 'site', 'tina');
+  await mkdir(projectDir, { recursive: true });
+  await writeFile(
+    path.join(projectDir, 'collections.ts'),
+    'export const collections = [{ name: "posts", label: "Posts", path: "content/posts", format: "mdx", fields: [] }];\n'
+  );
+  const configPath = path.join(projectDir, 'config.ts');
+  await writeFile(
+    configPath,
+    'import { collections } from "./collections";\n' +
+      'export default { plugins: [], schema: { collections } };\n'
+  );
+
+  const config = await loadTinaConfig(configPath);
+
+  expect(config.schema.collections.map((one) => one.name)).toEqual(['posts']);
 });

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
@@ -1,38 +1,60 @@
-// Node-only. Reads a project's `tina/config.ts` and hands back what defineConfig
-// returned — the entry point for everything that needs the config outside the
-// browser: the schema compile, the Local Data Layer, and (once it lands) the CLI.
+// This runs in Node only. It reads the `tina/config.ts` of a project, and returns the
+// output of defineConfig. Every consumer outside the browser enters here: the schema
+// compile, the local data layer, and the CLI.
 //
-// It runs the file through a throwaway Vite server rather than importing it. The
-// config is TypeScript, and node can strip that on its own now, but it also imports
-// `@tinacms/tinacms`, whose `exports` still point at raw `.ts` using extensionless
-// relative specifiers (`./core/plugin`) that node's resolver will not follow. Vite's
-// resolver will, and `tinacms dev` hosts a Vite server regardless, so this is the
-// mechanism that survives rather than a stopgap.
+// It runs the file through a temporary Vite server, and does not import it. The config
+// is TypeScript, and node can now strip the types by itself. But the config also imports
+// `@tinacms/tinacms`, whose `exports` still point at raw `.ts` files. Those exports use
+// relative specifiers with no extension, such as `./core/plugin`, and the node resolver
+// does not follow them. The Vite resolver does follow them. `tinacms dev` also hosts a
+// Vite server, so this mechanism stays.
 
+import path from 'node:path';
 import { createServer } from 'vite';
 import type { ResolvedConfig } from '../config';
 import { invariant } from '../core/invariant';
 
+// The one function that this module needs from a Vite server. A caller can therefore
+// pass the server that it already has, and this module does not depend on the full
+// ViteDevServer type.
+export interface ModuleLoader {
+  ssrLoadModule(url: string): Promise<Record<string, unknown>>;
+}
+
 export interface LoadTinaConfigOptions {
-  // Resolution overrides for the loading server. A real project needs none — it
-  // resolves `@tinacms/tinacms` from node_modules — but a workspace that aliases
-  // the package at its source has to pass the same aliases its app uses.
+  // The resolution overrides for the loading server. Few callers need them. A project
+  // resolves `@tinacms/tinacms` from node_modules, and a copy in a workspace resolves
+  // through its own `exports`.
   alias?: { find: string; replacement: string }[];
+  // Use the server of the caller, instead of a new one. The CLI passes the server that
+  // loaded it. A second server costs about one second at each run, and gives nothing.
+  loader?: ModuleLoader;
 }
 
 export const loadTinaConfig = async (
   configPath: string,
   options: LoadTinaConfigOptions = {}
 ): Promise<ResolvedConfig> => {
-  const server = await createServer({
-    // Ignore any vite.config in scope: this server exists to resolve one module,
-    // and inheriting a project's plugins would run its whole dev pipeline (and, in
-    // a workspace, recurse straight back into the config that called us).
-    configFile: false,
-    logLevel: 'warn',
-    server: { middlewareMode: true, hmr: false, watch: null },
-    resolve: { alias: options.alias ?? [] },
-  });
+  const server =
+    options.loader ??
+    (await createServer({
+      // Ignore any vite.config in scope. This server resolves one module. The plugins
+      // of a project would run its whole dev pipeline. In a workspace, they would
+      // also return to the config that called this function.
+      configFile: false,
+      // Without this the server roots at process.cwd(), so a config loaded from
+      // anywhere else resolves its relative imports and tsconfig paths against the
+      // caller's directory rather than the project's.
+      root: path.dirname(configPath),
+      logLevel: 'warn',
+      // The `ws: false` option is necessary. In middleware mode, Vite has no HTTP
+      // server for the HMR socket. The `hmr: false` option alone does not stop that
+      // socket. Vite then binds its default port, 24678, on every interface. A load
+      // of one config file would claim a fixed global port, and two loads at the same
+      // time would race. Only `ws: false` stops createWebSocketServer.
+      server: { middlewareMode: true, hmr: false, ws: false, watch: null },
+      resolve: { alias: options.alias ?? [] },
+    }));
   try {
     const loaded = await server.ssrLoadModule(configPath);
     const config = loaded.default as ResolvedConfig | undefined;
@@ -43,6 +65,8 @@ export const loadTinaConfig = async (
     );
     return config;
   } finally {
-    await server.close();
+    // Close only the server that this function opened. A server from the caller stays
+    // open.
+    if (!options.loader) await (server as { close(): Promise<void> }).close();
   }
 };


### PR DESCRIPTION
**TLDR:** Reading a config no longer binds Vite's HMR socket on a fixed port, and the e2e harness probes a free port instead of pinning 5174.

**Feats:**
- loadTinaConfig sets ws: false, so a config read opens no socket
- The playwright harness asks the OS for a port and publishes it to the workers; TINA_E2E_PORT still pins it
- A test asserts the property itself: a config load opens no server

**How to test:** The property is pinned by a unit test.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
- Start `pnpm test:e2e` twice at the same time.
- Confirm both runs bind their own port and pass.
