### PR TITLE
feat(v4): datetime field plugin

### DIFF
--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.client.tsx
@@ -1,0 +1,19 @@
+import { defineClientPlugin } from '../../../client';
+import { datetimeSchema } from './datetime-field.schema';
+import { DatetimeField } from './datetime-field.ui';
+
+export default defineClientPlugin({
+  field: {
+    Component: DatetimeField,
+    // No defaultValue: empty stays `undefined`, so an untouched field writes nothing.
+    metadata: { layout: 'inline' },
+    schema: datetimeSchema,
+    // A YAML frontmatter date arrives as a Date (js-yaml parses an unquoted date).
+    // Everything else stays the string that the file holds, so an untouched document
+    // digests back unchanged.
+    parse: (stored) => {
+      if (stored instanceof Date) return stored.toISOString();
+      return stored == null ? undefined : String(stored);
+    },
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.plugin.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '../../../core/plugin';
+import { DATETIME_FIELD_TYPE } from './datetime-field.schema';
+
+export const datetimeFieldPlugin = definePlugin({
+  name: 'tina:field:datetime',
+  provides: ['field'],
+  field: { type: DATETIME_FIELD_TYPE, contractVersion: 1 },
+  client: () => import('./datetime-field.client'),
+});
+
+export default datetimeFieldPlugin;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.schema.ts
@@ -1,0 +1,39 @@
+import { type ZodType, z } from 'zod';
+import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
+
+export const DATETIME_FIELD_TYPE = 'datetime';
+
+export interface DatetimeFieldSchema extends BaseFieldSchema {
+  type: typeof DATETIME_FIELD_TYPE;
+}
+
+export const datetime = (
+  config: Omit<DatetimeFieldSchema, 'type'>
+): DatetimeFieldSchema => ({ ...config, type: DATETIME_FIELD_TYPE });
+
+const labelOf = (field: DatetimeFieldSchema): string =>
+  field.label ?? field.name;
+
+// The value is an ISO-shaped string, and the field does no zone math anywhere. A YAML
+// frontmatter date arrives as a Date, because js-yaml parses an unquoted date, so the
+// preprocess folds that case back to the string form before the checks.
+export const datetimeSchema = (node: FieldSchema): ZodType => {
+  const field = node as DatetimeFieldSchema;
+  const schema = z
+    .string({
+      required_error: `${labelOf(field)} is required`,
+      invalid_type_error: `${labelOf(field)} must be a date string`,
+    })
+    .refine(
+      (value) => !Number.isNaN(Date.parse(value)),
+      `${labelOf(field)} must be a valid date`
+    );
+  const toDateString = (value: unknown): unknown => {
+    if (value instanceof Date) return value.toISOString();
+    return value === '' || value == null ? undefined : value;
+  };
+  if (field.required) {
+    return z.preprocess(toDateString, schema);
+  }
+  return z.preprocess(toDateString, schema.optional());
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.test.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { asResolvedConfig } from '../../../config';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import type {
+  CollectionSchema,
+  TinaDocument,
+} from '../../../core/schema/types';
+import { validateField } from '../../../core/validation';
+import { Field, FormProvider, TinaProvider } from '../../../editor';
+import { t } from '../../../index';
+import datetimeFieldPlugin from './datetime-field.plugin';
+
+// These tests render a runtime directly, and not a configured app. They therefore pass
+// TinaProvider the resolved shape, and do not call defineConfig.
+const NO_COLLECTIONS = { collections: [] };
+
+const collection: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  format: 'mdx',
+  fields: [t.datetime({ name: 'published', label: 'Published' })],
+};
+
+const publishedNode = collection.fields[0];
+
+const requiredNode = t.datetime({
+  name: 'published',
+  label: 'Published',
+  required: true,
+});
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins([datetimeFieldPlugin]);
+
+const renderPublished = (document?: TinaDocument) =>
+  render(
+    <TinaProvider
+      config={asResolvedConfig({
+        plugins: [datetimeFieldPlugin],
+        schema: NO_COLLECTIONS,
+      })}
+    >
+      <FormProvider
+        collection={collection}
+        path='content/posts/published.mdx'
+        document={document}
+      >
+        <Field address='published' />
+      </FormProvider>
+    </TinaProvider>
+  );
+
+describe('DatetimeField rendering', () => {
+  it('renders a stored datetime clipped to what the native input accepts', async () => {
+    renderPublished({ published: '2024-05-01T09:30:00.000Z' });
+    const input = (await screen.findByLabelText(
+      'published'
+    )) as HTMLInputElement;
+    expect(input.value).toBe('2024-05-01T09:30');
+  });
+
+  it('renders a stored date with no time as midnight', async () => {
+    renderPublished({ published: '2024-05-01' });
+    const input = (await screen.findByLabelText(
+      'published'
+    )) as HTMLInputElement;
+    expect(input.value).toBe('2024-05-01T00:00');
+  });
+
+  it('renders empty when the value is absent', async () => {
+    renderPublished();
+    const input = (await screen.findByLabelText(
+      'published'
+    )) as HTMLInputElement;
+    expect(input.value).toBe('');
+  });
+});
+
+describe('DatetimeField value updates', () => {
+  it('writes the picked datetime back through the form store', async () => {
+    renderPublished({ published: '2024-05-01T09:30' });
+    const input = (await screen.findByLabelText(
+      'published'
+    )) as HTMLInputElement;
+
+    fireEvent.change(input, { target: { value: '2025-12-24T18:00' } });
+    expect(input.value).toBe('2025-12-24T18:00');
+  });
+});
+
+describe('DatetimeField validation', () => {
+  it('accepts an ISO datetime and a plain date', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('datetime');
+    expect(
+      validateField(publishedNode, descriptor, '2024-05-01T09:30')
+    ).toEqual([]);
+    expect(validateField(publishedNode, descriptor, '2024-05-01')).toEqual([]);
+  });
+
+  it('accepts a Date instance, the shape a YAML frontmatter date arrives in', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('datetime');
+    expect(
+      validateField(publishedNode, descriptor, new Date('2024-05-01T09:30:00Z'))
+    ).toEqual([]);
+  });
+
+  it('rejects a string that is not a date', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('datetime');
+    expect(
+      validateField(publishedNode, descriptor, 'not-a-date')
+    ).not.toEqual([]);
+  });
+
+  it('accepts an absent value as optional', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('datetime');
+    expect(validateField(publishedNode, descriptor, undefined)).toEqual([]);
+    expect(validateField(publishedNode, descriptor, null)).toEqual([]);
+    expect(validateField(publishedNode, descriptor, '')).toEqual([]);
+  });
+
+  it('rejects an absent value when the field is required', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('datetime');
+    expect(validateField(requiredNode, descriptor, undefined)).not.toEqual([]);
+    expect(validateField(requiredNode, descriptor, '')).not.toEqual([]);
+  });
+});
+
+describe('DatetimeField ingest and digest', () => {
+  it('round-trips a stored string unchanged', async () => {
+    const registry = await resolveRegistry();
+    for (const published of ['2024-05-01T09:30:00.000Z', '2024-05-01']) {
+      const ingested = ingestDocument(
+        { published },
+        collection.fields,
+        registry
+      );
+      expect(ingested).toEqual({ published });
+      expect(digestDocument(ingested, collection.fields, registry)).toEqual({
+        published,
+      });
+    }
+  });
+
+  it('ingests a YAML Date instance as its ISO string', async () => {
+    const registry = await resolveRegistry();
+    const ingested = ingestDocument(
+      { published: new Date('2024-05-01T09:30:00.000Z') },
+      collection.fields,
+      registry
+    );
+    expect(ingested).toEqual({ published: '2024-05-01T09:30:00.000Z' });
+  });
+
+  it('writes nothing for an absent value', async () => {
+    const registry = await resolveRegistry();
+    expect(ingestDocument({}, collection.fields, registry)).toEqual({});
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.ui.tsx
@@ -1,0 +1,45 @@
+import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
+import { Input } from '@tinacms/ui/components/input';
+import { useRef } from 'react';
+import {
+  useFieldActivation,
+  useFieldAddress,
+  useFieldErrors,
+  useFieldValue,
+} from '../../../editor';
+
+// The native input wants `YYYY-MM-DDTHH:mm` exactly. A stored value can be longer
+// (seconds, a zone) or shorter (a date with no time), and either shape would render
+// as an empty input. This normalises for display only. The stored value does not
+// change until the author edits.
+//
+// ponytail: no zone math — a stored `Z` time shows as wall clock. Convert to the
+// zone of the author when a team asks for it.
+const toInputValue = (stored: string | undefined): string => {
+  if (!stored) return '';
+  return stored.includes('T') ? stored.slice(0, 16) : `${stored}T00:00`;
+};
+
+export function DatetimeField() {
+  const address = useFieldAddress();
+  const [value, setValue] = useFieldValue<string | undefined>(address);
+  const errors = useFieldErrors(address);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useFieldActivation(() => inputRef.current?.focus());
+
+  return (
+    <FieldWrapper errors={errors}>
+      <Input
+        ref={inputRef}
+        type='datetime-local'
+        id={address}
+        aria-label={address}
+        value={toInputValue(value)}
+        onChange={(event) =>
+          setValue(event.target.value === '' ? undefined : event.target.value)
+        }
+      />
+    </FieldWrapper>
+  );
+}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -1,5 +1,7 @@
 import booleanFieldPlugin from './boolean/boolean-field.plugin';
 import { boolean } from './boolean/boolean-field.schema';
+import datetimeFieldPlugin from './datetime/datetime-field.plugin';
+import { datetime } from './datetime/datetime-field.schema';
 import numberFieldPlugin from './number/number-field.plugin';
 import { number } from './number/number-field.schema';
 import richTextFieldPlugin from './rich-text/rich-text-field.plugin';
@@ -7,24 +9,26 @@ import { richText } from './rich-text/rich-text-field.schema';
 import stringFieldPlugin from './string/string-field.plugin';
 import { string } from './string/string-field.schema';
 
-// The built-in field plugins TinaCMS ships. The "is this a core plugin" check
-// reads this list, not the plugin name.
+// The built-in field plugins of TinaCMS. The check for a core plugin reads this list,
+// and not the name of the plugin.
 export const corePlugins = [
   stringFieldPlugin,
   booleanFieldPlugin,
   numberFieldPlugin,
+  datetimeFieldPlugin,
   richTextFieldPlugin,
 ];
 
-// Schema-authoring helpers, one per built-in field. Kept explicit (rather than
-// derived in a loop) so `t.string` stays statically typed; co-located with
-// corePlugins so the built-in set lives in one place.
-// TODO: once defineConfig (ADR-024) lands, generate `t` from the configured plugin
-// set so user-registered field plugins join it (typed). This stays the built-in
+// The schema helpers, one for each built-in field. Each one is written out, and none is
+// derived in a loop, so `t.string` keeps its static type. They sit beside corePlugins, so
+// the built-in set is in one place.
+// TODO: build `t` from the configured plugin set when defineConfig arrives (ADR-024). A
+// field plugin from a user then joins it, with its types. This list is the built-in
 // default until then.
-export const t = { string, boolean, number, richText };
+export const t = { string, boolean, number, datetime, richText };
 
 export type { BooleanFieldSchema } from './boolean/boolean-field.schema';
+export type { DatetimeFieldSchema } from './datetime/datetime-field.schema';
 export type { NumberFieldSchema } from './number/number-field.schema';
 export type { RichTextFieldSchema } from './rich-text/rich-text-field.schema';
 export type { StringFieldSchema } from './string/string-field.schema';


### PR DESCRIPTION
**TLDR:** The datetime field plugin: ISO-string values with no zone math.

**Feats:**
- The schema/plugin/client/ui quartet, like the other primitive fields
- A YAML frontmatter Date folds back to its string form on parse and validate, so an untouched document digests back unchanged

**How to test:** The field suite covers parse, validate and render.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
