### PR TITLE
feat(v4): a field declares its own equality, and the form store asks it

### DIFF
--- a/packages/v4/@tinacms/tinacms/src/core/field/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/field/contract.ts
@@ -22,7 +22,8 @@ export interface FieldMetadata {
 // What the transform of a field knows about its document, beyond its own schema node.
 // The `documentPath` is the file that the value came from, and that it returns to. The
 // extension of that file names the storage format, which lets a collection hold more
-// than one format. The rich-text field selects its codec from it. Refer to mdx-codec.ts.
+// than one format. The rich-text field selects its codec from it. Refer to
+// rich-text-codecs.ts.
 // The path is absent when a transform runs outside a document, such as in a unit test.
 // The media paths will also read this when the media capability arrives.
 export interface FieldTransformContext {
@@ -56,4 +57,14 @@ export interface FieldDescriptor<TValue = unknown, TStored = unknown> {
     node: FieldSchema,
     context: FieldTransformContext
   ) => TStored;
+  // Whether two editor values would write the same thing to the document. The form store
+  // asks this to tell a real edit from a value that only looks new. A field whose value
+  // is the value the document holds needs no answer here, because the store compares
+  // those as structure. Refer to core/form/compare.ts for the case that does.
+  isEqual?: (
+    a: TValue,
+    b: TValue,
+    node: FieldSchema,
+    context: FieldTransformContext
+  ) => boolean;
 }

--- a/packages/v4/@tinacms/tinacms/src/core/form/compare.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/compare.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { toFieldAddress } from '../field/address';
+import type { FieldDescriptor } from '../field/contract';
+import type { FieldRegistry } from '../field/registry';
+import type { FieldSchema } from '../schema/types';
+import { fieldEqualityFor } from './compare';
+
+const title = toFieldAddress('title');
+const body = toFieldAddress('body');
+
+const fields: FieldSchema[] = [
+  { name: 'title', type: 'string' },
+  { name: 'body', type: 'rich-text' },
+];
+
+// A field whose editor value is richer than its stored form. `source` is what the
+// document holds, and `editorOnly` is what the editor added to it.
+const sourceOnly: FieldDescriptor = {
+  Component: () => null,
+  isEqual: (a, b) =>
+    (a as { source: string }).source === (b as { source: string }).source,
+};
+
+const registryWith = (descriptors: Record<string, FieldDescriptor>) =>
+  new Map(Object.entries(descriptors)) as FieldRegistry;
+
+describe('fieldEqualityFor', () => {
+  it('asks the descriptor of the field that declares one', () => {
+    const equal = fieldEqualityFor(
+      fields,
+      registryWith({ 'rich-text': sourceOnly })
+    );
+    expect(
+      equal(body, { source: 'Prose.', editorOnly: 1 }, { source: 'Prose.' })
+    ).toBe(true);
+    expect(equal(body, { source: 'Prose.' }, { source: 'Edited.' })).toBe(
+      false
+    );
+  });
+
+  it('compares every other field as structure', () => {
+    const equal = fieldEqualityFor(
+      fields,
+      registryWith({ 'rich-text': sourceOnly })
+    );
+    expect(equal(title, 'Hello', 'Hello')).toBe(true);
+    expect(equal(title, 'Hello', 'Goodbye')).toBe(false);
+    // The declared answer belongs to its own address, and to no other.
+    expect(equal(title, { source: 'x', editorOnly: 1 }, { source: 'x' })).toBe(
+      false
+    );
+  });
+
+  it('compares as structure when no field declares an equality', () => {
+    const equal = fieldEqualityFor(fields, registryWith({}));
+    expect(equal(body, { source: 'Prose.' }, { source: 'Prose.' })).toBe(true);
+    expect(
+      equal(body, { source: 'Prose.', editorOnly: 1 }, { source: 'Prose.' })
+    ).toBe(false);
+  });
+
+  it('answers an address that belongs to no field', () => {
+    const unknown = toFieldAddress('unknown');
+    const equal = fieldEqualityFor(
+      fields,
+      registryWith({ 'rich-text': sourceOnly })
+    );
+    expect(equal(unknown, 'same', 'same')).toBe(true);
+    expect(equal(unknown, 'same', 'other')).toBe(false);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/core/form/compare.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/compare.ts
@@ -1,0 +1,63 @@
+import { type FieldAddress, toFieldAddress } from '../field/address';
+import type { FieldTransformContext } from '../field/contract';
+import type { FieldRegistry } from '../field/registry';
+import type { FieldSchema } from '../schema/types';
+
+// Whether a form still holds the value it started with. The form store asks this to tell
+// a real edit from a value that only looks new (ADR-010).
+//
+// Most values are their own answer. A string field holds the string that the document
+// holds, so a compare of the two values is exact. A field whose editor value is richer
+// than its stored form is not: Plate rewrites the rich-text tree as it mounts, with an id
+// on every node and a trailing block, so the tree in the editor never matches the tree
+// parsed from the file. Compared as structure, a body that its author has typed and then
+// deleted again reports an edit for ever, and the badge never leaves "Unsaved". Such a
+// field answers for itself, through isEqual on its descriptor.
+
+// The RHF subscription sends a clone of each value, but markSaved keeps the original as
+// the baseline. A reference test therefore holds a structural value, such as the
+// rich-text tree, dirty for ever. The values are JSON documents, so this compares their
+// structure. A wrong result costs one more dirty read. It never loses an edit.
+export const sameValue = (a: unknown, b: unknown): boolean => {
+  if (Object.is(a, b)) return true;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+  if (a === null || b === null) return false;
+  return JSON.stringify(a) === JSON.stringify(b);
+};
+
+// The equality of one open form, address by address. The form store holds one of these
+// per form, so the store itself needs no field registry.
+export type FieldEquality = (
+  address: FieldAddress,
+  a: unknown,
+  b: unknown
+) => boolean;
+
+// The answer for a form whose fields all hold their own stored value. It is also the
+// answer for a caller with no registry, such as a test.
+export const STRUCTURAL_EQUALITY: FieldEquality = (_address, a, b) =>
+  sameValue(a, b);
+
+// The equality of a form, built from the descriptors of its fields. Each isEqual is bound
+// to its own schema node and to the document, because a field resolves its transforms
+// from both. The rich-text field selects its codec in that way.
+export const fieldEqualityFor = (
+  fields: FieldSchema[],
+  registry: FieldRegistry,
+  context: FieldTransformContext = {}
+): FieldEquality => {
+  const declared = new Map<FieldAddress, (a: unknown, b: unknown) => boolean>();
+  for (const node of fields) {
+    const isEqual = registry.get(node.type)?.isEqual;
+    if (isEqual) {
+      declared.set(toFieldAddress(node.name), (a, b) =>
+        isEqual(a, b, node, context)
+      );
+    }
+  }
+  if (declared.size === 0) return STRUCTURAL_EQUALITY;
+  // The structural test runs first. It answers every untouched field by reference, so
+  // the field that is being edited is the only one that pays for its own compare.
+  return (address, a, b) =>
+    sameValue(a, b) || (declared.get(address)?.(a, b) ?? false);
+};

--- a/packages/v4/@tinacms/tinacms/src/form/form-store.hooks.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/form/form-store.hooks.test.tsx
@@ -9,9 +9,10 @@ import {
   useIsFormDirty,
 } from './form-store';
 
-// The exported hooks are the store's public surface (re-exported from editor/index.ts).
-// The getState() tests prove the reducer logic; these prove the Zustand selector actually
-// subscribes and re-renders a consumer when the form's status changes.
+// The exported hooks are the public surface of the store, and editor/index.ts re-exports
+// them. The getState() tests cover the reducer logic. These tests prove that the Zustand
+// selector subscribes, and that a consumer renders again when the status of the form
+// changes.
 const title = toFieldAddress('title');
 const postA = toFormId('posts/a.mdx');
 

--- a/packages/v4/@tinacms/tinacms/src/form/form-store.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/form/form-store.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { toFieldAddress } from '../core/field/address';
+import { type FieldEquality, sameValue } from '../core/form/compare';
 import {
   type FormId,
   fieldDirty,
@@ -33,7 +34,7 @@ describe('form-store registration', () => {
   it('re-registering an edited form keeps in-progress edits', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
     store.getState().setFieldValue(postA, title, 'Edited');
-    // A remount re-registers with the original values — the live edit must survive.
+    // A remount registers the original values again. The live edit must survive that.
     store.getState().registerForm(postA, { [title]: 'Hello' });
     expect(store.getState().forms[postA].values[title]).toBe('Edited');
     expect(statusOf(postA)).toBe('dirty');
@@ -69,20 +70,39 @@ describe('form-store dirty tracking', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
     store.getState().setFieldValue(postA, subtitle, 'x');
     expect(statusOf(postA)).toBe('dirty');
-    // RHF emits undefined on clear; absent and undefined are one state (JSON can't
-    // represent "present but undefined"), so this must read clean.
+    // RHF emits undefined when a field clears. An absent key and an undefined value
+    // are one state, because JSON cannot hold "present but undefined". This must
+    // therefore read clean.
     store.getState().setFieldValue(postA, subtitle, undefined);
     expect(statusOf(postA)).toBe('clean');
   });
 
-  // Composite field values (object/list/rich-text) aren't supported yet; when they land,
-  // `valuesEqual`/`fieldDirty` must delegate equality to the field descriptor (each field
-  // type owns its comparison) so an edit-then-revert of an object field reads clean rather
-  // than permanently dirty, and setFieldValue's no-op guard doesn't drop an in-place-mutated
-  // value. See the notes on those functions.
-  it.todo(
-    'object/list values: edit-then-revert is clean, not permanently dirty'
-  );
+  // A composite value arrives as a fresh object on every edit, so a reference test
+  // holds it dirty for ever. The default equality compares structure, which is what
+  // makes the revert below read clean. Refer to sameValue in core/form/compare.ts.
+  it('an object value that is edited and reverted is clean, not dirty', () => {
+    const hero = toFieldAddress('hero');
+    store.getState().registerForm(postA, { [hero]: { heading: 'Hello' } });
+    store.getState().setFieldValue(postA, hero, { heading: 'Goodbye' });
+    expect(statusOf(postA)).toBe('dirty');
+    expect(fieldDirty(store.getState().forms[postA], hero)).toBe(true);
+
+    // A new object, equal to the baseline in structure alone.
+    store.getState().setFieldValue(postA, hero, { heading: 'Hello' });
+    expect(statusOf(postA)).toBe('clean');
+    expect(fieldDirty(store.getState().forms[postA], hero)).toBe(false);
+  });
+
+  it('a list value that is edited and reverted is clean, not dirty', () => {
+    const tags = toFieldAddress('tags');
+    store.getState().registerForm(postA, { [tags]: ['news', 'release'] });
+    store.getState().setFieldValue(postA, tags, ['news']);
+    expect(statusOf(postA)).toBe('dirty');
+
+    store.getState().setFieldValue(postA, tags, ['news', 'release']);
+    expect(statusOf(postA)).toBe('clean');
+    expect(fieldDirty(store.getState().forms[postA], tags)).toBe(false);
+  });
 });
 
 describe('form-store save reset', () => {
@@ -94,7 +114,7 @@ describe('form-store save reset', () => {
     store.getState().markSaved(postA);
     expect(statusOf(postA)).toBe('clean');
 
-    // Baseline moved to the saved value: returning to the original is now dirty.
+    // The baseline is the saved value, so a return to the original value is dirty.
     store.getState().setFieldValue(postA, title, 'Hello');
     expect(statusOf(postA)).toBe('dirty');
   });
@@ -104,8 +124,8 @@ describe('form-store save reset', () => {
     store.getState().setFieldValue(postA, title, 'Saved value');
     const snapshot = { ...store.getState().forms[postA].values };
 
-    // Edit typed while the save was in flight: baseline is the snapshot, not
-    // the current values, so the newer edit still diffs dirty.
+    // An edit typed during the save. The baseline is the snapshot, and not the
+    // current values, so the newer edit still reads dirty.
     store.getState().setFieldValue(postA, title, 'Newer edit');
     store.getState().markSaved(postA, snapshot);
     expect(statusOf(postA)).toBe('dirty');
@@ -116,10 +136,10 @@ describe('form-store save reset', () => {
   });
 });
 
-// The store is fed from RHF's formState subscription, which hands over a clone of
-// each value, while markSaved baselines the values RHF itself holds. Primitives
-// compare equal across that split; a structure never does by reference, so a saved
-// rich-text document stayed dirty forever until equality became structural.
+// The store reads the formState subscription of RHF, which sends a clone of each value,
+// but markSaved keeps the values that RHF holds as the baseline. Two primitives compare
+// equal across that split. Two structures never do by reference, so a saved rich-text
+// document stayed dirty for ever until the comparison became structural.
 describe('form-store structural value equality', () => {
   const body = toFieldAddress('body');
   const ast = () => ({
@@ -155,10 +175,70 @@ describe('form-store structural value equality', () => {
   });
 });
 
+// A field whose editor value is richer than its stored form answers for itself, through
+// isEqual on its descriptor (core/form/compare.ts). The rich-text field is the one that
+// does today: Plate adds an id to every node, so the tree in the editor never matches the
+// tree parsed from the file, and structure alone would hold such a document dirty for
+// ever. The equality here stands in for that, so this test needs no editor.
+describe('form-store field-supplied equality', () => {
+  const body = toFieldAddress('body');
+  type Body = { source: string; editorOnly: number };
+  const equal: FieldEquality = (address, a, b) =>
+    address === body
+      ? (a as Body | undefined)?.source === (b as Body | undefined)?.source
+      : sameValue(a, b);
+  const withSource = (source: string, editorOnly: number): Body => ({
+    source,
+    editorOnly,
+  });
+
+  it('a write the document would not see is not an edit', () => {
+    store
+      .getState()
+      .registerForm(postA, { [body]: withSource('Prose.', 0) }, equal);
+    store.getState().setFieldValue(postA, body, withSource('Prose.', 1));
+    expect(statusOf(postA)).toBe('pristine');
+  });
+
+  it('an edit that is undone returns the form to clean', () => {
+    store
+      .getState()
+      .registerForm(postA, { [body]: withSource('Prose.', 0) }, equal);
+    store.getState().setFieldValue(postA, body, withSource('Edited.', 1));
+    expect(statusOf(postA)).toBe('dirty');
+    expect(fieldDirty(store.getState().forms[postA], body)).toBe(true);
+
+    // What the editor gives back is never the tree it was given, so this undo carries
+    // its own noise. Only the field can tell that the document is back where it was.
+    store.getState().setFieldValue(postA, body, withSource('Prose.', 2));
+    expect(statusOf(postA)).toBe('clean');
+    expect(fieldDirty(store.getState().forms[postA], body)).toBe(false);
+  });
+
+  it('keeps the equality of the form across an edit and a save', () => {
+    store
+      .getState()
+      .registerForm(postA, { [body]: withSource('Prose.', 0) }, equal);
+    const edited = withSource('Edited.', 1);
+    store.getState().setFieldValue(postA, body, edited);
+    store.getState().markSaved(postA, { [body]: edited });
+    expect(statusOf(postA)).toBe('clean');
+
+    store.getState().setFieldValue(postA, body, withSource('Edited.', 2));
+    expect(statusOf(postA)).toBe('clean');
+  });
+
+  it('compares as structure when the form registers no equality', () => {
+    store.getState().registerForm(postA, { [body]: withSource('Prose.', 0) });
+    store.getState().setFieldValue(postA, body, withSource('Prose.', 1));
+    expect(statusOf(postA)).toBe('dirty');
+  });
+});
+
 describe('form-store error mirror', () => {
-  // `errors` exists only on an edited scope — a pristine form has never been
-  // validated, so the store gives it no error map at all rather than an empty
-  // one. Narrowing here asserts against the real shape.
+  // The `errors` map exists only on an edited scope. A pristine form has never been
+  // validated, so the store gives it no error map at all, and not an empty one. This
+  // narrowing asserts against the real shape.
   const scope = () => store.getState().forms[postA];
   const errorsOf = () => {
     const current = scope();
@@ -189,12 +269,13 @@ describe('form-store error mirror', () => {
     store.getState().setFieldErrors(postA, { [title]: ['Too short'] });
     const before = scope();
 
-    // Same content, fresh arrays — RHF rebuilds these per keystroke.
+    // The same content in new arrays. RHF builds these again at each keystroke.
     store.getState().setFieldErrors(postA, { [title]: ['Too short'] });
     expect(scope()).toBe(before);
 
-    // A differing write replaces errors but must keep the values reference:
-    // error mirroring must not read as a value change to the preview wire.
+    // A write that differs replaces the errors, and it must keep the values
+    // reference. An error write must not look like a value change to the preview
+    // wire.
     store.getState().setFieldErrors(postA, {});
     expect(scope().values).toBe(before.values);
   });
@@ -245,6 +326,69 @@ describe('form-store per-field dirty', () => {
   });
 });
 
+describe('form-store discarded edits', () => {
+  it('puts the form back on its baseline, and back to pristine', () => {
+    store.getState().registerForm(postA, { [title]: 'Hello' });
+    store.getState().setFieldValue(postA, title, 'Edited');
+    expect(statusOf(postA)).toBe('dirty');
+
+    store.getState().discardEdits(postA);
+    expect(store.getState().forms[postA].values[title]).toBe('Hello');
+    // Pristine, and not clean. A discarded form is the form a fresh load would give,
+    // so a remount adopts new content rather than keeping this one.
+    expect(statusOf(postA)).toBe('pristine');
+  });
+
+  it('discards back to the last save, and not to the loaded content', () => {
+    store.getState().registerForm(postA, { [title]: 'Hello' });
+    store.getState().setFieldValue(postA, title, 'Saved value');
+    store.getState().markSaved(postA);
+    store.getState().setFieldValue(postA, title, 'Later edit');
+
+    store.getState().discardEdits(postA);
+    expect(store.getState().forms[postA].values[title]).toBe('Saved value');
+  });
+
+  it('drops the mirrored errors with the edits that raised them', () => {
+    store.getState().registerForm(postA, { [title]: 'Hello' });
+    store.getState().setFieldValue(postA, title, 'x');
+    store.getState().setFieldErrors(postA, { [title]: ['Too short'] });
+
+    store.getState().discardEdits(postA);
+    expect(isEdited(store.getState().forms[postA])).toBe(false);
+  });
+
+  it('keeps the equality of the form, so the next edit compares the same way', () => {
+    const equal: FieldEquality = (_address, a, b) => sameValue(a, b);
+    store.getState().registerForm(postA, { [title]: 'Hello' }, equal);
+    store.getState().setFieldValue(postA, title, 'Edited');
+    store.getState().discardEdits(postA);
+    expect(store.getState().forms[postA].equal).toBe(equal);
+  });
+
+  it('leaves a pristine form and an unopened form alone', () => {
+    store.getState().registerForm(postA, { [title]: 'Hello' });
+    const pristine = store.getState().forms[postA];
+    store.getState().discardEdits(postA);
+    expect(store.getState().forms[postA]).toBe(pristine);
+
+    expect(() => store.getState().discardEdits(postB)).not.toThrow();
+    expect(store.getState().forms[postB]).toBeUndefined();
+  });
+
+  it('discards one form without touching another', () => {
+    store.getState().registerForm(postA, { [title]: 'A' });
+    store.getState().registerForm(postB, { [title]: 'B' });
+    store.getState().setFieldValue(postA, title, 'A edited');
+    store.getState().setFieldValue(postB, title, 'B edited');
+
+    store.getState().discardEdits(postA);
+    expect(statusOf(postA)).toBe('pristine');
+    expect(statusOf(postB)).toBe('dirty');
+    expect(store.getState().forms[postB].values[title]).toBe('B edited');
+  });
+});
+
 describe('form-store teardown', () => {
   it('removeForm drops the scope', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
@@ -280,7 +424,7 @@ describe('form-store reference stability', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
     const before = store.getState().forms[postA];
     store.getState().setFieldValue(postA, title, 'Hello');
-    // No churn: same scope object, still pristine.
+    // Nothing changed. The scope is the same object, and it is still pristine.
     expect(store.getState().forms[postA]).toBe(before);
     expect(statusOf(postA)).toBe('pristine');
   });

--- a/packages/v4/@tinacms/tinacms/src/form/form-store.ts
+++ b/packages/v4/@tinacms/tinacms/src/form/form-store.ts
@@ -3,6 +3,11 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import type { Brand } from '../core/brand';
 import { type FieldAddress, toFieldAddress } from '../core/field/address';
+import {
+  type FieldEquality,
+  STRUCTURAL_EQUALITY,
+  sameValue,
+} from '../core/form/compare';
 import { invariant } from '../core/invariant';
 import type { TinaDocument } from '../core/schema/types';
 
@@ -64,13 +69,21 @@ export type FieldErrors = Partial<Record<FieldAddress, string[]>>;
 // pristine form with a different baseline impossible to build.
 // The name is OpenForm, not FormScope. FormScope is the form context of the editor in
 // editor/context.ts.
+// The `equal` of a form arrives with it, from the host that registered it, because the
+// answer belongs to the fields and the store holds no field registry. Refer to
+// core/form/compare.ts.
 type OpenForm =
-  | { readonly status: 'pristine'; readonly values: FormValues }
+  | {
+      readonly status: 'pristine';
+      readonly values: FormValues;
+      readonly equal: FieldEquality;
+    }
   | {
       readonly status: 'edited';
       readonly values: FormValues;
       readonly baseline: FormValues;
       readonly errors: FieldErrors;
+      readonly equal: FieldEquality;
     };
 
 // The only place that compares the discriminant. Every consumer calls this instead.
@@ -90,7 +103,13 @@ export interface FormStore {
   // Seed a form with the values it loaded. A second call on an edited form does
   // nothing, so a return to the form keeps the unsaved edits (ADR-012). A second call
   // on a pristine form adopts the new content, so a reload is never stale.
-  registerForm: (formId: FormId, values: FormValues) => void;
+  // The `equal` is the equality of this form's fields, from fieldEqualityFor. Without
+  // it, every field of the form compares as structure.
+  registerForm: (
+    formId: FormId,
+    values: FormValues,
+    equal?: FieldEquality
+  ) => void;
   setFieldValue: (
     formId: FormId,
     address: FieldAddress,
@@ -105,25 +124,20 @@ export interface FormStore {
   // clean. The caller passes the snapshot it saved, so an edit made during the save
   // stays dirty. Without a snapshot, the current values become the baseline.
   markSaved: (formId: FormId, savedValues?: FormValues) => void;
+  // Throw the edits away and put the form back on its baseline: the content it loaded,
+  // or the content it last saved. The form becomes pristine, and its mirrored errors go
+  // with the edits that raised them, because this is the form a fresh load would give.
+  // The host resets RHF alongside it. Refer to discardEdits in editor/provider.tsx.
+  discardEdits: (formId: FormId) => void;
   // Close the form and drop its state.
   removeForm: (formId: FormId) => void;
 }
 
-// The RHF subscription sends a clone of each value, but markSaved keeps the original
-// as the baseline. A reference test therefore holds a structural value, such as the
-// rich-text tree, dirty for ever. The values are JSON documents, so this compares
-// their structure. A wrong result costs one more dirty read. It never loses an edit.
-// TODO: each field descriptor must compare its own values, next to its parse and
-// serialize functions. That needs the field registry in the store, which the store
-// does not have today.
-const sameValue = (a: unknown, b: unknown): boolean => {
-  if (Object.is(a, b)) return true;
-  if (typeof a !== 'object' || typeof b !== 'object') return false;
-  if (a === null || b === null) return false;
-  return JSON.stringify(a) === JSON.stringify(b);
-};
-
-const valuesEqual = (current: FormValues, baseline: FormValues): boolean => {
+const valuesEqual = (
+  current: FormValues,
+  baseline: FormValues,
+  equal: FieldEquality
+): boolean => {
   // Compare the union of both key sets, so an undefined value equals an absent key.
   // JSON cannot hold "present but undefined", and a controlled input clears to
   // undefined. The two are one state.
@@ -132,12 +146,14 @@ const valuesEqual = (current: FormValues, baseline: FormValues): boolean => {
     ...Object.keys(current),
     ...Object.keys(baseline),
   ]) as Set<FieldAddress>;
-  return [...keys].every((key) => sameValue(current[key], baseline[key]));
+  return [...keys].every((key) => equal(key, current[key], baseline[key]));
 };
 
 export const formStatus = (scope: OpenForm | undefined): FormStatus => {
   if (!isEdited(scope)) return 'pristine';
-  return valuesEqual(scope.values, scope.baseline) ? 'clean' : 'dirty';
+  return valuesEqual(scope.values, scope.baseline, scope.equal)
+    ? 'clean'
+    : 'dirty';
 };
 
 // The dirty test for one field, behind the exported useIsFieldDirty. It compares
@@ -147,7 +163,7 @@ export const fieldDirty = (
   address: FieldAddress
 ): boolean =>
   isEdited(scope)
-    ? !sameValue(scope.values[address], scope.baseline[address])
+    ? !scope.equal(address, scope.values[address], scope.baseline[address])
     : false;
 
 // RHF builds new message arrays each time it derives the errors. This compares their
@@ -170,6 +186,7 @@ const DEVTOOLS_ACTION = {
   setFieldErrors: 'form/setFieldErrors',
   setActive: 'form/setActive',
   markSaved: 'form/markSaved',
+  discardEdits: 'form/discardEdits',
   removeForm: 'form/removeForm',
 } as const;
 type DevtoolsActionLabel =
@@ -190,7 +207,7 @@ export const useFormStore = create<FormStore>()(
         forms: {},
         active: null,
 
-        registerForm: (formId, values) =>
+        registerForm: (formId, values, equal = STRUCTURAL_EQUALITY) =>
           apply((state) => {
             // TODO(v4): the edited state also covers a clean form, so a clean form
             // does not adopt new content on a reload. The draft slice will choose
@@ -199,7 +216,7 @@ export const useFormStore = create<FormStore>()(
             return {
               forms: {
                 ...state.forms,
-                [formId]: { status: 'pristine', values: { ...values } },
+                [formId]: { status: 'pristine', values: { ...values }, equal },
               },
             };
           }, DEVTOOLS_ACTION.register),
@@ -208,16 +225,22 @@ export const useFormStore = create<FormStore>()(
           apply((state) => {
             const scope = state.forms[formId];
             if (!scope) return state;
-            // A write of the current value does nothing, because a controlled input
-            // fires onChange again with the same value. A field must send a new
-            // value, and must not change a value in place. This test drops a value
-            // that was changed in place.
-            if (sameValue(scope.values[address], value)) return state;
+            // A write that the document would not see does nothing, because a
+            // controlled input fires onChange again with the same value, and Plate
+            // rewrites its tree on a click alone. A field must send a new value, and
+            // must not change a value in place. This test drops a value that was
+            // changed in place.
+            if (scope.equal(address, scope.values[address], value))
+              return state;
             // The first edit keeps the pristine values as the baseline.
             return {
               forms: {
                 ...state.forms,
                 [formId]: {
+                  // Spread, so a rebuild carries the `equal` of the form rather
+                  // than relisting it. A rebuild that forgot it would silently
+                  // compare every field of the form as structure.
+                  ...scope,
                   status: 'edited',
                   values: { ...scope.values, [address]: value },
                   baseline: isEdited(scope) ? scope.baseline : scope.values,
@@ -260,8 +283,8 @@ export const useFormStore = create<FormStore>()(
               forms: {
                 ...state.forms,
                 [formId]: {
+                  ...scope,
                   status: 'edited',
-                  values: scope.values,
                   baseline: savedValues ?? scope.values,
                   // A save changes no values, so it changes no errors.
                   errors: isEdited(scope) ? scope.errors : {},
@@ -269,6 +292,24 @@ export const useFormStore = create<FormStore>()(
               },
             };
           }, DEVTOOLS_ACTION.markSaved),
+
+        discardEdits: (formId) =>
+          apply((state) => {
+            const scope = state.forms[formId];
+            // A form with no edits has nothing to discard. That covers a pristine
+            // form, and a form that is not open at all.
+            if (!isEdited(scope)) return state;
+            return {
+              forms: {
+                ...state.forms,
+                [formId]: {
+                  status: 'pristine',
+                  values: scope.baseline,
+                  equal: scope.equal,
+                },
+              },
+            };
+          }, DEVTOOLS_ACTION.discardEdits),
 
         removeForm: (formId) =>
           apply((state) => {
@@ -285,6 +326,13 @@ export const useFormStore = create<FormStore>()(
   )
 );
 
+// A read of the store that does not subscribe, for the places that need the current
+// state and not a render on every change. Callers use this rather than
+// useFormStore.getState() when the read happens during a render: the hook is a value
+// there and not a call, which breaks the rules of React and makes the React Compiler
+// skip the whole component. At module scope it is a plain read.
+export const readFormStore = (): FormStore => useFormStore.getState();
+
 export const useFormStatus = (formId: FormId): FormStatus =>
   useFormStore((state) => formStatus(state.forms[formId]));
 
@@ -299,7 +347,8 @@ export const useIsFieldDirty = (
 // The live values of any open form, mounted or not. The chrome, the collection views,
 // and the panels read the mirror. They do not touch the RHF instance of the form. The
 // selector returns a stable reference to the values. The memo then gives the caller a
-// stable document for each real change.
+// stable document for each real change. This package ships its source, so a consumer
+// that holds the document in a dependency list sees this hook as written.
 export const useFormValues = (formId: FormId): TinaDocument | undefined => {
   const values = useFormStore((state) => state.forms[formId]?.values);
   return useMemo(() => (values ? toDocument(values) : undefined), [values]);


### PR DESCRIPTION
**TLDR:** The form store consults a per-field equality instead of reference identity, so a typed-and-deleted body reaches clean again.

**Feats:**
- core/form/compare.ts: sameValue structural test, FieldEquality per open form
- The field contract gains isEqual, bound to the schema node and the document context
- rich-text answers equality through its codec

**How to test:** The store tests pin the behaviour; the playground shows it.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
- Run `pnpm dev` and open a document.
- Type one character in the body, then delete it.
- Confirm the document shows no unsaved badge.
