### PR TITLE
feat(v4): the preview connection becomes a store; focus marks the active field

### DIFF
--- a/packages/v4/@tinacms/tinacms/e2e/visual-editing.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/visual-editing.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test';
+
+// The click-to-edit half of visual editing, across a real iframe boundary. The vitest
+// suite fakes the two windows, so only this test observes the postMessage guards —
+// origin and source — against the browser's real values.
+test('a click on a marked element in the preview focuses its field in the form', async ({
+  page,
+}) => {
+  await page.goto(
+    `/#/collections/post/${encodeURIComponent('content/posts/hello-world.mdx')}`
+  );
+  await expect(page.getByRole('textbox', { name: 'body' })).toBeVisible();
+
+  const preview = page.frameLocator('iframe[title="Preview"]');
+  const markedTitle = preview.locator('[data-tina-field="title"]');
+  await expect(markedTitle).toBeVisible();
+  await markedTitle.click();
+
+  await expect(page.getByRole('textbox', { name: 'title' })).toBeFocused();
+});

--- a/packages/v4/@tinacms/tinacms/playground/src/app.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/app.tsx
@@ -3,8 +3,8 @@ import { TinaProvider, usePreviewConnection } from '@tinacms/tinacms/react';
 import { useRef } from 'react';
 import config from '../tina/config';
 
-// The site side of visual editing: usePreviewConnection streams the open form's
-// values into the iframe and turns a click in there into the active field.
+// The site side of visual editing. usePreviewConnection streams the values of the open
+// form into the iframe, and it turns a click in the iframe into the active field.
 function PreviewPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   usePreviewConnection(iframeRef);
@@ -18,9 +18,9 @@ function PreviewPane() {
   );
 }
 
-// The whole playground app now. Everything that used to live here — the collection's
-// fields, the document tabs, the status badge, the save button — comes from the admin
-// shell instead, driven by tina/config.ts.
+// The whole playground app. The admin shell now supplies the parts that this file held
+// before: the fields of the collection, the document tabs, the status badge, and the save
+// button. tina/config.ts drives all of them.
 export function App() {
   return (
     <TinaProvider config={config}>

--- a/packages/v4/@tinacms/tinacms/playground/src/content.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/content.ts
@@ -1,8 +1,8 @@
 import type { TinaDocument } from '@tinacms/tinacms';
 
-// Static seed for /preview.html opened standalone. `satisfies`, not an
-// annotation: useTina is generic, so keeping the literal shape lets the preview
-// read `body` as the mdx AST instead of casting it back out of `unknown`.
+// The static seed for /preview.html, when a browser opens that page by itself. This uses
+// `satisfies`, and not a type annotation. useTina is generic, so the literal shape lets
+// the preview read `body` as the MDX tree, and not cast it out of `unknown`.
 export const sampleDocument = {
   title: 'Hello World',
   featured: false,

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.test.tsx
@@ -3,9 +3,9 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readyMessage, valuesMessage } from '../../preview/protocol';
 import { useTina } from './use-tina';
 
-// Embedded-path scaffolding: happy-dom's window.parent === window (the
-// standalone default), so embedding is simulated by swapping window.parent for
-// a fake editor window and restoring it after each test.
+// The scaffolding for the embedded path. In happy-dom, window.parent equals window,
+// which is the standalone default. These tests therefore replace window.parent with a
+// false editor window, and put the original back after each test.
 const realParent = window.parent;
 afterEach(() => {
   Object.defineProperty(window, 'parent', {
@@ -46,7 +46,8 @@ describe('useTina standalone', () => {
     });
     rerender({ data: { title: 'Regenerated' } });
     expect(result.current.data).toEqual({ title: 'Regenerated' });
-    // Inert outside the editor: no message listener, no ready beacon.
+    // Outside the editor it does nothing. It adds no message listener, and it sends
+    // no ready message.
     expect(listenerSpy).not.toHaveBeenCalledWith('message', expect.anything());
     listenerSpy.mockRestore();
   });

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.ts
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useRef, useSyncExternalStore } from 'react';
 import type { TinaDocument } from '../../core/schema/types';
-import { connectToEditor } from '../../preview/connection';
+import { type PreviewStore, createPreviewStore } from '../../preview/store';
 
 export interface UseTinaOptions<T extends TinaDocument> {
   // The document as the site rendered it, in the SSR or the static build. This is the
@@ -17,11 +17,11 @@ export interface UseTinaResult<T extends TinaDocument> {
   isEditing: boolean;
 }
 
-// The site-side hook for visual editing (the v4 part of #6944). On a page by itself, it
-// does nothing. It adds no listener, it sends no ready message, and the props pass
-// through. Inside the editor iframe, it announces that it is ready, adopts every
-// document that arrives, and sends a click on a tinaField element up as an activate
-// message.
+// The site-side hook for visual editing (the v4 part of #6944), and the React binding of
+// ../../preview/store. The store holds what is true of every framework — that a page
+// outside the editor connects to nothing, that the editor's document supersedes the one
+// the site rendered — and this file holds the one thing that is React's: reading a
+// subscribe/getSnapshot pair, which useSyncExternalStore takes as it stands.
 //
 // There is one document for each connection. The tina:values message carries no document
 // identity, as the protocol header states, so every useTina on the page adopts the same
@@ -31,20 +31,31 @@ export function useTina<T extends TinaDocument = TinaDocument>({
   data,
   allowedOrigin,
 }: UseTinaOptions<T>): UseTinaResult<T> {
-  const [streamed, setStreamed] = useState<T | null>(null);
+  const store = usePreviewStore(allowedOrigin);
+  const streamed = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot
+  );
 
-  useEffect(() => {
-    if (window.parent === window) return;
-    const connection = connectToEditor({
-      previewWindow: window,
-      editorWindow: window.parent,
-      allowedOrigin: allowedOrigin ?? window.origin,
-      // The wire carries the document in the shape that the caller asserted for
-      // `data`. This is a cast at a serialization boundary.
-      onValues: (values) => setStreamed(values as T),
-    });
-    return () => connection.disconnect();
-  }, [allowedOrigin]);
+  // The wire carries the document in the shape that the caller asserted for `data`. This
+  // is a cast at a serialization boundary.
+  return { data: (streamed as T | null) ?? data, isEditing: streamed !== null };
+}
 
-  return { data: streamed ?? data, isEditing: streamed !== null };
+// One store for the life of the hook, rebuilt only when the origin it connects to
+// changes. Not useMemo: React may discard a memo, and discarding this one would drop the
+// document the editor has already streamed.
+function usePreviewStore(allowedOrigin: string | undefined): PreviewStore {
+  const heldStore = useRef<{
+    allowedOrigin?: string;
+    store: PreviewStore;
+  }>(null);
+  if (!heldStore.current || heldStore.current.allowedOrigin !== allowedOrigin) {
+    heldStore.current = {
+      allowedOrigin,
+      store: createPreviewStore({ allowedOrigin }),
+    };
+  }
+  return heldStore.current.store;
 }

--- a/packages/v4/@tinacms/tinacms/src/editor/active-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/active-field.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useRef } from 'react';
 import { describe, expect, it } from 'vitest';
 import { asResolvedConfig } from '../config';
 import type { CollectionSchema } from '../core/schema/types';
+import { useFormStore } from '../form/form-store';
 import { t } from '../index';
 import stringFieldPlugin from '../plugins/fields/string/string-field.plugin';
 import {
@@ -20,7 +22,10 @@ const NO_COLLECTIONS = { collections: [] };
 const collection: CollectionSchema = {
   name: 'post',
   format: 'mdx',
-  fields: [t.string({ name: 'title', label: 'Title' })],
+  fields: [
+    t.string({ name: 'title', label: 'Title' }),
+    t.string({ name: 'summary', label: 'Summary' }),
+  ],
 };
 
 // This drives the activation path in the same way as the click listener of the preview.
@@ -32,6 +37,25 @@ function ActivateProbe() {
       activate
     </button>
   );
+}
+
+// The view of this form on the active field, as a field plugin would read it.
+function ActiveReadout() {
+  const { active } = useActiveField();
+  return <span data-testid='active'>{active ?? 'none'}</span>;
+}
+
+// Records every new activation entry, by identity. The echo test needs the count of
+// entries, which no rendered value can show: a second entry for the same address
+// renders the same text.
+function ActivationLog({ entries }: { entries: string[] }) {
+  const active = useFormStore((state) => state.active);
+  const last = useRef<unknown>(null);
+  if (active && active !== last.current) {
+    last.current = active;
+    entries.push(active.address);
+  }
+  return null;
 }
 
 describe('active-field rail', () => {
@@ -88,5 +112,58 @@ describe('active-field rail', () => {
     expect(input).not.toHaveFocus();
     await userEvent.click(screen.getByText('activate'));
     expect(input).toHaveFocus();
+  });
+
+  it('focus in the form makes the focused field the active field', async () => {
+    render(
+      <TinaProvider
+        config={asResolvedConfig({
+          plugins: [stringFieldPlugin],
+          schema: NO_COLLECTIONS,
+        })}
+      >
+        <FormProvider
+          collection={collection}
+          path='content/posts/active.mdx'
+          document={{ title: 'Hi', summary: 'There' }}
+        >
+          <Field address='title' />
+          <Field address='summary' />
+          <ActiveReadout />
+        </FormProvider>
+      </TinaProvider>
+    );
+    expect(await screen.findByTestId('active')).toHaveTextContent('none');
+
+    await userEvent.click(screen.getByLabelText('title'));
+    expect(screen.getByTestId('active')).toHaveTextContent('title');
+
+    await userEvent.click(screen.getByLabelText('summary'));
+    expect(screen.getByTestId('active')).toHaveTextContent('summary');
+  });
+
+  it('an activation does not echo a second entry off the focus it causes', async () => {
+    const entries: string[] = [];
+    render(
+      <TinaProvider
+        config={asResolvedConfig({
+          plugins: [stringFieldPlugin],
+          schema: NO_COLLECTIONS,
+        })}
+      >
+        <FormProvider
+          collection={collection}
+          path='content/posts/active.mdx'
+          document={{ title: 'Hi' }}
+        >
+          <Field address='title' />
+          <ActivateProbe />
+          <ActivationLog entries={entries} />
+        </FormProvider>
+      </TinaProvider>
+    );
+    await userEvent.click(await screen.findByText('activate'));
+    expect(screen.getByLabelText('title')).toHaveFocus();
+    expect(entries).toEqual(['title']);
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/editor/continuity.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/continuity.test.tsx
@@ -34,8 +34,10 @@ import {
   FormProvider,
   type SaveHandler,
   TinaProvider,
+  useDiscardEdits,
   useFormId,
   useFormSave,
+  useFormSeedKey,
   useFormStatus,
 } from './index';
 
@@ -77,8 +79,25 @@ function SaveProbe() {
   );
 }
 
-// The switcher of the playground. Its FormProvider has a key, so a change of path tears
-// the form down and hosts the other document. The store keeps the edits.
+function DiscardProbe() {
+  const discard = useDiscardEdits();
+  return (
+    <button type='button' onClick={discard}>
+      discard
+    </button>
+  );
+}
+
+// The seed key is what a field hosting its own editor keys on, so a test that reads it
+// is testing that such a field would mount again. No string field needs it.
+function SeedKeyProbe() {
+  return <span data-testid='seed'>{useFormSeedKey()}</span>;
+}
+
+// A host that keys its FormProvider, so a change of path tears the form down and hosts
+// the other document. The store keeps the edits. The admin shell no longer keys its
+// provider — it switches in place, which the unkeyed describe below covers — but a host
+// that remounts is still supported, and ADR-012 must hold for it.
 const host = (path: string, document: TinaDocument, onSave?: SaveHandler) => (
   <TinaProvider
     config={asResolvedConfig({
@@ -96,6 +115,8 @@ const host = (path: string, document: TinaDocument, onSave?: SaveHandler) => (
       <Field address='title' />
       <StatusProbe />
       <SaveProbe />
+      <DiscardProbe />
+      <SeedKeyProbe />
     </FormProvider>
   </TinaProvider>
 );
@@ -396,6 +417,93 @@ describe('useFormValues', () => {
       useFormStore.getState().setFieldValue(formId, title, 'Edited');
     });
     expect(result.current).toEqual({ title: 'Edited' });
+  });
+});
+
+// Discarding an edit has to move three things at once: the store, RHF, and any editor
+// that owns its state. The last of those cannot be reset in place, so it keys on the seed
+// and mounts again. A string field needs none of that, so these tests read the seed key
+// directly — the rich-text e2e is what proves an editor follows it.
+describe('discarding edits', () => {
+  it('puts RHF and the store back on the loaded content, under a new seed', async () => {
+    render(host(pathA, { title: 'Hello' }));
+    const input = await screen.findByLabelText('title');
+    await userEvent.type(input, '!');
+    expect(screen.getByTestId('status')).toHaveTextContent('dirty');
+    const seed = screen.getByTestId('seed').textContent;
+
+    await userEvent.click(screen.getByText('discard'));
+
+    await waitFor(() => expect(input).toHaveValue('Hello'));
+    // Pristine, and not clean: a discarded form is the form a fresh load would give.
+    expect(screen.getByTestId('status')).toHaveTextContent('pristine');
+    expect(screen.getByTestId('seed').textContent).not.toBe(seed);
+  });
+
+  it('returns a saved form to what was saved, and not to what was loaded', async () => {
+    render(host(pathA, { title: 'Hello' }, () => {}));
+    const input = await screen.findByLabelText('title');
+    await userEvent.type(input, ' one');
+    await userEvent.click(screen.getByText('save'));
+    await waitFor(() =>
+      expect(screen.getByTestId('status')).toHaveTextContent('clean')
+    );
+
+    await userEvent.type(input, ' two');
+    await userEvent.click(screen.getByText('discard'));
+    await waitFor(() => expect(input).toHaveValue('Hello one'));
+    expect(screen.getByTestId('status')).toHaveTextContent('pristine');
+  });
+
+  it('takes the validation errors of the discarded edits with them', async () => {
+    render(host(pathA, { title: 'Hello' }));
+    const input = await screen.findByLabelText('title');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'x');
+    await screen.findByText('Title must be at least 3 characters');
+
+    await userEvent.click(screen.getByText('discard'));
+    await waitFor(() => expect(input).toHaveValue('Hello'));
+    expect(
+      screen.queryByText('Title must be at least 3 characters')
+    ).toBeNull();
+    expect(errorsOf(useFormStore.getState().forms, toFormId(pathA))).toBe(
+      undefined
+    );
+  });
+
+  it('does nothing to a form with no edits, and reseeds no editor', async () => {
+    render(host(pathA, { title: 'Hello' }));
+    const input = await screen.findByLabelText('title');
+    const seed = screen.getByTestId('seed').textContent;
+
+    await userEvent.click(screen.getByText('discard'));
+
+    expect(input).toHaveValue('Hello');
+    expect(screen.getByTestId('status')).toHaveTextContent('pristine');
+    expect(screen.getByTestId('seed').textContent).toBe(seed);
+  });
+
+  it('keeps the discarded form out of the way of another open form', async () => {
+    const { rerender } = render(host(pathA, { title: 'Doc A' }));
+    await userEvent.type(await screen.findByLabelText('title'), ' edited');
+
+    rerender(host(pathB, { title: 'Doc B' }));
+    await waitFor(() =>
+      expect(screen.getByLabelText('title')).toHaveValue('Doc B')
+    );
+    await userEvent.type(screen.getByLabelText('title'), ' edited');
+    await userEvent.click(screen.getByText('discard'));
+    await waitFor(() =>
+      expect(screen.getByLabelText('title')).toHaveValue('Doc B')
+    );
+
+    // A's edits are its own. Discarding B did not touch them.
+    rerender(host(pathA, { title: 'Doc A' }));
+    await waitFor(() =>
+      expect(screen.getByLabelText('title')).toHaveValue('Doc A edited')
+    );
+    expect(screen.getByTestId('status')).toHaveTextContent('dirty');
   });
 });
 

--- a/packages/v4/@tinacms/tinacms/src/editor/field.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/field.tsx
@@ -1,5 +1,6 @@
 import { use } from 'react';
 import { toFieldAddress } from '../core/field/address';
+import { useFormStore } from '../form/form-store';
 import {
   FieldAddressContext,
   FieldSchemaContext,
@@ -32,11 +33,36 @@ export function Field({ address }: FieldProps) {
     throw new Error(`No field plugin registered for type "${node.type}"`);
   }
 
+  const fieldAddress = toFieldAddress(address);
+
+  // Focus in the form is a producer of the active field, beside the click in the
+  // preview. It sits here, on the one wrapper every field shares, so no field plugin
+  // carries it. It writes the store directly, as the preview connection does, because
+  // this component must not re-render on the value it writes.
+  //
+  // The guard is necessary. An activation focuses the field, and that focus arrives
+  // back here. An unguarded write would then hand every activation a second entry,
+  // and every consumer of the entry would run twice. A focus on the field that is
+  // already active therefore writes nothing. The re-activation path keeps its
+  // semantics, because setActive itself stays unguarded: activating the same address
+  // again is a new entry, and focuses the field again.
+  const markActive = () => {
+    const { active, setActive } = useFormStore.getState();
+    if (active?.formId === scope.formId && active.address === fieldAddress) {
+      return;
+    }
+    setActive(scope.formId, fieldAddress);
+  };
+
   const Component = descriptor.Component;
   return (
-    <FieldAddressContext value={toFieldAddress(address)}>
+    <FieldAddressContext value={fieldAddress}>
       <FieldSchemaContext value={node}>
-        <Component />
+        {/* display: contents, because this wrapper exists for the focus listener
+            alone. It must not become a box in the layout of the form. */}
+        <div style={{ display: 'contents' }} onFocus={markActive}>
+          <Component />
+        </div>
       </FieldSchemaContext>
     </FieldAddressContext>
   );

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.test.tsx
@@ -264,7 +264,16 @@ describe('usePreviewConnection', () => {
     // A FormScopeContext alone is enough. The invariant throws in the body of the
     // hook, before an effect needs the runtime.
     const wrapper = ({ children }: { children: ReactNode }) => (
-      <FormScopeContext value={{ formId, path, collection, onSave: null }}>
+      <FormScopeContext
+        value={{
+          formId,
+          path,
+          collection,
+          onSave: null,
+          seedKey: path,
+          discardEdits: () => {},
+        }}
+      >
         {children}
       </FormScopeContext>
     );

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
@@ -7,7 +7,7 @@ import {
   isReadyMessage,
   valuesMessage,
 } from '../preview/protocol';
-import { useActiveField, useFormId } from './hooks';
+import { useFormId } from './hooks';
 
 export interface PreviewConnectionOptions {
   // The origin of the preview iframe. It defaults to the origin of the editor. A
@@ -31,7 +31,6 @@ export function usePreviewConnection(
   options?: PreviewConnectionOptions
 ): void {
   const formId = useFormId();
-  const { setActive } = useActiveField();
   const targetOrigin = options?.targetOrigin ?? window.origin;
   // This check runs at construction. A '*' origin would stream the values of the
   // document to any window that embeds the editor.
@@ -56,7 +55,12 @@ export function usePreviewConnection(
         const scope = useFormStore.getState().forms[formId];
         if (scope) postValues(scope.values);
       } else if (isActivateMessage(event.data)) {
-        setActive(toFieldAddress(event.data.address));
+        // The store directly, and not useActiveField. This hook writes the active
+        // field and never reads it, so subscribing would re-render the pane that
+        // holds the iframe on every activation for a value it does not use.
+        useFormStore
+          .getState()
+          .setActive(formId, toFieldAddress(event.data.address));
       }
     };
     window.addEventListener('message', onMessage);
@@ -75,5 +79,5 @@ export function usePreviewConnection(
       window.removeEventListener('message', onMessage);
       unsubscribe();
     };
-  }, [iframeRef, formId, setActive, targetOrigin]);
+  }, [iframeRef, formId, targetOrigin]);
 }

--- a/packages/v4/@tinacms/tinacms/src/preview/connection.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/connection.test.ts
@@ -2,8 +2,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type PreviewConnection, connectToEditor } from './connection';
 import { activateMessage, readyMessage, valuesMessage } from './protocol';
 
-// happy-dom's MessageEvent constructor doesn't reliably carry origin/source, so
-// force them on — every test needs both for the guards under test.
+// The MessageEvent constructor of happy-dom does not always carry the origin and the
+// source, so this sets them. Every test needs both for the guards under test.
 const messageEvent = (data: unknown, origin: string, source: unknown) => {
   const event = new MessageEvent('message', { data });
   Object.defineProperty(event, 'origin', { value: origin });
@@ -84,7 +84,8 @@ describe('connectToEditor', () => {
     const child = document.createElement('span');
     marked.appendChild(child);
     document.body.appendChild(marked);
-    // Clicks bubble up from descendants of the marked element too (closest).
+    // A click also bubbles up from a child of the marked element, which closest()
+    // finds.
     child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(editor.postMessage).toHaveBeenCalledWith(
       activateMessage('title'),
@@ -134,7 +135,7 @@ describe('connectToEditor', () => {
       readyMessage(),
       editorOrigin
     );
-    // The preview's own origin is no longer the allowed one.
+    // The origin of the preview is no longer the allowed origin.
     window.dispatchEvent(
       messageEvent(valuesMessage({ title: 'own' }), window.origin, editor)
     );

--- a/packages/v4/@tinacms/tinacms/src/preview/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/index.ts
@@ -2,6 +2,7 @@
 // editing that no framework owns (ADR-009 §4): the wire protocol and the tinaField
 // address marker. It uses neither React nor zustand. The bindings for each framework sit
 // under ./adapters/<framework>, and React is the first of them, at ./adapters/react. The
-// editor half is usePreviewConnection, on the ./react entry. connectToEditor and the
-// message constructors stay internal.
+// editor half is usePreviewConnection, on the ./react entry. connectToEditor, the message
+// constructors and createPreviewStore stay internal: a binding for a new framework lives
+// under ./adapters and imports the store directly, so it is not a published contract yet.
 export { TINA_FIELD_ATTR, tinaField } from './protocol';

--- a/packages/v4/@tinacms/tinacms/src/preview/store.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/store.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readyMessage, valuesMessage } from './protocol';
+import { createPreviewStore } from './store';
+
+// No framework here. The store takes its windows as arguments, so these drive the
+// boundary directly instead of standing a component up around it.
+
+const fakeEditor = () =>
+  ({ postMessage: vi.fn() }) as unknown as Window & { postMessage: any };
+
+const streamValues = (editor: Window, values: Record<string, unknown>) => {
+  const event = new MessageEvent('message', { data: valuesMessage(values) });
+  Object.defineProperty(event, 'origin', { value: window.origin });
+  Object.defineProperty(event, 'source', { value: editor });
+  window.dispatchEvent(event);
+};
+
+describe('a preview outside the editor', () => {
+  it('connects to nothing', () => {
+    const listenerSpy = vi.spyOn(window, 'addEventListener');
+    // A page opened on its own is its own parent.
+    const store = createPreviewStore({
+      previewWindow: window,
+      editorWindow: window,
+    });
+    const unsubscribe = store.subscribe(vi.fn());
+
+    expect(listenerSpy).not.toHaveBeenCalledWith('message', expect.anything());
+    expect(store.getSnapshot()).toBeNull();
+    expect(() => unsubscribe()).not.toThrow();
+    listenerSpy.mockRestore();
+  });
+});
+
+describe('a preview embedded in the editor', () => {
+  const embedded = () => {
+    const editor = fakeEditor();
+    const store = createPreviewStore({
+      previewWindow: window,
+      editorWindow: editor,
+    });
+    return { editor, store };
+  };
+
+  it('has streamed nothing until the editor says otherwise', () => {
+    const { store } = embedded();
+    expect(store.getSnapshot()).toBeNull();
+    expect(store.getServerSnapshot()).toBeNull();
+  });
+
+  it('announces readiness when the first subscriber arrives', () => {
+    const { editor, store } = embedded();
+    expect(editor.postMessage).not.toHaveBeenCalled();
+    store.subscribe(vi.fn());
+    expect(editor.postMessage).toHaveBeenCalledWith(
+      readyMessage(),
+      window.origin
+    );
+  });
+
+  it('adopts a streamed document and tells its subscribers', () => {
+    const { editor, store } = embedded();
+    const onChange = vi.fn();
+    store.subscribe(onChange);
+
+    streamValues(editor, { title: 'Edited live' });
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(store.getSnapshot()).toEqual({ title: 'Edited live' });
+  });
+
+  it('holds the snapshot steady between messages', () => {
+    const { editor, store } = embedded();
+    store.subscribe(vi.fn());
+    streamValues(editor, { title: 'Edited live' });
+    // Referential stability is the contract a store consumer reads to decide whether
+    // anything happened.
+    expect(store.getSnapshot()).toBe(store.getSnapshot());
+  });
+
+  it('shares one connection across subscribers', () => {
+    const { editor, store } = embedded();
+    const first = vi.fn();
+    const second = vi.fn();
+    store.subscribe(first);
+    store.subscribe(second);
+
+    expect(editor.postMessage).toHaveBeenCalledTimes(1);
+    streamValues(editor, { title: 'Edited live' });
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps listening while any subscriber remains', () => {
+    const { editor, store } = embedded();
+    const staying = vi.fn();
+    const leaving = vi.fn();
+    store.subscribe(staying);
+    const unsubscribe = store.subscribe(leaving);
+
+    unsubscribe();
+    streamValues(editor, { title: 'Edited live' });
+
+    expect(staying).toHaveBeenCalledTimes(1);
+    expect(leaving).not.toHaveBeenCalled();
+  });
+
+  it('disconnects when the last subscriber leaves', () => {
+    const { editor, store } = embedded();
+    const onChange = vi.fn();
+    const unsubscribe = store.subscribe(onChange);
+
+    unsubscribe();
+    streamValues(editor, { title: 'Edited live' });
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(store.getSnapshot()).toBeNull();
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/preview/store.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/store.ts
@@ -1,0 +1,76 @@
+// The preview connection as a store, which is the shape every framework already knows how
+// to consume: subscribe to changes, read a snapshot.
+//
+// React reads it with useSyncExternalStore, Svelte with its store contract, Vue with a
+// shallowRef, a plain script by calling subscribe. The rules that would otherwise be
+// rewritten in each of those — that a page outside the editor connects to nothing, that
+// nothing has streamed until the editor says so, that the last subscriber closes the
+// connection — live here once.
+
+import type { TinaDocument } from '../core/schema/types';
+import { type PreviewConnection, connectToEditor } from './connection';
+
+export interface CreatePreviewStoreOptions {
+  // The origin of the editor. It defaults to the origin of the page. A cross-origin
+  // embed is an explicit choice, and is never '*'.
+  allowedOrigin?: string;
+  // Both default to the globals. They are named so a test, or a host that renders
+  // somewhere other than a browser tab, can drive the boundary.
+  previewWindow?: Window;
+  editorWindow?: Window;
+}
+
+export interface PreviewStore {
+  // Start listening, and get back the unsubscribe. On a page that is not embedded in the
+  // editor this connects to nothing and the unsubscribe is a no-op.
+  subscribe: (onChange: () => void) => () => void;
+  // The document the editor streamed most recently, or null if it has streamed none. The
+  // reference only changes when a new one arrives, which is what a store consumer needs
+  // to decide whether anything happened.
+  getSnapshot: () => TinaDocument | null;
+  // Nothing has streamed during a server render, by definition.
+  getServerSnapshot: () => null;
+}
+
+export function createPreviewStore({
+  allowedOrigin,
+  previewWindow,
+  editorWindow,
+}: CreatePreviewStoreOptions = {}): PreviewStore {
+  const preview = previewWindow ?? globalThis.window;
+  const editor = editorWindow ?? preview?.parent;
+  // A page opened on its own is its own parent. There is no editor to talk to, so the
+  // store never adds a listener and never announces itself.
+  const embedded = Boolean(preview && editor && editor !== preview);
+
+  let streamed: TinaDocument | null = null;
+  let connection: PreviewConnection | null = null;
+  const listeners = new Set<() => void>();
+
+  return {
+    getSnapshot: () => streamed,
+    getServerSnapshot: () => null,
+    subscribe: (onChange) => {
+      if (!embedded) return () => {};
+      listeners.add(onChange);
+      // One connection for the store, opened by the first subscriber. Two views of the
+      // same preview should not each announce themselves to the editor.
+      connection ??= connectToEditor({
+        previewWindow: preview,
+        editorWindow: editor,
+        allowedOrigin: allowedOrigin ?? preview.origin,
+        onValues: (values) => {
+          streamed = values;
+          for (const listener of listeners) listener();
+        },
+      });
+      return () => {
+        listeners.delete(onChange);
+        if (listeners.size === 0) {
+          connection?.disconnect();
+          connection = null;
+        }
+      };
+    },
+  };
+}


### PR DESCRIPTION
**TLDR:** The preview connection becomes a subscribe/getSnapshot store, and focus in the form marks the active field.

**Feats:**
- createPreviewStore: the first subscriber opens the connection, the last one closes it
- A page outside the editor connects to nothing
- The shared field wrapper writes the active address on focus, guarded against double-fires
- Visual editing gets a real e2e spec

**How to test:** The store tests and the browser suite cover it.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`, then `pnpm test:e2e`.
