### PR TITLE
feat(v4): keep the CLI out of the build pipeline; implement the framework adapters

### DIFF
--- a/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
+++ b/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
@@ -10,7 +10,19 @@
 // opens its own server for the config, rooted at the directory the config sits in.
 
 import { fileURLToPath } from 'node:url';
-import { createServer } from 'vite';
+
+// Vite is an optional peer, because the browser runtime of this package does not need a
+// build tool and should not install one. The bin does need it, for the reason above, so
+// this reports the missing peer as the instruction it is. The `catch` goes when ADR-001
+// lands the dist build: from then the bin loads compiled JavaScript, and only the config
+// read needs a loader.
+const { createServer } = await import('vite').catch(() => {
+  console.error(
+    'tinacms: this command needs Vite to read tina/config.ts.\n' +
+      'Install it in your project:  npm i -D vite'
+  );
+  process.exit(1);
+});
 
 const server = await createServer({
   configFile: false,

--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -76,24 +76,33 @@
     }
   },
   "dependencies": {
-    "@hookform/resolvers": "^5.4.0",
     "@tinacms/graphql": "workspace:*",
     "@tinacms/mdx": "workspace:*",
     "@tinacms/rich-text": "workspace:*",
-    "@tinacms/schema-tools": "workspace:*",
     "@tinacms/ui": "workspace:*",
     "abstract-level": "catalog:",
     "gray-matter": "catalog:",
     "prism-react-renderer": "catalog:",
     "react-hook-form": "^7.80.0",
     "sqlite-level": "catalog:",
-    "vite": "^5.4.0",
     "zod": "catalog:",
     "zustand": "^5.0.14"
   },
   "peerDependencies": {
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "vite": "^5.4.0 || ^6.0.0 || ^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "vite": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.4",
@@ -111,6 +120,7 @@
     "react-dom": "^19.2.7",
     "tailwindcss": "^4.3.2",
     "typescript": "^5.7.3",
+    "vite": "^5.4.0",
     "vitest": "^2.1.9"
   }
 }

--- a/packages/v4/@tinacms/tinacms/src/adapters/astro/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/astro/index.ts
@@ -1,7 +1,34 @@
-// Server-only — `tinacms/adapters/astro`.
-// Mounts the runtime-composed RPC handler as Astro endpoint handlers.
+// The server entry, `tinacms/adapters/astro`. It mounts the composed RPC handler as
+// Astro endpoint handlers.
 //
-// Intended exports:
-//   mountHandler(config) → { GET, POST }   for src/pages/api/tina/[...slug].ts
+// The project owns the route, and Tina supplies the function that answers it. Nothing
+// here spawns a process or claims a port, so `astro dev` and `astro build` stay the
+// pipeline of the project (refer to packages/v4/README.md).
+//
+// An Astro endpoint takes an APIContext and returns a Web Response. The one member of
+// that context this adapter reads is `request`, so the parameter is typed structurally
+// and this file does not import `astro`.
 
-export {};
+import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
+
+export type { RpcHandlerConfig };
+
+export interface AstroRouteHandlers {
+  GET: (context: { request: Request }) => Promise<Response>;
+  POST: (context: { request: Request }) => Promise<Response>;
+}
+
+// Use it from src/pages/api/tina/[...slug].ts:
+//
+//   export const { GET, POST } = mountHandler({ plugins })
+//
+// The route needs `export const prerender = false`, or a project with `output: 'server'`.
+// A prerendered endpoint runs at build time and answers nothing at run time.
+//
+// Operations are POST (ADR-008). GET is exported so that a browser hitting the route gets
+// the 405 the dispatch returns, and not the 404 that Astro returns for a missing export.
+export const mountHandler = (config: RpcHandlerConfig): AstroRouteHandlers => {
+  const handler = createRpcHandler(config);
+  const route = ({ request }: { request: Request }) => handler(request);
+  return { GET: route, POST: route };
+};

--- a/packages/v4/@tinacms/tinacms/src/adapters/express/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/express/index.ts
@@ -1,7 +1,112 @@
-// Server-only — `tinacms/adapters/express`.
-// Mounts the runtime-composed RPC handler as an Express middleware.
+// The server entry, `tinacms/adapters/express`. It mounts the composed RPC handler as an
+// Express middleware.
 //
-// Intended exports:
-//   tinaMiddleware(config) → RequestHandler
+// The project owns the server, and Tina supplies a middleware for one route. Nothing here
+// listens, so the project keeps its own pipeline (refer to packages/v4/README.md).
+//
+// This is the one adapter with real work in it. Next, Astro, and Hono all hand over a Web
+// Request and take back a Web Response, which is already the signature of RpcHandler.
+// Express predates that and speaks node streams, so this file converts in both
+// directions. It types the two ends structurally with the `node:http` classes that
+// Express extends, and does not import `express`.
 
-export {};
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
+
+export type { RpcHandlerConfig };
+
+type ExpressLikeRequest = IncomingMessage & {
+  // Express strips the mount path from `url` and keeps the whole path here. The
+  // dispatch reads the last two segments either way, so this is for fidelity.
+  originalUrl?: string;
+  // A body parser upstream of this middleware leaves its result here.
+  body?: unknown;
+};
+
+export type TinaMiddleware = (
+  req: ExpressLikeRequest,
+  res: ServerResponse,
+  next: (error?: unknown) => void
+) => void;
+
+const readBody = async (req: ExpressLikeRequest): Promise<string> => {
+  // An `express.json()` in front of this middleware has already drained the socket and
+  // left the parsed value on `req.body`. Reading the stream again yields nothing, and
+  // the operation would see an empty body, so serialize what the parser produced.
+  if (req.body !== undefined && req.body !== null) {
+    return typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
+  }
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) chunks.push(chunk as Buffer);
+  return Buffer.concat(chunks).toString('utf8');
+};
+
+const toWebRequest = async (req: ExpressLikeRequest): Promise<Request> => {
+  // The Request constructor needs an absolute URL, and the dispatch reads only the
+  // path. Take the scheme from the socket rather than from `x-forwarded-proto`: a
+  // client sends that header too, and nothing here should trust it.
+  const scheme = (req.socket as { encrypted?: boolean }).encrypted
+    ? 'https'
+    : 'http';
+  const url = new URL(
+    req.originalUrl ?? req.url ?? '/',
+    `${scheme}://${req.headers.host ?? 'localhost'}`
+  );
+
+  const headers = new Headers();
+  for (const [name, value] of Object.entries(req.headers)) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) headers.append(name, entry);
+    } else {
+      headers.set(name, value);
+    }
+  }
+
+  const method = req.method ?? 'GET';
+  // A GET or HEAD Request may not carry a body, and the constructor throws if it does.
+  const body =
+    method === 'GET' || method === 'HEAD' ? undefined : await readBody(req);
+  return new Request(url, { method, headers, body });
+};
+
+const sendWebResponse = async (
+  response: Response,
+  res: ServerResponse
+): Promise<void> => {
+  // Iterating a Headers object joins repeated names with ", ". For Set-Cookie that
+  // makes one broken cookie out of two, so an auth plugin that writes a session cookie
+  // and a refresh cookie loses both. getSetCookie keeps them apart. It is optional
+  // here because it arrived after the rest of the fetch types.
+  const setCookie = response.headers.getSetCookie?.() ?? [];
+  for (const [name, value] of response.headers) {
+    if (name.toLowerCase() === 'set-cookie') continue;
+    res.setHeader(name, value);
+  }
+  if (setCookie.length > 0) res.setHeader('set-cookie', setCookie);
+  res.statusCode = response.status;
+  // The RPC transport carries JSON only, so buffering costs nothing and avoids the
+  // half-duplex stream plumbing that a streamed body would need.
+  res.end(Buffer.from(await response.arrayBuffer()));
+};
+
+// Mount it on the base URL of the client:
+//
+//   app.use('/api/tina', tinaMiddleware({ plugins }))
+//
+// It answers every request that reaches it and calls `next` only with an error, so the
+// error handler of the project reports a fault in the conversion.
+export const tinaMiddleware = (config: RpcHandlerConfig): TinaMiddleware => {
+  const handler = createRpcHandler(config);
+  return (req, res, next) => {
+    // Express ignores a returned promise, so the rejection is caught here. An
+    // unhandled one would take the process down.
+    void (async () => {
+      try {
+        await sendWebResponse(await handler(await toWebRequest(req)), res);
+      } catch (cause) {
+        next(cause);
+      }
+    })();
+  };
+};

--- a/packages/v4/@tinacms/tinacms/src/adapters/hono/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/hono/index.ts
@@ -1,7 +1,37 @@
-// Server-only — `tinacms/adapters/hono`.
-// Mounts the runtime-composed RPC handler as a Hono route.
+// The server entry, `tinacms/adapters/hono`. It mounts the composed RPC handler as a
+// Hono route.
 //
-// Intended exports:
-//   tinaRoute(config) → Hono — mountable via `app.route('/api/tina', tinaRoute(config))`
+// The project owns the route, and Tina supplies the function that answers it. Nothing
+// here spawns a process or claims a port, so the project keeps its own pipeline (refer
+// to packages/v4/README.md).
+//
+// The planned surface for this file was `tinaRoute(config) → Hono`, mounted with
+// `app.route()`. Returning a Hono instance means importing `hono`, and that would make
+// the framework a dependency of the runtime package for no gain: a Hono handler already
+// takes a Web Request through `c.req.raw` and returns a Web Response. So this exports the
+// handler, and the project mounts it with `app.all()`, which is the same one line.
 
-export {};
+import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
+
+export type { RpcHandlerConfig };
+
+// The one member of the Hono context this adapter reads. Typed structurally, so the
+// handler fits `app.all()` without `hono` in the import graph.
+export interface HonoRequestContext {
+  req: { raw: Request };
+}
+
+export type HonoRouteHandler = (
+  context: HonoRequestContext
+) => Promise<Response>;
+
+// Mount it on the wildcard that matches the base URL of the client:
+//
+//   app.all('/api/tina/*', mountHandler({ plugins }))
+//
+// The trailing `*` is required. Hono matches `/api/tina` alone otherwise, and every
+// operation below it returns 404.
+export const mountHandler = (config: RpcHandlerConfig): HonoRouteHandler => {
+  const handler = createRpcHandler(config);
+  return ({ req }) => handler(req.raw);
+};

--- a/packages/v4/@tinacms/tinacms/src/adapters/mount.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/mount.test.ts
@@ -1,0 +1,162 @@
+// Every adapter mounts the same RpcHandler into the server that the project already
+// runs. Next, Astro, and Hono hand over a Web Request and take back a Web Response, so
+// their tests assert the wiring. Express speaks node streams, so its conversion is the
+// part with behaviour worth covering.
+
+import { Readable } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+import { definePlugin } from '../core/plugin';
+import { defineServerPlugin, publicOp } from '../server';
+import { mountHandler as mountAstro } from './astro';
+import { tinaMiddleware } from './express';
+import { mountHandler as mountHono } from './hono';
+import { mountHandler as mountNext } from './next';
+
+// One public op, so these tests cover the transport and not the authorization. The
+// dispatch skips the session check for a publicOp, which handler.test.ts covers.
+const plugins = [
+  definePlugin({
+    name: 'test-media',
+    provides: ['media'],
+    server: async () => ({
+      default: defineServerPlugin({
+        echo: publicOp(async (input: { value: string }) => ({
+          echoed: input.value,
+        })),
+      }),
+    }),
+  }),
+];
+
+const ROUTE = '/api/tina/media/echo';
+
+const jsonRequest = (body: unknown) =>
+  new Request(`http://tina.local${ROUTE}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+describe('the Web-standard adapters', () => {
+  it('routes a Next.js route handler to the op', async () => {
+    const { POST } = mountNext({ plugins });
+    const response = await POST(jsonRequest({ value: 'next' }));
+    expect(await response.json()).toEqual({ echoed: 'next' });
+  });
+
+  it('routes an Astro endpoint to the op', async () => {
+    const { POST } = mountAstro({ plugins });
+    const response = await POST({ request: jsonRequest({ value: 'astro' }) });
+    expect(await response.json()).toEqual({ echoed: 'astro' });
+  });
+
+  it('routes a Hono handler to the op through c.req.raw', async () => {
+    const handler = mountHono({ plugins });
+    const response = await handler({
+      req: { raw: jsonRequest({ value: 'hono' }) },
+    });
+    expect(await response.json()).toEqual({ echoed: 'hono' });
+  });
+
+  // Operations are POST. A browser that opens the route gets the 405 that names the
+  // problem, and not the 404 a framework returns for a method with no export.
+  it('answers GET with 405 rather than leaving the method unexported', async () => {
+    const { GET } = mountNext({ plugins });
+    const response = await GET(new Request(`http://tina.local${ROUTE}`));
+    expect(response.status).toBe(405);
+  });
+});
+
+// A stand-in for the node request. Express extends IncomingMessage, which is a Readable,
+// so a Readable carrying the same members is what the middleware sees.
+const nodeRequest = (init: {
+  method?: string;
+  url?: string;
+  headers?: Record<string, string>;
+  body?: string;
+  parsedBody?: unknown;
+  encrypted?: boolean;
+}) =>
+  Object.assign(Readable.from(init.body ? [Buffer.from(init.body)] : []), {
+    method: init.method ?? 'POST',
+    url: init.url ?? ROUTE,
+    headers: {
+      host: 'tina.local',
+      'content-type': 'application/json',
+      ...init.headers,
+    },
+    socket: { encrypted: init.encrypted ?? false },
+    ...(init.parsedBody === undefined ? {} : { body: init.parsedBody }),
+  }) as never;
+
+// The middleware returns before it has answered, because Express ignores a returned
+// promise. "The request is done" therefore means `end` ran, or `next` got an error.
+const runMiddleware = async (req: never) => {
+  const headers: Record<string, string | string[]> = {};
+  const errors: unknown[] = [];
+  let settle: () => void = () => {};
+  const done = new Promise<void>((resolve) => {
+    settle = resolve;
+  });
+  const recorder = {
+    statusCode: 0,
+    body: '',
+    headers,
+    setHeader(name: string, value: string | string[]) {
+      headers[name.toLowerCase()] = value;
+    },
+    end(chunk?: Buffer) {
+      recorder.body = chunk?.toString() ?? '';
+      settle();
+    },
+  };
+  tinaMiddleware({ plugins })(req, recorder as never, (error) => {
+    errors.push(error);
+    settle();
+  });
+  await done;
+  return { recorder, errors };
+};
+
+describe('the Express adapter', () => {
+  it('converts a node request into a Request and answers on the node response', async () => {
+    const { recorder } = await runMiddleware(
+      nodeRequest({ body: JSON.stringify({ value: 'express' }) })
+    );
+    expect(recorder.statusCode).toBe(200);
+    expect(JSON.parse(recorder.body)).toEqual({ echoed: 'express' });
+    expect(recorder.headers['content-type']).toMatch(/application\/json/);
+  });
+
+  // express.json() upstream drains the socket and leaves the parsed value on req.body.
+  // Reading the stream again yields nothing, so the op would have seen no input.
+  it('reads a body that an upstream parser already consumed', async () => {
+    const { recorder } = await runMiddleware(
+      nodeRequest({ parsedBody: { value: 'parsed' } })
+    );
+    expect(JSON.parse(recorder.body)).toEqual({ echoed: 'parsed' });
+  });
+
+  // Express strips the mount path from `url` when the middleware is mounted with
+  // app.use('/api/tina', …). The dispatch reads the last two segments, so both forms
+  // must reach the same op.
+  it('routes whether or not Express stripped the mount path', async () => {
+    const { recorder } = await runMiddleware(
+      nodeRequest({
+        url: '/media/echo',
+        body: JSON.stringify({ value: 'mounted' }),
+      })
+    );
+    expect(JSON.parse(recorder.body)).toEqual({ echoed: 'mounted' });
+  });
+
+  it('does not send a body on a GET, and reports the 405', async () => {
+    // A GET Request may not carry a body; constructing one throws. That throw would
+    // reach `next` instead of the dispatch.
+    const { recorder, errors } = await runMiddleware(
+      nodeRequest({ method: 'GET', body: undefined })
+    );
+    expect(errors).toEqual([]);
+    expect(recorder.statusCode).toBe(405);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/adapters/next/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/next/index.ts
@@ -1,7 +1,31 @@
-// Server-only — `tinacms/adapters/next`.
-// Mounts the runtime-composed RPC handler as Next.js route handlers.
+// The server entry, `tinacms/adapters/next`. It mounts the composed RPC handler as
+// Next.js route handlers.
 //
-// Intended exports:
-//   mountHandler(config) → { GET, POST }   for app/api/tina/[...slug]/route.ts
+// The project owns the route, and Tina supplies the function that answers it. Nothing
+// here spawns a process or claims a port, so `next dev` and `next build` stay the
+// pipeline of the project (refer to packages/v4/README.md).
+//
+// An app-router route handler takes a Web Request and returns a Web Response, which is
+// the signature of RpcHandler. The adapter is therefore a rename, and this file does not
+// import `next`.
 
-export {};
+import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
+
+export type { RpcHandlerConfig };
+
+export interface NextRouteHandlers {
+  GET: (request: Request) => Promise<Response>;
+  POST: (request: Request) => Promise<Response>;
+}
+
+// Use it from app/api/tina/[...slug]/route.ts:
+//
+//   export const { GET, POST } = mountHandler({ plugins })
+//
+// Operations are POST (ADR-008). GET is exported so that a browser hitting the route
+// gets the 405 the dispatch returns, which names the problem, instead of the 404 that
+// Next returns for a method with no export.
+export const mountHandler = (config: RpcHandlerConfig): NextRouteHandlers => {
+  const handler = createRpcHandler(config);
+  return { GET: handler, POST: handler };
+};

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -30,6 +30,11 @@ export interface CodegenOptions {
   // An explicit path to the config, for a project that keeps it in another place.
   configPath?: string;
   load?: LoadTinaConfigOptions;
+  // Write the lock when it differs. It defaults to true. `tinacms codegen --check`
+  // passes false: in CI a lock that differs from the committed one is the failure to
+  // report, and not a file to repair. The outcome is the same either way, so the
+  // caller reads `outcome` to learn what a write would have done.
+  write?: boolean;
 }
 
 export type CodegenOutcome =
@@ -111,13 +116,16 @@ export const runCodegen = async (
     options.configPath ?? (await findConfigPath(options.rootDir));
   const lockPath = path.join(options.rootDir, TINA_DIRECTORY, LOCK_FILENAME);
 
+  const write = options.write ?? true;
   const config = await loadTinaConfig(configPath, options.load);
   const lock = compileSchema(config);
   const existing = await readExistingLock(lockPath);
 
   if (!existing) {
-    await mkdir(path.dirname(lockPath), { recursive: true });
-    await writeFile(lockPath, serializeLock(lock));
+    if (write) {
+      await mkdir(path.dirname(lockPath), { recursive: true });
+      await writeFile(lockPath, serializeLock(lock));
+    }
     return { configPath, lockPath, outcome: 'created', lock };
   }
 
@@ -132,7 +140,7 @@ export const runCodegen = async (
     check.status === 'unreadable' ? 'lock-unreadable' : 'lock-incompatible',
     check.message
   );
-  await writeFile(lockPath, serializeLock(lock));
+  if (write) await writeFile(lockPath, serializeLock(lock));
   return {
     configPath,
     lockPath,

--- a/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
@@ -116,6 +116,54 @@ describe('runCli', () => {
   });
 });
 
+// The pipeline of a project never runs this bin, so a config that changed without its
+// lock reaches CI unnoticed. --check is the guard, and it must never repair the file it
+// is checking: a CI run that rewrites the lock reports success and commits nothing.
+describe('runCli codegen --check', () => {
+  const writeConfig = () =>
+    writeFile(path.join(rootDir, 'tina', 'config.ts'), 'export default {}');
+  const lockPath = () => path.join(rootDir, 'tina', 'tina-lock.json');
+
+  it('exits 0 when the committed lock matches the schema', async () => {
+    const { context } = capture();
+    await writeConfig();
+    await runCli(['codegen'], context);
+
+    const { out, context: checkContext } = capture();
+    expect(await runCli(['codegen', '--check'], checkContext)).toBe(0);
+    expect(out.join('\n')).toMatch(/is up to date/);
+  });
+
+  it('exits 1 and writes nothing when no lock is committed', async () => {
+    const { err, context } = capture();
+    await writeConfig();
+
+    expect(await runCli(['codegen', '--check'], context)).toBe(1);
+    expect(err.join('\n')).toMatch(/is out of date/);
+    await expect(readFile(lockPath(), 'utf8')).rejects.toThrow();
+  });
+
+  it('exits 1 and leaves a stale lock untouched', async () => {
+    const { context } = capture();
+    await writeConfig();
+    // A lock that parses and carries a different schema digest is the drift this
+    // command exists to catch.
+    await runCli(['codegen'], context);
+    const committed = JSON.parse(await readFile(lockPath(), 'utf8'));
+    committed.schema.collections[0].fields.push({
+      name: 'subtitle',
+      type: 'string',
+    });
+    const stale = `${JSON.stringify(committed, null, 2)}\n`;
+    await writeFile(lockPath(), stale);
+
+    const { err, context: checkContext } = capture();
+    expect(await runCli(['codegen', '--check'], checkContext)).toBe(1);
+    expect(err.join('\n')).toMatch(/is out of date/);
+    expect(await readFile(lockPath(), 'utf8')).toBe(stale);
+  });
+});
+
 describe('runCli argument handling', () => {
   // parseArgs sat outside the try/catch, so a bad flag escaped as a stack trace —
   // against this file's own "a message, not a crash" contract.

--- a/packages/v4/@tinacms/tinacms/src/cli/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.ts
@@ -27,6 +27,7 @@ Commands:
 Options:
   --root <dir>      Project root (default: the working directory)
   --config <path>   Path to the config, when it is not under tina/
+  --check           Write nothing; exit 1 when the committed lock is stale
   -h, --help        Show this message
 `;
 
@@ -38,8 +39,8 @@ const describe = (result: CodegenResult): string => {
 };
 
 const codegenCommand = async (
-  values: { root?: string; config?: string },
-  context: Required<Pick<CliContext, 'cwd' | 'log'>> & CliContext
+  values: { root?: string; config?: string; check?: boolean },
+  context: Required<Pick<CliContext, 'cwd' | 'log' | 'logError'>> & CliContext
 ): Promise<number> => {
   const result = await runCodegen({
     rootDir: values.root ? resolveFrom(context.cwd, values.root) : context.cwd,
@@ -47,7 +48,22 @@ const codegenCommand = async (
       ? resolveFrom(context.cwd, values.config)
       : undefined,
     load: { loader: context.loader },
+    write: !values.check,
   });
+  // Under --check the lock on disk is the answer, and the command reports it instead
+  // of repairing it. The pipeline of the project never runs this bin (refer to the CLI
+  // rule in packages/v4/README.md), so this is how CI catches a config that changed
+  // without its lock.
+  if (values.check) {
+    if (result.outcome === 'unchanged') {
+      context.log(`${result.lockPath} is up to date`);
+      return 0;
+    }
+    context.logError(
+      `${result.lockPath} is out of date. Run \`tinacms codegen\` and commit the result.`
+    );
+    return 1;
+  }
   // A stale lock is written again, and does not fail the build, so this states the
   // reason. A change to the lock with no explanation in a commit hides the drift.
   if (result.warning) context.log(result.warning);
@@ -84,6 +100,7 @@ export const runCli = async (
       options: {
         root: { type: 'string' },
         config: { type: 'string' },
+        check: { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
       },
       allowPositionals: true,
@@ -98,7 +115,7 @@ export const runCli = async (
       log(USAGE);
       return 0;
     }
-    return await codegenCommand(values, { ...context, cwd, log });
+    return await codegenCommand(values, { ...context, cwd, log, logError });
   } catch (cause) {
     // A failure of the config or of the lock is a message for the developer, and not
     // a stack trace. Every throw on this path carries an explanation.

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
@@ -10,7 +10,6 @@
 // Vite server, so this mechanism stays.
 
 import path from 'node:path';
-import { createServer } from 'vite';
 import type { ResolvedConfig } from '../config';
 import { invariant } from '../core/invariant';
 
@@ -31,30 +30,51 @@ export interface LoadTinaConfigOptions {
   loader?: ModuleLoader;
 }
 
+// The fallback loader, reached only when the caller supplies no `loader` of its own. A
+// host that already has a module graph — a framework plugin, the `tinacms` bin, the
+// playground config — passes that graph in and never arrives here. Vite is therefore an
+// optional peer of the package and not a dependency, so a project that consumes only the
+// browser runtime does not install a build tool to get it. The import is dynamic to keep
+// that true: a static one puts Vite in the module graph of every importer of this file,
+// whatever they then do with it.
+const startLoadingServer = async (
+  configPath: string,
+  alias: LoadTinaConfigOptions['alias']
+) => {
+  const vite = await import('vite').catch(() => null);
+  // A missing optional peer otherwise surfaces as ERR_MODULE_NOT_FOUND against the
+  // string 'vite', which names neither the caller nor the two ways out of it.
+  invariant(
+    vite,
+    'config-loader-missing',
+    'Reading tina/config.ts needs Vite. Install vite as a dev dependency, or pass `loader` to use the module graph you already have.'
+  );
+  return vite.createServer({
+    // Ignore any vite.config in scope. This server resolves one module. The plugins
+    // of a project would run its whole dev pipeline. In a workspace, they would
+    // also return to the config that called this function.
+    configFile: false,
+    // Without this the server roots at process.cwd(), so a config loaded from
+    // anywhere else resolves its relative imports and tsconfig paths against the
+    // caller's directory rather than the project's.
+    root: path.dirname(configPath),
+    logLevel: 'warn',
+    // The `ws: false` option is necessary. In middleware mode, Vite has no HTTP
+    // server for the HMR socket. The `hmr: false` option alone does not stop that
+    // socket. Vite then binds its default port, 24678, on every interface. A load
+    // of one config file would claim a fixed global port, and two loads at the same
+    // time would race. Only `ws: false` stops createWebSocketServer.
+    server: { middlewareMode: true, hmr: false, ws: false, watch: null },
+    resolve: { alias: alias ?? [] },
+  });
+};
+
 export const loadTinaConfig = async (
   configPath: string,
   options: LoadTinaConfigOptions = {}
 ): Promise<ResolvedConfig> => {
   const server =
-    options.loader ??
-    (await createServer({
-      // Ignore any vite.config in scope. This server resolves one module. The plugins
-      // of a project would run its whole dev pipeline. In a workspace, they would
-      // also return to the config that called this function.
-      configFile: false,
-      // Without this the server roots at process.cwd(), so a config loaded from
-      // anywhere else resolves its relative imports and tsconfig paths against the
-      // caller's directory rather than the project's.
-      root: path.dirname(configPath),
-      logLevel: 'warn',
-      // The `ws: false` option is necessary. In middleware mode, Vite has no HTTP
-      // server for the HMR socket. The `hmr: false` option alone does not stop that
-      // socket. Vite then binds its default port, 24678, on every interface. A load
-      // of one config file would claim a fixed global port, and two loads at the same
-      // time would race. Only `ws: false` stops createWebSocketServer.
-      server: { middlewareMode: true, hmr: false, ws: false, watch: null },
-      resolve: { alias: options.alias ?? [] },
-    }));
+    options.loader ?? (await startLoadingServer(configPath, options.alias));
   try {
     const loaded = await server.ssrLoadModule(configPath);
     const config = loaded.default as ResolvedConfig | undefined;

--- a/packages/v4/README.md
+++ b/packages/v4/README.md
@@ -44,7 +44,7 @@ the publish rule for a package when a pull request changes that package.
 
 | Package | Path | Role | Build | Releases to |
 |---|---|---|---|---|
-| `@tinacms/tinacms` | `packages/v4/@tinacms/tinacms` | The v4 runtime. It supplies the universal entry and the subpath entries (`/react`, `/client`, `/server`, `/next`, `/express`, `/astro`, `/hono`). It also contains the CLI. The `tinacms` bin supplies the `init`, `dev`, `build`, and `codegen` commands. | Not decided. The alpha scaffold uses `src/*` directly through `exports`. ADR-001 specifies that the production build compiles to `dist/`. | npm `@tinacms/tinacms` |
+| `@tinacms/tinacms` | `packages/v4/@tinacms/tinacms` | The v4 runtime. It supplies the universal entry and the subpath entries (`/react`, `/client`, `/server`, `/next`, `/express`, `/astro`, `/hono`). It also contains the CLI. The `tinacms` bin supplies the `init` and `codegen` commands. It does not supply `dev` or `build`; refer to [The CLI stays out of the pipeline](#the-cli-stays-out-of-the-pipeline). | Not decided. The alpha scaffold uses `src/*` directly through `exports`. ADR-001 specifies that the production build compiles to `dist/`. | npm `@tinacms/tinacms` |
 | `@tinacms/app` | `packages/@tinacms/app` | The admin app bundle. `@tinacms/tinacms` uses it at build time and at development time. | `tinacms-scripts build` | npm `@tinacms/app` |
 | `@tinacms/auth` | `packages/@tinacms/auth` | Shared auth primitives. The core packages and TinaCloud use them. | `tinacms-scripts build` | npm `@tinacms/auth` |
 | `@tinacms/graphql` | `packages/@tinacms/graphql` | The GraphQL runtime. TinaCloud also uses it. | `tinacms-scripts build` | npm `@tinacms/graphql` |
@@ -64,6 +64,46 @@ list prevents a reviewer from moving them into this repository.
 | `mongodb-level` | https://github.com/tinacms/mongodb-level |
 | `sqlite-level` | https://github.com/tinacms/sqlite-level |
 | `upstash-redis-level` | https://github.com/tinacms/upstash-redis-level |
+
+## The CLI stays out of the pipeline
+
+v3 owns the pipeline of the project. `tinacms dev -c "next dev"` makes Tina the
+parent process of the framework, and `tinacms build && next build` makes Tina a
+build step. Thus a fault in Tina, or a build tool in Tina that does not agree
+with the one in the project, stops a build that has nothing to do with content.
+It is also the reason that `tinacms` and `@tinacms/cli` move together: two
+packages in one pipeline must agree at each release.
+
+v4 inverts that. The project owns its pipeline, and it calls Tina.
+
+**The rule: the `tinacms` bin only writes files into the repository that a person
+then commits. It does not wrap a process, it does not open a port, and it does
+not produce a build artifact.**
+
+The rule gives the commands that the bin can supply:
+
+| Command | What it writes | Allowed |
+|---|---|---|
+| `tinacms init` | `tina/config.ts`, the plugin registration, the admin route | Yes |
+| `tinacms codegen` | `tina/tina-lock.json` | Yes |
+| `tinacms codegen --check` | nothing; it exits 1 when the committed lock is stale | Yes |
+| `tinacms dev` | — | No. Run the dev server of the framework. The Vite plugin and the adapter do the rest. |
+| `tinacms build` | — | No. The lock is committed, so there is nothing to build. |
+
+Each capability therefore mounts into the server that the project already runs:
+
+- The local data layer is a Vite plugin that the project adds to its own config,
+  or an adapter route. `dispatchContentRequest` belongs to no transport, so a
+  host for another bundler is a small file.
+- The RPC handler is `(Request) => Promise<Response>`. The framework adapters
+  mount it as a route of the project.
+- The admin UI is a React component that the project renders on its own route.
+  It is not a bundle that a build step copies into `public/`.
+
+`tina-lock.json` is a committed file and not a build output (ADR-016). Thus CI
+and the deploy of a project never run the `tinacms` bin. `tinacms codegen
+--check` is available as a guard against drift, and it stays a check that a
+project opts into.
 
 ## Publish rules
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2760,9 +2760,6 @@ importers:
 
   packages/v4/@tinacms/tinacms:
     dependencies:
-      '@hookform/resolvers':
-        specifier: ^5.4.0
-        version: 5.5.7(@sinclair/typebox@0.34.41)(ajv@8.17.1)(react-hook-form@7.80.0(react@19.2.7))(typanion@3.13.0)(yup@1.7.1)(zod@3.25.76)
       '@tinacms/graphql':
         specifier: workspace:*
         version: link:../../../@tinacms/graphql
@@ -2772,9 +2769,6 @@ importers:
       '@tinacms/rich-text':
         specifier: workspace:*
         version: link:../rich-text
-      '@tinacms/schema-tools':
-        specifier: workspace:*
-        version: link:../../../@tinacms/schema-tools
       '@tinacms/ui':
         specifier: workspace:*
         version: link:../ui
@@ -2793,9 +2787,6 @@ importers:
       sqlite-level:
         specifier: 'catalog:'
         version: 2.1.0
-      vite:
-        specifier: ^5.4.0
-        version: 5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
       zod:
         specifier: 'catalog:'
         version: 3.25.76
@@ -2848,6 +2839,9 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
       vitest:
         specifier: ^2.1.9
         version: 2.1.9(@types/node@25.1.0)(happy-dom@15.10.2)(jsdom@15.2.1(bufferutil@4.1.0))(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)


### PR DESCRIPTION
**TLDR:** The bin only writes files a person commits — no dev, no build — and the four framework adapters do the serving instead.

**Feats:**
- `tinacms codegen --check` writes nothing and exits 1 on a stale lock, so CI guards drift without running the bin in the build
- Next, Astro and Hono adapters are pure wiring; Express converts node streams both ways
- Vite becomes an optional peer; react and react-dom become optional
- Unused dependencies dropped

**How to test:** The check mode is the new surface.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
- Run `node bin/tinacms.mjs codegen --check --root playground`.
- Confirm the exit code is 0.
