### PR TITLE
docs(v4): Simplified Technical English prose pass

### DIFF
--- a/packages/v4/@tinacms/tinacms/playground/aliases.ts
+++ b/packages/v4/@tinacms/tinacms/playground/aliases.ts
@@ -1,10 +1,10 @@
-// Point the public import strings at the package source, so the playground exercises
-// the same specifiers a real app will use (not relative paths into src/). The more
-// specific subpath must come first.
+// Point the public import strings at the source of the package, so the playground uses
+// the same specifiers that a real app uses. It does not use a relative path into src/.
+// The longer subpath must come first.
 //
-// Its own module because two servers need it: the dev server, and the throwaway one
-// loadTinaConfig spins up to read tina/config.ts. A real app needs neither — it
-// resolves @tinacms/tinacms from node_modules.
+// This is its own module, because two servers need it. Those are the dev server, and the
+// temporary server that loadTinaConfig starts to read tina/config.ts. A real app needs
+// neither, because it resolves @tinacms/tinacms from node_modules.
 
 import { fileURLToPath } from 'node:url';
 

--- a/packages/v4/@tinacms/tinacms/playground/content/posts/hello-world.mdx
+++ b/packages/v4/@tinacms/tinacms/playground/content/posts/hello-world.mdx
@@ -5,7 +5,7 @@ category: not-in-schema-yet
 ---
 
 This body prose and the `category` frontmatter key above are unknown to the
-schema — the local Hello data layer must round-trip both verbatim on every save
+schema — the local Hello <mark style={{ backgroundColor: "#BBF7D0" }}>data</mark> layer must round-trip both verbatim on every save
 (CONTEXT.md Unknown field)…..
 
 ***

--- a/packages/v4/@tinacms/tinacms/playground/content/posts/second-post.mdx
+++ b/packages/v4/@tinacms/tinacms/playground/content/posts/second-post.mdx
@@ -25,6 +25,14 @@ this will be ordered:
 
 $ asdf
 
+1. asdf
+2. asd
+   1. asdf
+      1. asdf
+         1. asdfdf
+            1. asdfsdf
+               1. asdfdsf
+
 # test
 
 ## test

--- a/packages/v4/@tinacms/tinacms/playground/tina/config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/tina/config.ts
@@ -1,18 +1,19 @@
-// The playground's composition root, standing in for a real app's tina/config.ts.
-// Two consumers import THIS file: the browser app (app.tsx) and the Vite config,
-// which runs it in node to boot the Local Data Layer. That is the point — the
-// collection was previously declared twice, once at wire level for the data layer
-// and once with the `t.*` builders for the form, and the two could drift.
+// The composition root of the playground. It stands in for the tina/config.ts of a real
+// app. Two consumers import this file: the browser app in app.tsx, and the Vite config,
+// which runs it in node to start the local data layer. That is the point of the file. The
+// collection was declared twice before, once at the wire level for the data layer and
+// once with the `t.*` builders for the form, and the two could drift.
 //
-// Importable from node because the universal entry keeps browser code behind lazy
-// segments: `localContentPlugin()` names its client with `() => import(...)`, and
-// the `t.*` builders are plain schema, so neither React nor Plate is pulled in.
+// Node can import it, because the universal entry keeps the browser code behind lazy
+// segments. `localContentPlugin()` names its client with `() => import(...)`, and the
+// `t.*` builders are plain schema. Neither React nor Plate is therefore loaded.
 
 import {
   type CollectionSchema,
   defineConfig,
   localContentPlugin,
   t,
+  definePlugin,
 } from '@tinacms/tinacms';
 
 export const postCollection = {
@@ -23,7 +24,8 @@ export const postCollection = {
   fields: [
     t.string({ name: 'title', label: 'Title', required: true, min: 3 }),
     t.boolean({ name: 'featured', label: 'Featured' }),
-    // v3 content model: the markdown body, served by GraphQL as the mdx AST.
+    // The v3 content model. This is the markdown body, which GraphQL serves as the
+    // MDX tree.
     t.richText({ name: 'body', label: 'Body', isBody: true }),
   ],
 } satisfies CollectionSchema;

--- a/packages/v4/@tinacms/tinacms/playground/vite.config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/vite.config.ts
@@ -6,8 +6,9 @@ import { loadTinaConfig } from '../src/codegen/load-config';
 import { tinaLocalDataLayerVitePlugin } from '../src/plugins/content/local/local-data-layer.vite';
 import { playgroundAliases } from './aliases';
 
-// The data layer indexes the collections the forms render, so both read the one
-// declaration — this loads it in node, app.tsx imports it in the browser.
+// The data layer indexes the collections that the forms render, so both read one
+// declaration. This file loads that declaration in node, and app.tsx imports it in the
+// browser.
 const tina = await loadTinaConfig(
   fileURLToPath(new URL('./tina/config.ts', import.meta.url)),
   { alias: playgroundAliases }
@@ -15,7 +16,12 @@ const tina = await loadTinaConfig(
 
 export default defineConfig({
   plugins: [
-    react(),
+    // The React Compiler memoises what this package's components would otherwise
+    // memoise by hand. It reaches the workspace packages too (@tinacms/ui and
+    // @tinacms/rich-text resolve to their source, not to node_modules), so the
+    // playground is the whole editor compiled. Consumers don't inherit it: v4
+    // still exports source, so it's their bundler that decides.
+    react({ babel: { plugins: ['babel-plugin-react-compiler'] } }),
     tailwindcss(),
     tinaLocalDataLayerVitePlugin({
       rootDir: fileURLToPath(new URL('.', import.meta.url)),

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.schema.ts
@@ -11,8 +11,9 @@ export const boolean = (
   config: Omit<BooleanFieldSchema, 'type'>
 ): BooleanFieldSchema => ({ ...config, type: BOOLEAN_FIELD_TYPE });
 
-// Two-state: `false` is valid and there's no empty state, so `required` can't be
-// enforced — this only type-guards the value (`null` passes as absent).
+// The field has two states. The value `false` is valid, and there is no empty state, so
+// this schema cannot enforce `required`. It checks the type of the value only, and `null`
+// passes as an absent value.
 export const booleanSchema = (_node: FieldSchema): ZodType =>
   z.preprocess(
     (value) => (value == null ? undefined : value),

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
@@ -16,15 +16,17 @@ export const number = (
 
 const labelOf = (node: NumberFieldSchema): string => node.label ?? node.name;
 
-// Coerce the editor string before validating. Guard empty (incl. whitespace-only)
-// explicitly: `0` is valid and a falsy test would smuggle empty in as zero.
+// Convert the editor string before the validation. Test for an empty string, and for a
+// string of spaces, directly. The value `0` is valid, and a falsy test would read an
+// empty string as zero.
 const toNumber = (value: unknown): unknown => {
   const trimmed = typeof value === 'string' ? value.trim() : value;
   return trimmed === '' || trimmed == null ? undefined : Number(trimmed);
 };
 
-// `min`/`max` are value bounds (not string length); a non-numeric string becomes
-// `NaN` and `.finite()` also rejects `Infinity` (which JSON would write as `null`).
+// The `min` and `max` values bound the number, and not the length of the string. A
+// string that is not a number becomes `NaN`. The `.finite()` check also rejects
+// `Infinity`, which JSON would write as `null`.
 export const numberSchema = (node: FieldSchema): ZodType => {
   const field = node as NumberFieldSchema;
   let schema = z
@@ -46,7 +48,7 @@ export const numberSchema = (node: FieldSchema): ZodType => {
     );
   }
   if (field.required) {
-    // Empty coerces to `undefined`, which fails the non-optional schema.
+    // An empty string becomes `undefined`, which fails a schema that is not optional.
     return z.preprocess(toNumber, schema);
   }
   return z.preprocess(toNumber, schema.optional());

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/string/string-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/string/string-field.schema.ts
@@ -24,9 +24,9 @@ const compileRegExp = (pattern: string): RegExp | null => {
   }
 };
 
-// Per-field validation only — `node` is this field alone. Cross-field rules
-// (validate against a sibling field) aren't supported here yet; they'll come via
-// useSiblingValue in the component, or a form-level refine / server segment.
+// This validates one field, because `node` is that field alone. A rule across two fields
+// is not supported here yet. Such a rule arrives through useSiblingValue in the
+// component, through a refine at the form level, or through a server segment.
 export const stringSchema = (node: FieldSchema): ZodType => {
   const field = node as StringFieldSchema;
   let schema = z.string();

--- a/packages/v4/@tinacms/tinacms/src/store/compose-slices.ts
+++ b/packages/v4/@tinacms/tinacms/src/store/compose-slices.ts
@@ -10,14 +10,15 @@ import {
   isSingletonSliceCapability,
 } from '../core/plugin';
 
-// Namespace → the slice creator mounted there. Composed once at boot from the resolved
-// client segments — the same input the field registry consumes (createFieldRegistry), through
-// the same order-independent override resolution (composeOverridableRegistry).
+// A map from a namespace to the slice creator that mounts there. It is composed once at
+// boot from the resolved client segments. createFieldRegistry reads the same input, and
+// composeOverridableRegistry resolves the overrides for both. That resolution does not
+// depend on the order.
 export type SliceRegistry = Map<string, ClientSlice>;
 
-// A namespace is either a singleton capability key (`media`) or a plugin name
-// (`editorial-workflow`); the two collide for different reasons, so the message differs. Only
-// a capability can be overridden, so a `duplicate-override` is always a capability.
+// A namespace is a singleton capability key, such as `media`, or a plugin name, such as
+// `editorial-workflow`. The two collide for different reasons, so the message differs.
+// Only a capability accepts an override, so a duplicate override is always a capability.
 const sliceConflictError = (
   conflict: RegistryConflict,
   namespace: string

--- a/packages/v4/@tinacms/tinacms/src/store/create-store.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/store/create-store.test.ts
@@ -9,8 +9,8 @@ import {
 import { composePluginSlices } from './compose-slices';
 import { createTinaStore, pickPersistableNamespaces } from './create-store';
 
-// The field registry resolves these from manifests at boot; the store composes the same
-// { manifest, segment } shape, so tests build it inline.
+// The field registry resolves these from the manifests at boot. The store composes the
+// same { manifest, segment } shape, so these tests build it inline.
 const resolved = (
   spec: {
     name: string;
@@ -27,8 +27,8 @@ const get = (store: ReturnType<typeof createTinaStore>) =>
   store.getState() as Record<string, any>;
 
 beforeEach(() => {
-  // Each store persists under the same key — clear so one test's durable state never
-  // rehydrates into the next.
+  // Every store persists under the same key, so clear it. The durable state of one
+  // test must not rehydrate into the next test.
   localStorage.clear();
 });
 
@@ -55,12 +55,12 @@ describe('composePluginSlices namespacing', () => {
   });
 
   it('rejects a plugin named after a capability it does not provide', () => {
-    // Peers read capability state at `get().media` — a feature plugin must not squat
-    // that namespace by name alone.
+    // A peer reads the capability state at `get().media`, so a feature plugin must
+    // not take that namespace by its name alone.
     expect(() =>
       composePluginSlices([resolved({ name: 'media' }, () => ({}))])
     ).toThrow(/does not provide it/);
-    // A genuine provider may carry the bare capability name.
+    // A real provider can carry the capability name.
     const registry = composePluginSlices([
       resolved({ name: 'media', provides: ['media'] }, () => ({})),
     ]);
@@ -207,7 +207,8 @@ describe('createTinaStore composition', () => {
     const authSlice: ClientSlice = () => ({ user: { id: 'u1' } });
     const mediaSlice: ClientSlice = (set) => ({
       items: ['a', 'b'],
-      // replace=true → replace this slice's own state, not merge.
+      // With replace set to true, this replaces the state of the slice, and does
+      // not merge into it.
       reset: () => set({ items: [] }, true),
     });
 
@@ -220,7 +221,7 @@ describe('createTinaStore composition', () => {
 
     // the slice was replaced (reset method dropped) …
     expect(get(store).media).toEqual({ items: [] });
-    // … but peers and core namespaces survive — no whole-store wipe.
+    // … but the peers and the core namespaces stay. Nothing clears the whole store.
     expect(get(store).auth.user.id).toBe('u1');
     expect(get(store).ui).toEqual({});
   });
@@ -265,7 +266,8 @@ describe('createTinaStore persistence round-trip', () => {
     const rebooted = get(boot());
     expect(rebooted.ui).toEqual({ theme: 'dark' });
     expect(rebooted.branch).toEqual({ current: 'feat' });
-    // documents + every plugin namespace are volatile: recomputed at boot, not rehydrated.
+    // The documents, and every plugin namespace, are volatile. The store computes
+    // them again at boot, and does not rehydrate them.
     expect(rebooted.documents).toEqual({});
     expect(rebooted.media).toEqual({ items: [] });
   });

--- a/packages/v4/@tinacms/tinacms/src/test/setup.ts
+++ b/packages/v4/@tinacms/tinacms/src/test/setup.ts
@@ -3,7 +3,8 @@ import { configure } from '@testing-library/dom';
 import { beforeEach } from 'vitest';
 import { useFormStore } from '../form/form-store';
 
-// findBy*/waitFor default to 1s — too tight for TinaProvider's async boot
+// findBy* and waitFor default to one second, which is too short for the async boot of
+// TinaProvider.
 // (plugin graph + lazy segment imports) on loaded CI runners.
 configure({ asyncUtilTimeout: 5000 });
 


### PR DESCRIPTION
**TLDR:** A Simplified Technical English pass over comments and playground fixtures; no behaviour changes.

**Feats:**
- Comment rewrites across the field schemas, store tests, preview tests and playground config
- Playground content gains a highlight mark and nested-list fodder for the editor

**How to test:** The suites confirm nothing moved.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
