### PR TITLE
feat(v4): plugins contribute admin screens

### DIFF
--- a/packages/v4/@tinacms/tinacms/src/admin/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/hooks.ts
@@ -1,6 +1,8 @@
-import { use } from 'react';
+import { use, useMemo } from 'react';
 import type { TinaSchema } from '../config';
 import { invariant } from '../core/invariant';
+import type { AdminScreen } from '../core/screen/contract';
+import { screenList } from '../core/screen/registry';
 import { TinaRuntimeContext } from '../editor/context';
 
 // The content model that the admin navigates, as defineConfig declared it. It is config
@@ -14,4 +16,21 @@ export function useTinaSchema(): TinaSchema {
     'useTinaSchema must be used within a TinaProvider'
   );
   return runtime.schema;
+}
+
+// The screens the plugins registered, in navigation order. Like the schema, this is
+// config composed at boot and not state, so it comes off the runtime rather than the
+// store (core/screen/registry.ts).
+export function useAdminScreens(): AdminScreen[] {
+  const runtime = use(TinaRuntimeContext);
+  invariant(
+    runtime,
+    'admin-screens-outside-provider',
+    'useAdminScreens must be used within a TinaProvider'
+  );
+  // The registry never changes after boot, so this array is sorted once per runtime and
+  // callers can use it as a dependency. The memo stays by hand: the React Compiler
+  // leaves a hook that returns a call result straight out unmemoised, so without it
+  // every render sorts a new array and every caller depending on it invalidates.
+  return useMemo(() => screenList(runtime.screens), [runtime.screens]);
 }

--- a/packages/v4/@tinacms/tinacms/src/admin/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/index.ts
@@ -2,8 +2,9 @@
 // a host mounts inside a TinaProvider. Everything it renders comes from the compiled
 // schema, so a host writes no code for a collection.
 
+export type { AdminScreen, AdminScreenProps } from '../core/screen/contract';
 export { TinaAdmin, type TinaAdminProps } from './admin';
-export { useTinaSchema } from './hooks';
+export { useAdminScreens, useTinaSchema } from './hooks';
 export {
   type AdminRoute,
   COLLECTIONS_ROUTE,

--- a/packages/v4/@tinacms/tinacms/src/admin/routing.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/routing.test.ts
@@ -11,6 +11,8 @@ describe('admin routing', () => {
     { view: 'collections' },
     { view: 'collection', collection: 'post' },
     { view: 'document', collection: 'post', path: 'content/posts/hello.mdx' },
+    { view: 'screen', screen: 'media', segments: [] },
+    { view: 'screen', screen: 'media', segments: ['photos', '2026'] },
   ];
 
   it.each(routes)('round-trips $view', (route) => {
@@ -50,6 +52,46 @@ describe('admin routing', () => {
       view: 'collection',
       collection: 'post',
     });
+  });
+});
+
+describe('admin routing for plugin screens', () => {
+  it('mounts a screen under its own prefix', () => {
+    expect(
+      formatAdminRoute({ view: 'screen', screen: 'media', segments: [] })
+    ).toBe('#/screens/media');
+  });
+
+  // The two prefixes are separate namespaces. A project with a collection called `page`
+  // is the case that named this prefix `screens` rather than `pages`.
+  it('does not confuse a screen with a collection of the same name', () => {
+    expect(parseAdminRoute('#/screens/page')).toEqual({
+      view: 'screen',
+      screen: 'page',
+      segments: [],
+    });
+    expect(parseAdminRoute('#/collections/page')).toEqual({
+      view: 'collection',
+      collection: 'page',
+    });
+  });
+
+  // Each segment is encoded on its own, so a segment holding a slash stays one segment.
+  it('keeps a screen segment whole when it holds a slash', () => {
+    const route: AdminRoute = {
+      view: 'screen',
+      screen: 'media',
+      segments: ['uploads/2026', 'a b & c'],
+    };
+    expect(formatAdminRoute(route)).toBe(
+      '#/screens/media/uploads%2F2026/a%20b%20%26%20c'
+    );
+    expect(parseAdminRoute(formatAdminRoute(route))).toEqual(route);
+  });
+
+  // A screen prefix with no name is not a screen. It falls back like any stale hash.
+  it.each(['#/screens', '#/screens/'])('falls back for %j', (hash) => {
+    expect(parseAdminRoute(hash)).toEqual(COLLECTIONS_ROUTE);
   });
 });
 

--- a/packages/v4/@tinacms/tinacms/src/admin/routing.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/routing.ts
@@ -7,12 +7,27 @@
 // simpler, and wrong. A reload would return the editor to the collection list, and a
 // link to a document would not work for anyone else.
 
+// The `screen` case is the open half of this grammar. The first three views are the
+// content model, which the schema generates and the shell renders. A `screen` is a view
+// a plugin registered (core/screen/contract.ts), and the shell routes to it without
+// knowing what it is. Its trailing `segments` belong to the screen, so a screen can
+// navigate within itself and still be linkable.
 export type AdminRoute =
   | { view: 'collections' }
   | { view: 'collection'; collection: string }
-  | { view: 'document'; collection: string; path: string };
+  | { view: 'document'; collection: string; path: string }
+  | { view: 'screen'; screen: string; segments: string[] };
 
 export const COLLECTIONS_ROUTE: AdminRoute = { view: 'collections' };
+
+// The two route prefixes. `collections` is the content model, `screens` is the plugin
+// views. They are separate namespaces, so a screen and a collection may share a name.
+//
+// `screens` and not `pages`: a project can have a collection called `page` — the
+// kitchen-sink schema does — and `#/pages/media` sitting beside `#/collections/page`
+// reads as though one is a case of the other. They are unrelated.
+const COLLECTIONS_PREFIX = 'collections';
+const SCREENS_PREFIX = 'screens';
 
 // The id of a document is a path that holds slashes, for example
 // `content/posts/hello.mdx`. It is therefore encoded as one segment, and not spread
@@ -20,9 +35,16 @@ export const COLLECTIONS_ROUTE: AdminRoute = { view: 'collections' };
 // one separator.
 export const formatAdminRoute = (route: AdminRoute): string => {
   if (route.view === 'collections') return '#/';
+  if (route.view === 'screen') {
+    // Each segment is encoded on its own, so a segment holding a slash stays one
+    // segment. The screen owns what they mean.
+    const parts = [route.screen, ...route.segments].map(encodeURIComponent);
+    return `#/${SCREENS_PREFIX}/${parts.join('/')}`;
+  }
   const collection = encodeURIComponent(route.collection);
-  if (route.view === 'collection') return `#/collections/${collection}`;
-  return `#/collections/${collection}/${encodeURIComponent(route.path)}`;
+  if (route.view === 'collection')
+    return `#/${COLLECTIONS_PREFIX}/${collection}`;
+  return `#/${COLLECTIONS_PREFIX}/${collection}/${encodeURIComponent(route.path)}`;
 };
 
 // decodeURIComponent throws a URIError on a malformed escape such as `100%`. This runs
@@ -40,11 +62,17 @@ export const parseAdminRoute = (hash: string): AdminRoute => {
   const raw = hash.replace(/^#\/?/, '').split('/').filter(Boolean);
   const decoded = raw.map(decodeSegment);
   if (decoded.some((segment) => segment === null)) return COLLECTIONS_ROUTE;
-  const segments = decoded as string[];
-  const [prefix, collection, path] = segments;
+  const [prefix, head, ...rest] = decoded as string[];
   // An unknown route goes to the collection list, and not to an error page. A stale
   // hash, or one typed by hand, is a navigation mistake and not a fault.
-  if (prefix !== 'collections' || !collection) return COLLECTIONS_ROUTE;
-  if (!path) return { view: 'collection', collection };
-  return { view: 'document', collection, path };
+  if (!head) return COLLECTIONS_ROUTE;
+  // A screen whose name is not registered still parses. The shell reports that, the
+  // same way it reports a collection outside the schema — the route is well-formed, and
+  // it names something that is not there.
+  if (prefix === SCREENS_PREFIX)
+    return { view: 'screen', screen: head, segments: rest };
+  if (prefix !== COLLECTIONS_PREFIX) return COLLECTIONS_ROUTE;
+  const [path] = rest;
+  if (!path) return { view: 'collection', collection: head };
+  return { view: 'document', collection: head, path };
 };

--- a/packages/v4/@tinacms/tinacms/src/admin/use-admin-route.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/use-admin-route.ts
@@ -1,4 +1,4 @@
-import { useCallback, useSyncExternalStore } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 import { type AdminRoute, formatAdminRoute, parseAdminRoute } from './routing';
 
 // The `location.hash` value is external state that React does not own. The back button
@@ -15,6 +15,13 @@ const readHash = () => window.location.hash;
 // what the admin shows before hydration.
 const readHashOnServer = () => '';
 
+// This assigns the hash, and does not call pushState. The assignment makes the history
+// entry that the back button needs, and it fires hashchange. There is then one path in
+// and one path out.
+const navigate = (route: AdminRoute) => {
+  window.location.hash = formatAdminRoute(route);
+};
+
 export interface AdminNavigation {
   route: AdminRoute;
   navigate: (route: AdminRoute) => void;
@@ -22,11 +29,9 @@ export interface AdminNavigation {
 
 export const useAdminRoute = (): AdminNavigation => {
   const hash = useSyncExternalStore(subscribe, readHash, readHashOnServer);
-  const navigate = useCallback((route: AdminRoute) => {
-    // This assigns the hash, and does not call pushState. The assignment makes the
-    // history entry that the back button needs, and it fires hashchange. There is then
-    // one path in and one path out.
-    window.location.hash = formatAdminRoute(route);
-  }, []);
-  return { route: parseAdminRoute(hash), navigate };
+  // Held against the hash, and not rebuilt each render. This is a public hook, and
+  // parseAdminRoute returns a fresh object with a fresh `segments` array — so a
+  // consumer with `[route]` or `[segments]` in its dependencies would loop.
+  const route = useMemo(() => parseAdminRoute(hash), [hash]);
+  return { route, navigate };
 };

--- a/packages/v4/@tinacms/tinacms/src/core/overridable-registry.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/overridable-registry.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { composeOverridableRegistry } from './overridable-registry';
 
-// A conflict factory that encodes kind:key so a test can assert which conflict fired.
+// A conflict factory that writes the kind and the key, so a test can assert which
+// conflict happened.
 const conflict = (kind: string, key: string) => new Error(`${kind}:${key}`);
 
 const base = (key: string, value: string) => ({
@@ -49,8 +50,8 @@ describe('composeOverridableRegistry', () => {
   });
 
   it('an override does not mask a base-vs-base collision', () => {
-    // Two different plugins both provide a base at "a" and a third overrides it: the
-    // override winning its key must not hide that the two bases genuinely collide.
+    // Two plugins both provide a base at "a", and a third one overrides it. The
+    // override wins its key, and it must not hide the collision between the two bases.
     expect(() =>
       composeOverridableRegistry(
         [base('a', '1'), override('a', 'over'), base('a', '2')],

--- a/packages/v4/@tinacms/tinacms/src/core/plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/plugin.ts
@@ -1,7 +1,7 @@
 import type { StoreApi } from 'zustand';
 import type { FieldDescriptor } from './field/contract';
 import { invariant } from './invariant';
-import type { AdminPage } from './page/contract';
+import type { AdminScreen } from './screen/contract';
 
 export type Capability = 'field' | 'content' | 'auth' | 'media' | 'search';
 
@@ -96,10 +96,10 @@ export interface ClientSegment {
   field?: FieldDescriptor;
   slice?: ClientSlice;
   // Screens this plugin adds to the admin, beside the collection views the schema
-  // generates. They compose into the page registry at boot. Refer to core/page/registry.
-  // A plugin declares no capability for these: a page is a contribution, and not a slot
-  // that one provider fills.
-  pages?: AdminPage[];
+  // generates. They compose into the screen registry at boot. Refer to
+  // core/screen/registry. A plugin declares no capability for these: a screen is a
+  // contribution, and not a slot that one provider fills.
+  screens?: AdminScreen[];
 }
 
 // One operation in a server segment (ADR-007). The whole contract is a flat record of

--- a/packages/v4/@tinacms/tinacms/src/core/resolve.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/resolve.ts
@@ -159,7 +159,15 @@ export const initializePlugins = async (
       await plugin.onInit?.();
       initialized.push(plugin);
     } catch (cause) {
-      await destroyInitialized().catch(() => {});
+      // The rollback failure must not replace the failure that caused it, but it must
+      // not vanish either: a half-torn-down plugin can leave a handle open, and the
+      // thrown `cause` says nothing about that.
+      await destroyInitialized().catch((rollbackFailure) => {
+        console.error(
+          '[tinacms] Plugin teardown failed while rolling back a failed init:',
+          rollbackFailure
+        );
+      });
       throw cause;
     }
   }

--- a/packages/v4/@tinacms/tinacms/src/core/screen/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/screen/contract.ts
@@ -1,0 +1,42 @@
+// A screen a plugin adds to the admin, beside the collection views the schema generates.
+//
+// The admin shell renders exactly one thing: the content model. A media library, a
+// branch view, a settings screen, and a search result are none of them a collection, and
+// nothing in the shell should have to name them. A plugin contributes one of these and
+// the shell routes to it, lists it in the navigation, and otherwise knows nothing about
+// it.
+//
+// A screen is not a UI slot (ADR-013). A slot is fan-in: many plugins stack chrome into
+// one named region, and the hard question is ordering. A screen is the inverse — one
+// component owns one route, and two plugins claiming one name is a collision to report.
+// That is the cardinality of a keyed capability, which is why the screen registry
+// composes through composeOverridableRegistry and a slot registry will not.
+
+import type { ComponentType } from 'react';
+
+export interface AdminScreenProps {
+  // The route segments after the screen name. `#/screens/media/photos/2026` gives
+  // `['photos', '2026']`. A screen with one view ignores this; a screen that navigates
+  // within itself reads it, and calls `navigate` from useAdminRoute to write it. The
+  // segments are decoded, so a segment may hold a slash.
+  segments: string[];
+}
+
+export interface AdminScreen {
+  // The route key, and the segment this screen mounts at under `#/screens/`. It must be
+  // a single segment: no slashes, because the segments after it belong to the screen.
+  name: string;
+  // The navigation entry.
+  label: string;
+  // Where this sits in the navigation, low to high. Explicit, because the order two
+  // plugins appear in must not depend on the order they were installed (ADR-006, and
+  // ADR-013 §6 for the same rule applied to slots). Screens that share an order — which
+  // is every screen that declares none — sort by name, so the arrangement is the same
+  // whichever way the plugin list is written.
+  order?: number;
+  component: ComponentType<AdminScreenProps>;
+}
+
+// The order of a screen that declares none. Zero and not Infinity, so a plugin can sit a
+// screen above the default set with a negative number as well as below it.
+export const DEFAULT_SCREEN_ORDER = 0;

--- a/packages/v4/@tinacms/tinacms/src/core/screen/registry.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/screen/registry.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { type ResolvedSegment, definePlugin } from '../plugin';
+import type { AdminScreen } from './contract';
+import { createScreenRegistry, screenList } from './registry';
+
+const View = () => null;
+
+const screen = (
+  name: string,
+  extra: Partial<AdminScreen> = {}
+): AdminScreen => ({
+  name,
+  label: name,
+  component: View,
+  ...extra,
+});
+
+const segmentOf = (name: string, screens: AdminScreen[]): ResolvedSegment => ({
+  manifest: definePlugin({ name }),
+  segment: { screens },
+});
+
+const labelsOf = (resolved: ResolvedSegment[]) =>
+  screenList(createScreenRegistry(resolved)).map((entry) => entry.label);
+
+describe('admin screen registry', () => {
+  it('composes the screens of every plugin', () => {
+    const registry = createScreenRegistry([
+      segmentOf('media-plugin', [screen('media')]),
+      segmentOf('search-plugin', [screen('search')]),
+    ]);
+    expect([...registry.keys()]).toEqual(['media', 'search']);
+  });
+
+  it('takes more than one screen from a single plugin', () => {
+    const registry = createScreenRegistry([
+      segmentOf('workflow', [screen('branches'), screen('pull-requests')]),
+    ]);
+    expect([...registry.keys()]).toEqual(['branches', 'pull-requests']);
+  });
+
+  it('ignores a plugin that contributes no screen', () => {
+    expect(
+      createScreenRegistry([
+        { manifest: definePlugin({ name: 'bare' }), segment: {} },
+      ]).size
+    ).toBe(0);
+  });
+
+  // Both would mount at the same hash, and there is no `overrides` for a screen to say
+  // which one wins.
+  it('rejects two plugins claiming one screen name', () => {
+    expect(() =>
+      createScreenRegistry([
+        segmentOf('first', [screen('media')]),
+        segmentOf('second', [screen('media')]),
+      ])
+    ).toThrow(/both contribute an admin screen named "media"/);
+  });
+
+  // A name holding a slash parses as a screen name plus a segment, so the screen would
+  // never match its own route. Caught at boot, and not as a dead navigation entry.
+  it('rejects a screen name that holds a slash', () => {
+    expect(() =>
+      createScreenRegistry([
+        segmentOf('media-plugin', [screen('media/photos')]),
+      ])
+    ).toThrow(/admin-screen-name-has-slash/);
+  });
+
+  it('rejects an empty screen name', () => {
+    expect(() =>
+      createScreenRegistry([segmentOf('media-plugin', [screen('')])])
+    ).toThrow(/admin-screen-no-name/);
+  });
+});
+
+describe('screen navigation order', () => {
+  it('sorts by the declared order, low to high', () => {
+    expect(
+      labelsOf([
+        segmentOf('a', [screen('third', { label: 'Third', order: 30 })]),
+        segmentOf('b', [screen('first', { label: 'First', order: 10 })]),
+        segmentOf('c', [screen('second', { label: 'Second', order: 20 })]),
+      ])
+    ).toEqual(['First', 'Second', 'Third']);
+  });
+
+  // The whole point of an explicit order: which plugin was installed first must not
+  // decide what the editor sees (ADR-006).
+  it('gives the same order whichever way the plugin list is written', () => {
+    const media = segmentOf('media-plugin', [
+      screen('media', { label: 'Media' }),
+    ]);
+    const search = segmentOf('search-plugin', [
+      screen('search', { label: 'Search' }),
+    ]);
+    expect(labelsOf([media, search])).toEqual(labelsOf([search, media]));
+  });
+
+  it('breaks a tie by name, and not by registration', () => {
+    expect(
+      labelsOf([
+        segmentOf('z-plugin', [screen('zebra', { label: 'Zebra' })]),
+        segmentOf('a-plugin', [screen('apple', { label: 'Apple' })]),
+      ])
+    ).toEqual(['Apple', 'Zebra']);
+  });
+
+  // Zero is the default, so a negative order sits a screen above the undeclared ones.
+  it('lets a negative order sit above the default', () => {
+    expect(
+      labelsOf([
+        segmentOf('a', [screen('media', { label: 'Media' })]),
+        segmentOf('b', [screen('home', { label: 'Home', order: -10 })]),
+      ])
+    ).toEqual(['Home', 'Media']);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/core/screen/registry.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/screen/registry.ts
@@ -1,0 +1,74 @@
+// The admin screens, composed at boot from the client segments of the plugins.
+//
+// This is a registry and not a store slice, for the reason the field registry is one
+// (refer to TinaRuntime in editor/context.ts): it is a fixed map of React components,
+// which is config and not state. It is decided at boot from the plugin list, nothing
+// mutates it afterwards, and the devtools could not serialize a component. What *is*
+// state — which screen is open — lives in the route, where a reload and a shared link
+// both keep it.
+
+import { invariant } from '../invariant';
+import {
+  REGISTRY_CONFLICTS,
+  type RegistryConflict,
+  composeOverridableRegistry,
+} from '../overridable-registry';
+import type { ResolvedSegment } from '../plugin';
+import { type AdminScreen, DEFAULT_SCREEN_ORDER } from './contract';
+
+export type ScreenRegistry = Map<string, AdminScreen>;
+
+const screenConflictError = (_conflict: RegistryConflict, key: string): Error =>
+  new Error(
+    `Two plugins both contribute an admin screen named "${key}", so both would mount ` +
+      `at \`#/screens/${key}\`. Rename one of them.`
+  );
+
+// The name is a route segment, so the router has to be able to give it back. A name
+// holding a slash would parse as a screen name plus a segment, and the screen would
+// never match its own route. Caught at boot, where the author can act on it, and not as
+// a navigation entry that leads to a blank view.
+const validateScreenName = (pluginName: string, screen: AdminScreen): void => {
+  invariant(
+    screen.name.length > 0,
+    'admin-screen-no-name',
+    `Plugin "${pluginName}" contributes an admin screen with an empty name.`
+  );
+  invariant(
+    !screen.name.includes('/'),
+    'admin-screen-name-has-slash',
+    `Plugin "${pluginName}" contributes the admin screen "${screen.name}", but a ` +
+      'screen name is one route segment and cannot hold a slash.'
+  );
+};
+
+export const createScreenRegistry = (
+  resolved: ResolvedSegment[]
+): ScreenRegistry =>
+  composeOverridableRegistry(
+    resolved.flatMap(({ manifest, segment }) =>
+      (segment.screens ?? []).map((screen) => {
+        validateScreenName(manifest.name, screen);
+        // No screen takes an override. `overrides` replaces a *capability* provider,
+        // and a screen is not one — two plugins wanting the same screen name is a
+        // collision to report, not one to resolve silently in favour of whoever
+        // declared it.
+        return { key: screen.name, value: screen, isOverride: false };
+      })
+    ),
+    screenConflictError
+  );
+
+// The screens in navigation order: by `order`, then by name.
+//
+// Never in registration order. That is the order the plugins happen to be listed in, so
+// moving one line in a config array would reshuffle the navigation — the "load order
+// never silently decides" rule of ADR-006. Sorting the ties by name instead makes the
+// arrangement a property of the screens themselves.
+export const screenList = (registry: ScreenRegistry): AdminScreen[] =>
+  [...registry.values()].sort((left, right) => {
+    const byOrder =
+      (left.order ?? DEFAULT_SCREEN_ORDER) -
+      (right.order ?? DEFAULT_SCREEN_ORDER);
+    return byOrder !== 0 ? byOrder : left.name.localeCompare(right.name);
+  });

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -17,6 +17,7 @@ export {
   type TinaLock,
 } from './codegen/compile-schema';
 export {
+  defineCollection,
   defineConfig,
   type ResolvedConfig,
   type TinaConfig,
@@ -27,6 +28,7 @@ export type {
   ContentSlice,
   DocumentEntry,
 } from './core/content/contract';
+export type { AdminScreen, AdminScreenProps } from './core/screen/contract';
 export {
   type Capability,
   definePlugin,
@@ -42,6 +44,7 @@ export { localContentPlugin } from './plugins/content/local/local-content.plugin
 export { corePlugins, t } from './plugins/fields';
 export type {
   BooleanFieldSchema,
+  DatetimeFieldSchema,
   NumberFieldSchema,
   RichTextFieldSchema,
   StringFieldSchema,


### PR DESCRIPTION
**TLDR:** A plugin can contribute an admin screen, and the route grammar gives each screen its own namespace.

**Feats:**
- AdminScreen contract and a keyed registry, ordered explicitly (ADR-006)
- The route grammar gains #/screens/<name>/<segments...>, apart from collections
- useAdminScreens serves the sorted list; the universal entry exports the contract

**How to test:** The routing and registry tests cover it.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
