### PR TITLE
feat(v4): the form column resizes; documents mount behind a transition

### DIFF
--- a/packages/v4/@tinacms/tinacms/e2e/form-column-resize.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/form-column-resize.spec.ts
@@ -1,0 +1,78 @@
+import { expect, test } from '@playwright/test';
+import {
+  columnWidth,
+  formColumn,
+  resizeHandle,
+  setColumnWidth,
+  toolbar,
+} from './form-column';
+
+// The form column opens narrow and is dragged wider. A browser is the only place this
+// can be checked: the width comes from pointer capture and a clamp against the window,
+// neither of which happy-dom has. These tests only read the document, so they stay
+// parallel with the ones that save.
+const DEFAULT_WIDTH = 352;
+
+const openDocument = async (page: import('@playwright/test').Page) => {
+  await page.goto(
+    `/#/collections/post/${encodeURIComponent('content/posts/second-post.mdx')}`
+  );
+  await expect(page.getByRole('textbox', { name: 'body' })).toBeVisible();
+};
+
+test.beforeEach(async ({ page }) => {
+  await page.setViewportSize({ width: 1800, height: 900 });
+  await openDocument(page);
+});
+
+test('opens at the default width and drags wider', async ({ page }) => {
+  await expect(formColumn(page)).toHaveCSS('width', `${DEFAULT_WIDTH}px`);
+
+  await setColumnWidth(page, 700);
+  expect(await columnWidth(page)).toBeGreaterThan(600);
+});
+
+// The toolbar hides tools it cannot fit, which is the reason the column resizes at all.
+// A wider column that showed no more of them would leave the feature pointless.
+test('a wider column shows more of the rich-text toolbar', async ({ page }) => {
+  const controlsShown = () =>
+    toolbar(page).evaluate(
+      (container) =>
+        (container.firstElementChild as HTMLElement).childElementCount
+    );
+
+  const atDefault = await controlsShown();
+  await setColumnWidth(page, 700);
+  expect(await controlsShown()).toBeGreaterThan(atDefault);
+});
+
+// The default is also the floor. It is the width the rich-text layout tests cover, so
+// the editor is known to work at it, and narrower is untested.
+test('does not drag narrower than the default', async ({ page }) => {
+  await setColumnWidth(page, 200);
+  expect(await columnWidth(page)).toBe(DEFAULT_WIDTH);
+});
+
+// A preference an editor has to set on every page load is not a preference.
+test('the width survives a reload, and Home returns it to the default', async ({
+  page,
+}) => {
+  await setColumnWidth(page, 700);
+  const chosen = await columnWidth(page);
+
+  await page.reload();
+  await expect(page.getByRole('textbox', { name: 'body' })).toBeVisible();
+  expect(await columnWidth(page)).toBe(chosen);
+
+  await resizeHandle(page).press('Home');
+  await expect(formColumn(page)).toHaveCSS('width', `${DEFAULT_WIDTH}px`);
+});
+
+// The handle is reachable without a pointer.
+test('the arrow keys resize the column', async ({ page }) => {
+  const before = await columnWidth(page);
+  await resizeHandle(page).focus();
+  await resizeHandle(page).press('ArrowRight');
+  await resizeHandle(page).press('ArrowRight');
+  expect(await columnWidth(page)).toBe(before + 32);
+});

--- a/packages/v4/@tinacms/tinacms/e2e/form-column.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/form-column.ts
@@ -1,0 +1,33 @@
+import type { Page } from '@playwright/test';
+
+// The shell renders two asides: the navigation of the Sidebar, and the form column
+// inside the main region. The form column is the second.
+export const formColumn = (page: Page) => page.locator('aside').last();
+
+export const resizeHandle = (page: Page) =>
+  page.getByRole('separator', { name: 'Resize the form column' });
+
+export const columnWidth = (page: Page) =>
+  formColumn(page).evaluate((column) => column.getBoundingClientRect().width);
+
+// The element that carries `@container/toolbar`, which is what the toolbar measures
+// itself against.
+export const toolbar = (page: Page) =>
+  page.locator('div.w-full.overflow-hidden.\\@container\\/toolbar');
+
+// Drags the handle rather than setting a width, because React owns the inline style on
+// the column and would overwrite an assignment on its next render. This also keeps the
+// pointer path — capture, move, release — under test.
+export const setColumnWidth = async (page: Page, target: number) => {
+  const from = await columnWidth(page);
+  const handle = resizeHandle(page);
+  const box = await handle.boundingBox();
+  if (!box) throw new Error('The resize handle is not visible.');
+
+  const x = box.x + box.width / 2;
+  const y = box.y + box.height / 2;
+  await page.mouse.move(x, y);
+  await page.mouse.down();
+  await page.mouse.move(x + (target - from), y, { steps: 8 });
+  await page.mouse.up();
+};

--- a/packages/v4/@tinacms/tinacms/src/admin/admin.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/admin.test.tsx
@@ -1,15 +1,18 @@
+import { QueryClient } from '@tanstack/react-query';
 import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { asResolvedConfig } from '../config';
 import type { ContentProvider, DocumentEntry } from '../core/content/contract';
 import { definePlugin } from '../core/plugin';
 import type { TinaDocument } from '../core/schema/types';
+import type { AdminScreenProps } from '../core/screen/contract';
 import { useFormId } from '../editor/hooks';
 import { TinaProvider } from '../editor/provider';
 import { useFormStore } from '../form/form-store';
 import stringFieldPlugin from '../plugins/fields/string/string-field.plugin';
 import { TinaAdmin } from './admin';
+import { useAdminRoute } from './use-admin-route';
 
 // A content provider in memory, which stands in for the local data layer. The admin
 // talks to the capability, so the code behind it does not affect these tests.
@@ -46,50 +49,59 @@ const provider: ContentProvider = {
   },
 };
 
+// Counted, so a test can assert that two components reading one collection share a
+// single request rather than each running their own.
+const listCalls: string[] = [];
+
 const contentPlugin = definePlugin({
   name: 'test:content',
   provides: ['content'],
   client: async () => ({
     default: {
-      slice: (set, get) => ({
-        documents: {},
-        loadDocuments: async (collection: string) => {
-          const documents = await provider.list(collection);
-          const cache = get().content?.documents as Record<string, unknown>;
-          set({ documents: { ...cache, [collection]: documents } });
-          return documents;
+      // The slice is the transport, and holds no cache. The query client caches, so a
+      // stub only has to answer.
+      slice: () => ({
+        list: (collection: string) => {
+          listCalls.push(collection);
+          return provider.list(collection);
         },
-        getDocument: provider.get,
-        // This writes the stored entry back into the list cache, as the real local
-        // slice does. Without it, the cache never changes after a save, and the
-        // re-seed that this file guards against cannot happen.
-        saveDocument: async (
-          collection: string,
-          path: string,
-          value: TinaDocument
-        ) => {
-          const entry = await provider.update(collection, path, value);
-          const cache = get().content?.documents as Record<
-            string,
-            DocumentEntry[]
-          >;
-          set({
-            documents: {
-              ...cache,
-              [collection]: (cache?.[collection] ?? []).map((candidate) =>
-                candidate.path === path ? entry : candidate
-              ),
-            },
-          });
-          return entry;
-        },
+        get: provider.get,
+        update: provider.update,
       }),
     },
   }),
 });
 
+// A screen a plugin contributes, to prove the shell routes to a view it knows nothing
+// about. It reads its own route segments.
+function MediaScreen({ segments }: AdminScreenProps) {
+  const { navigate } = useAdminRoute();
+  return (
+    <div>
+      <p>media library at /{segments.join('/')}</p>
+      <button
+        type='button'
+        onClick={() =>
+          navigate({ view: 'screen', screen: 'media', segments: ['photos'] })
+        }
+      >
+        Open photos
+      </button>
+    </div>
+  );
+}
+
+const screenPlugin = definePlugin({
+  name: 'test:media-screen',
+  client: async () => ({
+    default: {
+      screens: [{ name: 'media', label: 'Media', component: MediaScreen }],
+    },
+  }),
+});
+
 const config = asResolvedConfig({
-  plugins: [contentPlugin, stringFieldPlugin],
+  plugins: [contentPlugin, screenPlugin, stringFieldPlugin],
   schema: {
     collections: [
       {
@@ -110,9 +122,16 @@ const config = asResolvedConfig({
   },
 });
 
+// A client per render, so no cached list crosses between tests, and no retry hides a
+// rejection behind a delay.
 const renderAdmin = (preview?: React.ReactNode) =>
   render(
-    <TinaProvider config={config}>
+    <TinaProvider
+      config={config}
+      queryClient={
+        new QueryClient({ defaultOptions: { queries: { retry: false } } })
+      }
+    >
       <TinaAdmin preview={preview} />
     </TinaProvider>
   );
@@ -139,6 +158,7 @@ const FIXTURES: Record<string, DocumentEntry[]> = {
 
 beforeEach(() => {
   saved.length = 0;
+  listCalls.length = 0;
   window.location.hash = '';
   useFormStore.setState({ forms: {} });
   // provider.update mutates `store`, and nothing reset it, so a test that saved
@@ -240,6 +260,160 @@ describe('TinaAdmin', () => {
       name: /hello\.mdx/,
     });
     expect(helloEntry).toHaveTextContent('Unsaved');
+  });
+});
+
+describe('TinaAdmin content reads', () => {
+  // The sidebar's document list and the open document's scope both read the collection.
+  // Each ran its own effect and its own fetch before the query client, so opening a
+  // collection listed it twice.
+  it('reads a collection once when two components ask for it', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await screen.findByRole('button', { name: /hello\.mdx/ });
+
+    expect(listCalls.filter((name) => name === 'post')).toEqual(['post']);
+  });
+
+  // Returning to a collection inside the stale window serves the cache.
+  it('does not read a collection again on returning to it', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await screen.findByRole('button', { name: /hello\.mdx/ });
+    await user.click(await screen.findByRole('button', { name: 'Pages' }));
+    await screen.findByRole('button', { name: /about\.mdx/ });
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await screen.findByRole('button', { name: /hello\.mdx/ });
+
+    expect(listCalls).toEqual(['post', 'page']);
+  });
+
+  // A failed read and an empty collection are different answers. The failure used to
+  // reach console.error alone, and the sidebar said "No documents yet".
+  it('reports a collection that failed to load', async () => {
+    const user = userEvent.setup();
+    const failing = vi
+      .spyOn(provider, 'list')
+      .mockRejectedValueOnce(new Error('data layer offline'));
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+
+    expect(await screen.findByText(/data layer offline/)).toBeInTheDocument();
+    expect(screen.queryByText('No documents yet.')).not.toBeInTheDocument();
+    failing.mockRestore();
+  });
+
+  // The save writes the stored entry into the cached list, so the sidebar shows it
+  // without a second read of the collection.
+  it('shows a save in the document list without re-reading the collection', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await user.click(await screen.findByRole('button', { name: /hello\.mdx/ }));
+    await user.type(await screen.findByLabelText('title'), '!');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => expect(saved).toHaveLength(1));
+    expect(listCalls).toEqual(['post']);
+  });
+});
+
+describe('TinaAdmin screens', () => {
+  it('lists the screens a plugin registered', async () => {
+    renderAdmin();
+    const menu = await screen.findByRole('list', { name: 'Screens' });
+    expect(
+      within(menu)
+        .getAllByRole('button')
+        .map((button) => button.textContent)
+    ).toEqual(['Media']);
+  });
+
+  it('opens a screen and writes a shareable hash', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Media' }));
+
+    expect(await screen.findByText(/media library at/)).toBeInTheDocument();
+    await waitFor(() => expect(window.location.hash).toBe('#/screens/media'));
+  });
+
+  // The screen owns the segments below its name, so it can navigate within itself and
+  // stay linkable.
+  it('gives a screen its own route segments', async () => {
+    window.location.hash = '#/screens/media/photos/2026';
+    renderAdmin();
+    expect(
+      await screen.findByText('media library at /photos/2026')
+    ).toBeInTheDocument();
+  });
+
+  it('lets a screen navigate within itself', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Media' }));
+    await user.click(
+      await screen.findByRole('button', { name: 'Open photos' })
+    );
+
+    expect(
+      await screen.findByText('media library at /photos')
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(window.location.hash).toBe('#/screens/media/photos')
+    );
+  });
+
+  // A stale link, or a screen whose plugin is no longer installed.
+  it('reports a screen no plugin registered', async () => {
+    window.location.hash = '#/screens/ghost';
+    renderAdmin();
+    expect(await screen.findByText(/No screen named/)).toBeInTheDocument();
+  });
+
+  // A screen names no collection, so opening one closes the document list. The route is
+  // the state: `#/screens/media` has no collection in it, and a sidebar that kept one
+  // would be showing something a reload could not restore.
+  it('closes the open collection when a screen opens', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await screen.findByRole('list', { name: 'Posts documents' });
+
+    await user.click(await screen.findByRole('button', { name: 'Media' }));
+    await screen.findByText(/media library at/);
+
+    expect(
+      screen.queryByRole('list', { name: 'Posts documents' })
+    ).not.toBeInTheDocument();
+  });
+
+  // The form store keeps an unsaved form after its scope unmounts (ADR-012), and a
+  // screen unmounts that scope.
+  it('keeps unsaved edits across a visit to a screen', async () => {
+    const user = userEvent.setup();
+    renderAdmin();
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await user.click(await screen.findByRole('button', { name: /hello\.mdx/ }));
+    await user.type(await screen.findByLabelText('title'), '!');
+
+    await user.click(await screen.findByRole('button', { name: 'Media' }));
+    await screen.findByText(/media library at/);
+
+    await user.click(await screen.findByRole('button', { name: 'Posts' }));
+    await user.click(await screen.findByRole('button', { name: /hello\.mdx/ }));
+
+    expect(await screen.findByLabelText('title')).toHaveValue('Hello!');
   });
 });
 

--- a/packages/v4/@tinacms/tinacms/src/admin/admin.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/admin.tsx
@@ -20,7 +20,15 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '@tinacms/ui/components/sidebar';
-import { type CSSProperties, type ReactNode, use } from 'react';
+import { Skeleton } from '@tinacms/ui/components/skeleton';
+import {
+  type CSSProperties,
+  type ReactNode,
+  startTransition,
+  use,
+  useEffect,
+  useState,
+} from 'react';
 import type { CollectionSchema } from '../core/schema/types';
 import type { AdminScreen } from '../core/screen/contract';
 import { useCollectionDocuments } from '../editor/content-queries';
@@ -32,9 +40,12 @@ import { FormStatusBadge } from './document-status';
 import { useAdminScreens, useTinaSchema } from './hooks';
 import { type AdminRoute, COLLECTIONS_ROUTE } from './routing';
 import { useAdminRoute } from './use-admin-route';
+import { useFormColumnWidth } from './use-form-column-width';
 
-// Wider than the default of 16rem. These entries are file paths, and a list of
-// truncated paths has little value.
+/**
+ * Wider than the default of 16rem. The entries are file paths, and a list of truncated
+ * paths has little value.
+ */
 const SHELL_WIDTH = { '--sidebar-width': '18rem' } as CSSProperties;
 
 const documentName = (path: string) => path.split('/').at(-1) ?? path;
@@ -70,9 +81,13 @@ function CollectionMenu({
   );
 }
 
-// This is a separate component, because the documents load through the content
-// capability at the mount. A hook higher in the tree would load every collection, and
-// not the open one alone.
+/**
+ * The document list of one collection.
+ *
+ * This is a separate component, because the documents load through the content
+ * capability at the mount. A hook higher in the tree would load every collection, and
+ * not the open one alone.
+ */
 function DocumentMenu({
   collection,
   activePath,
@@ -161,9 +176,11 @@ function ScreenMenu({
   );
 }
 
-// The registered view for a `screen` route, rendered where the form and the preview
-// otherwise sit. A screen owns the whole pane: it is not a collection, so the document
-// form beside it would have nothing to edit.
+/**
+ * The registered view for a `screen` route, rendered where the form and the preview
+ * otherwise sit. A screen owns the whole pane. A screen is not a collection, so the
+ * document form beside it would have nothing to edit.
+ */
 function ScreenOutlet({
   name,
   screen,
@@ -193,9 +210,13 @@ function ScreenOutlet({
   );
 }
 
-// This tests the form scope, and not the route. On a deep link, the two differ for one
-// frame, because the route is known before the document loads. A preview mounted in that
-// gap would read a form that does not exist yet.
+/**
+ * The host of the preview, beside the form.
+ *
+ * This tests the form scope, and not the route. On a deep link, the two differ for one
+ * frame, because the route is known before the document loads. A preview mounted in that
+ * gap would read a form that does not exist yet.
+ */
 function PreviewSlot({ preview }: { preview?: ReactNode }) {
   if (!use(FormScopeContext)) {
     return <Placeholder>Select a document to edit.</Placeholder>;
@@ -203,10 +224,99 @@ function PreviewSlot({ preview }: { preview?: ReactNode }) {
   return <>{preview ?? <Placeholder>No preview configured.</Placeholder>}</>;
 }
 
+/**
+ * What the form column shows while the next document's fields build in a transition.
+ * It stands where the fields will, so the column neither collapses nor jumps.
+ */
+function FormColumnSkeleton() {
+  return (
+    <div role='status' aria-label='Loading document' className='space-y-4'>
+      <Skeleton className='h-5 w-2/3' />
+      <Skeleton className='h-8 w-full' />
+      <Skeleton className='h-5 w-1/3' />
+      <Skeleton className='h-40 w-full' />
+    </div>
+  );
+}
+
+/**
+ * An aside inside the main region. It supports the preview, which holds the work, so it
+ * opens narrow. A form column that grows with the window is hard to read.
+ *
+ * Narrow is the default, and not the limit. The rich-text toolbar sizes itself to this
+ * column and hides the tools it cannot fit, so an editor who works in prose can drag the
+ * column wider and keep them. The rich-text e2e tests cover the default width, which is
+ * also the floor.
+ */
+function FormColumn({ openPath }: { openPath?: string }) {
+  const { width, isResizing, handleProps } = useFormColumnWidth();
+  const scope = use(FormScopeContext);
+  const seedKey = scope?.seedKey;
+
+  // The mount of the fields is deferred behind a transition. Building the rich-text
+  // editor is the most expensive render in the admin, and it grows with the document —
+  // long prose froze the whole shell for most of a second when it rendered in the
+  // urgent pass. The urgent pass now commits the skeleton below, which also unmounts
+  // the outgoing editor at once: nothing stale is left focusable while the reset and
+  // the build are in flight. The transition then renders the fields concurrently, so
+  // the main thread keeps yielding to input and to the preview until they are ready.
+  const [mountedSeedKey, setMountedSeedKey] = useState<string | undefined>(
+    undefined
+  );
+  useEffect(() => {
+    if (mountedSeedKey === seedKey) return;
+    startTransition(() => setMountedSeedKey(seedKey));
+  }, [seedKey, mountedSeedKey]);
+
+  return (
+    <>
+      <aside
+        className='flex min-w-0 shrink-0 flex-col overflow-y-auto border-r border-sidebar-border p-4'
+        style={{ width }}
+      >
+        <div className='mb-2 flex items-center gap-1'>
+          <SidebarTrigger />
+          {openPath === undefined ? (
+            <span className='text-sm text-muted-foreground'>
+              Select a document to edit
+            </span>
+          ) : null}
+        </div>
+        {mountedSeedKey === seedKey ? (
+          /* Keyed on the seed key, and not on the path. Plate reads its value at mount
+             only, and the seed key advances when the provider's reset lands, so the
+             fields mount once, on the new document's values. The key stays here. On the
+             FormProvider above it remounted the preview iframe on every switch. */
+          <DocumentForm key={seedKey} />
+        ) : (
+          <FormColumnSkeleton />
+        )}
+      </aside>
+
+      {/* The grab area is wider than the line it draws, because a 1px target is a miss
+          more often than a hit. */}
+      <div
+        className='-ml-1 z-10 w-2 shrink-0 cursor-col-resize touch-none select-none focus-visible:outline-none'
+        {...handleProps}
+      />
+
+      {/* Pointer capture keeps the drag events coming, but the pointer still travels over
+          the form and the preview. This holds the resize cursor over both, and stops the
+          drag from selecting their text. */}
+      {isResizing ? (
+        <div className='fixed inset-0 z-50 cursor-col-resize' />
+      ) : null}
+    </>
+  );
+}
+
 export interface TinaAdminProps {
-  // This renders beside the editor. It is the site preview, in a host that has one. It
-  // is a prop, and not a UI slot. The set of slot names is a first-party set that the
-  // core has not defined yet (ADR-013), and a name invented here would prejudge it.
+  /**
+   * This renders beside the editor. It is the site preview, in a host that has one.
+   *
+   * It is a prop, and not a UI slot. The set of slot names is a first-party set that
+   * the core has not defined yet (ADR-013), and a name invented here would prejudge it.
+   */
   preview?: ReactNode;
 }
 
@@ -224,6 +334,12 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
   );
   const openPath = route.view === 'document' ? route.path : undefined;
   const activeScreen = route.view === 'screen' ? route : undefined;
+  /**
+   * A route that names a collection outside the schema is stale, and not broken. The
+   * sidebar says so, instead of a screen that looks correct.
+   */
+  const isStaleCollectionRoute =
+    activeCollectionName !== undefined && collection === undefined;
 
   const layout = (
     <SidebarProvider style={SHELL_WIDTH}>
@@ -250,15 +366,13 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
             />
           </SidebarGroup>
 
-          {/* A route that names a collection outside the schema is stale, and not
-              broken. Say so, instead of a screen that looks correct. */}
-          {activeCollectionName && !collection && (
+          {isStaleCollectionRoute ? (
             <Placeholder>
               No collection named “{activeCollectionName}”.
             </Placeholder>
-          )}
+          ) : null}
 
-          {collection && (
+          {collection ? (
             <SidebarGroup>
               <SidebarGroupLabel>
                 {collection.label ?? collection.name}
@@ -269,11 +383,11 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
                 navigate={navigate}
               />
             </SidebarGroup>
-          )}
+          ) : null}
 
           {/* The group is absent when no plugin registered a screen, so an admin with
               no screen plugins looks exactly as it did before they existed. */}
-          {screens.length > 0 && (
+          {screens.length > 0 ? (
             <SidebarGroup>
               <SidebarGroupLabel>Screens</SidebarGroupLabel>
               <ScreenMenu
@@ -282,7 +396,7 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
                 navigate={navigate}
               />
             </SidebarGroup>
-          )}
+          ) : null}
         </SidebarContent>
       </Sidebar>
 
@@ -307,25 +421,7 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
            the sidebar and re-fetched the document list on every open and close. */
         <DocumentScope collection={collection} path={openPath}>
           <SidebarInset className='flex-row'>
-            {/* An aside inside the main region. It supports the preview, which holds the
-            work. Its width is fixed and narrow. A form column that grows with the
-            window is hard to read, and the rich-text editor must work at this width.
-            The e2e tests cover that. */}
-            <aside className='flex w-88 min-w-0 shrink-0 flex-col overflow-y-auto border-r border-sidebar-border p-4'>
-              <div className='mb-2 flex items-center gap-1'>
-                <SidebarTrigger />
-                {!openPath && (
-                  <span className='text-sm text-muted-foreground'>
-                    Select a document to edit
-                  </span>
-                )}
-              </div>
-              {/* Keyed on the path: the fields remount on a document switch. Plate reads
-              its value at mount only, so without this the editor keeps the previous
-              document's prose. The key sits here, and not on the FormProvider above,
-              because there it remounted the sidebar and the preview with it. */}
-              <DocumentForm key={openPath} />
-            </aside>
+            <FormColumn openPath={openPath} />
 
             <div className='min-w-0 flex-1'>
               <PreviewSlot preview={preview} />

--- a/packages/v4/@tinacms/tinacms/src/admin/document-form.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/document-form.tsx
@@ -1,340 +1,118 @@
-// The shell of the admin UI: the collection list, then the document list, then the form.
-// The compiled schema drives all of it. No code here names a collection or a field type.
-// Add a collection to tina/config.ts, and it appears. This is what ADR-016 §1 means when
-// it says that the schema fans out to the forms.
+// The editing pane. It holds the fields of the open document, and the save. Component
+// resolution renders each field (ADR-009). <Field> finds the plugin from the `type` of
+// the schema node, so this file never learns what a rich-text field is.
 //
-// There are three panes. The Sidebar of @tinacms/ui holds the navigation, the form sits
-// beside it, and the preview comes last. Navigation and editing are separate tasks. The
-// sidebar collapses, so the editor can use the width.
+// It does not own the form scope. DocumentScope owns it, above the whole layout, because
+// the preview needs the same scope and sits outside this pane.
 
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarGroup,
-  SidebarGroupLabel,
-  SidebarHeader,
-  SidebarInset,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-  SidebarProvider,
-  SidebarTrigger,
-} from '@tinacms/ui/components/sidebar';
-import { type CSSProperties, type ReactNode, use } from 'react';
-import type { CollectionSchema } from '../core/schema/types';
-import type { AdminScreen } from '../core/screen/contract';
-import { useCollectionDocuments } from '../editor/content-queries';
+import { Button } from '@tinacms/ui/components/button';
+import { Label } from '@tinacms/ui/components/label';
+import { use, useState } from 'react';
+import { toFieldAddress } from '../core/field/address';
+import type { FieldSchema } from '../core/schema/types';
 import { FormScopeContext } from '../editor/context';
-import { toFormId } from '../form/form-store';
-import { DocumentForm } from './document-form';
-import { DocumentScope } from './document-scope';
-import { FormStatusBadge } from './document-status';
-import { useAdminScreens, useTinaSchema } from './hooks';
-import { type AdminRoute, COLLECTIONS_ROUTE } from './routing';
-import { useAdminRoute } from './use-admin-route';
+import { Field } from '../editor/field';
+import { useFieldRegistry, useFormId, useFormSave } from '../editor/hooks';
+import { useIsFieldDirty, useIsFormDirty } from '../form/form-store';
+import { DocumentStatus } from './document-status';
 
-// Wider than the default of 16rem. These entries are file paths, and a list of
-// truncated paths has little value.
-const SHELL_WIDTH = { '--sidebar-width': '18rem' } as CSSProperties;
-
-const documentName = (path: string) => path.split('/').at(-1) ?? path;
-
-function Placeholder({ children }: { children: ReactNode }) {
-  return <p className='p-4 text-sm text-muted-foreground'>{children}</p>;
-}
-
-function CollectionMenu({
-  collections,
-  activeName,
-  navigate,
-}: {
-  collections: CollectionSchema[];
-  activeName?: string;
-  navigate: (route: AdminRoute) => void;
-}) {
+// The shell owns this label, and the field plugin does not. A plugin renders FieldWrapper
+// with no label, because its control carries an aria-label of the field address. That
+// left the visible text and the accessible name as two different strings, which is WCAG
+// 2.5.3 Label in Name wherever a collection's `label` differs from its `name`, and a
+// label that focused nothing when clicked. `htmlFor` ties them together, and each control
+// now carries its address as an id, which settles the focus half.
+//
+// The accessible name is not settled. The string, number and boolean controls still set
+// `aria-label` to the address, and that outranks this label, so Label in Name closes when
+// those fields drop it.
+//
+// The dirty mark reads as text. An aria-label on a bare span is ignored on a generic
+// element, so the 6px dot was the only signal it gave.
+function FieldRow({ node }: { node: FieldSchema }) {
+  const name = node.name;
+  const dirty = useIsFieldDirty(useFormId(), toFieldAddress(name));
+  // Rich text is the case this asks about: its control is a contenteditable, which HTML
+  // cannot label, so `for` would point at nothing.
+  const labelable =
+    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
   return (
-    <SidebarMenu aria-label='Collections'>
-      {collections.map((collection) => (
-        <SidebarMenuItem key={collection.name}>
-          <SidebarMenuButton
-            isActive={collection.name === activeName}
-            onClick={() =>
-              navigate({ view: 'collection', collection: collection.name })
-            }
-          >
-            {collection.label ?? collection.name}
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  );
-}
-
-// This is a separate component, because the documents load through the content
-// capability at the mount. A hook higher in the tree would load every collection, and
-// not the open one alone.
-function DocumentMenu({
-  collection,
-  activePath,
-  navigate,
-}: {
-  collection: CollectionSchema;
-  activePath?: string;
-  navigate: (route: AdminRoute) => void;
-}) {
-  const { documents, isLoading, error } = useCollectionDocuments(
-    collection.name
-  );
-  const label = collection.label ?? collection.name;
-  // A read that failed and a collection that is empty are different answers, and the
-  // editor has to be able to tell them apart. Before the query client, a failed list
-  // reached console.error and the sidebar said "No documents yet."
-  if (error) {
-    return (
-      <p className='px-2 py-1.5 text-sm text-destructive'>
-        Could not load {label}. {error.message}
-      </p>
-    );
-  }
-  if (isLoading) {
-    return (
-      <p className='px-2 py-1.5 text-sm text-muted-foreground'>Loading…</p>
-    );
-  }
-  if (documents.length === 0) {
-    return (
-      <p className='px-2 py-1.5 text-sm text-muted-foreground'>
-        No documents yet.
-      </p>
-    );
-  }
-  return (
-    <SidebarMenu aria-label={`${label} documents`}>
-      {documents.map(({ path }) => (
-        <SidebarMenuItem key={path}>
-          {/* The status sits inside the button, and not in SidebarMenuBadge. That
-              slot has an absolute position for a count, and this status is words. */}
-          <SidebarMenuButton
-            isActive={path === activePath}
-            onClick={() =>
-              navigate({ view: 'document', collection: collection.name, path })
-            }
-          >
-            <span className='flex-1 truncate'>{documentName(path)}</span>
-            {/* The badge reads the store, so a document that was edited and left
-                still reads as unsaved after its form unmounts (ADR-012). */}
-            <FormStatusBadge formId={toFormId(path)} />
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  );
-}
-
-function ScreenMenu({
-  screens,
-  activeName,
-  navigate,
-}: {
-  screens: AdminScreen[];
-  activeName?: string;
-  navigate: (route: AdminRoute) => void;
-}) {
-  return (
-    <SidebarMenu aria-label='Screens'>
-      {screens.map((screen) => (
-        <SidebarMenuItem key={screen.name}>
-          <SidebarMenuButton
-            isActive={screen.name === activeName}
-            // Navigating to a screen from the sidebar enters it at its root. The
-            // segments below that belong to the screen, and only the screen knows how
-            // to build one.
-            onClick={() =>
-              navigate({ view: 'screen', screen: screen.name, segments: [] })
-            }
-          >
-            {screen.label}
-          </SidebarMenuButton>
-        </SidebarMenuItem>
-      ))}
-    </SidebarMenu>
-  );
-}
-
-// The registered view for a `screen` route, rendered where the form and the preview
-// otherwise sit. A screen owns the whole pane: it is not a collection, so the document
-// form beside it would have nothing to edit.
-function ScreenOutlet({
-  name,
-  screen,
-  segments,
-}: {
-  name: string;
-  screen: AdminScreen | undefined;
-  segments: string[];
-}) {
-  return (
-    <SidebarInset>
-      <div className='flex items-center gap-1 p-4 pb-2'>
-        <SidebarTrigger />
-      </div>
-      <div className='min-h-0 flex-1 overflow-y-auto'>
-        {screen ? (
-          // Keyed on the name, so moving between two screens remounts rather than
-          // handing the next screen the last one's state.
-          <screen.component key={screen.name} segments={segments} />
-        ) : (
-          // A route naming a screen no plugin registered is stale, the same way a
-          // route naming a collection outside the schema is.
-          <Placeholder>No screen named “{name}”.</Placeholder>
-        )}
-      </div>
-    </SidebarInset>
-  );
-}
-
-// This tests the form scope, and not the route. On a deep link, the two differ for one
-// frame, because the route is known before the document loads. A preview mounted in that
-// gap would read a form that does not exist yet.
-function PreviewSlot({ preview }: { preview?: ReactNode }) {
-  if (!use(FormScopeContext)) {
-    return <Placeholder>Select a document to edit.</Placeholder>;
-  }
-  return <>{preview ?? <Placeholder>No preview configured.</Placeholder>}</>;
-}
-
-export interface TinaAdminProps {
-  // This renders beside the editor. It is the site preview, in a host that has one. It
-  // is a prop, and not a UI slot. The set of slot names is a first-party set that the
-  // core has not defined yet (ADR-013), and a name invented here would prejudge it.
-  preview?: ReactNode;
-}
-
-export function TinaAdmin({ preview }: TinaAdminProps) {
-  const schema = useTinaSchema();
-  const screens = useAdminScreens();
-  const { route, navigate } = useAdminRoute();
-
-  const activeCollectionName =
-    route.view === 'collection' || route.view === 'document'
-      ? route.collection
-      : undefined;
-  const collection = schema.collections.find(
-    (candidate) => candidate.name === activeCollectionName
-  );
-  const openPath = route.view === 'document' ? route.path : undefined;
-  const activeScreen = route.view === 'screen' ? route : undefined;
-
-  const layout = (
-    <SidebarProvider style={SHELL_WIDTH}>
-      <Sidebar aria-label='Content' role='navigation'>
-        <SidebarHeader>
-          <SidebarMenu>
-            <SidebarMenuItem>
-              <SidebarMenuButton onClick={() => navigate(COLLECTIONS_ROUTE)}>
-                <span className='text-xs font-semibold tracking-wide uppercase'>
-                  TinaCMS
-                </span>
-              </SidebarMenuButton>
-            </SidebarMenuItem>
-          </SidebarMenu>
-        </SidebarHeader>
-
-        <SidebarContent>
-          <SidebarGroup>
-            <SidebarGroupLabel>Collections</SidebarGroupLabel>
-            <CollectionMenu
-              collections={schema.collections}
-              activeName={collection?.name}
-              navigate={navigate}
+    <div className='mb-4 min-w-0'>
+      <Label className='mb-1' htmlFor={labelable ? name : undefined}>
+        {node.label ?? name}
+        {dirty ? (
+          <>
+            <span
+              aria-hidden='true'
+              className='size-1.5 rounded-full bg-primary'
             />
-          </SidebarGroup>
-
-          {/* A route that names a collection outside the schema is stale, and not
-              broken. Say so, instead of a screen that looks correct. */}
-          {activeCollectionName && !collection && (
-            <Placeholder>
-              No collection named “{activeCollectionName}”.
-            </Placeholder>
-          )}
-
-          {collection && (
-            <SidebarGroup>
-              <SidebarGroupLabel>
-                {collection.label ?? collection.name}
-              </SidebarGroupLabel>
-              <DocumentMenu
-                collection={collection}
-                activePath={openPath}
-                navigate={navigate}
-              />
-            </SidebarGroup>
-          )}
-
-          {/* The group is absent when no plugin registered a screen, so an admin with
-              no screen plugins looks exactly as it did before they existed. */}
-          {screens.length > 0 && (
-            <SidebarGroup>
-              <SidebarGroupLabel>Screens</SidebarGroupLabel>
-              <ScreenMenu
-                screens={screens}
-                activeName={activeScreen?.screen}
-                navigate={navigate}
-              />
-            </SidebarGroup>
-          )}
-        </SidebarContent>
-      </Sidebar>
-
-      {/* A screen replaces the editor panes rather than sitting beside them, so the two
-          branches swap here. That unmounts the form scope, which is right: a screen is
-          not a document, and there is nothing for the form to edit. The unsaved edits
-          survive it — the form store keeps a form after its scope goes (ADR-012), so
-          returning to the document finds them again. */}
-      {activeScreen ? (
-        <ScreenOutlet
-          name={activeScreen.screen}
-          screen={screens.find(
-            (candidate) => candidate.name === activeScreen.screen
-          )}
-          segments={activeScreen.segments}
-        />
-      ) : (
-        /* The scope wraps the two panes that read the open form, and not the whole
-           shell. A swap at this position rebuilds them, which is right — both are
-           created and destroyed with the document anyway — while the SidebarProvider
-           and the navigation above keep their state. Wrapping the whole layout reset
-           the sidebar and re-fetched the document list on every open and close. */
-        <DocumentScope collection={collection} path={openPath}>
-          <SidebarInset className='flex-row'>
-            {/* An aside inside the main region. It supports the preview, which holds the
-            work. Its width is fixed and narrow. A form column that grows with the
-            window is hard to read, and the rich-text editor must work at this width.
-            The e2e tests cover that. */}
-            <aside className='flex w-88 min-w-0 shrink-0 flex-col overflow-y-auto border-r border-sidebar-border p-4'>
-              <div className='mb-2 flex items-center gap-1'>
-                <SidebarTrigger />
-                {!openPath && (
-                  <span className='text-sm text-muted-foreground'>
-                    Select a document to edit
-                  </span>
-                )}
-              </div>
-              {/* Keyed on the path: the fields remount on a document switch. Plate reads
-              its value at mount only, so without this the editor keeps the previous
-              document's prose. The key sits here, and not on the FormProvider above,
-              because there it remounted the sidebar and the preview with it. */}
-              <DocumentForm key={openPath} />
-            </aside>
-
-            <div className='min-w-0 flex-1'>
-              <PreviewSlot preview={preview} />
-            </div>
-          </SidebarInset>
-        </DocumentScope>
-      )}
-    </SidebarProvider>
+            <span className='sr-only'>(unsaved)</span>
+          </>
+        ) : null}
+      </Label>
+      <Field address={name} />
+    </div>
   );
+}
 
-  return layout;
+function SaveButton() {
+  const dirty = useIsFormDirty(useFormId());
+  const save = useFormSave();
+  // A write can fail, and the form stays dirty when it does, so the edit is still there
+  // to retry. Without this the rejection went unhandled and the only signal the author
+  // got was the badge staying "Unsaved", which is also what a save in flight looks like.
+  const [failure, setFailure] = useState<string | null>(null);
+  return (
+    <div className='flex flex-col items-start gap-2'>
+      {/* aria-disabled, and not disabled. `disabled` takes the button out of the tab
+          order at the moment it is pressed, so keyboard focus fell to <body> after
+          every save. */}
+      <Button
+        type='button'
+        className='aria-disabled:pointer-events-none aria-disabled:opacity-50'
+        aria-disabled={!dirty}
+        onClick={() => {
+          if (!dirty) return;
+          setFailure(null);
+          save().catch((cause) => {
+            console.error('[tinacms] Save failed:', cause);
+            setFailure(
+              cause instanceof Error && cause.message
+                ? cause.message
+                : 'Save failed.'
+            );
+          });
+        }}
+      >
+        Save
+      </Button>
+      {failure ? (
+        <p role='alert' className='text-sm text-destructive'>
+          {failure}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export function DocumentForm() {
+  // This reads the scope, and does not require it. The pane sits in a layout that also
+  // renders with no open document. An empty pane is a state, and not a fault.
+  const scope = use(FormScopeContext);
+  if (!scope) return null;
+
+  return (
+    <>
+      <header className='mb-4 flex items-center justify-between gap-2'>
+        <h2 className='truncate text-sm font-semibold' title={scope.path}>
+          {scope.path.split('/').at(-1)}
+        </h2>
+        <DocumentStatus />
+      </header>
+      {scope.collection.fields.map((node) => (
+        <FieldRow key={node.name} node={node} />
+      ))}
+      <SaveButton />
+    </>
+  );
 }

--- a/packages/v4/@tinacms/tinacms/src/admin/use-form-column-width.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/use-form-column-width.ts
@@ -1,0 +1,141 @@
+import {
+  type ComponentPropsWithoutRef,
+  type KeyboardEvent,
+  type PointerEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+// The form column opens narrow, because a form that grows with the window is hard to
+// read. Narrow is the right default, but it is the wrong ceiling: the rich-text toolbar
+// sizes itself to the column, and at the default width it has room for six tools and
+// puts the rest behind a menu. An editor working in prose wants those tools. So the
+// width is a preference, not a constant, and the drag survives a reload.
+//
+// The preference lives in localStorage rather than the store. The `ui` core slice, which
+// is where it belongs, is still empty — move this there when that slice lands.
+const DEFAULT_WIDTH = 352;
+// The floor is the default. That is the width the rich-text e2e tests cover, so the
+// editor is known to work at it; anything narrower is untested. Dragging widens.
+const MIN_WIDTH = DEFAULT_WIDTH;
+// The preview is the point of the pane beside it, so the column stops before it would
+// squeeze the preview out.
+const MIN_PREVIEW_WIDTH = 400;
+const KEYBOARD_STEP = 16;
+const STORAGE_KEY = 'tina-form-column-width';
+
+// Storage throws when a browser blocks it (private windows, disabled cookies). A width
+// preference is not worth failing the shell over, so both directions swallow it.
+const readStoredWidth = (): number | null => {
+  try {
+    const stored = Number(window.localStorage.getItem(STORAGE_KEY));
+    return Number.isFinite(stored) && stored > 0 ? stored : null;
+  } catch {
+    return null;
+  }
+};
+
+const writeStoredWidth = (width: number) => {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(width));
+  } catch {
+    // Ignored, see above.
+  }
+};
+
+const clampWidth = (width: number) =>
+  Math.max(MIN_WIDTH, Math.min(width, window.innerWidth - MIN_PREVIEW_WIDTH));
+
+export interface FormColumnWidth {
+  width: number;
+  isResizing: boolean;
+  handleProps: ComponentPropsWithoutRef<'div'>;
+}
+
+export const useFormColumnWidth = (): FormColumnWidth => {
+  // The stored width is read after mount, and not in the initializer. The admin renders
+  // on the server too, where there is no localStorage, and a first client render that
+  // disagreed with the server markup would be a hydration mismatch on the style attribute.
+  const [width, setWidth] = useState(DEFAULT_WIDTH);
+  const [isResizing, setIsResizing] = useState(false);
+  const dragStart = useRef<{ x: number; width: number } | null>(null);
+
+  useEffect(() => {
+    const stored = readStoredWidth();
+    if (stored !== null) setWidth(clampWidth(stored));
+  }, []);
+
+  // A window that shrinks can leave the column wider than the clamp allows, which would
+  // push the preview out of view until the next drag.
+  useEffect(() => {
+    const onWindowResize = () => setWidth(clampWidth);
+    window.addEventListener('resize', onWindowResize);
+    return () => window.removeEventListener('resize', onWindowResize);
+  }, []);
+
+  // Only the settled width is stored. Writing on each pointermove would hit storage
+  // synchronously on every frame of a drag.
+  useEffect(() => {
+    if (isResizing) return;
+    writeStoredWidth(width);
+  }, [isResizing, width]);
+
+  const onPointerDown = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      // Without this the drag starts a text selection in the form behind the handle.
+      event.preventDefault();
+      event.currentTarget.setPointerCapture(event.pointerId);
+      dragStart.current = { x: event.clientX, width };
+      setIsResizing(true);
+    },
+    [width]
+  );
+
+  const onPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    const start = dragStart.current;
+    if (!start) return;
+    // Measured from where the drag began, not from the pointer position, so the column
+    // does not jump by the offset between the grab point and the edge.
+    setWidth(clampWidth(start.width + (event.clientX - start.x)));
+  }, []);
+
+  const endDrag = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    if (!dragStart.current) return;
+    dragStart.current = null;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    setIsResizing(false);
+  }, []);
+
+  const onKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    const step =
+      event.key === 'ArrowLeft'
+        ? -KEYBOARD_STEP
+        : event.key === 'ArrowRight'
+          ? KEYBOARD_STEP
+          : 0;
+    if (step === 0 && event.key !== 'Home') return;
+    event.preventDefault();
+    if (event.key === 'Home') setWidth(clampWidth(DEFAULT_WIDTH));
+    else setWidth((current) => clampWidth(current + step));
+  }, []);
+
+  return {
+    width,
+    isResizing,
+    handleProps: {
+      role: 'separator',
+      'aria-orientation': 'vertical',
+      'aria-label': 'Resize the form column',
+      'aria-valuenow': width,
+      'aria-valuemin': MIN_WIDTH,
+      tabIndex: 0,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+      onKeyDown,
+    },
+  };
+};

--- a/packages/v4/@tinacms/ui/src/components/alert-dialog.tsx
+++ b/packages/v4/@tinacms/ui/src/components/alert-dialog.tsx
@@ -1,0 +1,119 @@
+import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog';
+import type * as React from 'react';
+
+import { cn } from '@tinacms/ui/lib/utils';
+
+// The dialog for an action that cannot be undone. It differs from Sheet in what it
+// refuses to do: it has no close button, and a click outside it or the Escape key does
+// not dismiss it. The choice has to be made.
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot='alert-dialog' {...props} />;
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot='alert-dialog-trigger' {...props} />
+  );
+}
+
+function AlertDialogClose({ ...props }: AlertDialogPrimitive.Close.Props) {
+  return (
+    <AlertDialogPrimitive.Close data-slot='alert-dialog-close' {...props} />
+  );
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot='alert-dialog-overlay'
+      className={cn(
+        'fixed inset-0 z-50 bg-black/10 transition-opacity duration-150 data-ending-style:opacity-0 data-starting-style:opacity-0 supports-backdrop-filter:backdrop-blur-xs',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogContent({
+  className,
+  children,
+  ...props
+}: AlertDialogPrimitive.Popup.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot='alert-dialog-portal'>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot='alert-dialog-content'
+        className={cn(
+          'fixed top-1/2 left-1/2 z-50 flex w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 -translate-y-1/2 flex-col gap-4 rounded-xl border border-border bg-popover bg-clip-padding p-4 text-sm text-popover-foreground shadow-lg transition duration-150 data-ending-style:scale-95 data-ending-style:opacity-0 data-starting-style:scale-95 data-starting-style:opacity-0',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Popup>
+    </AlertDialogPrimitive.Portal>
+  );
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='alert-dialog-header'
+      className={cn('flex flex-col gap-1', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='alert-dialog-footer'
+      className={cn('flex justify-end gap-2', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: AlertDialogPrimitive.Title.Props) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot='alert-dialog-title'
+      className={cn('text-base font-medium text-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: AlertDialogPrimitive.Description.Props) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot='alert-dialog-description'
+      className={cn('text-sm text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogClose,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+};

--- a/packages/v4/@tinacms/ui/src/components/sidebar.tsx
+++ b/packages/v4/@tinacms/ui/src/components/sidebar.tsx
@@ -32,6 +32,14 @@ const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
+const isEditable = (target: EventTarget | null) => {
+  const element = target as HTMLElement | null;
+  if (!element || typeof element.closest !== 'function') return false;
+  return Boolean(
+    element.closest('input, textarea, select, [contenteditable="true"]')
+  );
+};
+
 type SidebarContextProps = {
   state: 'expanded' | 'collapsed';
   open: boolean;
@@ -99,28 +107,25 @@ function SidebarProvider({
   // Cmd/Ctrl+B is Bold in every text editor, and this listener is on `window` with a
   // preventDefault, so hosting a rich-text field inside a sidebar layout silently killed
   // it. A shortcut for chrome should not outrank the field the chrome exists to edit.
-  React.useEffect(() => {
-    const isEditable = (target: EventTarget | null) => {
-      const element = target as HTMLElement | null;
-      if (!element || typeof element.closest !== 'function') return false;
-      return Boolean(
-        element.closest('input, textarea, select, [contenteditable="true"]')
-      );
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (
-        event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-        (event.metaKey || event.ctrlKey) &&
-        !isEditable(event.target)
-      ) {
-        event.preventDefault();
-        toggleSidebar();
-      }
-    };
+  //
+  // The listener is also bound once rather than on every `toggleSidebar`, which the
+  // registry rebuilds whenever `open` or `isMobile` changes — so opening and closing
+  // the sidebar used to detach and re-attach a window listener each time.
+  const handleKeyDown = React.useEffectEvent((event: KeyboardEvent) => {
+    if (
+      event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+      (event.metaKey || event.ctrlKey) &&
+      !isEditable(event.target)
+    ) {
+      event.preventDefault();
+      toggleSidebar();
+    }
+  });
 
+  React.useEffect(() => {
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [toggleSidebar]);
+  }, []);
 
   // We add a state so that we can do data-state="expanded" or "collapsed".
   // This makes it easier to style the sidebar with Tailwind classes.
@@ -193,13 +198,17 @@ function Sidebar({
   }
 
   if (isMobile) {
+    // `props` go to SheetContent, and not to Sheet. Sheet is Dialog.Root, which renders
+    // no element — so the aria-label and role a caller puts on <Sidebar> would land
+    // nowhere on mobile.
     return (
-      <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+      <Sheet open={openMobile} onOpenChange={setOpenMobile}>
         <SheetContent
           dir={dir}
           data-sidebar='sidebar'
           data-slot='sidebar'
           data-mobile='true'
+          {...props}
           className='w-(--sidebar-width) bg-sidebar p-0 text-sidebar-foreground [&>button]:hidden'
           style={
             {

--- a/packages/v4/@tinacms/ui/src/hooks/use-mobile.ts
+++ b/packages/v4/@tinacms/ui/src/hooks/use-mobile.ts
@@ -2,20 +2,29 @@ import * as React from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 
+// The one query. The seed and the listener both answer from it, so they cannot disagree
+// about the viewport that is exactly the breakpoint wide.
+const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+// Seeded from matchMedia rather than from `undefined`. Starting undefined reports
+// desktop on the first render, so on a narrow viewport the Sidebar rendered its desktop
+// branch and then swapped to the Sheet branch, remounting the whole subtree. The
+// initializer runs once, and guards `window` for the server render.
+const matchesMobile = () =>
+  typeof window !== 'undefined' && window.matchMedia(MOBILE_QUERY).matches;
+
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined
-  );
+  const [isMobile, setIsMobile] = React.useState(matchesMobile);
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const mql = window.matchMedia(MOBILE_QUERY);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(mql.matches);
     };
     mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(mql.matches);
     return () => mql.removeEventListener('change', onChange);
   }, []);
 
-  return !!isMobile;
+  return isMobile;
 }


### PR DESCRIPTION
**TLDR:** The form column resizes by drag or keyboard and persists its width, and the next document mounts behind a transition so long prose does not freeze the shell.

**Feats:**
- useFormColumnWidth: persisted width, floored at the tested default, stopping before it squeezes the preview out
- The urgent pass commits a skeleton and unmounts the outgoing editor at once; fields mount in a transition
- @tinacms/ui gains AlertDialog plus Sidebar and use-mobile fixes; e2e covers the drag

**How to test:** The e2e drives the drag.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`, then `pnpm test:e2e`.
- Run `pnpm dev`, drag the divider beside the form, and reload.
- Confirm the width holds.
