### PR TITLE
feat(v4): content reads through a React Query cache

### DIFF
--- a/packages/v4/@tinacms/tinacms/src/admin/document-scope.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/document-scope.tsx
@@ -6,6 +6,12 @@
 // main pane, not the sidebar. Scoping the form to the sidebar put the preview outside
 // it, which is a runtime throw with no type to catch it. Anything else the shell grows
 // that reads the open document (a toolbar, a document-actions menu) lands the same way.
+//
+// With nothing open, or with the entry still loading, it renders `children` bare. That
+// swap changes the element type at this position, so React unmounts and rebuilds what
+// sits below — the two document panes, including the preview iframe. It is confined to
+// those panes on purpose: the sidebar and its document list sit above this scope and
+// keep their open state, their fetch, and their scroll position across a switch.
 
 import { type ReactNode, useEffect, useRef } from 'react';
 import type { DocumentEntry } from '../core/content/contract';
@@ -52,18 +58,34 @@ export function DocumentScope({
   path,
   children,
 }: DocumentScopeProps) {
-  const content = useContentSlice();
-  // From the same list the sidebar renders, not a second fetch: two reads of one
-  // document can disagree, and the form would seed from the loser.
-  const cached = useCollectionDocuments(collection.name).find(
-    (candidate) => candidate.path === path
-  );
-  // Pinned for the life of this scope. A save feeds the persisted entry back into
-  // that cache, which has to keep the list badges fresh WITHOUT re-seeding the
-  // mounted form: a fresh `document` prop re-ingests and resets RHF, dropping both
-  // the saved-clean baseline and any keystroke typed while the save was in flight.
-  // Switching documents remounts on the `key` below, so the pin never goes stale.
-  const entry = useMemo(() => cached, [cached?.path]);
+  // This reads the list that the sidebar renders, and shares its request — it does not
+  // fetch again. Two reads of one document can disagree, and the form would then seed
+  // from the older one.
+  const { documents } = useCollectionDocuments(collection?.name);
+  const cached = documents.find((candidate) => candidate.path === path);
+  const entry = usePinnedDocument(path, cached);
+
+  // The save handler is stable, so FormProvider's formScope memo holds. Rebuilt each
+  // render it changed on every content-slice update, which defeated the memo and the
+  // "changes only on a document switch" contract in editor/context.ts.
+  const { save: saveDocument } = useSaveDocument();
+  // The open document travels as one value, because only a collection and a path
+  // together name one. Either alone is not half a document, it is no document.
+  const openDocument = (): { collection: string; path: string } | null =>
+    collection && path ? { collection: collection.name, path } : null;
+  const saveRef = useRef({ target: openDocument(), saveDocument });
+  // Written after the commit, and not during the render. `save` is permanently stable
+  // and reads this when the author invokes it, which is always after a commit — so a
+  // render React starts and then throws away must not leave this pointing at that
+  // render's document.
+  useEffect(() => {
+    saveRef.current = { target: openDocument(), saveDocument };
+  });
+  const save = useRef(async (value: TinaDocument) => {
+    const { target, saveDocument: latestSave } = saveRef.current;
+    if (!target) return;
+    await latestSave({ ...target, value });
+  }).current;
 
   // Nothing open: no form scope to provide, so the panes render without one and read
   // that absence through FormScopeContext.
@@ -72,26 +94,19 @@ export function DocumentScope({
   // Wait for the document. Mounting the provider without one seeds the form empty, and
   // Plate reads its value at mount only — so the editor stayed blank once the entry
   // arrived. The panes below therefore mount once, with a value.
-  //
-  // This is the swap the shell used to do around the whole layout. Here it is confined
-  // to the two panes that hold the document, which are created with it in any case; the
-  // sidebar sits above this and keeps its state.
   if (!entry) return children;
 
   return (
-    // Keyed on the path, and it has to be. FormProvider does re-seed when its formId
-    // changes, but the reset lands in an effect — after the children have rendered — so
-    // Plate, which reads its value at mount only, keeps the previous document's prose.
-    // A fresh RHF instance means the fields mount with the right values to begin with.
-    //
-    // The cost is that these children remount per document, so the preview iframe
-    // reloads on a switch. That is why this scope wraps the two panes and not the whole
-    // shell: the sidebar and its document list sit above it and survive.
+    // No key, and that is the point. The provider hosts a switch of document in place:
+    // it resets RHF to the next document's seed and advances the seed key, which is
+    // what a field hosting its own editor remounts on. The continuity tests pin that
+    // down under "unkeyed document switches". A key here remounted everything below on
+    // every switch — including the preview iframe, whose same-origin reload runs on the
+    // admin's own main thread and froze the whole shell while the preview re-booted.
     <FormProvider
-      key={path}
       collection={collection}
       path={path}
-      document={entry?.document}
+      document={entry.document}
       onSave={save}
     >
       {children}

--- a/packages/v4/@tinacms/tinacms/src/editor/content-queries.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/content-queries.test.tsx
@@ -1,0 +1,181 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { createStore } from 'zustand';
+import type { ContentProvider, DocumentEntry } from '../core/content/contract';
+import type { TinaStoreState } from '../core/plugin';
+import { useCollectionDocuments, useSaveDocument } from './content-queries';
+import { type TinaRuntime, TinaRuntimeContext } from './context';
+
+const ENTRIES: DocumentEntry[] = [
+  { path: 'content/posts/hello.mdx', document: { title: 'Hello' } },
+  { path: 'content/posts/second.mdx', document: { title: 'Second' } },
+];
+
+// The runtime these hooks read: a store with a content namespace, and nothing else they
+// touch. The registry and the schema are not on this path.
+const renderWithContent = (provider: ContentProvider) => {
+  const store = createStore<TinaStoreState>()(() => ({
+    content: provider as unknown as Record<string, unknown>,
+  }));
+  const runtime = { store } as unknown as TinaRuntime;
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TinaRuntimeContext value={runtime}>{children}</TinaRuntimeContext>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+};
+
+const stubProvider = (
+  overrides: Partial<ContentProvider> = {}
+): ContentProvider => ({
+  list: vi.fn(async () => ENTRIES),
+  get: vi.fn(async () => null),
+  update: vi.fn(async (_collection, path, value) => ({
+    path,
+    document: value,
+  })),
+  ...overrides,
+});
+
+describe('useCollectionDocuments', () => {
+  it('reads the collection through the capability', async () => {
+    const provider = stubProvider();
+    const { wrapper } = renderWithContent(provider);
+    const { result } = renderHook(() => useCollectionDocuments('post'), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.documents).toEqual(ENTRIES));
+    expect(provider.list).toHaveBeenCalledWith('post');
+  });
+
+  // No collection is a real state — nothing is open — and not a read of one named ''.
+  it('reads nothing and reports no load without a collection', async () => {
+    const provider = stubProvider();
+    const { wrapper } = renderWithContent(provider);
+    const { result } = renderHook(() => useCollectionDocuments(undefined), {
+      wrapper,
+    });
+
+    expect(result.current.documents).toEqual([]);
+    expect(result.current.isLoading).toBe(false);
+    expect(provider.list).not.toHaveBeenCalled();
+  });
+
+  // The list renders straight from this, so a new array each render would re-render
+  // every consumer of it.
+  it('returns the same empty list identity across renders', () => {
+    const { wrapper } = renderWithContent(stubProvider());
+    const { result, rerender } = renderHook(
+      () => useCollectionDocuments(undefined),
+      { wrapper }
+    );
+    const first = result.current.documents;
+    rerender();
+    expect(result.current.documents).toBe(first);
+  });
+
+  it('surfaces a failed read instead of an empty collection', async () => {
+    const provider = stubProvider({
+      list: vi.fn(async () => {
+        throw new Error('data layer offline');
+      }),
+    });
+    const { wrapper } = renderWithContent(provider);
+    const { result } = renderHook(() => useCollectionDocuments('post'), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(result.current.error?.message).toBe('data layer offline')
+    );
+    expect(result.current.documents).toEqual([]);
+  });
+});
+
+describe('useSaveDocument', () => {
+  // The stored entry can hold more than the value that was sent, and the cached list
+  // has to show what was stored rather than what the form had.
+  it('replaces the cached entry with what the data layer stored', async () => {
+    const persisted: DocumentEntry = {
+      path: 'content/posts/hello.mdx',
+      document: { title: 'Renamed', category: 'not-in-schema' },
+    };
+    const provider = stubProvider({ update: vi.fn(async () => persisted) });
+    const { wrapper } = renderWithContent(provider);
+    const { result } = renderHook(
+      () => ({
+        list: useCollectionDocuments('post'),
+        saving: useSaveDocument(),
+      }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.list.documents).toEqual(ENTRIES));
+    await result.current.saving.save({
+      collection: 'post',
+      path: 'content/posts/hello.mdx',
+      value: { title: 'Renamed' },
+    });
+
+    await waitFor(() =>
+      expect(result.current.list.documents).toEqual([persisted, ENTRIES[1]])
+    );
+    // Written into the cache, not refetched: the stored entry is already the
+    // authoritative result of the write.
+    expect(provider.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('appends the stored entry when the path is not in the cached list', async () => {
+    const persisted: DocumentEntry = {
+      path: 'content/posts/new.mdx',
+      document: { title: 'New' },
+    };
+    const provider = stubProvider({ update: vi.fn(async () => persisted) });
+    const { wrapper } = renderWithContent(provider);
+    const { result } = renderHook(
+      () => ({
+        list: useCollectionDocuments('post'),
+        saving: useSaveDocument(),
+      }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.list.documents).toEqual(ENTRIES));
+    await result.current.saving.save({
+      collection: 'post',
+      path: 'content/posts/new.mdx',
+      value: { title: 'New' },
+    });
+
+    await waitFor(() =>
+      expect(result.current.list.documents).toEqual([...ENTRIES, persisted])
+    );
+  });
+
+  // useFormSave marks the form clean only after the save resolves, so the rejection has
+  // to reach it.
+  it('rejects when the write does', async () => {
+    const provider = stubProvider({
+      update: vi.fn(async () => {
+        throw new Error('update failed (500)');
+      }),
+    });
+    const { wrapper } = renderWithContent(provider);
+    const { result } = renderHook(() => useSaveDocument(), { wrapper });
+
+    await expect(
+      result.current.save({
+        collection: 'post',
+        path: 'content/posts/hello.mdx',
+        value: {},
+      })
+    ).rejects.toThrow(/update failed \(500\)/);
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/editor/content-queries.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/content-queries.ts
@@ -1,0 +1,185 @@
+// The cache over the content capability. The capability itself is a transport of plain
+// promises (ContentSlice), and this file is the one consumer that decides policy:
+// deduplicate concurrent reads, when a read goes stale, what a failed one does, and what
+// a save writes back.
+//
+// The split matters because ContentSlice is the plugin contract. TinaCloud, the
+// self-hosted layer, and the v3 shim each implement it, and none of them should have to
+// ship a caching strategy — or take a dependency on this query client — to be a data
+// layer. React Query stays on this side of that boundary.
+//
+// These hooks return their own shapes rather than the React Query result. The components
+// need the data, the pending flag, and the error, and nothing else; returning the result
+// object would also mean spreading it, which reads every tracked property and re-renders
+// the caller on query state it never used.
+
+import {
+  skipToken,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
+import type { DocumentEntry } from '../core/content/contract';
+import type { TinaDocument } from '../core/schema/types';
+import { useContentSlice } from './hooks';
+
+// One namespace for every content read, so an invalidation can reach the whole
+// capability or one collection of it. The functions build on each other, so
+// invalidating `all()` reaches every key below it.
+export const contentKeys = {
+  all: () => ['tina', 'content'] as const,
+  list: (collection: string) => [...contentKeys.all(), 'list', collection],
+  document: (collection: string, path: string) => [
+    ...contentKeys.all(),
+    'document',
+    collection,
+    path,
+  ],
+};
+
+// Content changes underneath the editor — someone edits the file in their IDE, or a
+// teammate pushes — but not on the timescale of a click. Half a minute keeps navigation
+// between collections instant without serving a list from the morning.
+export const CONTENT_STALE_TIME = 30_000;
+
+// A stable fallback, so a caller that renders the list does not see a new array on every
+// render while the first read is in flight.
+const EMPTY_DOCUMENTS: DocumentEntry[] = [];
+
+export interface CollectionDocuments {
+  documents: DocumentEntry[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * The documents of one collection.
+ *
+ * Passing no collection is a real state — nothing is open — and not a load of one named
+ * ''. `skipToken` models that as a query with no function: nothing is fetched, and the
+ * result is an empty list that never reports itself as loading.
+ *
+ * Two components asking for the same collection share one request. The sidebar's
+ * document list and the open document's scope both call this, so before the cache each
+ * ran its own effect and its own fetch of the same collection.
+ */
+export const useCollectionDocuments = (
+  collection: string | undefined
+): CollectionDocuments => {
+  const content = useContentSlice();
+  const query = useQuery({
+    queryKey: contentKeys.list(collection ?? ''),
+    queryFn: collection ? () => content.list(collection) : skipToken,
+    staleTime: CONTENT_STALE_TIME,
+  });
+  return {
+    documents: query.data ?? EMPTY_DOCUMENTS,
+    // `isLoading`, and not `isPending`. A skipped query is pending forever, because it
+    // has no data and never will; `isLoading` is that pending state narrowed to a read
+    // actually in flight, which is what a caller renders a spinner for.
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+};
+
+export interface DocumentRead {
+  // One absent case, and not three. A read that has not run, a skipped one, and a
+  // document that does not exist all have no entry, and `isLoading` is what separates a
+  // read in flight from a settled one.
+  entry: DocumentEntry | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * One document, read directly rather than out of its collection list.
+ *
+ * The admin shell does not use this. It reads the open document from the list it already
+ * holds, so that two reads of one document cannot disagree and seed the form from the
+ * older one. A page plugin that opens a document without its collection list needs this.
+ */
+export const useDocument = (
+  collection: string | undefined,
+  path: string | undefined
+): DocumentRead => {
+  const content = useContentSlice();
+  const query = useQuery({
+    queryKey: contentKeys.document(collection ?? '', path ?? ''),
+    queryFn:
+      collection && path ? () => content.get(collection, path) : skipToken,
+    staleTime: CONTENT_STALE_TIME,
+  });
+  return {
+    entry: query.data ?? null,
+    isLoading: query.isLoading,
+    error: query.error,
+  };
+};
+
+const upsertByPath = (
+  entries: DocumentEntry[],
+  entry: DocumentEntry
+): DocumentEntry[] => {
+  const index = entries.findIndex((cached) => cached.path === entry.path);
+  if (index === -1) return [...entries, entry];
+  const next = [...entries];
+  next[index] = entry;
+  return next;
+};
+
+export interface SaveDocumentInput {
+  collection: string;
+  path: string;
+  value: TinaDocument;
+}
+
+export interface DocumentSave {
+  // Rejects when the write does, so useFormSave leaves the form dirty.
+  save: (input: SaveDocumentInput) => Promise<DocumentEntry>;
+  isSaving: boolean;
+}
+
+/**
+ * The save. It writes the stored entry back into the cached list, so the sidebar shows
+ * the save without a refetch, and it does not invalidate that list.
+ *
+ * Not invalidating is deliberate. The stored entry is the authoritative result of this
+ * write, so a refetch could only return the same thing — or, against a data layer that
+ * reads its own write late, something older. Refer to usePinnedDocument in
+ * document-scope.tsx for why re-seeding the open form off a fresh list is the failure
+ * this avoids.
+ */
+export const useSaveDocument = (): DocumentSave => {
+  const content = useContentSlice();
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: ({ collection, path, value }: SaveDocumentInput) =>
+      content.update(collection, path, value),
+    onSuccess: (entry, { collection }) => {
+      queryClient.setQueryData<DocumentEntry[]>(
+        contentKeys.list(collection),
+        // Only a list that was read. Seeding an unread one writes a fresh single-
+        // document list, which the next useCollectionDocuments mount reads as the whole
+        // collection and skips its fetch. Returning undefined leaves the key unset.
+        (cached) => (cached ? upsertByPath(cached, entry) : undefined)
+      );
+      queryClient.setQueryData(
+        contentKeys.document(collection, entry.path),
+        entry
+      );
+    },
+  });
+  // `mutateAsync` is stable across renders, so a caller can hold it in a stable save
+  // handler. Refer to the FormProvider scope memo in document-scope.tsx.
+  return { save: mutation.mutateAsync, isSaving: mutation.isPending };
+};
+
+/**
+ * Drop every cached content read, so the next render fetches again. The editorial
+ * workflow needs this on a branch switch: the documents of the last branch are not the
+ * documents of this one.
+ */
+export const useInvalidateContent = (): (() => Promise<void>) => {
+  const queryClient = useQueryClient();
+  return () => queryClient.invalidateQueries({ queryKey: contentKeys.all() });
+};

--- a/packages/v4/@tinacms/tinacms/src/editor/context.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/context.ts
@@ -3,19 +3,22 @@ import type { StoreApi } from 'zustand';
 import type { TinaSchema } from '../config';
 import type { FieldAddress } from '../core/field/address';
 import type { FieldRegistry } from '../core/field/registry';
-import type { PageRegistry } from '../core/page/registry';
 import type { TinaStoreState } from '../core/plugin';
 import type {
   CollectionSchema,
   FieldSchema,
   TinaDocument,
 } from '../core/schema/types';
+import type { ScreenRegistry } from '../core/screen/registry';
 import type { FormId } from '../form/form-store';
 
-// The point where the content capability joins the save flow (ADR-018 and ADR-019). The
-// host gives FormProvider a handler that stores the digested document. A rejection
-// leaves the form dirty, because useFormSave marks the form clean only after the handler
-// resolves.
+/**
+ * The point where the content capability joins the save flow (ADR-018 and ADR-019). The
+ * host gives FormProvider a handler that stores the digested document.
+ *
+ * A rejection leaves the form dirty. useFormSave marks the form clean only after the
+ * handler resolves.
+ */
 export type SaveHandler = (document: TinaDocument) => void | Promise<void>;
 
 // There is one context for each scope in the tree: the app, the form, and the field.
@@ -24,42 +27,70 @@ export type SaveHandler = (document: TinaDocument) => void | Promise<void>;
 // store holds the status and the active field. More contexts would therefore save no
 // render.
 
-// The app scope, from TinaProvider. It holds the runtime composed at boot, from one
-// resolveClientSegments pass that feeds both halves. The registry stays out of the
-// store. It is a fixed map of React components, which is config and not state. The
-// devtools could also not serialize it.
+/**
+ * The app scope, from TinaProvider. It holds the runtime composed at boot, from one
+ * resolveClientSegments pass that feeds both halves.
+ *
+ * The registry stays out of the store. It is a fixed map of React components, which is
+ * config and not state. The devtools could also not serialize it.
+ */
 export interface TinaRuntime {
   registry: FieldRegistry;
   store: StoreApi<TinaStoreState>;
-  // The content model that the admin navigates. It is config, and not state. It comes
-  // from the build (ADR-016), so it sits beside the registry and not in the store.
+  /**
+   * The content model that the admin navigates. It is config, and not state. It comes
+   * from the build (ADR-016), so it sits beside the registry and not in the store.
+   */
   schema: TinaSchema;
-  // The screens the plugins add to the admin. A fixed map of components composed at
-  // boot, so it sits here for the same reason the field registry does.
-  pages: PageRegistry;
+  /**
+   * The screens that the plugins add to the admin. It is a fixed map of components
+   * composed at boot, so it sits here for the same reason the field registry does.
+   */
+  screens: ScreenRegistry;
 }
 export const TinaRuntimeContext = createContext<TinaRuntime | null>(null);
 
-// The form scope, from FormProvider. It holds the identity of the open document, its
-// schema, and the save handler. It changes only when the document changes. The
-// `collection` and the save handler probably become reads from the store, or from a
-// capability, when the data layer arrives (ADR-019). This scope then holds the id alone.
+/**
+ * The form scope, from FormProvider. It holds the identity of the open document, its
+ * schema, and the save handler. It changes only when the document changes.
+ *
+ * The `collection` and the save handler become reads from the store, or from a
+ * capability, when the data layer arrives (ADR-019). This scope then holds the id alone.
+ */
 export interface FormScope {
   formId: FormId;
-  // The path of the open document, beside the form id derived from it. The save needs
-  // the path to build the transform context that the ingest used. Refer to
-  // FieldTransformContext. A form id cannot give the path back.
+  /**
+   * The path of the open document, beside the form id derived from it. The save needs
+   * the path to build the transform context that the ingest used. Refer to
+   * FieldTransformContext. A form id cannot give the path back.
+   */
   path: string;
   collection: CollectionSchema;
   onSave: SaveHandler | null;
-  // The identity of the values the form was seeded from. A reseed changes it, so an
-  // editor that owns its own state can mount again on the new values.
+  /**
+   * The identity of the values that the form is seeded from. A field that hosts an
+   * editor owning its own state keys on this. RHF reseeds in place, and such an editor
+   * has to mount again to read a new seed.
+   *
+   * It changes on a discard, and when the document changes under the form. Refer to
+   * FormProvider.
+   */
   seedKey: string;
+  /**
+   * Throw the edits away and put the form back on its baseline. The provider owns this,
+   * and not the store, because RHF and the mounted editors move with the store.
+   */
+  discardEdits: () => void;
 }
 export const FormScopeContext = createContext<FormScope | null>(null);
 
-// The field scope. A field receives its address from <Field> (ADR-009). <Field> also
-// passes the resolved schema node, which holds the config that the field renders from.
-// The declarative validation stays on the validation path.
+/**
+ * The field scope. A field receives its address from `Field` (ADR-009).
+ */
 export const FieldAddressContext = createContext<FieldAddress | null>(null);
+
+/**
+ * The resolved schema node of the field, also passed by `Field`. It holds the config
+ * that the field renders from. The declarative validation stays on the validation path.
+ */
 export const FieldSchemaContext = createContext<FieldSchema | null>(null);

--- a/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
@@ -1,4 +1,4 @@
-import { use, useCallback, useEffect, useRef } from 'react';
+import { use, useCallback, useEffect, useEffectEvent, useMemo } from 'react';
 import { useController, useFormContext, useFormState } from 'react-hook-form';
 import { useStore } from 'zustand';
 import type { ContentSlice } from '../core/content/contract';
@@ -64,16 +64,25 @@ export function useFormId(): FormId {
 
 // The path of the open document. A field whose behaviour depends on the storage format
 // builds its FieldTransformContext from this, so it resolves the same codec that the
-// ingest and the save resolve.
+// ingest and the save resolve. Reading it any other way lets the three disagree.
 export function useDocumentPath(): string {
   return useFormScope('document-path-outside-provider', 'useDocumentPath').path;
 }
 
 // The identity of the values the form was seeded from. A field whose editor owns its own
-// state keys on this, so that a reseed mounts it again on the new values.
+// state keys on this, so that a reseed of RHF mounts it again on the new values. Every
+// other field reads its value through useFieldValue and needs nothing here.
 export function useFormSeedKey(): string {
   return useFormScope('form-seed-key-outside-provider', 'useFormSeedKey')
     .seedKey;
+}
+
+// Throw the edits of this form away and put it back on its baseline: the content it
+// loaded, or the content it last saved. It cannot be undone, so the caller confirms
+// first. No control in the admin calls this yet.
+export function useDiscardEdits(): () => void {
+  return useFormScope('discard-edits-outside-provider', 'useDiscardEdits')
+    .discardEdits;
 }
 
 export interface ActiveField {
@@ -90,12 +99,16 @@ export function useActiveField(): ActiveField {
   const active = useFormStore((state) =>
     state.active?.formId === formId ? state.active.address : null
   );
+  // Memoised by hand. Only the playground and the test config run the React Compiler,
+  // and this package ships its source — so a consumer's bundler sees these hooks
+  // uncompiled, and a fresh identity here re-runs their `[setActive]` effects on every
+  // render.
   const setActive = useCallback(
     (address: FieldAddress | null) =>
       useFormStore.getState().setActive(formId, address),
     [formId]
   );
-  return { active, setActive };
+  return useMemo(() => ({ active, setActive }), [active, setActive]);
 }
 
 // Build the document again from the values of the form, and give it to the save handler
@@ -107,6 +120,8 @@ export function useFormSave(): () => Promise<void> {
   const registry = useFieldRegistry();
   const scope = useFormScope('form-save-outside-provider', 'useFormSave');
   const { getValues } = useFormContext<TinaDocument>();
+  // Memoised for the same reason as useActiveField above: consumers hold this in
+  // `[save]` dependencies, and this package ships uncompiled source.
   return useCallback(async () => {
     const { formId, path, collection, onSave } = scope;
     const values = getValues();
@@ -117,7 +132,7 @@ export function useFormSave(): () => Promise<void> {
     });
     await onSave?.(digested);
     useFormStore.getState().markSaved(formId, toFormValues(values));
-  }, [registry, scope, getValues]);
+  }, [scope, getValues, registry]);
 }
 
 export function useFieldAddress(): FieldAddress {
@@ -162,15 +177,18 @@ export function useFieldActivation(handler: () => void): void {
   // object at each call, so a second activation of the same field calls the handler
   // again. A boolean would hold its value, and the second click would do nothing.
   const active = useFormStore((state) => state.active);
-  const handlerRef = useRef(handler);
-  handlerRef.current = handler;
+  // The activation entry is the reactive half, and the handler is not. Every call site
+  // passes a new closure on each render, so a handler in the dependencies would fire on
+  // each render instead of on an activation. An Effect Event reads the latest closure
+  // without joining them.
+  const onActivate = useEffectEvent(handler);
   useEffect(() => {
     if (
       address != null &&
       active?.formId === formId &&
       active.address === address
     ) {
-      handlerRef.current();
+      onActivate();
     }
   }, [active, formId, address]);
 }

--- a/packages/v4/@tinacms/tinacms/src/editor/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/index.ts
@@ -38,11 +38,26 @@ export {
   type PreviewConnectionOptions,
   usePreviewConnection,
 } from './preview-connection';
+// The cache over the content capability. A plugin's client segment reads content
+// through these, and not through the slice: the slice is a transport, and these hold
+// the deduplication, the staleness policy, and the save's write-back.
+export {
+  type CollectionDocuments,
+  CONTENT_STALE_TIME,
+  contentKeys,
+  type DocumentRead,
+  type DocumentSave,
+  type SaveDocumentInput,
+  useCollectionDocuments,
+  useDocument,
+  useInvalidateContent,
+  useSaveDocument,
+} from './content-queries';
 export {
   type ActiveField,
   useActiveField,
-  useCollectionDocuments,
   useContentSlice,
+  useDiscardEdits,
   useDocumentPath,
   useFieldActivation,
   useFieldAddress,

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
@@ -40,7 +40,7 @@ describe('TinaProvider boot', () => {
       </TinaProvider>
     );
     expect(await screen.findByTestId('field-types')).toHaveTextContent(
-      'boolean,number,rich-text,string'
+      'boolean,datetime,number,rich-text,string'
     );
     expect(screen.getByTestId('namespaces')).toHaveTextContent(
       'branch,documents,ui'

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
@@ -1,6 +1,8 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import {
   type ReactNode,
   use,
+  useCallback,
   useEffect,
   useMemo,
   useRef,
@@ -10,13 +12,17 @@ import { FormProvider as RhfFormProvider, useForm } from 'react-hook-form';
 import type { ResolvedConfig } from '../config';
 import { toFieldAddress } from '../core/field/address';
 import { createFieldRegistry } from '../core/field/registry';
+import { fieldEqualityFor } from '../core/form/compare';
 import { ingestDocument } from '../core/form/ingest';
-import { resolveClientSegments } from '../core/plugin';
+import { type PluginManifest, resolveClientSegments } from '../core/plugin';
 import { initializePlugins, validateCapabilityGraph } from '../core/resolve';
 import type { CollectionSchema, TinaDocument } from '../core/schema/types';
+import { createScreenRegistry } from '../core/screen/registry';
 import {
   type FieldErrors,
+  type FormId,
   isEdited,
+  readFormStore,
   toDocument,
   toFormId,
   toFormValues,
@@ -37,58 +43,130 @@ import {
 import { buildFormResolver } from './resolver';
 
 export interface TinaProviderProps {
-  // The output of defineConfig — its plugin list is already composed (built-ins
-  // folded in) and graph-validated, so boot here is import-and-mount. A test that
-  // is not a configured app can hand over the literal instead.
+  /**
+   * The output of defineConfig. It already holds the composed plugin list, with the
+   * built-ins folded in and the graph validated. This provider only imports and mounts.
+   * A test that is not a configured app can pass the object directly.
+   */
   config: ResolvedConfig;
+  /**
+   * The cache for the content reads (content-queries.ts). One is created if none is
+   * passed, so a host needs no setup. Pass one to share the cache with the surrounding
+   * app, or to control the retry and staleness policy in a test.
+   *
+   * A nested QueryClientProvider is supported, so an app with its own client keeps it.
+   * The client here shadows that one for the editor's queries only. A passed client
+   * must come from the same @tanstack/react-query install, or its context is a
+   * different one.
+   */
+  queryClient?: QueryClient;
   children: ReactNode;
 }
 
-// What the async boot produces. The runtime the tree sees is this plus the schema,
-// which needs no booting.
+/**
+ * The editor's default cache policy. It retries once. A content read crosses a dev
+ * server that restarts, and one retry covers that without sitting on a real failure.
+ */
+const createDefaultQueryClient = () =>
+  new QueryClient({ defaultOptions: { queries: { retry: 1 } } });
+
+/**
+ * The result of the async boot. The tree sees this result and the schema. The schema
+ * needs no boot.
+ */
 type BootedRuntime = Omit<TinaRuntime, 'schema'>;
 
-// Serializes the plugin lifecycle across provider instances — including
-// StrictMode's mount→unmount→remount and a pluginsKey change: the next boot's
-// onInit waits for the previous instance's teardown, so an outgoing onDestroy
-// can never land after a successor's onInit. Module-level on purpose: manifests
-// are module singletons, so their lifecycle is global state.
+/**
+ * A boot token that changes when the plugin set does: the names, in order.
+ *
+ * The names are compared member by member, and not by array reference. A config object
+ * that is rebuilt on each render holds an equal plugin set, and must not boot again.
+ * They are not compared by identity either. A host that calls defineConfig inside a
+ * component mints a new manifest for every plugin on every render, so an identity check
+ * makes the token climb for ever, and each setBooted schedules the next destroy and
+ * init.
+ *
+ * The cost is a config swapped at runtime for one that keeps every plugin name and
+ * changes a plugin's config. `localContentPlugin({ url })` puts that config on the
+ * instance. The boot does not run again, and the manifests and client segments of the
+ * first config stay. Build the config once, outside the component, and remount the
+ * provider to change it.
+ */
+const usePluginsKey = (plugins: PluginManifest[]): number => {
+  const previous = useRef<PluginManifest[] | null>(null);
+  const token = useRef(0);
+  const unchanged =
+    previous.current !== null &&
+    previous.current.length === plugins.length &&
+    previous.current.every(
+      (plugin, index) => plugin.name === plugins[index].name
+    );
+  if (!unchanged) {
+    previous.current = plugins;
+    token.current += 1;
+  }
+  return token.current;
+};
+
+/**
+ * This puts the plugin lifecycle of all provider instances into one sequence. It covers
+ * the mount, unmount, and remount of StrictMode, and a change of the plugin key. The
+ * onInit of the next boot waits for the teardown of the last instance, so an onDestroy
+ * never runs after the onInit that follows it.
+ *
+ * It is module level because the manifests are module singletons, so their lifecycle is
+ * global state.
+ */
 let lifecycleTurn: Promise<void> = Promise.resolve();
 
-export function TinaProvider({ config, children }: TinaProviderProps) {
-  // One resolveClientSegments pass feeds both runtime halves (ADR-003), held as a
-  // single state object so registry and store always appear together (no tearing).
-  // The schema is NOT part of it: the boot is keyed on the plugin set, so folding
-  // build-time config into the async result would pin a stale schema whenever it
-  // changed without the plugin names changing.
+export function TinaProvider({
+  config,
+  queryClient,
+  children,
+}: TinaProviderProps) {
+  /**
+   * Created once per provider, and never during render of the tree below it. A client
+   * built inline would be replaced on every render, and discard the cache each time.
+   */
+  const [ownQueryClient] = useState(createDefaultQueryClient);
+  const activeQueryClient = queryClient ?? ownQueryClient;
+  /**
+   * One resolveClientSegments pass feeds both halves of the runtime (ADR-003). One
+   * state object holds them, so the registry and the store always appear together.
+   *
+   * The schema stays out of that object. The boot is keyed on the plugin set, so a
+   * schema held here would go stale when the schema changed and the plugin names did
+   * not.
+   */
   const [booted, setBooted] = useState<BootedRuntime | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const composedPlugins = config.plugins;
-  const pluginsKey = composedPlugins.map((plugin) => plugin.name).join('|');
+  const pluginsKey = usePluginsKey(composedPlugins);
 
   useEffect(() => {
     let mounted = true;
-    // The graph pass (ADR-006) validates the manifests before any segment is
-    // imported — a conflicting or unsatisfiable config fails here, not mid-boot.
-    // Composition runs BEFORE init (a per-type field conflict only surfaces in
-    // createFieldRegistry, and it must not leave initialized plugins behind);
-    // onInit runs last, before the runtime is exposed, so no consumer sees a
-    // half-initialized plugin set.
+    // The graph pass (ADR-006) validates the manifests before it imports a
+    // segment. A config with a conflict, or with a missing provider, fails here.
+    // It does not fail part-way through the boot. The composition runs before the
+    // init, because a field type conflict appears only in createFieldRegistry, and
+    // it must not leave initialized plugins behind. The onInit runs last, before
+    // the runtime is exposed, so no consumer sees a half-initialized plugin set.
     const boot = lifecycleTurn.then(async () => {
       validateCapabilityGraph(composedPlugins);
       const resolved = await resolveClientSegments(composedPlugins);
       const runtime: BootedRuntime = {
         registry: createFieldRegistry(resolved),
         store: createTinaStore(resolved),
+        screens: createScreenRegistry(resolved),
       };
       const destroyPlugins = await initializePlugins(composedPlugins);
       if (mounted) setBooted(runtime);
       return destroyPlugins;
     });
-    // Advance the shared turn at mount, not just at teardown: a second provider
-    // mounting in the same commit then chains its onInit after this boot instead
-    // of racing it on the module-singleton manifests. Teardown replaces the turn
-    // again with the destroy.
+    // Advance the shared turn at the mount, and not only at the teardown. A
+    // second provider that mounts in the same commit then chains its onInit after
+    // this boot. It does not race this boot on the module singleton manifests.
+    // The teardown replaces the turn again with the destroy.
     lifecycleTurn = boot.then(
       () => undefined,
       () => undefined
@@ -103,12 +181,12 @@ export function TinaProvider({ config, children }: TinaProviderProps) {
     });
     return () => {
       mounted = false;
-      // Teardown awaits the boot (the init sequence isn't cancellable, so
-      // unmounting mid-boot still destroys whatever finished initializing) and
-      // becomes the next lifecycle turn. A failed boot has nothing to destroy —
-      // initializePlugins tore its partial sequence down and setError surfaced
-      // the cause. A destroy failure is logged, not rethrown: unmount has no
-      // error boundary to feed.
+      // The teardown waits for the boot, and then becomes the next lifecycle
+      // turn. The init sequence cannot be cancelled, so an unmount during the
+      // boot still destroys the plugins that completed their init. A failed boot
+      // has nothing to destroy. initializePlugins already tore down its partial
+      // sequence, and setError reported the cause. A failed destroy is logged and
+      // not thrown again, because an unmount has no error boundary.
       const destroyBootedPlugins = async () => {
         const destroyPlugins = await boot.catch(() => null);
         await destroyPlugins?.();
@@ -119,6 +197,15 @@ export function TinaProvider({ config, children }: TinaProviderProps) {
     };
   }, [pluginsKey]);
 
+  /**
+   * Held, and not rebuilt. Every use(TinaRuntimeContext) consumer re-renders when this
+   * object changes identity. Only the playground and the test config run the React
+   * Compiler, and this package ships its source, so a consumer's bundler sees this hook
+   * as written.
+   *
+   * A config rebuilt on each render still churns here, through `config.schema`.
+   * usePluginsKey absorbs that for the plugin list only.
+   */
   const runtime = useMemo(
     () => (booted ? { ...booted, schema: config.schema } : null),
     [booted, config.schema]
@@ -126,13 +213,19 @@ export function TinaProvider({ config, children }: TinaProviderProps) {
 
   if (error) throw error;
   if (!runtime) return null;
-  return <TinaRuntimeContext value={runtime}>{children}</TinaRuntimeContext>;
+  return (
+    <QueryClientProvider client={activeQueryClient}>
+      <TinaRuntimeContext value={runtime}>{children}</TinaRuntimeContext>
+    </QueryClientProvider>
+  );
 }
 
 export interface FormProviderProps {
   collection: CollectionSchema;
-  // The open document's path — a form is opened per document (ADR-010), so this is
-  // the form's identity in the form-state store.
+  /**
+   * The path of the open document. There is one form for each document (ADR-010), so
+   * this path identifies the form in the form state store.
+   */
   path: string;
   document?: TinaDocument;
   onSave?: SaveHandler;
@@ -153,28 +246,49 @@ export function FormProvider({
   const { registry } = runtime;
 
   const formId = toFormId(path);
-  // The document's own path travels with its values: a field transform that
-  // depends on the storage format (rich-text picking a codec) reads it from here,
-  // so a mixed-format collection resolves per document rather than per collection.
+  /**
+   * The path of the document travels with its values. A field transform that depends on
+   * the storage format reads the path from here. The rich-text field selects its codec
+   * in this way. A collection with more than one format therefore resolves for each
+   * document, and not for the whole collection.
+   */
   const transformContext = useMemo(() => ({ documentPath: path }), [path]);
+  /**
+   * Held, and not rebuilt. Rebuilt on each render, this parses every field again — for
+   * the rich-text field that is a whole parseMDX of the body — and hands the seed effect
+   * below a new object, which reseeds the form on every render.
+   *
+   * Only the playground and the test config run the React Compiler, and this package
+   * ships its source, so a consumer's bundler sees these hooks as written.
+   */
   const ingested = useMemo(
     () =>
       ingestDocument(document, collection.fields, registry, transformContext),
     [document, collection, registry, transformContext]
   );
-  // Kept EDITS win over the incoming document: the store retains an unsaved
-  // form across teardown (ADR-012), so hosting that formId again re-adopts its
-  // values AND their mirrored errors into the fresh RHF instance instead of
-  // re-seeding from the document. Edited scopes only — a pristine kept scope
-  // must re-adopt the incoming document (registerForm's "pristine is never
-  // stale" contract), not shadow it with the old mirror. Read once per hosted
-  // form ([formId], not reactive): while THIS instance hosts the form, the
-  // store mirrors RHF — adopting the mirror back mid-flight would be a cycle,
-  // and a document swap under kept edits keeps the edits (matching the store's
-  // edited no-op; the future draft slice arbitrates reload-vs-keep,
-  // form-store.ts registerForm).
+  /**
+   * The store compares values, and the fields own the answer. This is where the two
+   * meet. The registry lives on the runtime, and the store must not import it.
+   */
+  const equal = useMemo(
+    () => fieldEqualityFor(collection.fields, registry, transformContext),
+    [collection, registry, transformContext]
+  );
+  /**
+   * The kept edits win over the incoming document. The store keeps an unsaved form
+   * after the teardown (ADR-012). A new host of the same form id therefore adopts the
+   * kept values and their mirrored errors into the new RHF instance, and does not seed
+   * from the document. This applies to edited forms only. A kept pristine form adopts
+   * the incoming document, because a pristine form is never stale.
+   *
+   * The hook reads the store once for each hosted form, keyed on the form id alone.
+   * While this instance hosts the form, the store mirrors RHF, so a read of that mirror
+   * during the mount would make a cycle. A change of document under kept edits keeps
+   * the edits, which matches the store. The draft slice will later choose between the
+   * new content and the kept edits.
+   */
   const kept = useMemo(() => {
-    const scope = useFormStore.getState().forms[formId];
+    const scope = readFormStore().forms[formId];
     if (!isEdited(scope)) return { seed: null, errors: {} };
     const errors: Record<string, FieldErrorEntry> = {};
     for (const [address, messages] of Object.entries(scope.errors)) {
@@ -183,40 +297,73 @@ export function FormProvider({
     return { seed: toDocument(scope.values), errors };
   }, [formId]);
   const seedValues = kept.seed ?? ingested;
-  const resolver = useMemo(
-    () => buildFormResolver(collection, registry),
-    [collection, registry]
-  );
+  const resolver = buildFormResolver(collection, registry);
   const methods = useForm<TinaDocument>({
     defaultValues: seedValues,
-    // Kept errors seed like kept values — RHF adopts them wholesale (its
-    // errors-prop effect), so a re-mounted invalid form shows its errors with
-    // no trigger() round trip. Always an object: on an unkeyed switch the
-    // identity change makes RHF replace the previous host's errors ({} wipes;
-    // null would skip the effect and leak them).
+    /**
+     * The kept errors seed like the kept values. RHF adopts the whole map in its errors
+     * effect, so an invalid form shows its errors again after a remount. It needs no
+     * call to trigger().
+     *
+     * This is always an object. On a switch between forms, the new identity makes RHF
+     * replace the errors of the last host. An empty object clears them. A null would
+     * skip the effect and leak them.
+     */
     errors: kept.errors,
     resolver,
     mode: 'onChange',
-    // Error seeding must not steal focus (RHF focuses the first errored field
-    // whenever its errors prop lands); saves don't go through handleSubmit, so
-    // nothing else uses the flag.
+    /**
+     * The error seeding must not take the focus. RHF focuses the first field with an
+     * error each time its errors prop arrives. A save does not call handleSubmit, so
+     * nothing else uses this flag.
+     */
     shouldFocusError: false,
   });
 
-  // Adopt the seed. RHF's useForm reads defaultValues only at mount, so a
-  // seed change resets the form — compared by a JSON signature that carries
-  // the formId (an unkeyed switch between identical-content documents must
-  // still reset, or the old form's RHF edits would render — and save — under
-  // the new form's path), while a same-content re-render won't wipe
-  // in-progress edits. The mount run only registers: defaultValues already
-  // seeded RHF. The one remaining divergence seam — a document swap on a form
-  // edited while mounted — still resets RHF while the store keeps its edits,
-  // awaiting the draft slice's reload-vs-keep arbitration (form-store.ts
-  // registerForm TODO).
+  /**
+   * A counter, so that two seeds of the same form id still give two different keys.
+   */
+  const reseeds = useRef(0);
+  /**
+   * The identity of the seed that the mounted fields read. RHF resets its values in
+   * place, and a field that hosts an editor owning its own state cannot follow that. It
+   * has to mount again. Plate is that editor. This key changes whenever this provider
+   * reseeds RHF — a discard below, a document that changed under the form, or a switch
+   * of document — and it holds the form id of that seed. Refer to useFormSeedKey.
+   *
+   * It is state updated when the reseed lands, and not a value computed from the formId
+   * of the render. Computed, the key changed on the switch render itself — one render
+   * before the reset below replaces the values — so an editor keyed on it mounted once
+   * on the old document's values and again after the reset. The seed the fields read
+   * does not change until the reset runs, so the key must not claim that it has.
+   */
+  const [seedKey, setSeedKey] = useState(() => `${formId}#${reseeds.current}`);
+  const advanceSeedKey = useCallback((seededFormId: FormId) => {
+    reseeds.current += 1;
+    setSeedKey(`${seededFormId}#${reseeds.current}`);
+  }, []);
+
+  /**
+   * The signature of the seed that RHF holds. The effect below adopts a new seed.
+   *
+   * The useForm hook of RHF reads defaultValues at the mount only, so a new seed must
+   * reset the form. A JSON signature detects the change, and that signature holds the
+   * form id. The form id is part of it because a switch between two documents with
+   * equal content must still reset the form. Without that reset, the RHF edits of the
+   * old form would render, and save, under the path of the new form. A re-render with
+   * the same content clears no edit in progress.
+   *
+   * The first run registers the form only, because defaultValues already seeded RHF.
+   *
+   * One gap remains. A document that changes under a mounted and edited form resets
+   * RHF, while the store keeps the edits. The draft slice will resolve this.
+   */
   const seededSignature = useRef<string | null>(null);
   useEffect(() => {
-    // No removeForm on unmount (ADR-012): navigating away keeps unsaved edits.
-    useFormStore.getState().registerForm(formId, toFormValues(seedValues));
+    // The unmount does not call removeForm (ADR-012). A move away keeps the edits.
+    useFormStore
+      .getState()
+      .registerForm(formId, toFormValues(seedValues), equal);
     const signature = JSON.stringify([formId, seedValues]);
     if (seededSignature.current === null) {
       seededSignature.current = signature;
@@ -224,27 +371,45 @@ export function FormProvider({
     }
     if (seededSignature.current !== signature) {
       seededSignature.current = signature;
-      // A kept seed arrives with its errors already seeded (RHF's errors-prop
-      // effect runs before this one) — don't let the reset wipe them. Any
-      // other seed is fresh content whose old errors must go.
+      // A kept seed arrives with its errors in place, because the errors effect
+      // of RHF runs before this one. The reset must keep them. Any other seed is
+      // new content, so its old errors must go.
       methods.reset(seedValues, { keepErrors: kept.seed !== null });
+      advanceSeedKey(formId);
     }
-  }, [formId, seedValues, kept, methods]);
+  }, [formId, seedValues, kept, methods, equal, advanceSeedKey]);
 
-  // One-way RHF → form-store sync, values and errors on one subscription: RHF
-  // stays the value/render authority, the form-store is the sole
-  // pristine/dirty/clean authority (ADR-010). methods.subscribe is the single
-  // chokepoint — wrapping field.onChange instead would miss reset/setValue and
-  // be bypassable via a raw useController. The subscription's lifetime IS the
-  // hosted form's, so a derivation can never land under another form's id —
-  // and every emission it sees post-dates the error seeding above, so there is
-  // no pre-derivation noise to guard against.
+  /**
+   * Throw the edits away and put the form back on its baseline: the content it loaded,
+   * or the content it last saved.
+   *
+   * Three places hold a value, and they move together — the store, RHF, and any editor
+   * that owns its state. The store goes first, so the reset that RHF broadcasts lands
+   * on a form that is already pristine.
+   */
+  const discardEdits = useCallback(() => {
+    const store = readFormStore();
+    const scope = store.forms[formId];
+    if (!isEdited(scope)) return;
+    const baseline = toDocument(scope.baseline);
+    store.discardEdits(formId);
+    methods.reset(baseline);
+    advanceSeedKey(formId);
+  }, [formId, methods, advanceSeedKey]);
+
+  // A one-way sync from RHF to the form store, with the values and the errors on one
+  // subscription. RHF owns the values and the render. The form store owns the
+  // pristine, dirty, and clean status (ADR-010). The methods.subscribe call is the one
+  // place that reads RHF. A wrapper around field.onChange would miss reset() and
+  // setValue(), and a raw useController could go around it. The subscription lives as
+  // long as the hosted form, so an update never lands under the id of another form.
+  // Every update it receives also comes after the error seeding above.
   useEffect(() => {
     const unsubscribe = methods.subscribe({
       formState: { values: true, errors: true },
       callback: ({ values, errors, name }) => {
         const store = useFormStore.getState();
-        // `name` is undefined on reset — re-adopting the baseline is registerForm's job.
+        // The name is undefined on a reset. registerForm adopts the baseline.
         if (name !== undefined) {
           store.setFieldValue(formId, toFieldAddress(name), values[name]);
         }
@@ -261,16 +426,28 @@ export function FormProvider({
     return () => unsubscribe();
   }, [formId, methods]);
 
+  /**
+   * Held, and it has to be. editor/context.ts documents this scope as changing only
+   * when the document changes, and useFormSave keys its own useCallback on it.
+   */
   const formScope = useMemo(
-    () => ({ formId, path, collection, onSave: onSave ?? null, seedKey: formId }),
-    [formId, path, collection, onSave]
+    () => ({
+      formId,
+      path,
+      collection,
+      onSave: onSave ?? null,
+      seedKey,
+      discardEdits,
+    }),
+    [formId, path, collection, onSave, seedKey, discardEdits]
   );
 
   return (
     <FormScopeContext value={formScope}>
       <RhfFormProvider {...methods}>
-        {/* Fragment pins children to a ReactElement — RHF's FormProvider children
-            type predates the bigint that React 19's ReactNode includes. */}
+        {/* The fragment makes the children a ReactElement. The children type of
+            the RHF FormProvider is older than the bigint in the ReactNode of
+            React 19. */}
         <>{children}</>
       </RhfFormProvider>
     </FormScopeContext>


### PR DESCRIPTION
**TLDR:** Content reads go through one React Query key namespace, and the provider owns its plugin lifecycle.

**Feats:**
- Dedupe, 30s staleness and save-writeback over the content capability; the plugin contract stays plain promises
- TinaProvider accepts or creates a QueryClient and serialises plugin init/teardown across mounts
- DocumentScope pins the open document and reads the sidebar's list instead of fetching again

**How to test:** The query tests count the reads.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
