### PR TITLE
docs(v4): strip the narrated comments across the v4 packages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ tests/                 # Build verification tests
 
 ## Coding Standards
 
+- **Comments are a last resort.** Write code that explains itself; comment only what the code cannot say (a non-obvious invariant, a documented workaround). No narrated comments, no restating what the next line does, no essay-length headers riding on a few lines of code.
+- **Error narrowing is an `if`, not an expression.** Use `if (err instanceof Error) { … } else { … }` — never `(err instanceof Error && err.message) || fallback` or a ternary that smuggles narrowing into an expression.
 - **Linting/Formatting:** Biome (`biome.json` at root). Example apps extend with `"extends": ["../../../biome.json"]`
 - **TypeScript:** Base config at `base.tsconfig.json`. Examples extend it. Strict mode enabled.
 - **Package manager:** pnpm only. Never use npm or yarn.

--- a/packages/v4/@tinacms/rich-text/src/boundary.test.ts
+++ b/packages/v4/@tinacms/rich-text/src/boundary.test.ts
@@ -3,12 +3,6 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
-// The extraction rests on one property: this package never imports its host.
-// `@tinacms/tinacms` depends on this one, so an import back would be a cycle —
-// and a cycle pnpm tolerates, so nothing else would complain until a bundler or
-// a publish did. Cheap to assert, and it is the thing that quietly rots: the
-// editor used to reach for `useActiveField`, and someone re-adding that import
-// would find it working locally.
 const SRC = path.dirname(fileURLToPath(import.meta.url));
 
 const sourceFiles = (dir: string): string[] =>
@@ -42,8 +36,6 @@ describe('package boundary', () => {
   });
 
   it('never reaches outside its own src directory', () => {
-    // A relative path that climbs past src/ would resolve into the host's tree
-    // in this monorepo — same cycle, harder to spot than a bare specifier.
     const offenders = files.filter((file) =>
       importsOf(file)
         .filter((specifier) => specifier.startsWith('.'))

--- a/packages/v4/@tinacms/rich-text/src/editor.ts
+++ b/packages/v4/@tinacms/rich-text/src/editor.ts
@@ -1,9 +1,3 @@
-// `@tinacms/rich-text/editor` — the Plate editor.
-//
-// Separate from the root entry because this is the heavy half: importing it pulls
-// Plate, Radix and the rest. A host loads it from a lazily-imported module (v4's
-// field plugin does it from its client segment) so the weight only lands in the
-// browser bundle when a rich-text field is actually rendered.
 export { RichEditor, type RichEditorProps } from './plate';
 export {
   EditorContext,

--- a/packages/v4/@tinacms/rich-text/src/error-message.tsx
+++ b/packages/v4/@tinacms/rich-text/src/error-message.tsx
@@ -1,7 +1,3 @@
-// The node @tinacms/mdx emits instead of throwing when it can't parse a body, so
-// the editor can still show the source. Named here — the plate-free layer both
-// the schema and the Plate plugin already depend on — because a typo would
-// silently disarm the guard that stops a save overwriting good markdown with it.
 export const INVALID_MARKDOWN_TYPE = 'invalid_markdown';
 
 export type EmptyTextElement = { type: 'text'; text: '' };

--- a/packages/v4/@tinacms/rich-text/src/index.ts
+++ b/packages/v4/@tinacms/rich-text/src/index.ts
@@ -1,8 +1,3 @@
-// `@tinacms/rich-text` — the value contract.
-//
-// Deliberately free of the editor and its ~40 packages: a host that only needs to
-// describe or transform rich-text content (a codec, a renderer, a schema) imports
-// this entry and pays nothing for Plate. The editor itself is `./editor`.
 export {
   EMPTY_RICH_TEXT,
   type RichTextNode,

--- a/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
@@ -44,7 +44,7 @@ import { ToolbarGroup } from './plate-ui/toolbar';
 
 type ToolbarItem = {
   label: string;
-  width: (paragraphIconExists?: boolean) => number; // Use function to calculate width
+  width: (paragraphIconExists?: boolean) => number;
   Component: React.ReactNode;
 };
 
@@ -147,7 +147,6 @@ export default function FixedToolbarButtons() {
   const { overrides, templates } = useToolbarContext();
   const showEmbedButton = templates.length > 0;
 
-  // Without a `toolbar` list, every button; an empty list, none.
   let items: ToolbarItem[] =
     overrides?.toolbar === undefined
       ? Object.values(toolbarItems)
@@ -159,7 +158,6 @@ export default function FixedToolbarButtons() {
     items = items.filter((item) => item.label !== toolbarItems.embed.label);
   }
 
-  // v4 has no raw markdown editor yet, so the button would toggle nothing.
   items = items.filter((item) => item.label !== toolbarItems.raw.label);
 
   const editorState = useEditorState();
@@ -177,13 +175,10 @@ export default function FixedToolbarButtons() {
     const availableWidth = width - headingWidth;
 
     const countItemsFitting = (budget: number) => {
-      // The heading is measured above, so it starts the count already spent.
       let count = headingButton ? 1 : 0;
       let used = 0;
       for (const item of items) {
         if (item.label === HEADING_LABEL) continue;
-        // The row renders a contiguous prefix, so the first item that does not
-        // fit ends the count.
         if (used + item.width() > budget) break;
         used += item.width();
         count += 1;
@@ -191,8 +186,6 @@ export default function FixedToolbarButtons() {
       return count;
     };
 
-    // Reserve room for the overflow menu only once we know it will render, or a
-    // toolbar that fits exactly loses a button to a menu that never appears.
     const fitCount = countItemsFitting(availableWidth);
 
     setItemsShown(
@@ -232,9 +225,6 @@ export default function FixedToolbarButtons() {
               {item.Component}
             </div>
           ))}
-          {/* The menu follows the last button rather than sitting against the far
-              edge. Pushed right, the leftover width opens as a gap mid-row, which
-              reads as a button that failed to render. */}
           {items.length > itemsShown && (
             <div className='w-fit'>
               <OverflowMenu>

--- a/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
@@ -147,9 +147,7 @@ export default function FixedToolbarButtons() {
   const { overrides, templates } = useToolbarContext();
   const showEmbedButton = templates.length > 0;
 
-  // The buttons the schema asks for, in the order it asks for them. Without a
-  // `toolbar` list, the toolbar holds every button. An empty list holds none, and
-  // the filter drops a name that no button answers to.
+  // Without a `toolbar` list, every button; an empty list, none.
   let items: ToolbarItem[] =
     overrides?.toolbar === undefined
       ? Object.values(toolbarItems)
@@ -161,8 +159,7 @@ export default function FixedToolbarButtons() {
     items = items.filter((item) => item.label !== toolbarItems.embed.label);
   }
 
-  // v4 has no raw markdown editor to switch to, so the button would toggle
-  // nothing. Drop it until raw-mode is ported rather than ship a dead control.
+  // v4 has no raw markdown editor yet, so the button would toggle nothing.
   items = items.filter((item) => item.label !== toolbarItems.raw.label);
 
   const editorState = useEditorState();
@@ -173,26 +170,20 @@ export default function FixedToolbarButtons() {
   useResize(toolbarRef, (entry) => {
     const width = entry.target.getBoundingClientRect().width;
     const headingButton = items.find((item) => item.label === HEADING_LABEL);
-    // This element carries `@container/toolbar`, so its own width is what the
-    // `@md/toolbar` query on the heading label resolves against.
     const headingWidth = headingButton
       ? headingButton.width(width >= CONTAINER_MD_BREAKPOINT)
       : 0;
 
-    // Calculate the available width excluding the heading button
     const availableWidth = width - headingWidth;
 
-    // Count numbers of buttons can fit into the available width
     const countItemsFitting = (budget: number) => {
-      // The heading is measured above, so it starts the count already spent —
-      // but only when it is actually in the list.
+      // The heading is measured above, so it starts the count already spent.
       let count = headingButton ? 1 : 0;
       let used = 0;
       for (const item of items) {
         if (item.label === HEADING_LABEL) continue;
-        // The row renders a contiguous prefix of `items`, so the first item that
-        // does not fit ends the count. A narrower item further down the list
-        // cannot take its place, and counting one that way overfills the row.
+        // The row renders a contiguous prefix, so the first item that does not
+        // fit ends the count.
         if (used + item.width() > budget) break;
         used += item.width();
         count += 1;
@@ -200,9 +191,8 @@ export default function FixedToolbarButtons() {
       return count;
     };
 
-    // Reserve room for the overflow menu itself, but only once we know it will
-    // be rendered — otherwise a toolbar that fits exactly loses a button to a
-    // menu that never appears.
+    // Reserve room for the overflow menu only once we know it will render, or a
+    // toolbar that fits exactly loses a button to a menu that never appears.
     const fitCount = countItemsFitting(availableWidth);
 
     setItemsShown(

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-combobox.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-combobox.tsx
@@ -19,9 +19,7 @@ import {
 } from './command';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 
-// Languages available in lowlight (base + important additional languages)
 const languages: { label: string; value: string }[] = [
-  // Base languages
   { label: 'Plain Text', value: 'plaintext' },
   { label: 'Arduino', value: 'arduino' },
   { label: 'Bash', value: 'bash' },
@@ -61,7 +59,6 @@ const languages: { label: string; value: string }[] = [
   { label: 'XML', value: 'xml' },
   { label: 'YAML', value: 'yaml' },
 
-  // Additional important languages
   { label: 'ASCIIDoc', value: 'asciidoc' },
   { label: 'Clojure', value: 'clojure' },
   { label: 'CMake', value: 'cmake' },

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-toolbar-button.tsx
@@ -4,7 +4,6 @@ import { withRef } from '@udecode/cn';
 import { useEditorState } from '@udecode/plate/react';
 
 import { insertEmptyCodeBlock } from '@udecode/plate-code-block';
-// import { insertEmptyCodeBlock } from '../../transforms/insert-empty-block';
 import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
 import { helpers } from '../../plugins/core/common';
 import { Icons } from './icons';

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/code-block-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/code-block-element.tsx
@@ -31,8 +31,6 @@ export function codeLineToString(content: PlateCodeBlockElement): string {
     .join('\n');
 }
 
-//the default code block element from @udecode/plate-code-block
-//custom styling to match TinaCMS branding + remove copy button
 export const CodeBlockElement = withRef<typeof PlateElement>(
   ({ children, className, ...props }, ref) => {
     const { editor, element } = props;
@@ -41,7 +39,6 @@ export const CodeBlockElement = withRef<typeof PlateElement>(
     const [codeBlockError, setCodeBlockError] = useState<string | null>(null);
 
     useEffect(() => {
-      // Look to find mermaid errors as well as format ( formatCodeBlock(editor, { element })})
       if ((element.lang as string) !== 'mermaid') {
         return;
       }
@@ -59,10 +56,11 @@ export const CodeBlockElement = withRef<typeof PlateElement>(
           }
         } catch (err) {
           if (!isCancelled) {
-            setCodeBlockError(
-              (err instanceof Error && err.message) ||
-                'An error occurred while parsing the diagram.'
-            );
+            if (err instanceof Error && err.message) {
+              setCodeBlockError(err.message);
+            } else {
+              setCodeBlockError('An error occurred while parsing the diagram.');
+            }
           }
         }
       };
@@ -164,7 +162,7 @@ export const CodeBlockElement = withRef<typeof PlateElement>(
             )}
             <CodeBlockCombobox
               onLanguageChange={(lang) => {
-                setCodeBlockError(null); // Clear errors on language change
+                setCodeBlockError(null);
                 editor.tf.setNodes<TCodeBlockElement>(
                   { lang },
                   { at: element }

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/heading-items.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/heading-items.ts
@@ -3,9 +3,6 @@ import { ParagraphPlugin } from '@udecode/plate/react';
 import type { ComponentType, SVGProps } from 'react';
 import { Icons } from './icons';
 
-// Permissive enough to accept both Lucide icons and the project's
-// custom SVG components, both of which only need `className` from
-// the caller.
 export type HeadingItemIcon = ComponentType<SVGProps<SVGSVGElement>>;
 
 export interface HeadingMenuItem {
@@ -15,8 +12,6 @@ export interface HeadingMenuItem {
   value: string;
 }
 
-// Builder that preserves the `Record<HeadingLevel, T>` shape without
-// `as` — each key is spelled out so TS verifies exhaustiveness.
 const buildByLevel = <T>(
   make: (level: HeadingLevel) => T
 ): Record<HeadingLevel, T> => ({
@@ -46,8 +41,5 @@ export const paragraphItem: HeadingMenuItem = {
   value: ParagraphPlugin.key,
 };
 
-/** Looks up the menu item for any block value. Returns `undefined`
- * for non-heading values so callers can fall back as they see fit
- * (e.g. to `paragraphItem` for the dropdown trigger label). */
 export const getHeadingItem = (value: string): HeadingMenuItem | undefined =>
   isHeadingLevel(value) ? headingItemsByLevel[value] : undefined;

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/icons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/icons.tsx
@@ -322,7 +322,6 @@ export const Icons = {
   arrowDown: ChevronDown,
   bg: PaintBucket,
   blockquote: Quote,
-  // bold: Bold,
   overflow: Overflow,
   borderAll,
   borderBottom,
@@ -335,7 +334,6 @@ export const Icons = {
   chevronsUpDown: ChevronsUpDown,
   clear: X,
   close: X,
-  // code: Code2,
   paint: PaintBucket,
   codeblock: FileCode,
   color: Baseline,
@@ -355,16 +353,12 @@ export const Icons = {
   h4: Heading4,
   h5: Heading5,
   h6: Heading6,
-  // image: Image,
   indent: Indent,
-  // italic: Italic,
   kbd: Keyboard,
   lineHeight: WrapText,
-  // link: Link2,
   minus: Minus,
   mermaid: MermaidIcon,
   more: MoreHorizontal,
-  // ol: ListOrdered,
   outdent: Outdent,
   paragraph: Pilcrow,
   refresh: RotateCcw,
@@ -378,7 +372,6 @@ export const Icons = {
   table: Table,
   text: Text,
   trash: Trash,
-  // ul: List,
   underline: Underline,
   unlink: Link2Off,
   viewing: Eye,
@@ -399,7 +392,6 @@ export const Icons = {
   bold: BoldIcon,
   italic: ItalicIcon,
   raw: RawMarkdown,
-  // www
   gitHub: (props: LucideProps) => (
     <svg viewBox='0 0 438.549 438.549' {...props}>
       <path

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/image-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/image-toolbar-button.tsx
@@ -19,9 +19,6 @@ const useImageToolbarButtonState = () => {
 };
 
 // ponytail: inert until the media capability exists — picking an image needs a
-// media library to pick from (plugins/media/ is a .gitkeep). Existing image
-// nodes still render and serialize; only insertion is unavailable, so the button
-// reports itself disabled rather than opening nothing.
 const useImageToolbarButton = (state) => {
   useEditorState();
 

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/inline-combobox.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/inline-combobox.tsx
@@ -96,10 +96,6 @@ const InlineCombobox = ({
     [setValueProp, hasValueProp]
   );
 
-  /**
-   * Track the point just before the input element so we know where to
-   * insertText if the combobox closes due to a selection change.
-   */
   const insertPoint = React.useRef<Point | null>(null);
 
   useEffect(() => {
@@ -161,15 +157,10 @@ const InlineCombobox = ({
 
   const items = store.useState('items');
 
-  /**
-   * If there is no active ID and the list of items changes, select the first
-   * item.
-   */
   useEffect(() => {
     if (!store.getState().activeId) {
       store.setActiveId(store.first());
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [items, store]);
 
   return (
@@ -205,13 +196,6 @@ const InlineComboboxInput = forwardRef<
 
   const ref = useComposedRef(propRef, contextRef);
 
-  /**
-   * To create an auto-resizing input, we render a visually hidden span
-   * containing the input value and position the input element on top of it.
-   * This works well for all cases except when input exceeds the width of the
-   * container.
-   */
-
   return (
     <>
       {showTrigger && trigger}
@@ -246,7 +230,6 @@ const InlineComboboxContent: typeof ComboboxPopover = ({
   className,
   ...props
 }) => {
-  // Portal prevents CSS from leaking into popover
   return (
     <Portal>
       <ComboboxPopover
@@ -292,7 +275,6 @@ const InlineComboboxItem = ({
 
   const store = useComboboxContext();
 
-  // Optimization: Do not subscribe to value if filter is false
   // biome-ignore lint/correctness/useHookAtTopLevel: not ready to fix these yet
   const search = filter && store.useState('value');
 

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-floating-toolbar.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-floating-toolbar.tsx
@@ -84,7 +84,6 @@ export function LinkFloatingToolbar({
     };
   }, [activeCommentId, activeSuggestionId]);
 
-  //when adding a new link
   const insertState = useFloatingLinkInsertState({
     ...state,
     floatingOptions: {
@@ -99,7 +98,6 @@ export function LinkFloatingToolbar({
     textInputProps,
   } = useFloatingLinkInsert(insertState);
 
-  //when editing an existing link
   const editState = useFloatingLinkEditState({
     ...state,
     floatingOptions: {
@@ -119,7 +117,6 @@ export function LinkFloatingToolbar({
 
   if (hidden) return null;
 
-  // container of popup for links, including the input fields and buttons
   const input = (
     <div
       className='z-[999999] flex w-[330px] flex-col relative'
@@ -235,8 +232,6 @@ export function LinkFloatingToolbar({
         ref={insertRef}
         className={popoverVariants()}
         {...insertProps}
-        // Override plate-floating's inline z-index (which beats the z-[999999]
-        // class) so the portaled popover sits above the form field wrappers.
         style={{
           ...(insertProps.style as React.CSSProperties),
           zIndex: 999999,
@@ -272,7 +267,6 @@ function LinkOpenButton() {
       const [element] = entry;
       return getLinkAttributes(editor, element);
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [editor, selection]
   );
 

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-element.tsx
@@ -8,10 +8,6 @@ export const MermaidElementWithRef = ({ config }) => {
     const node = mermaidRef.current?.querySelector<HTMLElement>('.mermaid');
     if (!node) return;
 
-    // mermaid.run rejects for a diagram it cannot parse, and the author types one
-    // character at a time, so most intermediate states do not parse. Reporting that is
-    // the code block's job — code-block-element.tsx validates and shows the message.
-    // Here the rejection only has to stop being an unhandled one.
     mermaid.run({ nodes: [node] }).catch(() => {});
   }, [config]);
 

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/slash-input-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/slash-input-element.tsx
@@ -60,8 +60,6 @@ const headingRulesByLevel: Record<HeadingLevel, SlashCommandRule> = {
   },
 };
 
-// The slash menu historically only exposed h1-h3; preserve that default so
-// existing editors don't suddenly grow new entries.
 const DEFAULT_SLASH_HEADING_LEVELS: readonly HeadingLevel[] = [
   'h1',
   'h2',

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-element.tsx
@@ -348,13 +348,6 @@ function ColorDropdownMenu({ children, tooltip }: ColorDropdownMenuProps) {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent align='start'>
-        {/* <DropdownMenuGroup label="Colors">
-          <ColorDropdownMenuItems
-            className="px-2"
-            colors={DEFAULT_COLORS}
-            updateColor={onUpdateColor}
-          />
-        </DropdownMenuGroup> */}
         <DropdownMenuGroup>
           <DropdownMenuItem className='p-2' onClick={onClearColor}>
             <EraserIcon />

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/templates-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/templates-toolbar-button.tsx
@@ -24,7 +24,6 @@ interface EmbedButtonProps {
   templates: MdxTemplate[];
 }
 
-// Below this many, the list is short enough to scan and the input is just noise.
 const TEMPLATE_COUNT_NEEDING_FILTER = 10;
 
 const EmbedButton: React.FC<EmbedButtonProps> = ({ editor, templates }) => {

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/toolbar.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/toolbar.tsx
@@ -58,7 +58,6 @@ const toolbarButtonVariants = cva(
 );
 
 const ToolbarButton = withTooltip(
-  // eslint-disable-next-line react/display-name
   React.forwardRef<
     React.ElementRef<typeof ToolbarToggleItem>,
     {

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/tooltip.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/tooltip.tsx
@@ -20,8 +20,6 @@ export const TooltipContent = withCn(
   'z-[9999] overflow-hidden rounded border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md'
 );
 
-// React 19 narrowed ElementRef's constraint: keyof HTMLElementTagNameMap admits
-// tags JSX doesn't (and ElementRef is the old name for ComponentRef).
 export function withTooltip<T extends React.ElementType>(Component: T) {
   return React.forwardRef<
     React.ComponentRef<T>,

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/use-floating-toolbar-hook.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/use-floating-toolbar-hook.tsx
@@ -18,8 +18,6 @@ export const useCustomFloatingToolbar = ({
   showWhenReadOnly,
   waitForCollapsedSelection,
 }: ReturnType<typeof useFloatingToolbarState>) => {
-  // On refocus, the editor keeps the previous selection,
-  // so we need to wait it's collapsed at the new position before displaying the floating toolbar.
   React.useEffect(() => {
     if (!(editorId === focusedEditorId)) {
       setWaitForCollapsedSelection(true);
@@ -46,7 +44,6 @@ export const useCustomFloatingToolbar = ({
       document.removeEventListener('mousedown', mousedown);
     };
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   React.useEffect(() => {

--- a/packages/v4/@tinacms/rich-text/src/plate/editor-context.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/editor-context.tsx
@@ -1,19 +1,11 @@
 import React from 'react';
 import type { MdxTemplate } from './types';
 
-// What the host tells the editor about the field being edited. The host renders
-// the provider; this package never reaches back into it, which is what keeps the
-// dependency one-way and lets `@tinacms/tinacms` depend on this package rather
-// than the two importing each other.
 export interface EditorContextValue {
   fieldName: string;
   templates: MdxTemplate[];
   rawMode: boolean;
   setRawMode: (mode: boolean) => void;
-  // Called when the author selects an embed, with the address of that embed's
-  // props. What activation *means* is the host's business — v4 puts it in the
-  // form store's single active field. The no-op default keeps the editor usable
-  // without a host (a test, a story).
   onActivateField: (address: string) => void;
 }
 

--- a/packages/v4/@tinacms/rich-text/src/plate/editor-field.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/editor-field.ts
@@ -1,10 +1,6 @@
 import type { ToolbarOverrides } from './toolbar/toolbar-overrides';
 import type { MdxTemplate } from './types';
 
-// The slice of a field's schema the editor actually reads: which embeds exist
-// and which toolbar controls to show. Named here rather than imported from the
-// host so the dependency stays one-way — the host's RichTextFieldSchema
-// satisfies this structurally and carries the rest (name, isBody, codec).
 export interface RichEditorField {
   templates?: MdxTemplate[];
   overrides?: ToolbarOverrides;

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/embed-hooks.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/embed-hooks.ts
@@ -7,17 +7,7 @@ const handleCloseBase = (editor, element) => {
   const path = editor.findPath(element);
   const editorEl = editor.toDOMNode(editor, editor);
   if (editorEl) {
-    /**
-     * FIXME: there must be a better way to do this. When jumping
-     * back from a nested form, the entire editor doesn't receive
-     * focus, so enable that, but what we also want is to ensure
-     * that this node is selected - so do that, too. But there
-     * seems to be a race condition where the `editorEl.focus` doesn't
-     * happen in time for the Transform to take effect, hence the
-     * setTimeout. I _think_ it just needs to queue and the actual
-     * ms timeout is irrelevant, but might be worth checking on
-     * devices with lower CPUs
-     */
+    // FIXME: jumping back from a nested form needs both editor focus and node
     editorEl.focus();
     setTimeout(() => {
       editor.tf.select(path);
@@ -35,12 +25,6 @@ const handleRemoveBase = (editor, element) => {
 export const useHotkey = (key, callback) => {
   const selected = useSelected();
 
-  /**
-   * Bound once, for the life of the node. `selected`, `key`, and the callback are all
-   * read when the key is pressed, so the listener never churns on a selection change
-   * and never fires a callback from an earlier render — the callbacks here close over
-   * the editor and the element, and only `selected` used to re-create them.
-   */
   const onKeyDown = React.useEffectEvent((e) => {
     if (!selected || !isHotkey(key, e)) return;
     e.preventDefault();
@@ -64,8 +48,6 @@ export const useEmbedHandles = (editor, element, baseFieldName: string) => {
   };
   const path = editor.findPath(element);
   const fieldName = `${baseFieldName}.children.${path.join('.children.')}.props`;
-  // The host decides what selecting an embed does — this package only says which
-  // address was selected, so it never has to import the host's form store.
   const handleSelect = () => onActivateField(fieldName);
 
   const handleRemove = () => {

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/use-resize.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/use-resize.ts
@@ -4,13 +4,6 @@ export const useResize = (
   ref: React.RefObject<HTMLElement | null>,
   callback: (entry: ResizeObserverEntry) => void
 ) => {
-  /**
-   * The callback closes over render values — the toolbar's caller rebuilds its item
-   * list every render — so it is read at each resize rather than captured when the
-   * observer is created. `ref.current` was the previous dependency, which a ref never
-   * makes reactive: the effect saw null on the first render and the node on the second,
-   * then never re-ran, leaving the observer holding the second render's closure.
-   */
   const onResize = React.useEffectEvent(callback);
 
   React.useEffect(() => {

--- a/packages/v4/@tinacms/rich-text/src/plate/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/index.tsx
@@ -12,27 +12,16 @@ import { createEditorPlugins } from './plugins/editor-plugins';
 import { Components } from './plugins/ui/components';
 import { ToolbarProvider } from './toolbar/toolbar-provider';
 
-// The v4 field component (rich-text-field.ui.tsx) reads value/schema through
-// address-keyed hooks and hands them here as `input`/`field` — the one seam
-// between Plate and v4's form store.
 export interface RichEditorProps {
   input: {
     value: RichTextValue;
     onChange: (value: RichTextValue) => void;
   };
   field: RichEditorField;
-  // Goes on the contenteditable itself — a label on the wrapper is invisible to
-  // assistive tech, and every other v4 field labels its control.
   ariaLabel?: string;
 }
 
 export const RichEditor = ({ input, field, ariaLabel }: RichEditorProps) => {
-  // Seeded once: Plate owns the value after mount. Remounting on a document
-  // switch is the field component's job (it keys this on the form id).
-  // A lazy useState initialiser, and not a useMemo with an empty dependency list:
-  // the seed reads `input.value`, so an empty list claims a narrower dependency
-  // than the body has. That is the one memo the React Compiler cannot preserve, and
-  // it skips the whole component over it. useState says "once at mount" outright.
   const [initialValue] = React.useState(() => {
     if (input.value?.children?.length) {
       return helpers.withRootNodeIds(
@@ -41,10 +30,7 @@ export const RichEditor = ({ input, field, ariaLabel }: RichEditorProps) => {
     }
     return [{ type: 'p', children: [{ type: 'text', text: '' }] }];
   });
-  // Filter out FloatingToolbarPlugin if showFloatingToolbar is false
   const showFloatingToolbar = field?.overrides?.showFloatingToolbar !== false;
-  // Held: this package is not built with the React Compiler, and usePlateEditor reads
-  // the list at mount only, so rebuilding it on every keystroke buys nothing.
   const builtPlugins = React.useMemo(
     () =>
       createEditorPlugins({
@@ -62,15 +48,11 @@ export const RichEditor = ({ input, field, ariaLabel }: RichEditorProps) => {
     components: Components(),
   });
 
-  // Focus-on-activation lives in the v4 field component (useFieldActivation),
-  // which is why v3's experimental_focusIntent effect is gone from here.
   return (
     <div>
       <Plate
         editor={editor}
         onChange={(value) => {
-          // Normalize links in code blocks before saving (we dont want type: 'a' inside code blocks, this will break the mdx parser)
-          // Ideal Solution: let code block provider to have a option for exclude certain plugins
           const normalized = (value.value as any[]).map(
             normalizeLinksInCodeBlocks
           );

--- a/packages/v4/@tinacms/rich-text/src/plate/media.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/media.tsx
@@ -1,19 +1,12 @@
 import { FileIcon, Trash2Icon } from 'lucide-react';
 import type React from 'react';
 
-// v4 has no media capability yet (plugins/media/ is a .gitkeep), so the pieces
-// the ported image node needs live here: the type, the extension test, and the
-// read-only chrome. The media plugin takes these over when it lands — that's
-// also when the image toolbar button stops being inert.
-
 export interface Media {
   id: string;
   filename: string;
   src?: string;
 }
 
-// http://stackoverflow.com/questions/10473185/regex-javascript-image-file-extension
-// (\?.*)? matches a query string (e.g. TinaCloud's).
 export const isImage = (filename: string): boolean =>
   /\.(gif|jpg|jpeg|tiff|png|svg|webp|avif)(\?.*)?$/i.test(filename);
 

--- a/packages/v4/@tinacms/rich-text/src/plate/nested-form.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/nested-form.tsx
@@ -1,12 +1,6 @@
 import type { TemplateField } from './types';
 
 // ponytail: stub — editing an embed's props needs a nested form panel, and that
-// panel is the object field (plugins/fields/object/, not built yet). Embeds
-// still parse, render, and serialize; only their side panel is missing, so
-// opening a document here loses nothing from it.
-//
-// When the object field lands, this renders it against `fields`/`initialValues`
-// and reports edits through `onChange` — every call site already passes all three.
 export const NestedForm = (_props: {
   onClose: () => void;
   id: string;

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-block.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-block.ts
@@ -10,7 +10,6 @@ import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
 import { HEADING_KEYS } from '@udecode/plate-heading';
 import { HorizontalRulePlugin } from '@udecode/plate-horizontal-rule/react';
 import { ParagraphPlugin } from '@udecode/plate/react';
-// import { insertEmptyCodeBlock } from '../../../transforms/insert-empty-block';
 import { preFormat } from './autoformat-utils';
 
 const headingAutoformatByLevel: Record<HeadingLevel, AutoformatRule> = {
@@ -58,16 +57,10 @@ const nonHeadingAutoformatBlocks: AutoformatRule[] = [
 export const getAutoformatBlocks = (
   headingLevels: readonly HeadingLevel[] = ALL_HEADING_LEVELS
 ): AutoformatRule[] => [
-  // Normalize so a pure-JS schema passing e.g. `['h7']` doesn't push an
-  // `undefined` rule into the autoformat config. The toolbar context
-  // applies the same filter, keeping both surfaces consistent.
   ...normalizeHeadingLevels(headingLevels).map(
     (level) => headingAutoformatByLevel[level]
   ),
   ...nonHeadingAutoformatBlocks,
 ];
 
-// Default rule set with all heading levels — consumed by the static
-// `autoformatRules` aggregate. The field-aware editor opts into a
-// filtered set via `getAutoformatBlocks(headingLevels)`.
 export const autoformatBlocks: AutoformatRule[] = getAutoformatBlocks();

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/common.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/common.tsx
@@ -32,13 +32,6 @@ const isListActive = (editor, type) => {
   return !!res && res.list[0].type === type;
 };
 
-// NodeIdPlugin normalizes the initial value by walking every node, one editor
-// operation each, so the walk grows with the document — it was most of the editor's
-// build time on a long body. The plugin skips the whole walk when the first and the
-// last root nodes already carry an id: partial ids are a state Plate supports, and
-// its insert overrides id new nodes as they arrive. Seeding the root ids here turns
-// the walk into that skip. Plain object copies, because at this point the value is
-// data, and not yet an editor.
 let seededNodeIds = 0;
 const withRootNodeIds = (nodes: any[]) =>
   nodes.map((node) =>
@@ -61,7 +54,6 @@ const normalize = (node: any) => {
         children: node.children.map(normalize),
       };
     }
-    // Always supply an empty text leaf
     return {
       ...node,
       children: [{ text: '' }],
@@ -96,41 +88,28 @@ const isCurrentBlockEmpty = (editor) => {
   const isEmpty =
     !NodeApi.string(node) &&
     !node.children?.some((child) => editor.api.isInline(child)) &&
-    // Only do this if we're at the start of a block
     editor.api.isStart(cursor, blockAbove[1]);
 
   return isEmpty;
 };
 
-/** Specifies node types which mdx can be embedded.
- * This prevents nodes like code blocks from having
- * MDX elements in them, which can't be parsed
- * NOTE: this also excludes block quotes, but probably should
- * allow for that, at the moment blockquotes are strict
- */
 const currentNodeSupportsMDX = (editor: PlateEditor) =>
   editor.api.node({
     match: { type: HANDLES_MDX },
   });
 
-/**
- * Recursively removes link nodes (type: 'a') from inside code blocks,
- * replacing them with their text children.
- */
 export function normalizeLinksInCodeBlocks(node) {
-  // If this is a code_line node, flatten any 'a' children
   if (node.type === 'code_line' && node.children) {
     return {
       ...node,
       children: node.children.flatMap((child) => {
         if (child.type === 'a') {
-          return child.children || []; // Replace link node with its text children
+          return child.children || [];
         }
         return [normalizeLinksInCodeBlocks(child)];
       }),
     };
   }
-  // Recurse for other nodes with children
   if (node.children) {
     return {
       ...node,

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/formatting.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/formatting.tsx
@@ -18,23 +18,6 @@ export const HANDLES_MDX = [
   ParagraphPlugin.key,
 ];
 
-const resetBlockTypesCommonRule = {
-  types: [
-    BlockquotePlugin.key,
-    HEADING_KEYS.h1,
-    HEADING_KEYS.h2,
-    HEADING_KEYS.h3,
-    HEADING_KEYS.h4,
-    HEADING_KEYS.h5,
-    HEADING_KEYS.h6,
-    // NOTE: code blocks behave strangely when used here
-  ],
-  defaultType: ParagraphPlugin.key,
-};
-
-// The inferred plugin type names @udecode/plate-core's internals, which resolve
-// through a React 18 copy at the repo root and so aren't portable in a .d.ts.
-// Plate's own plugin types aren't exported in a usable shape here.
 export const plugins: any[] = [
   TrailingBlockPlugin,
   AutoformatPlugin.configure({
@@ -45,13 +28,9 @@ export const plugins: any[] = [
   ExitBreakPlugin.configure({
     options: {
       rules: [
-        // Break out of a block entirely, eg. get out of a blockquote
-        // TOOD: maybe this should be shift+enter, but that's a soft break
-        // for other things like list items (see below)
         {
           hotkey: 'mod+enter',
         },
-        // Same as above but drops you at the top of a block
         {
           hotkey: 'mod+shift+enter',
           before: true,
@@ -67,22 +46,7 @@ export const plugins: any[] = [
       ],
     },
   }),
-  //See the usage code example from https://platejs.org/docs/reset-node
   ResetNodePlugin.configure({
-    // options: {
-    //   rules: [
-    //     {
-    //       ...resetBlockTypesCommonRule,
-    //       hotkey: 'Enter',
-    //       predicate: editor.api.isEmpty(editor.selection, { block: true }),
-    //     },
-    //     {
-    //       ...resetBlockTypesCommonRule,
-    //       hotkey: 'Backspace',
-    //       predicate: isSelectionAtBlockStart,
-    //     },
-    //   ],
-    // },
   }),
   SoftBreakPlugin.configure({
     options: {

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/index.tsx
@@ -1,4 +1,3 @@
-// export { plugins as commonPlugins } from './common';
 export { plugins as formattingPlugins } from './formatting';
 
 //TODO (Ask Jeff): Check with Jeff if we still need this export (we already rewrite the plugin in a different file)

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-html-block/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-html-block/index.tsx
@@ -22,9 +22,6 @@ export const createHTMLInlinePlugin = createPlatePlugin({
 
 export const KEY_BLOCKQUOTE_ENTER_BREAK = 'blockquote-enter-break';
 
-// Custom Plate plugin to handle Enter key inside blockquotes.
-// Our parsing logic expects a soft break with type 'break' to be inserted for proper handling within blockquotes.
-// This plugin inserts a 'break' element and a new paragraph when Enter is pressed inside a blockquote.
 export const createBlockquoteEnterBreakPlugin = createPlatePlugin({
   key: KEY_BLOCKQUOTE_ENTER_BREAK,
 
@@ -38,7 +35,6 @@ export const createBlockquoteEnterBreakPlugin = createPlatePlugin({
       if (!blockquoteEntry) return;
 
       event.preventDefault();
-      // Log the entire editor value BEFORE insertion
       const cursorPosition = editor.selection?.focus;
       if (!cursorPosition) return;
 
@@ -58,7 +54,6 @@ export const createBlockquoteEnterBreakPlugin = createPlatePlugin({
 
 export const ELEMENT_BREAK = 'break';
 
-// Custom Plate plugin to handle Enter key inside blockquotes. We dont need those slate attributes as we just need a br to render in the editor. If we adding those attributes, it will break the editor. children from plate it will cause weird behavior in firefox browser
 export const createBreakPlugin = createPlatePlugin({
   key: ELEMENT_BREAK,
   node: {

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/component.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/component.tsx
@@ -85,9 +85,6 @@ export const ImageForm = (props) => {
     <NestedForm
       id='image-form'
       label='Image'
-      // v3 selected a UI widget per field with `component`; v4 resolves the
-      // component from `type` through the field registry (ADR-009). `image` has
-      // no v4 field plugin yet, so the URL is a plain string for now.
       fields={[
         { label: 'URL', name: 'url', type: 'string' },
         { label: 'Caption', name: 'caption', type: 'string' },

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/index.tsx
@@ -41,7 +41,6 @@ export const insertImg = (editor: PlateEditor, media: Media) => {
     });
   }
 
-  // Normalizing the editor after insertion
   editor.tf.normalize({ force: true });
 };
 

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-invalid-markdown-plugin/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-invalid-markdown-plugin/index.tsx
@@ -32,10 +32,6 @@ function InvalidMarkdownElement({
   );
 }
 
-// v3 offered a "switch to raw-mode" button here. v4 has no raw editor to switch
-// to, so it would have done nothing — the recovery instruction points at the
-// file instead. Saving is safe meanwhile: the serializer writes this node's
-// original source back rather than a blank body.
 function ErrorMessage({ error }) {
   const message = buildErrorMessage(error);
   return (

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-mdx-plugins/component.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-mdx-plugins/component.tsx
@@ -88,7 +88,6 @@ export const InlineEmbed = ({
       {children}
       <Wrapper inline={true}>
         <span
-          // give just enough margin so that the cursor is visible when adjacent to this node.
           style={{ margin: '0 0.5px' }}
           className='relative inline-flex shadow-sm rounded leading-none'
         >
@@ -97,7 +96,6 @@ export const InlineEmbed = ({
           )}
           <span
             style={{ fontWeight: 'inherit', maxWidth: '275px' }}
-            // Tailwind reset puts styles on buttons
             className='truncate cursor-pointer relative inline-flex items-center justify-start px-2 py-0.5 rounded-l border border-gray-200 bg-white  hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500'
             onMouseDown={handleSelect}
           >

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/editor-plugins.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/editor-plugins.tsx
@@ -42,8 +42,6 @@ import { SlashPlugin } from '@udecode/plate-slash-command/react';
 import { TablePlugin } from '@udecode/plate-table/react';
 import { TrailingBlockPlugin } from '@udecode/plate-trailing-block';
 import { ParagraphPlugin } from '@udecode/plate/react';
-// @ts-ignore
-// NOTE: Linter complains about ESM import here, as per conversation with Jeff it will be fine at build time—ignore this linting error for now.
 import { all, createLowlight } from 'lowlight';
 import React from 'react';
 import { LinkFloatingToolbar } from '../components/plate-ui/link-floating-toolbar';
@@ -65,7 +63,6 @@ import {
 } from './create-mdx-plugins';
 import { FloatingToolbarPlugin } from './ui/floating-toolbar-plugin';
 
-// Define block types that support MDX embedding
 export const HANDLES_MDX = [
   HEADING_KEYS.h1,
   HEADING_KEYS.h2,
@@ -76,7 +73,6 @@ export const HANDLES_MDX = [
   ParagraphPlugin.key,
 ];
 
-// Common rule for resetting block types
 const resetBlockTypesCommonRule = {
   defaultType: ParagraphPlugin.key,
   types: [...HEADING_LEVELS, BlockquotePlugin.key],
@@ -88,10 +84,6 @@ const resetBlockTypesCodeBlockRule = {
   onReset: unwrapCodeBlock,
 };
 
-// View Plugins: Basic nodes and marks
-// The inferred plugin type names @udecode/plate-core's internals, which resolve
-// through a React 18 copy at the repo root and so aren't portable in a .d.ts.
-// Plate's own plugin types aren't exported in a usable shape here.
 export const viewPlugins: any[] = [
   BasicMarksPlugin,
   UnderlinePlugin,
@@ -143,14 +135,9 @@ const ClearHighlightOnEnterPlugin = createSlatePlugin({
 }));
 
 export interface CreateEditorPluginsOptions {
-  /** Heading levels exposed via markdown autoformat shortcuts (`# `, `## `, …).
-   * Omit to allow all levels 1-6. */
   headingLevels?: readonly HeadingLevel[];
 }
 
-// Functional and formatting plugins for the rich-text editor. Built lazily
-// per-field so the schema can scope behaviors like which heading levels
-// participate in markdown autoformat shortcuts.
 export const createEditorPlugins = ({
   headingLevels,
 }: CreateEditorPluginsOptions = {}): any[] => [
@@ -165,7 +152,6 @@ export const createEditorPlugins = ({
   ClearHighlightOnEnterPlugin,
   LinkPlugin.configure({
     options: {
-      // Custom validation function to allow relative links, e.g., /about
       isUrl: (url) => isUrl(url),
     },
     render: { afterEditable: () => <LinkFloatingToolbar /> },
@@ -178,8 +164,6 @@ export const createEditorPlugins = ({
   NodeIdPlugin,
   TablePlugin,
   SlashPlugin,
-  // Keeps a blank paragraph at the end of the editor so users can keep
-  // typing after a heading, quote, or other terminal block.
   TrailingBlockPlugin,
   createBreakPlugin,
   FloatingToolbarPlugin,
@@ -199,7 +183,6 @@ export const createEditorPlugins = ({
       ].map(
         (rule): AutoformatRule => ({
           ...rule,
-          // Suppress autoformat inside code blocks so e.g. `# ` stays literal.
           query: (editor) =>
             !editor.api.some({
               match: { type: editor.getType(CodeBlockPlugin) },
@@ -209,7 +192,6 @@ export const createEditorPlugins = ({
     },
   }),
 
-  // Lets users "break out" of a block (e.g. a heading) with Enter.
   ExitBreakPlugin.configure({
     options: {
       rules: [
@@ -222,8 +204,6 @@ export const createEditorPlugins = ({
       ],
     },
   }),
-  // Lets users turn a heading back into a paragraph by pressing Enter on
-  // an empty heading or Backspace at the start of one.
   ResetNodePlugin.configure({
     options: {
       rules: [
@@ -248,11 +228,6 @@ export const createEditorPlugins = ({
           hotkey: 'Backspace',
           predicate: isSelectionAtCodeBlockStart,
         },
-        // Plate's ListPlugin usually resets lists to paragraphs on Backspace
-        // at the start of a list item, but when the list is the editor's
-        // first node the default doesn't fully unwrap and we end up with an
-        // invalid structure (e.g. <li> inside <p>). `onReset: unwrapList`
-        // forces a clean reset in that case.
         {
           types: [BulletedListPlugin.key, NumberedListPlugin.key],
           defaultType: ParagraphPlugin.key,

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/components.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/components.tsx
@@ -49,21 +49,9 @@ import { TableElement } from '../../components/plate-ui/table/table-element';
 import { TableRowElement } from '../../components/plate-ui/table/table-row-element';
 import { classNames } from './helpers';
 
-/**
- * For blocks elements (p, blockquote, ul, ...etc), it
- * can be jarring to see the cursor jump inconsistently
- * based on .prose styles. These classes aim to normalize
- * blocks behavior so they take up the same space
- */
 const blockClasses = 'mt-0.5';
-/** prose sets a bold font, making bold marks impossible to see */
 const headerClasses = 'font-normal';
 
-/**
- * Returns black or white depending on the luminance of the given background
- * color, ensuring the text on top meets WCAG contrast requirements.
- * Accepts any CSS color format (hex, rgb, hsl, named colors).
- */
 function getContrastColor(color: string): string {
   const parsed = colorString.get.rgb(color);
   if (!parsed) return '#000000';
@@ -166,7 +154,6 @@ const Heading4 = ({
   </h4>
 );
 
-/** Tailwind prose doesn't style h5 and h6 elements */
 const headerFontStyle: React.CSSProperties = {
   fontFamily: "'Inter', sans-serif",
   fontWeight: '400',

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/helpers.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/helpers.tsx
@@ -2,12 +2,3 @@ export function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(' ');
 }
 
-export const uuid = () => {
-  // @ts-ignore
-  return ([1e7] + -1e3 + -4e3 + -8e3 + -1e11).replace(/[018]/g, (c) =>
-    (
-      c ^
-      (crypto.getRandomValues(new Uint8Array(1))[0] & (15 >> (c / 4)))
-    ).toString(16)
-  );
-};

--- a/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-overrides.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-overrides.tsx
@@ -1,17 +1,12 @@
 import type { HeadingLevel, ToolbarOverrideType } from '@tinacms/schema-tools';
 export type { HeadingLevel, ToolbarOverrideType };
 
-// Measured off the rendered toolbar in Chromium, not derived from the classes: a
-// button is `h-9 px-2` around a `size-5` icon, and the row that holds the buttons
-// sets no gap, so each of these is the whole horizontal cost of one item.
 export const STANDARD_ICON_WIDTH = 36;
 export const HEADING_ICON_WITH_TEXT = 130;
 export const HEADING_ICON_ONLY = 62;
 export const EMBED_ICON_WIDTH = 54;
-// Highlight opens a colour swatch, so it carries a dropdown arrow that the plain
-// icon buttons do not.
 export const HIGHLIGHT_ICON_WIDTH = 54;
-export const CONTAINER_MD_BREAKPOINT = 448; // Tailwind's 'md' breakpoint for container with default `max-width` scale https://tailwindcss.com/blog/tailwindcss-v3-2
+export const CONTAINER_MD_BREAKPOINT = 448;
 export const OVERFLOW_MENU_WIDTH = 36;
 
 export const HEADING_LABEL = 'Headings';

--- a/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-provider.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-provider.tsx
@@ -13,12 +13,6 @@ interface ToolbarContextProps {
   templates: MdxTemplate[];
   overrides: ToolbarOverrides | undefined;
   headingLevels: readonly HeadingLevel[];
-  /**
-   * True when the schema explicitly sets `overrides.headingLevels`
-   * (including an explicit empty array, which means "no headings").
-   * Lets consumers (e.g. the slash menu) distinguish "user opted in"
-   * from "use the legacy default" without re-deriving the check.
-   */
   headingLevelsConfigured: boolean;
 }
 

--- a/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.ts
@@ -1,52 +1,41 @@
-/**
- * RegExps. A URL must match #1 or #2 or #3 or #4.
- */
 
 const protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
 const emailLintRE = /mailto:([^?\\]+)/;
-const telLintRE = /tel:([\d-]+)/; // Added regex for tel: links
+const telLintRE = /tel:([\d-]+)/;
 const localhostDomainRE = /^localhost[\d:?]*(?:[^\d:?]\S*)?$/;
 const nonLocalhostDomainRE = /^[^\s.]+\.\S{2,}$/;
-const localUrlRE = /^\/\S+/; // Regular expression for local URLs
+const localUrlRE = /^\/\S+/;
 
-/** Loosely validate a URL `string`. */
 export const isUrl = (value: unknown) => {
   if (typeof value !== 'string') {
     return false;
   }
 
-  // Check if the string is a bare hash link
   if (value.startsWith('#')) {
     return true;
   }
 
   const generalMatch = value.match(protocolAndDomainRE);
   const emailLinkMatch = value.match(emailLintRE);
-  const telLinkMatch = value.match(telLintRE); // Check for tel: link match
-  const localUrlMatch = value.match(localUrlRE); // Check for local URL match
+  const telLinkMatch = value.match(telLintRE);
+  const localUrlMatch = value.match(localUrlRE);
 
-  // Check if any of the specific link types or the general pattern match
   if (emailLinkMatch || telLinkMatch || localUrlMatch) {
-    // For tel and mailto, we can consider them valid if they match the specific regex.
-    // For local URLs, the regex already covers it.
     return true;
   }
 
-  // If none of the specific types matched, check the general URL pattern
   if (generalMatch) {
     const everythingAfterProtocol = generalMatch[1];
     if (!everythingAfterProtocol) {
       return false;
     }
 
-    // Fallback to URL constructor for stricter validation of complex URLs
     try {
       new URL(value);
     } catch {
       return false;
     }
 
-    // Validate the domain part for general URLs
     return (
       localhostDomainRE.test(everythingAfterProtocol) ||
       nonLocalhostDomainRE.test(everythingAfterProtocol)

--- a/packages/v4/@tinacms/rich-text/src/plate/types.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/types.ts
@@ -1,15 +1,7 @@
-// The editor carries a template's fields through to the host's nested-form panel
-// without reading them, so it names only what it needs. The host's richer
-// FieldSchema satisfies this structurally — which is why this package does not
-// import it.
 export interface TemplateField {
   name: string;
   label?: string;
   type?: string;
-  // The field whose value labels the embed in the editor, as `Template: value`. Refer
-  // to getLabel in create-mdx-plugins/component.tsx, which reads this. Templates are
-  // author-written config, so the key reaches here even though v4's own FieldSchema
-  // does not model it yet.
   isTitle?: boolean;
 }
 

--- a/packages/v4/@tinacms/rich-text/src/value.test.ts
+++ b/packages/v4/@tinacms/rich-text/src/value.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { EMPTY_RICH_TEXT } from './value';
 
 describe('EMPTY_RICH_TEXT', () => {
-  // It is shared, not copied: a field descriptor's defaultValue reaches form
-  // values by reference, so every empty rich-text field in every open document
-  // points at this one object. A mutation would surface as one document's edits
-  // appearing in another — and a form store comparing structurally would not
-  // notice. Frozen, so it throws instead.
   it('cannot be mutated', () => {
     expect(Object.isFrozen(EMPTY_RICH_TEXT)).toBe(true);
     expect(Object.isFrozen(EMPTY_RICH_TEXT.children)).toBe(true);
@@ -19,8 +14,6 @@ describe('EMPTY_RICH_TEXT', () => {
   });
 
   it('is an empty document, not a document with an empty paragraph', () => {
-    // `required` counts children, so a stray placeholder node would make every
-    // untouched field read as filled in.
     expect(EMPTY_RICH_TEXT).toEqual({ type: 'root', children: [] });
   });
 });

--- a/packages/v4/@tinacms/rich-text/src/value.ts
+++ b/packages/v4/@tinacms/rich-text/src/value.ts
@@ -1,15 +1,4 @@
-// The document model the editor edits.
-//
-// It lives in this package, not in the host, because the editor is what defines
-// the shape — a codec's job is to produce it from a file and turn it back into
-// one. Putting it here also keeps the dependency one-way: `@tinacms/tinacms`
-// imports this package, never the reverse.
-//
-// Deliberately dependency-free so a codec can implement the contract without
-// pulling the editor (or its 40-odd packages) in behind it.
 
-// A node in the document. Plate owns the full shape per node type; `type` is the
-// only field anything outside the editor reads, so it is the only one named.
 export interface RichTextNode {
   type: string;
   [key: string]: unknown;
@@ -20,12 +9,6 @@ export interface RichTextValue {
   children: RichTextNode[];
 }
 
-// Frozen because it is shared, not copied: a field descriptor's defaultValue is
-// handed into form values by reference, so every empty rich-text field in every
-// open document points at this one object. Nothing mutates it today — the editor
-// seeds from it and builds its own tree — but a form store comparing values
-// structurally would not notice if something did. Freezing makes that an
-// immediate error rather than one document's edits appearing in another.
 export const EMPTY_RICH_TEXT: RichTextValue = Object.freeze({
   type: 'root',
   children: Object.freeze([]) as RichTextNode[],

--- a/packages/v4/@tinacms/rich-text/vitest.config.ts
+++ b/packages/v4/@tinacms/rich-text/vitest.config.ts
@@ -1,10 +1,6 @@
 /// <reference types="vitest" />
 import { defineConfig } from 'vitest/config';
 
-// Node, not a DOM: what is testable here without a browser is the value contract
-// and the package boundary. The editor itself needs real layout and real
-// beforeinput events, so its coverage lives in the host's Playwright suite
-// (packages/v4/@tinacms/tinacms/e2e) rather than in a simulated DOM here.
 export default defineConfig({
   test: {
     globals: true,

--- a/packages/v4/@tinacms/tinacms/e2e/form-column-resize.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/form-column-resize.spec.ts
@@ -7,10 +7,6 @@ import {
   toolbar,
 } from './form-column';
 
-// The form column opens narrow and is dragged wider. A browser is the only place this
-// can be checked: the width comes from pointer capture and a clamp against the window,
-// neither of which happy-dom has. These tests only read the document, so they stay
-// parallel with the ones that save.
 const DEFAULT_WIDTH = 352;
 
 const openDocument = async (page: import('@playwright/test').Page) => {
@@ -32,8 +28,6 @@ test('opens at the default width and drags wider', async ({ page }) => {
   expect(await columnWidth(page)).toBeGreaterThan(600);
 });
 
-// The toolbar hides tools it cannot fit, which is the reason the column resizes at all.
-// A wider column that showed no more of them would leave the feature pointless.
 test('a wider column shows more of the rich-text toolbar', async ({ page }) => {
   const controlsShown = () =>
     toolbar(page).evaluate(
@@ -46,14 +40,11 @@ test('a wider column shows more of the rich-text toolbar', async ({ page }) => {
   expect(await controlsShown()).toBeGreaterThan(atDefault);
 });
 
-// The default is also the floor. It is the width the rich-text layout tests cover, so
-// the editor is known to work at it, and narrower is untested.
 test('does not drag narrower than the default', async ({ page }) => {
   await setColumnWidth(page, 200);
   expect(await columnWidth(page)).toBe(DEFAULT_WIDTH);
 });
 
-// A preference an editor has to set on every page load is not a preference.
 test('the width survives a reload, and Home returns it to the default', async ({
   page,
 }) => {
@@ -68,7 +59,6 @@ test('the width survives a reload, and Home returns it to the default', async ({
   await expect(formColumn(page)).toHaveCSS('width', `${DEFAULT_WIDTH}px`);
 });
 
-// The handle is reachable without a pointer.
 test('the arrow keys resize the column', async ({ page }) => {
   const before = await columnWidth(page);
   await resizeHandle(page).focus();

--- a/packages/v4/@tinacms/tinacms/e2e/form-column.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/form-column.ts
@@ -1,7 +1,5 @@
 import type { Page } from '@playwright/test';
 
-// The shell renders two asides: the navigation of the Sidebar, and the form column
-// inside the main region. The form column is the second.
 export const formColumn = (page: Page) => page.locator('aside').last();
 
 export const resizeHandle = (page: Page) =>
@@ -10,14 +8,9 @@ export const resizeHandle = (page: Page) =>
 export const columnWidth = (page: Page) =>
   formColumn(page).evaluate((column) => column.getBoundingClientRect().width);
 
-// The element that carries `@container/toolbar`, which is what the toolbar measures
-// itself against.
 export const toolbar = (page: Page) =>
   page.locator('div.w-full.overflow-hidden.\\@container\\/toolbar');
 
-// Drags the handle rather than setting a width, because React owns the inline style on
-// the column and would overwrite an assignment on its next render. This also keeps the
-// pointer path — capture, move, release — under test.
 export const setColumnWidth = async (page: Page, target: number) => {
   const from = await columnWidth(page);
   const handle = resizeHandle(page);

--- a/packages/v4/@tinacms/tinacms/e2e/visual-editing.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/visual-editing.spec.ts
@@ -1,8 +1,5 @@
 import { expect, test } from '@playwright/test';
 
-// The click-to-edit half of visual editing, across a real iframe boundary. The vitest
-// suite fakes the two windows, so only this test observes the postMessage guards —
-// origin and source — against the browser's real values.
 test('a click on a marked element in the preview focuses its field in the form', async ({
   page,
 }) => {

--- a/packages/v4/@tinacms/tinacms/playground/aliases.ts
+++ b/packages/v4/@tinacms/tinacms/playground/aliases.ts
@@ -1,10 +1,3 @@
-// Point the public import strings at the source of the package, so the playground uses
-// the same specifiers that a real app uses. It does not use a relative path into src/.
-// The longer subpath must come first.
-//
-// This is its own module, because two servers need it. Those are the dev server, and the
-// temporary server that loadTinaConfig starts to read tina/config.ts. A real app needs
-// neither, because it resolves @tinacms/tinacms from node_modules.
 
 import { fileURLToPath } from 'node:url';
 

--- a/packages/v4/@tinacms/tinacms/playground/src/app.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/app.tsx
@@ -3,8 +3,6 @@ import { TinaProvider, usePreviewConnection } from '@tinacms/tinacms/react';
 import { useRef } from 'react';
 import config from '../tina/config';
 
-// The site side of visual editing. usePreviewConnection streams the values of the open
-// form into the iframe, and it turns a click in the iframe into the active field.
 function PreviewPane() {
   const iframeRef = useRef<HTMLIFrameElement>(null);
   usePreviewConnection(iframeRef);
@@ -18,9 +16,6 @@ function PreviewPane() {
   );
 }
 
-// The whole playground app. The admin shell now supplies the parts that this file held
-// before: the fields of the collection, the document tabs, the status badge, and the save
-// button. tina/config.ts drives all of them.
 export function App() {
   return (
     <TinaProvider config={config}>

--- a/packages/v4/@tinacms/tinacms/playground/src/content.ts
+++ b/packages/v4/@tinacms/tinacms/playground/src/content.ts
@@ -1,8 +1,5 @@
 import type { TinaDocument } from '@tinacms/tinacms';
 
-// The static seed for /preview.html, when a browser opens that page by itself. This uses
-// `satisfies`, and not a type annotation. useTina is generic, so the literal shape lets
-// the preview read `body` as the MDX tree, and not cast it out of `unknown`.
 export const sampleDocument = {
   title: 'Hello World',
   featured: false,

--- a/packages/v4/@tinacms/tinacms/playground/src/preview/post-preview.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/preview/post-preview.tsx
@@ -5,10 +5,6 @@ import {
 } from '@tinacms/tinacms/adapters/react';
 import { sampleDocument } from '../content';
 
-// The site side of visual editing, written as a real site would write it. useTina seeds
-// from the document that the site rendered, which is the whole document when a browser
-// opens /preview.html directly. Inside the editor, useTina adopts the values that arrive.
-// tinaField marks the elements that an author can click.
 export function PostPreview() {
   const { data: post, isEditing } = useTina({ data: sampleDocument });
 
@@ -34,8 +30,6 @@ export function PostPreview() {
           ? 'This preview renders the document streamed from the editor. Click the title or the badge to focus its field in the sidebar.'
           : 'Standalone preview — rendering the static document.'}
       </p>
-      {/* The body arrives as the mdx AST the editor is editing, so keystrokes
-          in the rich-text field show up here without a round-trip to disk. */}
       <div {...tinaField('body')}>
         <TinaMarkdown content={post.body} />
       </div>

--- a/packages/v4/@tinacms/tinacms/playground/tina/config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/tina/config.ts
@@ -1,12 +1,3 @@
-// The composition root of the playground. It stands in for the tina/config.ts of a real
-// app. Two consumers import this file: the browser app in app.tsx, and the Vite config,
-// which runs it in node to start the local data layer. That is the point of the file. The
-// collection was declared twice before, once at the wire level for the data layer and
-// once with the `t.*` builders for the form, and the two could drift.
-//
-// Node can import it, because the universal entry keeps the browser code behind lazy
-// segments. `localContentPlugin()` names its client with `() => import(...)`, and the
-// `t.*` builders are plain schema. Neither React nor Plate is therefore loaded.
 
 import {
   type CollectionSchema,
@@ -24,8 +15,6 @@ export const postCollection = {
   fields: [
     t.string({ name: 'title', label: 'Title', required: true, min: 3 }),
     t.boolean({ name: 'featured', label: 'Featured' }),
-    // The v3 content model. This is the markdown body, which GraphQL serves as the
-    // MDX tree.
     t.richText({ name: 'body', label: 'Body', isBody: true }),
   ],
 } satisfies CollectionSchema;

--- a/packages/v4/@tinacms/tinacms/playwright.config.ts
+++ b/packages/v4/@tinacms/tinacms/playwright.config.ts
@@ -1,24 +1,10 @@
 import { createServer } from 'node:net';
 import { defineConfig, devices } from '@playwright/test';
 
-// A browser is the only place two of this package's guarantees can be observed:
-// layout (happy-dom has no layout engine, so an overflow is invisible to vitest)
-// and Plate editing (Slate needs real beforeinput events, which synthetic
-// keystrokes don't produce). Everything else stays in the vitest suite.
-//
-// The harness is the playground — the same app `pnpm dev` serves.
-//
-// The port is asked for rather than fixed, so a second run of this suite (another
-// checkout, a watch process, two CI shards on one box) doesn't collide with the
-// first. Pin it with TINA_E2E_PORT, which also restores `reuseExistingServer`.
 const freePort = (): Promise<number> =>
   new Promise((resolve, reject) => {
     const probe = createServer();
     probe.once('error', reject);
-    // Port 0 asks the OS for an unused one, which is free at the moment it's read
-    // back — hence --strictPort below. If something claims it in the gap before
-    // vite binds, that has to fail loudly rather than drift to a port baseURL
-    // isn't pointing at.
     probe.listen(0, '127.0.0.1', () => {
       const address = probe.address();
       probe.close(() => {
@@ -29,11 +15,11 @@ const freePort = (): Promise<number> =>
   });
 
 const pinned = process.env.TINA_E2E_PORT;
-const PORT = pinned ? Number(pinned) : await freePort();
-// Playwright evaluates this config once in the runner and again in each worker it
-// forks. Only the runner starts the server, so the port it picked has to reach the
-// workers — otherwise they each probe their own and navigate to a port nothing is
-// serving. Workers fork after this line, so they inherit it.
+const pinnedPort = pinned ? Number.parseInt(pinned, 10) : Number.NaN;
+if (pinned && !Number.isInteger(pinnedPort)) {
+  throw new Error(`TINA_E2E_PORT must be an integer, got "${pinned}".`);
+}
+const PORT = Number.isInteger(pinnedPort) ? pinnedPort : await freePort();
 process.env.TINA_E2E_PORT = String(PORT);
 
 export default defineConfig({
@@ -52,7 +38,6 @@ export default defineConfig({
   webServer: {
     command: `npx vite playground --port ${PORT} --strictPort`,
     url: `http://localhost:${PORT}/`,
-    // Only a pinned port can be reused; a probed one is fresh every run by design.
     reuseExistingServer: !process.env.CI && Boolean(pinned),
     timeout: 60000,
   },

--- a/packages/v4/@tinacms/tinacms/src/adapters/astro/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/astro/index.ts
@@ -1,13 +1,3 @@
-// The server entry, `tinacms/adapters/astro`. It mounts the composed RPC handler as
-// Astro endpoint handlers.
-//
-// The project owns the route, and Tina supplies the function that answers it. Nothing
-// here spawns a process or claims a port, so `astro dev` and `astro build` stay the
-// pipeline of the project (refer to packages/v4/README.md).
-//
-// An Astro endpoint takes an APIContext and returns a Web Response. The one member of
-// that context this adapter reads is `request`, so the parameter is typed structurally
-// and this file does not import `astro`.
 
 import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
 
@@ -18,15 +8,6 @@ export interface AstroRouteHandlers {
   POST: (context: { request: Request }) => Promise<Response>;
 }
 
-// Use it from src/pages/api/tina/[...slug].ts:
-//
-//   export const { GET, POST } = mountHandler({ plugins })
-//
-// The route needs `export const prerender = false`, or a project with `output: 'server'`.
-// A prerendered endpoint runs at build time and answers nothing at run time.
-//
-// Operations are POST (ADR-008). GET is exported so that a browser hitting the route gets
-// the 405 the dispatch returns, and not the 404 that Astro returns for a missing export.
 export const mountHandler = (config: RpcHandlerConfig): AstroRouteHandlers => {
   const handler = createRpcHandler(config);
   const route = ({ request }: { request: Request }) => handler(request);

--- a/packages/v4/@tinacms/tinacms/src/adapters/express/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/express/index.ts
@@ -1,14 +1,3 @@
-// The server entry, `tinacms/adapters/express`. It mounts the composed RPC handler as an
-// Express middleware.
-//
-// The project owns the server, and Tina supplies a middleware for one route. Nothing here
-// listens, so the project keeps its own pipeline (refer to packages/v4/README.md).
-//
-// This is the one adapter with real work in it. Next, Astro, and Hono all hand over a Web
-// Request and take back a Web Response, which is already the signature of RpcHandler.
-// Express predates that and speaks node streams, so this file converts in both
-// directions. It types the two ends structurally with the `node:http` classes that
-// Express extends, and does not import `express`.
 
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
@@ -16,10 +5,7 @@ import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
 export type { RpcHandlerConfig };
 
 type ExpressLikeRequest = IncomingMessage & {
-  // Express strips the mount path from `url` and keeps the whole path here. The
-  // dispatch reads the last two segments either way, so this is for fidelity.
   originalUrl?: string;
-  // A body parser upstream of this middleware leaves its result here.
   body?: unknown;
 };
 
@@ -30,9 +16,6 @@ export type TinaMiddleware = (
 ) => void;
 
 const readBody = async (req: ExpressLikeRequest): Promise<string> => {
-  // An `express.json()` in front of this middleware has already drained the socket and
-  // left the parsed value on `req.body`. Reading the stream again yields nothing, and
-  // the operation would see an empty body, so serialize what the parser produced.
   if (req.body !== undefined && req.body !== null) {
     return typeof req.body === 'string' ? req.body : JSON.stringify(req.body);
   }
@@ -42,9 +25,6 @@ const readBody = async (req: ExpressLikeRequest): Promise<string> => {
 };
 
 const toWebRequest = async (req: ExpressLikeRequest): Promise<Request> => {
-  // The Request constructor needs an absolute URL, and the dispatch reads only the
-  // path. Take the scheme from the socket rather than from `x-forwarded-proto`: a
-  // client sends that header too, and nothing here should trust it.
   const scheme = (req.socket as { encrypted?: boolean }).encrypted
     ? 'https'
     : 'http';
@@ -64,7 +44,6 @@ const toWebRequest = async (req: ExpressLikeRequest): Promise<Request> => {
   }
 
   const method = req.method ?? 'GET';
-  // A GET or HEAD Request may not carry a body, and the constructor throws if it does.
   const body =
     method === 'GET' || method === 'HEAD' ? undefined : await readBody(req);
   return new Request(url, { method, headers, body });
@@ -74,10 +53,6 @@ const sendWebResponse = async (
   response: Response,
   res: ServerResponse
 ): Promise<void> => {
-  // Iterating a Headers object joins repeated names with ", ". For Set-Cookie that
-  // makes one broken cookie out of two, so an auth plugin that writes a session cookie
-  // and a refresh cookie loses both. getSetCookie keeps them apart. It is optional
-  // here because it arrived after the rest of the fetch types.
   const setCookie = response.headers.getSetCookie?.() ?? [];
   for (const [name, value] of response.headers) {
     if (name.toLowerCase() === 'set-cookie') continue;
@@ -85,22 +60,12 @@ const sendWebResponse = async (
   }
   if (setCookie.length > 0) res.setHeader('set-cookie', setCookie);
   res.statusCode = response.status;
-  // The RPC transport carries JSON only, so buffering costs nothing and avoids the
-  // half-duplex stream plumbing that a streamed body would need.
   res.end(Buffer.from(await response.arrayBuffer()));
 };
 
-// Mount it on the base URL of the client:
-//
-//   app.use('/api/tina', tinaMiddleware({ plugins }))
-//
-// It answers every request that reaches it and calls `next` only with an error, so the
-// error handler of the project reports a fault in the conversion.
 export const tinaMiddleware = (config: RpcHandlerConfig): TinaMiddleware => {
   const handler = createRpcHandler(config);
   return (req, res, next) => {
-    // Express ignores a returned promise, so the rejection is caught here. An
-    // unhandled one would take the process down.
     void (async () => {
       try {
         await sendWebResponse(await handler(await toWebRequest(req)), res);

--- a/packages/v4/@tinacms/tinacms/src/adapters/hono/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/hono/index.ts
@@ -1,22 +1,8 @@
-// The server entry, `tinacms/adapters/hono`. It mounts the composed RPC handler as a
-// Hono route.
-//
-// The project owns the route, and Tina supplies the function that answers it. Nothing
-// here spawns a process or claims a port, so the project keeps its own pipeline (refer
-// to packages/v4/README.md).
-//
-// The planned surface for this file was `tinaRoute(config) → Hono`, mounted with
-// `app.route()`. Returning a Hono instance means importing `hono`, and that would make
-// the framework a dependency of the runtime package for no gain: a Hono handler already
-// takes a Web Request through `c.req.raw` and returns a Web Response. So this exports the
-// handler, and the project mounts it with `app.all()`, which is the same one line.
 
 import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
 
 export type { RpcHandlerConfig };
 
-// The one member of the Hono context this adapter reads. Typed structurally, so the
-// handler fits `app.all()` without `hono` in the import graph.
 export interface HonoRequestContext {
   req: { raw: Request };
 }
@@ -25,12 +11,6 @@ export type HonoRouteHandler = (
   context: HonoRequestContext
 ) => Promise<Response>;
 
-// Mount it on the wildcard that matches the base URL of the client:
-//
-//   app.all('/api/tina/*', mountHandler({ plugins }))
-//
-// The trailing `*` is required. Hono matches `/api/tina` alone otherwise, and every
-// operation below it returns 404.
 export const mountHandler = (config: RpcHandlerConfig): HonoRouteHandler => {
   const handler = createRpcHandler(config);
   return ({ req }) => handler(req.raw);

--- a/packages/v4/@tinacms/tinacms/src/adapters/mount.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/mount.test.ts
@@ -1,19 +1,13 @@
-// Every adapter mounts the same RpcHandler into the server that the project already
-// runs. Next, Astro, and Hono hand over a Web Request and take back a Web Response, so
-// their tests assert the wiring. Express speaks node streams, so its conversion is the
-// part with behaviour worth covering.
 
 import { Readable } from 'node:stream';
 import { describe, expect, it } from 'vitest';
 import { definePlugin } from '../core/plugin';
 import { defineServerPlugin, publicOp } from '../server';
 import { mountHandler as mountAstro } from './astro';
-import { tinaMiddleware } from './express';
+import { type TinaMiddleware, tinaMiddleware } from './express';
 import { mountHandler as mountHono } from './hono';
 import { mountHandler as mountNext } from './next';
 
-// One public op, so these tests cover the transport and not the authorization. The
-// dispatch skips the session check for a publicOp, which handler.test.ts covers.
 const plugins = [
   definePlugin({
     name: 'test-media',
@@ -58,8 +52,6 @@ describe('the Web-standard adapters', () => {
     expect(await response.json()).toEqual({ echoed: 'hono' });
   });
 
-  // Operations are POST. A browser that opens the route gets the 405 that names the
-  // problem, and not the 404 a framework returns for a method with no export.
   it('answers GET with 405 rather than leaving the method unexported', async () => {
     const { GET } = mountNext({ plugins });
     const response = await GET(new Request(`http://tina.local${ROUTE}`));
@@ -67,8 +59,6 @@ describe('the Web-standard adapters', () => {
   });
 });
 
-// A stand-in for the node request. Express extends IncomingMessage, which is a Readable,
-// so a Readable carrying the same members is what the middleware sees.
 const nodeRequest = (init: {
   method?: string;
   url?: string;
@@ -87,11 +77,12 @@ const nodeRequest = (init: {
     },
     socket: { encrypted: init.encrypted ?? false },
     ...(init.parsedBody === undefined ? {} : { body: init.parsedBody }),
-  }) as never;
+  }) as unknown as MiddlewareRequest;
 
-// The middleware returns before it has answered, because Express ignores a returned
-// promise. "The request is done" therefore means `end` ran, or `next` got an error.
-const runMiddleware = async (req: never) => {
+type MiddlewareRequest = Parameters<TinaMiddleware>[0];
+type MiddlewareResponse = Parameters<TinaMiddleware>[1];
+
+const runMiddleware = async (req: MiddlewareRequest) => {
   const headers: Record<string, string | string[]> = {};
   const errors: unknown[] = [];
   let settle: () => void = () => {};
@@ -110,10 +101,14 @@ const runMiddleware = async (req: never) => {
       settle();
     },
   };
-  tinaMiddleware({ plugins })(req, recorder as never, (error) => {
-    errors.push(error);
-    settle();
-  });
+  tinaMiddleware({ plugins })(
+    req,
+    recorder as unknown as MiddlewareResponse,
+    (error) => {
+      errors.push(error);
+      settle();
+    }
+  );
   await done;
   return { recorder, errors };
 };
@@ -128,8 +123,6 @@ describe('the Express adapter', () => {
     expect(recorder.headers['content-type']).toMatch(/application\/json/);
   });
 
-  // express.json() upstream drains the socket and leaves the parsed value on req.body.
-  // Reading the stream again yields nothing, so the op would have seen no input.
   it('reads a body that an upstream parser already consumed', async () => {
     const { recorder } = await runMiddleware(
       nodeRequest({ parsedBody: { value: 'parsed' } })
@@ -137,9 +130,6 @@ describe('the Express adapter', () => {
     expect(JSON.parse(recorder.body)).toEqual({ echoed: 'parsed' });
   });
 
-  // Express strips the mount path from `url` when the middleware is mounted with
-  // app.use('/api/tina', …). The dispatch reads the last two segments, so both forms
-  // must reach the same op.
   it('routes whether or not Express stripped the mount path', async () => {
     const { recorder } = await runMiddleware(
       nodeRequest({
@@ -151,8 +141,6 @@ describe('the Express adapter', () => {
   });
 
   it('does not send a body on a GET, and reports the 405', async () => {
-    // A GET Request may not carry a body; constructing one throws. That throw would
-    // reach `next` instead of the dispatch.
     const { recorder, errors } = await runMiddleware(
       nodeRequest({ method: 'GET', body: undefined })
     );

--- a/packages/v4/@tinacms/tinacms/src/adapters/next/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/next/index.ts
@@ -1,13 +1,3 @@
-// The server entry, `tinacms/adapters/next`. It mounts the composed RPC handler as
-// Next.js route handlers.
-//
-// The project owns the route, and Tina supplies the function that answers it. Nothing
-// here spawns a process or claims a port, so `next dev` and `next build` stay the
-// pipeline of the project (refer to packages/v4/README.md).
-//
-// An app-router route handler takes a Web Request and returns a Web Response, which is
-// the signature of RpcHandler. The adapter is therefore a rename, and this file does not
-// import `next`.
 
 import { type RpcHandlerConfig, createRpcHandler } from '../../rpc/handler';
 
@@ -18,13 +8,6 @@ export interface NextRouteHandlers {
   POST: (request: Request) => Promise<Response>;
 }
 
-// Use it from app/api/tina/[...slug]/route.ts:
-//
-//   export const { GET, POST } = mountHandler({ plugins })
-//
-// Operations are POST (ADR-008). GET is exported so that a browser hitting the route
-// gets the 405 the dispatch returns, which names the problem, instead of the 404 that
-// Next returns for a method with no export.
 export const mountHandler = (config: RpcHandlerConfig): NextRouteHandlers => {
   const handler = createRpcHandler(config);
   return { GET: handler, POST: handler };

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/index.ts
@@ -1,13 +1,4 @@
-// The public entry `@tinacms/tinacms/adapters/react`. It is the React binding of the
-// site-side protocol for visual editing. The wire protocol in `./preview` belongs to no
-// framework, and each framework gets an adapter like this one. React is the first. This
-// file also exports tinaField, so a React site imports from one place.
 export { TINA_FIELD_ATTR, tinaField } from '../../preview/protocol';
-// The renderer for the value of a rich-text field. It turns the MDX tree into React. The
-// editor edits that tree, and the GraphQL pipeline serves it. The walk itself lives in
-// ../../rich-text and names no framework, so a binding for another framework starts from
-// the same instructions instead of from a rewrite. The surface here is the one v3
-// published, so an existing custom `components` map still works.
 export {
   type Components,
   StaticTinaMarkdown,

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.test.tsx
@@ -3,10 +3,6 @@ import { describe, expect, it } from 'vitest';
 import type { TinaMarkdownContent } from '../../rich-text';
 import { StaticTinaMarkdown, TinaMarkdown } from './tina-markdown';
 
-// The binding is thin, so these tests are about the markup it lands on: the fallbacks a
-// site gets without supplying anything, and the seams where a supplied component takes
-// over. They double as the parity check between the memoised and the static renderer.
-
 const html = (
   content: TinaMarkdownContent | TinaMarkdownContent[],
   components?: any
@@ -165,8 +161,6 @@ describe('supplied components', () => {
 });
 
 describe('tables', () => {
-  // A cell holds a list of blocks, and the renderer swaps `p` for the cell element, so
-  // the paragraph wrapper is what becomes the th or td.
   const cell = (value: string) => ({
     value: [{ type: 'p', children: [text(value)] }] as any,
   });

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.tsx
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.tsx
@@ -1,10 +1,3 @@
-// The React binding of the rich-text renderer.
-//
-// The render lives in ../../rich-text and names no framework. All that is left here is
-// RichTextHost: how React builds an element, calls a component, makes a text value, joins
-// siblings, and caches a node. Everything a reader would call rich-text behaviour — the
-// node types, the fallback markup, the marks, the tables — is in the core, so a change
-// there reaches this binding and every other one without an edit.
 
 import React from 'react';
 import {
@@ -16,33 +9,6 @@ import {
 
 export type { TinaMarkdownContent };
 
-/**
- * Define the allowed components and their props
- * ```ts
- * const components:
- * Components<{
- *  BlockQuote: {
- *      children: TinaMarkdownContent;
- *      authorName: string;
- *    };
- *  }> = {
- *    BlockQuote: (props: {
- *      children: TinaMarkdownContent;
- *      authorName: string;
- *    }) => {
- *      return (
- *        <div>
- *          <blockquote>
- *            <TinaMarkdown content={props.children} />
- *            {props.authorName}
- *          </blockquote>
- *        </div>
- *      );
- *    }
- *  }
- * }
- * ```
- */
 export type Components<ComponentAndProps extends object> = RichTextComponents<
   ComponentAndProps,
   React.JSX.Element
@@ -83,8 +49,6 @@ const reactHost: RichTextHost<React.ReactNode> = {
   memo: (render, cacheKey) => <MemoNode render={render} cacheKey={cacheKey} />,
 };
 
-// The same host without the memo, for a tree that renders once. useMemo buys
-// as-you-type responsiveness in the editor and buys nothing on a server.
 const staticReactHost: RichTextHost<React.ReactNode> = {
   ...reactHost,
   memo: undefined,
@@ -99,7 +63,6 @@ export const TinaMarkdown = <
   <>{renderRichText(content, components, reactHost)}</>
 );
 
-/** A static-ready TinaMarkdown. The one difference is the memo boundary. */
 export const StaticTinaMarkdown = <
   CustomComponents extends { [key: string]: object } = any,
 >({
@@ -109,18 +72,7 @@ export const StaticTinaMarkdown = <
   <>{renderRichText(content, components, staticReactHost)}</>
 );
 
-// FIXME: this needs more testing. But in theory all props
-// are serializable anyway so the JSON.stringify comparison makes sense.
-// I haven't thought all the way through this though, and maybe it'll break
-// down with custom components in some way.
-// In general this component handles most things without too many issues but for
-// large bodies of text it becomes pretty painful to see as-you-type updates, especially
-// in Safari.
-// The memo stays by hand. It compares the key by content, and the React Compiler
-// only memoises by identity — the caller builds a new key on every render, so a
-// compiled version would rebuild this subtree each time and bring back the typing lag
-// above. The compiler skips this component for the same reason: a JSON.stringify in a
-// dependency list is not an expression it can track.
+// FIXME: needs more testing with custom components. The memo stays by hand:
 const MemoNode = ({
   render,
   cacheKey,

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.test.tsx
@@ -3,9 +3,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { readyMessage, valuesMessage } from '../../preview/protocol';
 import { useTina } from './use-tina';
 
-// The scaffolding for the embedded path. In happy-dom, window.parent equals window,
-// which is the standalone default. These tests therefore replace window.parent with a
-// false editor window, and put the original back after each test.
 const realParent = window.parent;
 afterEach(() => {
   Object.defineProperty(window, 'parent', {
@@ -46,8 +43,6 @@ describe('useTina standalone', () => {
     });
     rerender({ data: { title: 'Regenerated' } });
     expect(result.current.data).toEqual({ title: 'Regenerated' });
-    // Outside the editor it does nothing. It adds no message listener, and it sends
-    // no ready message.
     expect(listenerSpy).not.toHaveBeenCalledWith('message', expect.anything());
     listenerSpy.mockRestore();
   });

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/use-tina.ts
@@ -3,30 +3,15 @@ import type { TinaDocument } from '../../core/schema/types';
 import { type PreviewStore, createPreviewStore } from '../../preview/store';
 
 export interface UseTinaOptions<T extends TinaDocument> {
-  // The document as the site rendered it, in the SSR or the static build. This is the
-  // whole document when the page is outside the editor.
   data: T;
-  // The origin of the editor. It defaults to the origin of the page. A cross-origin
-  // embed is an explicit choice, and is never '*'.
   allowedOrigin?: string;
 }
 
 export interface UseTinaResult<T extends TinaDocument> {
   data: T;
-  // True once the editor has streamed values into this preview.
   isEditing: boolean;
 }
 
-// The site-side hook for visual editing (the v4 part of #6944), and the React binding of
-// ../../preview/store. The store holds what is true of every framework — that a page
-// outside the editor connects to nothing, that the editor's document supersedes the one
-// the site rendered — and this file holds the one thing that is React's: reading a
-// subscribe/getSnapshot pair, which useSyncExternalStore takes as it stands.
-//
-// There is one document for each connection. The tina:values message carries no document
-// identity, as the protocol header states, so every useTina on the page adopts the same
-// hosted form. A page with more than one document needs the discriminator that arrives
-// with multi-form editing.
 export function useTina<T extends TinaDocument = TinaDocument>({
   data,
   allowedOrigin,
@@ -38,14 +23,9 @@ export function useTina<T extends TinaDocument = TinaDocument>({
     store.getServerSnapshot
   );
 
-  // The wire carries the document in the shape that the caller asserted for `data`. This
-  // is a cast at a serialization boundary.
   return { data: (streamed as T | null) ?? data, isEditing: streamed !== null };
 }
 
-// One store for the life of the hook, rebuilt only when the origin it connects to
-// changes. Not useMemo: React may discard a memo, and discarding this one would drop the
-// document the editor has already streamed.
 function usePreviewStore(allowedOrigin: string | undefined): PreviewStore {
   const heldStore = useRef<{
     allowedOrigin?: string;

--- a/packages/v4/@tinacms/tinacms/src/admin/admin.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/admin.tsx
@@ -1,11 +1,5 @@
-// The shell of the admin UI: the collection list, then the document list, then the form.
-// The compiled schema drives all of it. No code here names a collection or a field type.
-// Add a collection to tina/config.ts, and it appears. This is what ADR-016 §1 means when
-// it says that the schema fans out to the forms.
-//
-// There are three panes. The Sidebar of @tinacms/ui holds the navigation, the form sits
-// beside it, and the preview comes last. Navigation and editing are separate tasks. The
-// sidebar collapses, so the editor can use the width.
+// The admin shell. The compiled schema drives all of it: no code here names a
+// collection or a field type (ADR-016 §1).
 
 import {
   Sidebar,
@@ -42,10 +36,7 @@ import { type AdminRoute, COLLECTIONS_ROUTE } from './routing';
 import { useAdminRoute } from './use-admin-route';
 import { useFormColumnWidth } from './use-form-column-width';
 
-/**
- * Wider than the default of 16rem. The entries are file paths, and a list of truncated
- * paths has little value.
- */
+// Wider than the 16rem default: the entries are file paths.
 const SHELL_WIDTH = { '--sidebar-width': '18rem' } as CSSProperties;
 
 const documentName = (path: string) => path.split('/').at(-1) ?? path;
@@ -81,13 +72,7 @@ function CollectionMenu({
   );
 }
 
-/**
- * The document list of one collection.
- *
- * This is a separate component, because the documents load through the content
- * capability at the mount. A hook higher in the tree would load every collection, and
- * not the open one alone.
- */
+// Separate component: a hook higher in the tree would load every collection.
 function DocumentMenu({
   collection,
   activePath,
@@ -101,9 +86,7 @@ function DocumentMenu({
     collection.name
   );
   const label = collection.label ?? collection.name;
-  // A read that failed and a collection that is empty are different answers, and the
-  // editor has to be able to tell them apart. Before the query client, a failed list
-  // reached console.error and the sidebar said "No documents yet."
+  // A failed read and an empty collection are different answers.
   if (error) {
     return (
       <p className='px-2 py-1.5 text-sm text-destructive'>
@@ -127,8 +110,6 @@ function DocumentMenu({
     <SidebarMenu aria-label={`${label} documents`}>
       {documents.map(({ path }) => (
         <SidebarMenuItem key={path}>
-          {/* The status sits inside the button, and not in SidebarMenuBadge. That
-              slot has an absolute position for a count, and this status is words. */}
           <SidebarMenuButton
             isActive={path === activePath}
             onClick={() =>
@@ -136,8 +117,6 @@ function DocumentMenu({
             }
           >
             <span className='flex-1 truncate'>{documentName(path)}</span>
-            {/* The badge reads the store, so a document that was edited and left
-                still reads as unsaved after its form unmounts (ADR-012). */}
             <FormStatusBadge formId={toFormId(path)} />
           </SidebarMenuButton>
         </SidebarMenuItem>
@@ -161,9 +140,6 @@ function ScreenMenu({
         <SidebarMenuItem key={screen.name}>
           <SidebarMenuButton
             isActive={screen.name === activeName}
-            // Navigating to a screen from the sidebar enters it at its root. The
-            // segments below that belong to the screen, and only the screen knows how
-            // to build one.
             onClick={() =>
               navigate({ view: 'screen', screen: screen.name, segments: [] })
             }
@@ -176,11 +152,6 @@ function ScreenMenu({
   );
 }
 
-/**
- * The registered view for a `screen` route, rendered where the form and the preview
- * otherwise sit. A screen owns the whole pane. A screen is not a collection, so the
- * document form beside it would have nothing to edit.
- */
 function ScreenOutlet({
   name,
   screen,
@@ -197,12 +168,9 @@ function ScreenOutlet({
       </div>
       <div className='min-h-0 flex-1 overflow-y-auto'>
         {screen ? (
-          // Keyed on the name, so moving between two screens remounts rather than
-          // handing the next screen the last one's state.
+          // Keyed so moving between screens remounts.
           <screen.component key={screen.name} segments={segments} />
         ) : (
-          // A route naming a screen no plugin registered is stale, the same way a
-          // route naming a collection outside the schema is.
           <Placeholder>No screen named “{name}”.</Placeholder>
         )}
       </div>
@@ -210,13 +178,9 @@ function ScreenOutlet({
   );
 }
 
-/**
- * The host of the preview, beside the form.
- *
- * This tests the form scope, and not the route. On a deep link, the two differ for one
- * frame, because the route is known before the document loads. A preview mounted in that
- * gap would read a form that does not exist yet.
- */
+// Tests the form scope, not the route: on a deep link the two differ for one
+// frame, and a preview mounted in that gap would read a form that does not
+// exist yet.
 function PreviewSlot({ preview }: { preview?: ReactNode }) {
   if (!use(FormScopeContext)) {
     return <Placeholder>Select a document to edit.</Placeholder>;
@@ -224,10 +188,6 @@ function PreviewSlot({ preview }: { preview?: ReactNode }) {
   return <>{preview ?? <Placeholder>No preview configured.</Placeholder>}</>;
 }
 
-/**
- * What the form column shows while the next document's fields build in a transition.
- * It stands where the fields will, so the column neither collapses nor jumps.
- */
 function FormColumnSkeleton() {
   return (
     <div role='status' aria-label='Loading document' className='space-y-4'>
@@ -239,27 +199,15 @@ function FormColumnSkeleton() {
   );
 }
 
-/**
- * An aside inside the main region. It supports the preview, which holds the work, so it
- * opens narrow. A form column that grows with the window is hard to read.
- *
- * Narrow is the default, and not the limit. The rich-text toolbar sizes itself to this
- * column and hides the tools it cannot fit, so an editor who works in prose can drag the
- * column wider and keep them. The rich-text e2e tests cover the default width, which is
- * also the floor.
- */
 function FormColumn({ openPath }: { openPath?: string }) {
   const { width, isResizing, handleProps } = useFormColumnWidth();
   const scope = use(FormScopeContext);
   const seedKey = scope?.seedKey;
 
-  // The mount of the fields is deferred behind a transition. Building the rich-text
-  // editor is the most expensive render in the admin, and it grows with the document —
-  // long prose froze the whole shell for most of a second when it rendered in the
-  // urgent pass. The urgent pass now commits the skeleton below, which also unmounts
-  // the outgoing editor at once: nothing stale is left focusable while the reset and
-  // the build are in flight. The transition then renders the fields concurrently, so
-  // the main thread keeps yielding to input and to the preview until they are ready.
+  // The field mount is deferred behind a transition: building the rich-text
+  // editor is the most expensive render in the admin, and long prose froze the
+  // shell for most of a second in the urgent pass. The urgent pass commits the
+  // skeleton, which also unmounts the outgoing editor at once.
   const [mountedSeedKey, setMountedSeedKey] = useState<string | undefined>(
     undefined
   );
@@ -283,26 +231,23 @@ function FormColumn({ openPath }: { openPath?: string }) {
           ) : null}
         </div>
         {mountedSeedKey === seedKey ? (
-          /* Keyed on the seed key, and not on the path. Plate reads its value at mount
-             only, and the seed key advances when the provider's reset lands, so the
-             fields mount once, on the new document's values. The key stays here. On the
-             FormProvider above it remounted the preview iframe on every switch. */
+          /* Keyed on the seed key: Plate reads its value at mount only. The key
+             stays here — on FormProvider it remounted the preview iframe on
+             every switch. */
           <DocumentForm key={seedKey} />
         ) : (
           <FormColumnSkeleton />
         )}
       </aside>
 
-      {/* The grab area is wider than the line it draws, because a 1px target is a miss
-          more often than a hit. */}
+      {/* Grab area wider than the line it draws: a 1px target is a miss. */}
       <div
         className='-ml-1 z-10 w-2 shrink-0 cursor-col-resize touch-none select-none focus-visible:outline-none'
         {...handleProps}
       />
 
-      {/* Pointer capture keeps the drag events coming, but the pointer still travels over
-          the form and the preview. This holds the resize cursor over both, and stops the
-          drag from selecting their text. */}
+      {/* Holds the resize cursor over the panes and stops the drag selecting
+          their text. */}
       {isResizing ? (
         <div className='fixed inset-0 z-50 cursor-col-resize' />
       ) : null}
@@ -311,12 +256,8 @@ function FormColumn({ openPath }: { openPath?: string }) {
 }
 
 export interface TinaAdminProps {
-  /**
-   * This renders beside the editor. It is the site preview, in a host that has one.
-   *
-   * It is a prop, and not a UI slot. The set of slot names is a first-party set that
-   * the core has not defined yet (ADR-013), and a name invented here would prejudge it.
-   */
+  // The site preview. A prop, not a UI slot: the slot names are a first-party
+  // set the core has not defined yet (ADR-013).
   preview?: ReactNode;
 }
 
@@ -334,10 +275,7 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
   );
   const openPath = route.view === 'document' ? route.path : undefined;
   const activeScreen = route.view === 'screen' ? route : undefined;
-  /**
-   * A route that names a collection outside the schema is stale, and not broken. The
-   * sidebar says so, instead of a screen that looks correct.
-   */
+  // A route naming a collection outside the schema is stale, not broken.
   const isStaleCollectionRoute =
     activeCollectionName !== undefined && collection === undefined;
 
@@ -385,8 +323,6 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
             </SidebarGroup>
           ) : null}
 
-          {/* The group is absent when no plugin registered a screen, so an admin with
-              no screen plugins looks exactly as it did before they existed. */}
           {screens.length > 0 ? (
             <SidebarGroup>
               <SidebarGroupLabel>Screens</SidebarGroupLabel>
@@ -400,11 +336,9 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
         </SidebarContent>
       </Sidebar>
 
-      {/* A screen replaces the editor panes rather than sitting beside them, so the two
-          branches swap here. That unmounts the form scope, which is right: a screen is
-          not a document, and there is nothing for the form to edit. The unsaved edits
-          survive it — the form store keeps a form after its scope goes (ADR-012), so
-          returning to the document finds them again. */}
+      {/* A screen replaces the editor panes. That unmounts the form scope, but
+          unsaved edits survive it: the store keeps a form after its scope goes
+          (ADR-012). */}
       {activeScreen ? (
         <ScreenOutlet
           name={activeScreen.screen}
@@ -414,11 +348,9 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
           segments={activeScreen.segments}
         />
       ) : (
-        /* The scope wraps the two panes that read the open form, and not the whole
-           shell. A swap at this position rebuilds them, which is right — both are
-           created and destroyed with the document anyway — while the SidebarProvider
-           and the navigation above keep their state. Wrapping the whole layout reset
-           the sidebar and re-fetched the document list on every open and close. */
+        /* The scope wraps only the panes that read the open form: wrapping the
+           whole layout reset the sidebar and re-fetched the document list on
+           every open and close. */
         <DocumentScope collection={collection} path={openPath}>
           <SidebarInset className='flex-row'>
             <FormColumn openPath={openPath} />

--- a/packages/v4/@tinacms/tinacms/src/admin/document-form.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/document-form.tsx
@@ -1,10 +1,3 @@
-// The editing pane. It holds the fields of the open document, and the save. Component
-// resolution renders each field (ADR-009). <Field> finds the plugin from the `type` of
-// the schema node, so this file never learns what a rich-text field is.
-//
-// It does not own the form scope. DocumentScope owns it, above the whole layout, because
-// the preview needs the same scope and sits outside this pane.
-
 import { Button } from '@tinacms/ui/components/button';
 import { Label } from '@tinacms/ui/components/label';
 import { use, useState } from 'react';
@@ -16,24 +9,9 @@ import { useFieldRegistry, useFormId, useFormSave } from '../editor/hooks';
 import { useIsFieldDirty, useIsFormDirty } from '../form/form-store';
 import { DocumentStatus } from './document-status';
 
-// The shell owns this label, and the field plugin does not. A plugin renders FieldWrapper
-// with no label, because its control carries an aria-label of the field address. That
-// left the visible text and the accessible name as two different strings, which is WCAG
-// 2.5.3 Label in Name wherever a collection's `label` differs from its `name`, and a
-// label that focused nothing when clicked. `htmlFor` ties them together, and each control
-// now carries its address as an id, which settles the focus half.
-//
-// The accessible name is not settled. The string, number and boolean controls still set
-// `aria-label` to the address, and that outranks this label, so Label in Name closes when
-// those fields drop it.
-//
-// The dirty mark reads as text. An aria-label on a bare span is ignored on a generic
-// element, so the 6px dot was the only signal it gave.
 function FieldRow({ node }: { node: FieldSchema }) {
   const name = node.name;
   const dirty = useIsFieldDirty(useFormId(), toFieldAddress(name));
-  // Rich text is the case this asks about: its control is a contenteditable, which HTML
-  // cannot label, so `for` would point at nothing.
   const labelable =
     useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
   return (
@@ -58,15 +36,9 @@ function FieldRow({ node }: { node: FieldSchema }) {
 function SaveButton() {
   const dirty = useIsFormDirty(useFormId());
   const save = useFormSave();
-  // A write can fail, and the form stays dirty when it does, so the edit is still there
-  // to retry. Without this the rejection went unhandled and the only signal the author
-  // got was the badge staying "Unsaved", which is also what a save in flight looks like.
   const [failure, setFailure] = useState<string | null>(null);
   return (
     <div className='flex flex-col items-start gap-2'>
-      {/* aria-disabled, and not disabled. `disabled` takes the button out of the tab
-          order at the moment it is pressed, so keyboard focus fell to <body> after
-          every save. */}
       <Button
         type='button'
         className='aria-disabled:pointer-events-none aria-disabled:opacity-50'
@@ -96,8 +68,6 @@ function SaveButton() {
 }
 
 export function DocumentForm() {
-  // This reads the scope, and does not require it. The pane sits in a layout that also
-  // renders with no open document. An empty pane is a state, and not a fault.
   const scope = use(FormScopeContext);
   if (!scope) return null;
 

--- a/packages/v4/@tinacms/tinacms/src/admin/document-scope.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/document-scope.tsx
@@ -1,18 +1,3 @@
-// This owns the form scope of the open document. It sits above the whole layout, and not
-// around the field list.
-//
-// The preview is the reason. It streams the open form's values across the iframe
-// boundary, so it reads the same scope the fields write to — and it renders in the
-// main pane, not the sidebar. Scoping the form to the sidebar put the preview outside
-// it, which is a runtime throw with no type to catch it. Anything else the shell grows
-// that reads the open document (a toolbar, a document-actions menu) lands the same way.
-//
-// With nothing open, or with the entry still loading, it renders `children` bare. That
-// swap changes the element type at this position, so React unmounts and rebuilds what
-// sits below — the two document panes, including the preview iframe. It is confined to
-// those panes on purpose: the sidebar and its document list sit above this scope and
-// keep their open state, their fetch, and their scroll position across a switch.
-
 import { type ReactNode, useEffect, useRef } from 'react';
 import type { DocumentEntry } from '../core/content/contract';
 import type { CollectionSchema, TinaDocument } from '../core/schema/types';
@@ -23,25 +8,11 @@ import {
 import { FormProvider } from '../editor/provider';
 
 export interface DocumentScopeProps {
-  // Both absent when no document is open. The component still renders, so the panes
-  // below keep their place in the tree.
   collection?: CollectionSchema;
   path?: string;
   children: ReactNode;
 }
 
-/**
- * The document the form seeds from, pinned for as long as `path` is open.
- *
- * A save writes the stored entry back into the list cache. The cache has to keep the
- * list badges current, and must not seed the mounted form again — a new `document` prop
- * ingests again and resets RHF, dropping the clean baseline the save just set and any
- * key typed while it was in flight.
- *
- * A ref, not useMemo. useMemo is a cache React is allowed to discard, and a discarded
- * one returns the post-save entry: the exact re-seed this exists to prevent, arriving
- * unpredictably rather than never.
- */
 const usePinnedDocument = (
   path: string | undefined,
   cached: DocumentEntry | undefined
@@ -58,26 +29,14 @@ export function DocumentScope({
   path,
   children,
 }: DocumentScopeProps) {
-  // This reads the list that the sidebar renders, and shares its request — it does not
-  // fetch again. Two reads of one document can disagree, and the form would then seed
-  // from the older one.
   const { documents } = useCollectionDocuments(collection?.name);
   const cached = documents.find((candidate) => candidate.path === path);
   const entry = usePinnedDocument(path, cached);
 
-  // The save handler is stable, so FormProvider's formScope memo holds. Rebuilt each
-  // render it changed on every content-slice update, which defeated the memo and the
-  // "changes only on a document switch" contract in editor/context.ts.
   const { save: saveDocument } = useSaveDocument();
-  // The open document travels as one value, because only a collection and a path
-  // together name one. Either alone is not half a document, it is no document.
   const openDocument = (): { collection: string; path: string } | null =>
     collection && path ? { collection: collection.name, path } : null;
   const saveRef = useRef({ target: openDocument(), saveDocument });
-  // Written after the commit, and not during the render. `save` is permanently stable
-  // and reads this when the author invokes it, which is always after a commit — so a
-  // render React starts and then throws away must not leave this pointing at that
-  // render's document.
   useEffect(() => {
     saveRef.current = { target: openDocument(), saveDocument };
   });
@@ -87,22 +46,11 @@ export function DocumentScope({
     await latestSave({ ...target, value });
   }).current;
 
-  // Nothing open: no form scope to provide, so the panes render without one and read
-  // that absence through FormScopeContext.
   if (!(collection && path)) return children;
 
-  // Wait for the document. Mounting the provider without one seeds the form empty, and
-  // Plate reads its value at mount only — so the editor stayed blank once the entry
-  // arrived. The panes below therefore mount once, with a value.
   if (!entry) return children;
 
   return (
-    // No key, and that is the point. The provider hosts a switch of document in place:
-    // it resets RHF to the next document's seed and advances the seed key, which is
-    // what a field hosting its own editor remounts on. The continuity tests pin that
-    // down under "unkeyed document switches". A key here remounted everything below on
-    // every switch — including the preview iframe, whose same-origin reload runs on the
-    // admin's own main thread and froze the whole shell while the preview re-booted.
     <FormProvider
       collection={collection}
       path={path}

--- a/packages/v4/@tinacms/tinacms/src/admin/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/hooks.ts
@@ -5,9 +5,6 @@ import type { AdminScreen } from '../core/screen/contract';
 import { screenList } from '../core/screen/registry';
 import { TinaRuntimeContext } from '../editor/context';
 
-// The content model that the admin navigates, as defineConfig declared it. It is config
-// from the build, and not state (ADR-016), so this reads it from the runtime and not
-// from the store.
 export function useTinaSchema(): TinaSchema {
   const runtime = use(TinaRuntimeContext);
   invariant(
@@ -18,9 +15,6 @@ export function useTinaSchema(): TinaSchema {
   return runtime.schema;
 }
 
-// The screens the plugins registered, in navigation order. Like the schema, this is
-// config composed at boot and not state, so it comes off the runtime rather than the
-// store (core/screen/registry.ts).
 export function useAdminScreens(): AdminScreen[] {
   const runtime = use(TinaRuntimeContext);
   invariant(
@@ -28,9 +22,5 @@ export function useAdminScreens(): AdminScreen[] {
     'admin-screens-outside-provider',
     'useAdminScreens must be used within a TinaProvider'
   );
-  // The registry never changes after boot, so this array is sorted once per runtime and
-  // callers can use it as a dependency. The memo stays by hand: the React Compiler
-  // leaves a hook that returns a call result straight out unmemoised, so without it
-  // every render sorts a new array and every caller depending on it invalidates.
   return useMemo(() => screenList(runtime.screens), [runtime.screens]);
 }

--- a/packages/v4/@tinacms/tinacms/src/admin/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/index.ts
@@ -1,7 +1,3 @@
-// The browser entry, `@tinacms/tinacms/admin`. It holds the shell of the admin UI, which
-// a host mounts inside a TinaProvider. Everything it renders comes from the compiled
-// schema, so a host writes no code for a collection.
-
 export type { AdminScreen, AdminScreenProps } from '../core/screen/contract';
 export { TinaAdmin, type TinaAdminProps } from './admin';
 export { useAdminScreens, useTinaSchema } from './hooks';

--- a/packages/v4/@tinacms/tinacms/src/admin/routing.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/routing.test.ts
@@ -19,7 +19,6 @@ describe('admin routing', () => {
     expect(parseAdminRoute(formatAdminRoute(route))).toEqual(route);
   });
 
-  // The document id is a path, so its slashes must not read as route separators.
   it('carries a document path as one encoded segment', () => {
     expect(
       formatAdminRoute({
@@ -39,7 +38,6 @@ describe('admin routing', () => {
     expect(parseAdminRoute(formatAdminRoute(route))).toEqual(route);
   });
 
-  // A stale or hand-typed hash is a navigation mistake, not a fault.
   it.each(['', '#', '#/', '#/nonsense', '#/collections', '#/collections/'])(
     'falls back to the collection list for %j',
     (hash) => {
@@ -62,8 +60,6 @@ describe('admin routing for plugin screens', () => {
     ).toBe('#/screens/media');
   });
 
-  // The two prefixes are separate namespaces. A project with a collection called `page`
-  // is the case that named this prefix `screens` rather than `pages`.
   it('does not confuse a screen with a collection of the same name', () => {
     expect(parseAdminRoute('#/screens/page')).toEqual({
       view: 'screen',
@@ -76,7 +72,6 @@ describe('admin routing for plugin screens', () => {
     });
   });
 
-  // Each segment is encoded on its own, so a segment holding a slash stays one segment.
   it('keeps a screen segment whole when it holds a slash', () => {
     const route: AdminRoute = {
       view: 'screen',
@@ -89,15 +84,12 @@ describe('admin routing for plugin screens', () => {
     expect(parseAdminRoute(formatAdminRoute(route))).toEqual(route);
   });
 
-  // A screen prefix with no name is not a screen. It falls back like any stale hash.
   it.each(['#/screens', '#/screens/'])('falls back for %j', (hash) => {
     expect(parseAdminRoute(hash)).toEqual(COLLECTIONS_ROUTE);
   });
 });
 
 describe('parseAdminRoute on input a user can type', () => {
-  // decodeURIComponent throws a URIError on these, and parseAdminRoute runs during
-  // render — so an unguarded throw white-screened the admin.
   it.each([
     '#/collections/100%',
     '#/collections/post/%E0%A4%A',

--- a/packages/v4/@tinacms/tinacms/src/admin/routing.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/routing.ts
@@ -1,17 +1,3 @@
-// The location of the editor, as a URL.
-//
-// This uses hash routing. It does not use path routing, and it does not use component
-// state. The build writes the admin to static files, and a plain folder serves them. In
-// v3 that folder is `public/admin`. A path router therefore needs a server rewrite for
-// each deep link, and a hash needs nothing from the host. Component state would be
-// simpler, and wrong. A reload would return the editor to the collection list, and a
-// link to a document would not work for anyone else.
-
-// The `screen` case is the open half of this grammar. The first three views are the
-// content model, which the schema generates and the shell renders. A `screen` is a view
-// a plugin registered (core/screen/contract.ts), and the shell routes to it without
-// knowing what it is. Its trailing `segments` belong to the screen, so a screen can
-// navigate within itself and still be linkable.
 export type AdminRoute =
   | { view: 'collections' }
   | { view: 'collection'; collection: string }
@@ -20,24 +6,12 @@ export type AdminRoute =
 
 export const COLLECTIONS_ROUTE: AdminRoute = { view: 'collections' };
 
-// The two route prefixes. `collections` is the content model, `screens` is the plugin
-// views. They are separate namespaces, so a screen and a collection may share a name.
-//
-// `screens` and not `pages`: a project can have a collection called `page` — the
-// kitchen-sink schema does — and `#/pages/media` sitting beside `#/collections/page`
-// reads as though one is a case of the other. They are unrelated.
 const COLLECTIONS_PREFIX = 'collections';
 const SCREENS_PREFIX = 'screens';
 
-// The id of a document is a path that holds slashes, for example
-// `content/posts/hello.mdx`. It is therefore encoded as one segment, and not spread
-// across the route. Without that, the route grammar and the document path would share
-// one separator.
 export const formatAdminRoute = (route: AdminRoute): string => {
   if (route.view === 'collections') return '#/';
   if (route.view === 'screen') {
-    // Each segment is encoded on its own, so a segment holding a slash stays one
-    // segment. The screen owns what they mean.
     const parts = [route.screen, ...route.segments].map(encodeURIComponent);
     return `#/${SCREENS_PREFIX}/${parts.join('/')}`;
   }
@@ -47,9 +21,6 @@ export const formatAdminRoute = (route: AdminRoute): string => {
   return `#/${COLLECTIONS_PREFIX}/${collection}/${encodeURIComponent(route.path)}`;
 };
 
-// decodeURIComponent throws a URIError on a malformed escape such as `100%`. This runs
-// during render, so an unguarded throw white-screens the admin — for a hash a user can
-// type, which is the case the fallback below exists for.
 const decodeSegment = (segment: string): string | null => {
   try {
     return decodeURIComponent(segment);
@@ -63,12 +34,7 @@ export const parseAdminRoute = (hash: string): AdminRoute => {
   const decoded = raw.map(decodeSegment);
   if (decoded.some((segment) => segment === null)) return COLLECTIONS_ROUTE;
   const [prefix, head, ...rest] = decoded as string[];
-  // An unknown route goes to the collection list, and not to an error page. A stale
-  // hash, or one typed by hand, is a navigation mistake and not a fault.
   if (!head) return COLLECTIONS_ROUTE;
-  // A screen whose name is not registered still parses. The shell reports that, the
-  // same way it reports a collection outside the schema — the route is well-formed, and
-  // it names something that is not there.
   if (prefix === SCREENS_PREFIX)
     return { view: 'screen', screen: head, segments: rest };
   if (prefix !== COLLECTIONS_PREFIX) return COLLECTIONS_ROUTE;

--- a/packages/v4/@tinacms/tinacms/src/admin/use-admin-route.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/use-admin-route.ts
@@ -1,23 +1,14 @@
 import { useMemo, useSyncExternalStore } from 'react';
 import { type AdminRoute, formatAdminRoute, parseAdminRoute } from './routing';
 
-// The `location.hash` value is external state that React does not own. The back button
-// changes it, and so does a pasted link, both outside the component tree.
-// useSyncExternalStore is the primitive for that state. A copy in useState would miss
-// both changes.
 const subscribe = (onChange: () => void) => {
   window.addEventListener('hashchange', onChange);
   return () => window.removeEventListener('hashchange', onChange);
 };
 
 const readHash = () => window.location.hash;
-// The server has no location, and the client renders the admin. The collection list is
-// what the admin shows before hydration.
 const readHashOnServer = () => '';
 
-// This assigns the hash, and does not call pushState. The assignment makes the history
-// entry that the back button needs, and it fires hashchange. There is then one path in
-// and one path out.
 const navigate = (route: AdminRoute) => {
   window.location.hash = formatAdminRoute(route);
 };
@@ -29,9 +20,6 @@ export interface AdminNavigation {
 
 export const useAdminRoute = (): AdminNavigation => {
   const hash = useSyncExternalStore(subscribe, readHash, readHashOnServer);
-  // Held against the hash, and not rebuilt each render. This is a public hook, and
-  // parseAdminRoute returns a fresh object with a fresh `segments` array — so a
-  // consumer with `[route]` or `[segments]` in its dependencies would loop.
   const route = useMemo(() => parseAdminRoute(hash), [hash]);
   return { route, navigate };
 };

--- a/packages/v4/@tinacms/tinacms/src/admin/use-form-column-width.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/use-form-column-width.ts
@@ -8,19 +8,12 @@ import {
   useState,
 } from 'react';
 
-// The form column width is a preference, not a constant: the rich-text toolbar
-// sizes itself to the column. Lives in localStorage until the `ui` core slice
-// lands — move it there then.
 const DEFAULT_WIDTH = 352;
-// The floor is the default: the width the rich-text e2e tests cover.
 const MIN_WIDTH = DEFAULT_WIDTH;
-// Stop before the column would squeeze the preview out.
 const MIN_PREVIEW_WIDTH = 400;
 const KEYBOARD_STEP = 16;
 const STORAGE_KEY = 'tina-form-column-width';
 
-// Storage throws when a browser blocks it; a width preference is not worth
-// failing the shell over.
 const readStoredWidth = (): number | null => {
   try {
     const stored = Number(window.localStorage.getItem(STORAGE_KEY));
@@ -33,8 +26,7 @@ const readStoredWidth = (): number | null => {
 const writeStoredWidth = (width: number) => {
   try {
     window.localStorage.setItem(STORAGE_KEY, String(width));
-  } catch {
-  }
+  } catch {}
 };
 
 const clampWidth = (width: number) =>
@@ -47,8 +39,6 @@ export interface FormColumnWidth {
 }
 
 export const useFormColumnWidth = (): FormColumnWidth => {
-  // Read after mount, not in the initializer: the admin renders on the server
-  // too, and a disagreeing first render is a hydration mismatch.
   const [width, setWidth] = useState(DEFAULT_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
   const dragStart = useRef<{ x: number; width: number } | null>(null);
@@ -58,14 +48,12 @@ export const useFormColumnWidth = (): FormColumnWidth => {
     if (stored !== null) setWidth(clampWidth(stored));
   }, []);
 
-  // A shrinking window can leave the column wider than the clamp allows.
   useEffect(() => {
     const onWindowResize = () => setWidth(clampWidth);
     window.addEventListener('resize', onWindowResize);
     return () => window.removeEventListener('resize', onWindowResize);
   }, []);
 
-  // Only the settled width: writing per pointermove hits storage every frame.
   useEffect(() => {
     if (isResizing) return;
     writeStoredWidth(width);
@@ -73,7 +61,6 @@ export const useFormColumnWidth = (): FormColumnWidth => {
 
   const onPointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
-      // Without this the drag starts a text selection behind the handle.
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       dragStart.current = { x: event.clientX, width };
@@ -85,8 +72,6 @@ export const useFormColumnWidth = (): FormColumnWidth => {
   const onPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const start = dragStart.current;
     if (!start) return;
-    // From where the drag began, so the column does not jump by the offset
-    // between the grab point and the edge.
     setWidth(clampWidth(start.width + (event.clientX - start.x)));
   }, []);
 

--- a/packages/v4/@tinacms/tinacms/src/admin/use-form-column-width.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/use-form-column-width.ts
@@ -8,26 +8,19 @@ import {
   useState,
 } from 'react';
 
-// The form column opens narrow, because a form that grows with the window is hard to
-// read. Narrow is the right default, but it is the wrong ceiling: the rich-text toolbar
-// sizes itself to the column, and at the default width it has room for six tools and
-// puts the rest behind a menu. An editor working in prose wants those tools. So the
-// width is a preference, not a constant, and the drag survives a reload.
-//
-// The preference lives in localStorage rather than the store. The `ui` core slice, which
-// is where it belongs, is still empty — move this there when that slice lands.
+// The form column width is a preference, not a constant: the rich-text toolbar
+// sizes itself to the column. Lives in localStorage until the `ui` core slice
+// lands — move it there then.
 const DEFAULT_WIDTH = 352;
-// The floor is the default. That is the width the rich-text e2e tests cover, so the
-// editor is known to work at it; anything narrower is untested. Dragging widens.
+// The floor is the default: the width the rich-text e2e tests cover.
 const MIN_WIDTH = DEFAULT_WIDTH;
-// The preview is the point of the pane beside it, so the column stops before it would
-// squeeze the preview out.
+// Stop before the column would squeeze the preview out.
 const MIN_PREVIEW_WIDTH = 400;
 const KEYBOARD_STEP = 16;
 const STORAGE_KEY = 'tina-form-column-width';
 
-// Storage throws when a browser blocks it (private windows, disabled cookies). A width
-// preference is not worth failing the shell over, so both directions swallow it.
+// Storage throws when a browser blocks it; a width preference is not worth
+// failing the shell over.
 const readStoredWidth = (): number | null => {
   try {
     const stored = Number(window.localStorage.getItem(STORAGE_KEY));
@@ -41,7 +34,6 @@ const writeStoredWidth = (width: number) => {
   try {
     window.localStorage.setItem(STORAGE_KEY, String(width));
   } catch {
-    // Ignored, see above.
   }
 };
 
@@ -55,9 +47,8 @@ export interface FormColumnWidth {
 }
 
 export const useFormColumnWidth = (): FormColumnWidth => {
-  // The stored width is read after mount, and not in the initializer. The admin renders
-  // on the server too, where there is no localStorage, and a first client render that
-  // disagreed with the server markup would be a hydration mismatch on the style attribute.
+  // Read after mount, not in the initializer: the admin renders on the server
+  // too, and a disagreeing first render is a hydration mismatch.
   const [width, setWidth] = useState(DEFAULT_WIDTH);
   const [isResizing, setIsResizing] = useState(false);
   const dragStart = useRef<{ x: number; width: number } | null>(null);
@@ -67,16 +58,14 @@ export const useFormColumnWidth = (): FormColumnWidth => {
     if (stored !== null) setWidth(clampWidth(stored));
   }, []);
 
-  // A window that shrinks can leave the column wider than the clamp allows, which would
-  // push the preview out of view until the next drag.
+  // A shrinking window can leave the column wider than the clamp allows.
   useEffect(() => {
     const onWindowResize = () => setWidth(clampWidth);
     window.addEventListener('resize', onWindowResize);
     return () => window.removeEventListener('resize', onWindowResize);
   }, []);
 
-  // Only the settled width is stored. Writing on each pointermove would hit storage
-  // synchronously on every frame of a drag.
+  // Only the settled width: writing per pointermove hits storage every frame.
   useEffect(() => {
     if (isResizing) return;
     writeStoredWidth(width);
@@ -84,7 +73,7 @@ export const useFormColumnWidth = (): FormColumnWidth => {
 
   const onPointerDown = useCallback(
     (event: PointerEvent<HTMLDivElement>) => {
-      // Without this the drag starts a text selection in the form behind the handle.
+      // Without this the drag starts a text selection behind the handle.
       event.preventDefault();
       event.currentTarget.setPointerCapture(event.pointerId);
       dragStart.current = { x: event.clientX, width };
@@ -96,8 +85,8 @@ export const useFormColumnWidth = (): FormColumnWidth => {
   const onPointerMove = useCallback((event: PointerEvent<HTMLDivElement>) => {
     const start = dragStart.current;
     if (!start) return;
-    // Measured from where the drag began, not from the pointer position, so the column
-    // does not jump by the offset between the grab point and the edge.
+    // From where the drag began, so the column does not jump by the offset
+    // between the grab point and the edge.
     setWidth(clampWidth(start.width + (event.clientX - start.x)));
   }, []);
 

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -1,7 +1,4 @@
-// The `tinacms codegen` command. It reads the config of the project, compiles its
-// schema, and writes tina-lock.json (ADR-016). The lock is committed, so the write is
-// careful. An unchanged lock stays as it is, and a contract version that does not match
-// stops the command.
+// `tinacms codegen`: compiles the schema and writes tina-lock.json (ADR-016).
 
 import { constants } from 'node:fs';
 import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
@@ -20,28 +17,22 @@ import { invariant } from '../../core/invariant';
 export const TINA_DIRECTORY = 'tina';
 export const LOCK_FILENAME = 'tina-lock.json';
 
-// In the order of the config files. The list holds `.tsx`, because a collection with a
-// custom field component holds JSX. The v3 examples name their config config.tsx for
-// that reason.
+// `.tsx` included: a collection with a custom field component holds JSX.
 const CONFIG_FILENAMES = ['config.ts', 'config.tsx', 'config.js', 'config.mjs'];
 
 export interface CodegenOptions {
   rootDir: string;
-  // An explicit path to the config, for a project that keeps it in another place.
   configPath?: string;
   load?: LoadTinaConfigOptions;
-  // Write the lock when it differs. It defaults to true. `tinacms codegen --check`
-  // passes false: in CI a lock that differs from the committed one is the failure to
-  // report, and not a file to repair. The outcome is the same either way, so the
-  // caller reads `outcome` to learn what a write would have done.
+  // Defaults to true. `--check` passes false: in CI a differing lock is the
+  // failure to report, not a file to repair.
   write?: boolean;
 }
 
 export type CodegenOutcome =
   | 'created'
   | 'updated'
-  // The output holds the same bytes as the committed file, so this command wrote
-  // nothing. The lock must not appear in `git status` after each build.
+  // Same bytes as the committed file; nothing written.
   | 'unchanged';
 
 export interface CodegenResult {
@@ -49,21 +40,17 @@ export interface CodegenResult {
   lockPath: string;
   outcome: CodegenOutcome;
   lock: TinaLock;
-  // Set when the committed lock was older than the schema. The command wrote it again.
   warning?: string;
 }
 
 const firstExisting = async (candidates: string[]): Promise<string | null> => {
   for (const candidate of candidates) {
     try {
-      // access, not readFile: slurping the file reported an unreadable or
-      // directory-shaped config as a missing one, and anything that is not ENOENT is
-      // a real fault the developer needs to see.
+      // access, not readFile: an unreadable config must surface as a fault, not
+      // read as missing.
       await access(candidate, constants.R_OK);
       return candidate;
     } catch (cause) {
-      // Try the next candidate. A missing file here is the question, and not a fault.
-      // An unreadable one is, so it surfaces rather than reading as "no config".
       if ((cause as NodeJS.ErrnoException).code !== 'ENOENT') throw cause;
     }
   }
@@ -87,9 +74,8 @@ export const findConfigPath = async (rootDir: string): Promise<string> => {
 const readExistingLock = async (lockPath: string): Promise<TinaLock | null> => {
   try {
     const parsed: unknown = JSON.parse(await readFile(lockPath, 'utf8'));
-    // A lock that parses to `[]`, `3`, or `{}` after a bad merge is as untrustworthy
-    // as one that does not parse at all; the cast alone let it reach checkLock and
-    // throw a TypeError on `lock.primitives[type]`.
+    // A lock that parses to `[]` or `3` after a bad merge must not reach
+    // checkLock and TypeError on `lock.primitives[type]`.
     const lock = parsed as TinaLock | null;
     if (!lock || typeof lock !== 'object' || Array.isArray(lock)) return null;
     if (typeof lock.primitives !== 'object' || lock.primitives === null) {
@@ -97,15 +83,12 @@ const readExistingLock = async (lockPath: string): Promise<TinaLock | null> => {
     }
     return lock;
   } catch {
-    // A lock that is absent, on the first run, and a lock that does not parse, after
-    // a hand edit or a bad merge, are one situation. There is nothing to compare
-    // against, so compile again.
+    // Absent and unparsable are one situation: nothing to compare, compile again.
     return null;
   }
 };
 
-// The file is formatted, and it ends with a newline, because it is a committed file that
-// people read in a diff. It is not a build output.
+// Formatted with a trailing newline: a committed file people read in a diff.
 const serializeLock = (lock: TinaLock): string =>
   `${JSON.stringify(lock, null, 2)}\n`;
 
@@ -133,8 +116,8 @@ export const runCodegen = async (
   if (check.status === 'current') {
     return { configPath, lockPath, outcome: 'unchanged', lock };
   }
-  // This is the one failure of the command. A field type changed its shape under a
-  // committed lock. A write here would be the silent break that ADR-016 prevents.
+  // The one failure: a field type changed shape under a committed lock. A write
+  // here would be the silent break ADR-016 prevents.
   invariant(
     check.status === 'stale',
     check.status === 'unreadable' ? 'lock-unreadable' : 'lock-incompatible',

--- a/packages/v4/@tinacms/tinacms/src/cli/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.ts
@@ -1,9 +1,5 @@
-// The command dispatch of the `tinacms` bin. v4 puts the CLI in the runtime package
-// (ADR-001), so this file sits beside the code that it drives. There is no separate
-// @tinacms/cli package.
-//
-// parseArgs from node:util reads the arguments. The command surface is four flags wide,
-// which does not need a dependency.
+// Command dispatch of the `tinacms` bin. The CLI lives in the runtime package
+// (ADR-001); four flags do not need an argument-parsing dependency.
 
 import path from 'node:path';
 import { parseArgs } from 'node:util';
@@ -11,8 +7,8 @@ import type { ModuleLoader } from '../codegen/load-config';
 import { type CodegenResult, runCodegen } from './commands/codegen';
 
 export interface CliContext {
-  // The Vite server that the bin used to load this module. The bin passes it down, so
-  // the config read uses it and does not start a second one.
+  // The Vite server the bin used to load this module, so the config read does
+  // not start a second one.
   loader?: ModuleLoader;
   cwd?: string;
   log?: (message: string) => void;
@@ -50,10 +46,8 @@ const codegenCommand = async (
     load: { loader: context.loader },
     write: !values.check,
   });
-  // Under --check the lock on disk is the answer, and the command reports it instead
-  // of repairing it. The pipeline of the project never runs this bin (refer to the CLI
-  // rule in packages/v4/README.md), so this is how CI catches a config that changed
-  // without its lock.
+  // Under --check the lock on disk is the answer: this is how CI catches a
+  // config that changed without its lock.
   if (values.check) {
     if (result.outcome === 'unchanged') {
       context.log(`${result.lockPath} is up to date`);
@@ -64,15 +58,13 @@ const codegenCommand = async (
     );
     return 1;
   }
-  // A stale lock is written again, and does not fail the build, so this states the
-  // reason. A change to the lock with no explanation in a commit hides the drift.
+  // A stale lock is rewritten without failing the build, so state the reason.
   if (result.warning) context.log(result.warning);
   context.log(describe(result));
   return 0;
 };
 
-// path.resolve, not a `/` test: `C:\\site` is absolute and `startsWith('/')` says it
-// is not, so it was concatenated onto cwd and reported as a missing config.
+// path.resolve, not a `/` test: `C:\site` is absolute on Windows.
 const resolveFrom = (cwd: string, target: string): string =>
   path.resolve(cwd, target);
 
@@ -92,9 +84,7 @@ export const runCli = async (
   }
 
   try {
-    // Inside the try. An unknown flag, or `--root` with no value, makes parseArgs
-    // throw, and outside this block that reached the caller as a stack trace — which
-    // is what the comment below promises it never does.
+    // Inside the try: an unknown flag makes parseArgs throw.
     const { values } = parseArgs({
       args: rest,
       options: {
@@ -105,8 +95,8 @@ export const runCli = async (
       },
       allowPositionals: true,
     });
-    // The command is checked before --help, so a typo does not exit 0 just because
-    // the user also asked for usage.
+    // Command before --help, so a typo does not exit 0 just because the user
+    // also asked for usage.
     if (command !== 'codegen') {
       logError(`Unknown command "${command}".\n\n${USAGE}`);
       return 1;
@@ -117,8 +107,7 @@ export const runCli = async (
     }
     return await codegenCommand(values, { ...context, cwd, log, logError });
   } catch (cause) {
-    // A failure of the config or of the lock is a message for the developer, and not
-    // a stack trace. Every throw on this path carries an explanation.
+    // A message for the developer, not a stack trace.
     logError(cause instanceof Error ? cause.message : String(cause));
     return 1;
   }

--- a/packages/v4/@tinacms/tinacms/src/client/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/client/index.ts
@@ -1,10 +1,3 @@
-// The browser entry, `tinacms/client`. The client segments of the plugins import it. It
-// must not import from ./server or from ./adapters/*.
-//
-// `defineClientPlugin` declares the client segment of a plugin, which holds the field
-// descriptor that the plugin owns (ADR-009). `createRpcClient` is the primitive for the
-// capability RPC (ADR-007). The ambient `server` proxy arrives with defineConfig
-// (ADR-024), which knows the URL of the mounted handler.
 
 import type { ClientSegment } from '../core/plugin';
 

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.test.ts
@@ -5,20 +5,9 @@ import path from 'node:path';
 import { afterEach, beforeEach, expect, it, vi } from 'vitest';
 import { loadTinaConfig } from './load-config';
 
-// v4 mounts into the server that the host app already runs. The RPC handler goes through
-// a framework adapter, and the local data layer goes through a middleware. No code under
-// src/ therefore owns a port. A read of the config file is the easiest place to lose that
-// property, because it starts a Vite server. In middleware mode, Vite has no HTTP server
-// for the HMR socket, so it binds its default port, 24678, on every interface. The
-// `hmr: false` option does not stop that. Two loads at the same time then race for one
-// fixed global port, and one of them fails.
-//
-// This test asserts the property, and not the flag that gives it today.
 let rootDir: string;
 let listened: unknown[][];
 
-// http.Server inherits listen from net.Server, so a patch on the one prototype sees every
-// socket that either class would open.
 const realListen = Server.prototype.listen;
 
 beforeEach(async () => {
@@ -29,8 +18,6 @@ beforeEach(async () => {
     ...args: Parameters<typeof realListen>
   ) {
     listened.push(args);
-    // Call the original. A regression must fail this assertion. The loader must not
-    // behave differently in a test and in production.
     return realListen.apply(this, args);
   } as typeof realListen;
 });
@@ -48,14 +35,10 @@ it('loads a config without binding a port', async () => {
 
   const config = await loadTinaConfig(configPath);
 
-  // This assertion stops the port check below from passing because the loader stopped
-  // early and started nothing.
   expect(config.schema.collections).toEqual([]);
   expect(listened).toEqual([]);
 });
 
-// The server this function opens is its own, and it closes it. A server the caller
-// passed belongs to the caller, who may still be using it for the rest of a command.
 it('leaves a caller-supplied loader open', async () => {
   const configPath = path.join(rootDir, 'config.ts');
   await writeFile(
@@ -77,9 +60,6 @@ it('leaves a caller-supplied loader open', async () => {
   expect(close).not.toHaveBeenCalled();
 });
 
-// Without a root the server sits at process.cwd(), so a config loaded from anywhere
-// else resolves its relative imports against the caller's directory. `tinacms codegen
-// --root <dir>` is exactly that case.
 it('resolves a relative import against the config directory, not the cwd', async () => {
   const projectDir = path.join(rootDir, 'site', 'tina');
   await mkdir(projectDir, { recursive: true });

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
@@ -1,69 +1,45 @@
-// This runs in Node only. It reads the `tina/config.ts` of a project, and returns the
-// output of defineConfig. Every consumer outside the browser enters here: the schema
-// compile, the local data layer, and the CLI.
-//
-// It runs the file through a temporary Vite server, and does not import it. The config
-// is TypeScript, and node can now strip the types by itself. But the config also imports
-// `@tinacms/tinacms`, whose `exports` still point at raw `.ts` files. Those exports use
-// relative specifiers with no extension, such as `./core/plugin`, and the node resolver
-// does not follow them. The Vite resolver does follow them. `tinacms dev` also hosts a
-// Vite server, so this mechanism stays.
+// Node-only: loads `tina/config.ts` through a temporary Vite server rather than
+// importing it. Node can strip the types itself, but the config imports
+// `@tinacms/tinacms`, whose `exports` point at raw `.ts` files with
+// extensionless relative specifiers — the node resolver does not follow them,
+// the Vite resolver does.
 
 import path from 'node:path';
 import type { ResolvedConfig } from '../config';
 import { invariant } from '../core/invariant';
 
-// The one function that this module needs from a Vite server. A caller can therefore
-// pass the server that it already has, and this module does not depend on the full
-// ViteDevServer type.
 export interface ModuleLoader {
   ssrLoadModule(url: string): Promise<Record<string, unknown>>;
 }
 
 export interface LoadTinaConfigOptions {
-  // The resolution overrides for the loading server. Few callers need them. A project
-  // resolves `@tinacms/tinacms` from node_modules, and a copy in a workspace resolves
-  // through its own `exports`.
   alias?: { find: string; replacement: string }[];
-  // Use the server of the caller, instead of a new one. The CLI passes the server that
-  // loaded it. A second server costs about one second at each run, and gives nothing.
+  // Use the caller's server instead of starting one (~1s per run).
   loader?: ModuleLoader;
 }
 
-// The fallback loader, reached only when the caller supplies no `loader` of its own. A
-// host that already has a module graph — a framework plugin, the `tinacms` bin, the
-// playground config — passes that graph in and never arrives here. Vite is therefore an
-// optional peer of the package and not a dependency, so a project that consumes only the
-// browser runtime does not install a build tool to get it. The import is dynamic to keep
-// that true: a static one puts Vite in the module graph of every importer of this file,
-// whatever they then do with it.
+// Vite is an optional peer, imported dynamically so a browser-only consumer
+// never pulls it into the module graph.
 const startLoadingServer = async (
   configPath: string,
   alias: LoadTinaConfigOptions['alias']
 ) => {
   const vite = await import('vite').catch(() => null);
-  // A missing optional peer otherwise surfaces as ERR_MODULE_NOT_FOUND against the
-  // string 'vite', which names neither the caller nor the two ways out of it.
   invariant(
     vite,
     'config-loader-missing',
     'Reading tina/config.ts needs Vite. Install vite as a dev dependency, or pass `loader` to use the module graph you already have.'
   );
   return vite.createServer({
-    // Ignore any vite.config in scope. This server resolves one module. The plugins
-    // of a project would run its whole dev pipeline. In a workspace, they would
-    // also return to the config that called this function.
+    // Ignore any vite.config in scope: a project's plugins would run its whole
+    // dev pipeline, and in a workspace would re-enter this config load.
     configFile: false,
-    // Without this the server roots at process.cwd(), so a config loaded from
-    // anywhere else resolves its relative imports and tsconfig paths against the
-    // caller's directory rather than the project's.
+    // Root at the config, not process.cwd(), so relative imports and tsconfig
+    // paths resolve against the project.
     root: path.dirname(configPath),
     logLevel: 'warn',
-    // The `ws: false` option is necessary. In middleware mode, Vite has no HTTP
-    // server for the HMR socket. The `hmr: false` option alone does not stop that
-    // socket. Vite then binds its default port, 24678, on every interface. A load
-    // of one config file would claim a fixed global port, and two loads at the same
-    // time would race. Only `ws: false` stops createWebSocketServer.
+    // `ws: false` is required: `hmr: false` alone still binds the HMR socket on
+    // port 24678, so two concurrent loads would race on a global port.
     server: { middlewareMode: true, hmr: false, ws: false, watch: null },
     resolve: { alias: alias ?? [] },
   });
@@ -85,8 +61,7 @@ export const loadTinaConfig = async (
     );
     return config;
   } finally {
-    // Close only the server that this function opened. A server from the caller stays
-    // open.
+    // Close only the server this function opened.
     if (!options.loader) await (server as { close(): Promise<void> }).close();
   }
 };

--- a/packages/v4/@tinacms/tinacms/src/codegen/package-version.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/package-version.ts
@@ -1,0 +1,19 @@
+
+import { createRequire } from 'node:module';
+
+const packageJson: { version: string } = createRequire(import.meta.url)(
+  '../../package.json'
+);
+
+export interface PackageVersion {
+  fullVersion: string;
+  major: string;
+  minor: string;
+  patch: string;
+}
+
+export const packageVersion = (): PackageVersion => {
+  const fullVersion: string = packageJson.version;
+  const [major, minor, patch] = fullVersion.split('.');
+  return { fullVersion, major, minor, patch };
+};

--- a/packages/v4/@tinacms/tinacms/src/config.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/config.test.ts
@@ -34,15 +34,12 @@ describe('defineConfig', () => {
     ).toEqual([customString]);
   });
 
-  // The data layer has no default, so it is the one required entry.
   it('rejects a config with no content provider', () => {
     expect(() => defineConfig({ schema })).toThrow(
       /provides the "content" capability/
     );
   });
 
-  // The graph pass runs here, and not at boot, so a broken config fails at the import
-  // of tina/config.ts.
   it('rejects a capability conflict at config time', () => {
     const second = definePlugin({
       name: 'other:content',
@@ -67,8 +64,6 @@ describe('defineConfig', () => {
 });
 
 describe('defineConfig schema validation', () => {
-  // The schema reached the compile step unchecked, so a malformed one imported cleanly
-  // and died later as a TypeError far from the config that caused it.
   it.each([
     ['a schema with no collections', {} as never],
     ['collections that are not an array', { collections: {} } as never],

--- a/packages/v4/@tinacms/tinacms/src/config.ts
+++ b/packages/v4/@tinacms/tinacms/src/config.ts
@@ -1,7 +1,3 @@
-// The composition root (ADR-024). It sits above core/ and plugins/, because it is the
-// one place that knows both. It takes the two concerns of the user, and returns the
-// resolved plugin set that every consumer boots from. The editor, the compile step, and
-// the framework adapters all read that one object. None of them derives it again.
 
 import type { Brand } from './core/brand';
 import { invariant } from './core/invariant';
@@ -14,30 +10,12 @@ export interface TinaSchema {
   collections: CollectionSchema[];
 }
 
-/**
- * Type a collection where it is written. It returns its input, and exists so a
- * collection in its own file gets its type errors at its own site, and not inside
- * the config object that gathers it.
- */
 export const defineCollection = (
   collection: CollectionSchema
 ): CollectionSchema => collection;
 
 export interface TinaConfig {
-  /**
-   * Additions and overrides only. Tina installs the built-in field plugins whether
-   * or not they appear here (ADR-024 §3). A plugin with the name of a built-in
-   * replaces that built-in. This is how you replace the standard `string` field.
-   *
-   * The config for a capability sits on the plugin that provides it, for example
-   * `localContentPlugin({ url })`. It is never a key at the top level.
-   */
   plugins?: PluginManifest[];
-  /**
-   * The content model. It sits beside `plugins`, and is not one of them, because it
-   * is the content of the user and not an extension. Its field types resolve against
-   * the installed field plugins.
-   */
   schema: TinaSchema;
 }
 
@@ -46,30 +24,13 @@ export interface ComposedConfig {
   schema: TinaSchema;
 }
 
-/**
- * The output of defineConfig. It holds the composed plugin list, with the built-ins
- * folded in and the order fixed. It also holds the schema. The graph is already valid.
- *
- * Branded, because the structure alone is not the guarantee. `{ plugins: [], schema }`
- * satisfies the shape and boots a runtime with no built-in field plugins at all, which
- * is a blank editor rather than an error. The brand makes defineConfig the only way in.
- * A test that wants a bare runtime says so with `asResolvedConfig`.
- */
 export type ResolvedConfig = Brand<ComposedConfig, 'ResolvedConfig'>;
 
-/**
- * Assert a hand-built config. For a test that renders a runtime rather than a
- * configured app — it deliberately skips the built-in fold-in and every check
- * defineConfig runs, so it has no place in application code.
- */
 export const asResolvedConfig = (config: ComposedConfig): ResolvedConfig =>
   config as ResolvedConfig;
 
 const CONTENT_CAPABILITY = 'content' as const satisfies Capability;
 
-// A plugin of the user with the name of a built-in replaces that built-in. This is not
-// an `overrides` declaration (ADR-006), which replaces by capability key. This replaces
-// by name. It lets `plugins` add to the built-in set without a conflict.
 const composePlugins = (plugins: PluginManifest[]): PluginManifest[] => {
   const replaced = new Set(plugins.map((plugin) => plugin.name));
   return [
@@ -78,23 +39,13 @@ const composePlugins = (plugins: PluginManifest[]): PluginManifest[] => {
   ];
 };
 
-/**
- * Wire a project together. It runs at module scope in the `tina/config.ts` of the
- * user. Every error that it can find therefore fails at the import, and not part-way
- * through a boot. Those errors are a capability conflict, a missing provider, and a
- * dependency cycle.
- */
 export const defineConfig = (config: TinaConfig): ResolvedConfig => {
-  // The schema is the other half of the config and was reaching the compile step
-  // unchecked, so `schema: {}` imported cleanly and died later as a TypeError.
   invariant(
     Array.isArray(config.schema?.collections),
     'config-schema-not-collections',
     '`schema.collections` must be an array of collections.'
   );
   const plugins = composePlugins(config.plugins ?? []);
-  // The data layer is the one thing that the config cannot default (ADR-024 §3). The
-  // local, self-hosted, and TinaCloud layers are different at build time.
   invariant(
     plugins.some((plugin) => plugin.provides.includes(CONTENT_CAPABILITY)),
     'config-no-content-provider',

--- a/packages/v4/@tinacms/tinacms/src/core/brand.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/brand.ts
@@ -1,6 +1,1 @@
-// A branded type. The structure is still `T`, but TypeScript treats `Brand<T, K>` as a
-// different type. A plain `T` therefore cannot go where the brand is expected. Use it to
-// give a domain identifier its own type, with a constructor that validates the value and
-// applies the brand. Refer to `toFieldAddress`. The `__brand` member exists in the type
-// only, and never at runtime.
 export type Brand<T, K extends string> = T & { readonly __brand: K };

--- a/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/content/contract.ts
@@ -1,29 +1,13 @@
 import type { TinaDocument } from '../schema/types';
 
-// A document with its identity. The path is the id (ADR-017). A path is relative to the
-// project root, for example 'content/posts/hello.mdx'.
 export interface DocumentEntry {
   path: string;
   document: TinaDocument;
 }
 
-// The abstract level of the `content` capability (ADR-019). Every data layer implements
-// this set of operations. The layers are the local one in this package, TinaCloud, the
-// self-hosted one, and a v3 provider that maps these operations onto the v3 GraphQL
-// client. The client talks to this interface only, so a change of provider does not
-// touch the editor.
-//
-// The set holds get, list, and update, which is the save (ADR-018). These operations
-// wait for a consumer: create, delete, rename, cursor pagination, filter and sort on
-// indexed fields, and the system metadata. The GraphQL wire format and the generated
-// typed client also wait. They arrive with codegen (ADR-019 §2).
 export interface ContentProvider {
   get(collection: string, path: string): Promise<DocumentEntry | null>;
   list(collection: string): Promise<DocumentEntry[]>;
-  // The save. It writes the JSON content value. It also writes when the file is
-  // absent, because a document that another program deleted must not lose the save of
-  // the editor (ADR-018). It returns the stored result, which can hold more than
-  // `value`. The unknown fields of the stored document merge into it.
   update(
     collection: string,
     path: string,
@@ -31,20 +15,6 @@ export interface ContentProvider {
   ): Promise<DocumentEntry>;
 }
 
-// The contents of `get().content`. It is the ContentProvider above, and nothing more.
-//
-// It holds no cache. A data layer is a transport, and the caching policy — deduplicating
-// concurrent reads, deciding when a read went stale, retrying a failed one — belongs to
-// the one consumer that renders it. That consumer is the admin, and it uses React Query
-// (content-queries.ts). An earlier version of this interface carried a
-// `documents: Record<collection, DocumentEntry[]>` cache with its own load and save
-// operations, which meant every data layer author re-implemented a fraction of a query
-// client, each one differently.
-//
-// A rejection from `update` passes to the caller, so useFormSave leaves the form dirty.
-// Refer to SaveHandler in context.ts.
 export type ContentSlice = ContentProvider;
 
-// The default mount path of the wire endpoint for the content capability. The client
-// slice and the dev server that hosts the data layer both use it.
 export const DEFAULT_CONTENT_URL = '/api/tina/content';

--- a/packages/v4/@tinacms/tinacms/src/core/field/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/field/contract.ts
@@ -2,51 +2,23 @@ import type { ComponentType } from 'react';
 import type { ZodType } from 'zod';
 import type { FieldSchema } from '../schema/types';
 
-// The layout hint that a composite field reads to render a child. A composite field is
-// an object, a list, or a rich-text field. The hint lets it render the child without a
-// branch on the type of that child (ADR-009). An `inline` child renders in the line, for
-// example a single-line input. A `block` child renders as its own section.
 export type FieldLayout = 'inline' | 'block';
 
 export interface FieldMetadata {
   layout?: FieldLayout;
-  /**
-   * Whether a host's `<label for>` can target this field's control. Defaults to true.
-   * Set it false for a control HTML cannot label — a contenteditable is not a labelable
-   * element, so `for` would point at nothing and the association would be worse than
-   * none. Such a field names itself instead.
-   */
   labelable?: boolean;
 }
 
-// What the transform of a field knows about its document, beyond its own schema node.
-// The `documentPath` is the file that the value came from, and that it returns to. The
-// extension of that file names the storage format, which lets a collection hold more
-// than one format. The rich-text field selects its codec from it. Refer to
-// rich-text-codecs.ts.
-// The path is absent when a transform runs outside a document, such as in a unit test.
-// The media paths will also read this when the media capability arrives.
 export interface FieldTransformContext {
   documentPath?: string;
 }
 
-// The rendering half of a field plugin. Its type key sits on the manifest, in
-// FieldProvision, and not here. The compile step needs that key, and must not import
-// this file.
 export interface FieldDescriptor<TValue = unknown, TStored = unknown> {
   Component: ComponentType;
   defaultValue?: TValue;
   metadata?: FieldMetadata;
   schema?: (node: FieldSchema) => ZodType;
   validate?: (value: TValue) => string | null;
-  // The parse and serialize functions are the ingest and digest transforms of one
-  // field. The string and boolean fields return the value as it is. The number field
-  // converts between a string and a number. The image, datetime, and reference fields
-  // will also use them, for a path and a media object, or an ISO string and a Date.
-  // The `node` is the schema of the field. The rich-text field reads its templates from
-  // the node, and parses the markdown into the MDX tree. The `context` is the document
-  // above. The rich-text field reads it to select a codec for each file, and not for
-  // each collection. A field with a value-only transform ignores both arguments.
   parse?: (
     stored: TStored,
     node: FieldSchema,
@@ -57,10 +29,6 @@ export interface FieldDescriptor<TValue = unknown, TStored = unknown> {
     node: FieldSchema,
     context: FieldTransformContext
   ) => TStored;
-  // Whether two editor values would write the same thing to the document. The form store
-  // asks this to tell a real edit from a value that only looks new. A field whose value
-  // is the value the document holds needs no answer here, because the store compares
-  // those as structure. Refer to core/form/compare.ts for the case that does.
   isEqual?: (
     a: TValue,
     b: TValue,

--- a/packages/v4/@tinacms/tinacms/src/core/field/registry.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/field/registry.test.ts
@@ -10,14 +10,11 @@ import { createFieldRegistry } from './registry';
 
 const Noop = () => null;
 
-// A small field descriptor, tagged with defaultValue, so a test can see which one won.
 const fieldOf = (tag: string): FieldDescriptor => ({
   Component: Noop,
   defaultValue: tag,
 });
 
-// The `type` sits on the manifest, and the descriptor sits on the segment. A real field
-// plugin splits them across its .plugin.ts and .client.tsx files.
 const resolved = (
   spec: { name: string; type?: string; overrides?: CapabilityOverride[] },
   field?: FieldDescriptor
@@ -50,8 +47,6 @@ describe('createFieldRegistry', () => {
     expect(registry.size).toBe(0);
   });
 
-  // One half alone is an error by the author. The boot catches it, so it does not
-  // appear as an unknown field type at the render.
   it('throws when a manifest declares a field type with no descriptor', () => {
     expect(() =>
       createFieldRegistry([resolved({ name: 'custom:string', type: 'string' })])
@@ -87,7 +82,6 @@ describe('createFieldRegistry', () => {
       fieldOf('custom')
     );
 
-    // base-first and override-first both resolve to the override.
     expect(winnerTag(createFieldRegistry([base, override]))).toBe('custom');
     expect(winnerTag(createFieldRegistry([override, base]))).toBe('custom');
   });
@@ -109,9 +103,6 @@ describe('createFieldRegistry', () => {
 });
 
 describe('resolveClientSegments', () => {
-  // The registry's paired check below can never see this plugin: resolveClientSegments
-  // skips a manifest with no client, so the type would compile into the lock and then
-  // resolve to nothing at render.
   it('throws when a field provider has no client segment at all', async () => {
     await expect(
       resolveClientSegments([

--- a/packages/v4/@tinacms/tinacms/src/core/form/compare.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/compare.test.ts
@@ -13,8 +13,6 @@ const fields: FieldSchema[] = [
   { name: 'body', type: 'rich-text' },
 ];
 
-// A field whose editor value is richer than its stored form. `source` is what the
-// document holds, and `editorOnly` is what the editor added to it.
 const sourceOnly: FieldDescriptor = {
   Component: () => null,
   isEqual: (a, b) =>
@@ -45,7 +43,6 @@ describe('fieldEqualityFor', () => {
     );
     expect(equal(title, 'Hello', 'Hello')).toBe(true);
     expect(equal(title, 'Hello', 'Goodbye')).toBe(false);
-    // The declared answer belongs to its own address, and to no other.
     expect(equal(title, { source: 'x', editorOnly: 1 }, { source: 'x' })).toBe(
       false
     );

--- a/packages/v4/@tinacms/tinacms/src/core/form/compare.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/compare.ts
@@ -3,21 +3,6 @@ import type { FieldTransformContext } from '../field/contract';
 import type { FieldRegistry } from '../field/registry';
 import type { FieldSchema } from '../schema/types';
 
-// Whether a form still holds the value it started with. The form store asks this to tell
-// a real edit from a value that only looks new (ADR-010).
-//
-// Most values are their own answer. A string field holds the string that the document
-// holds, so a compare of the two values is exact. A field whose editor value is richer
-// than its stored form is not: Plate rewrites the rich-text tree as it mounts, with an id
-// on every node and a trailing block, so the tree in the editor never matches the tree
-// parsed from the file. Compared as structure, a body that its author has typed and then
-// deleted again reports an edit for ever, and the badge never leaves "Unsaved". Such a
-// field answers for itself, through isEqual on its descriptor.
-
-// The RHF subscription sends a clone of each value, but markSaved keeps the original as
-// the baseline. A reference test therefore holds a structural value, such as the
-// rich-text tree, dirty for ever. The values are JSON documents, so this compares their
-// structure. A wrong result costs one more dirty read. It never loses an edit.
 export const sameValue = (a: unknown, b: unknown): boolean => {
   if (Object.is(a, b)) return true;
   if (typeof a !== 'object' || typeof b !== 'object') return false;
@@ -25,22 +10,15 @@ export const sameValue = (a: unknown, b: unknown): boolean => {
   return JSON.stringify(a) === JSON.stringify(b);
 };
 
-// The equality of one open form, address by address. The form store holds one of these
-// per form, so the store itself needs no field registry.
 export type FieldEquality = (
   address: FieldAddress,
   a: unknown,
   b: unknown
 ) => boolean;
 
-// The answer for a form whose fields all hold their own stored value. It is also the
-// answer for a caller with no registry, such as a test.
 export const STRUCTURAL_EQUALITY: FieldEquality = (_address, a, b) =>
   sameValue(a, b);
 
-// The equality of a form, built from the descriptors of its fields. Each isEqual is bound
-// to its own schema node and to the document, because a field resolves its transforms
-// from both. The rich-text field selects its codec in that way.
 export const fieldEqualityFor = (
   fields: FieldSchema[],
   registry: FieldRegistry,
@@ -56,8 +34,6 @@ export const fieldEqualityFor = (
     }
   }
   if (declared.size === 0) return STRUCTURAL_EQUALITY;
-  // The structural test runs first. It answers every untouched field by reference, so
-  // the field that is being edited is the only one that pays for its own compare.
   return (address, a, b) =>
     sameValue(a, b) || (declared.get(address)?.(a, b) ?? false);
 };

--- a/packages/v4/@tinacms/tinacms/src/core/form/ingest.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/ingest.ts
@@ -2,20 +2,8 @@ import type { FieldTransformContext } from '../field/contract';
 import type { FieldRegistry } from '../field/registry';
 import type { FieldSchema, TinaDocument } from '../schema/types';
 
-// The ingest and the digest are the only callers of the parse and serialize functions of
-// a field, so the document context passes through here. It has a default, so a caller
-// with no document is not affected. Those callers are the tests, and every field with a
-// value-only transform.
 const NO_DOCUMENT: FieldTransformContext = {};
 
-// Flatten a document at the load (ADR-010). This turns a stored document into the
-// initial values of the form. For each field, it runs the parse() of the field plugin,
-// which converts the stored value into the editor value. When the key is absent, it uses
-// the defaultValue of the field. The string and boolean fields return the value as it
-// is. The number field converts a stored number into an editor string. The image,
-// datetime, and reference fields will add their own transforms.
-// Plan: the content capability supplies the document when the data layer arrives
-// (ADR-019). Today the caller passes it.
 export const ingestDocument = (
   storedDocument: TinaDocument | undefined,
   fields: FieldSchema[],
@@ -37,11 +25,6 @@ export const ingestDocument = (
   return values;
 };
 
-// Build the document again at the save (ADR-010). This turns the values of the form back
-// into the shape of a document. It runs the serialize() of each field, which is the
-// reverse of parse(). It drops an undefined value, and it keeps a null value.
-// Plan: the result goes to the content capability, which writes it to git, to disk, and
-// to TinaCloud (ADR-018). The document lifecycle hooks run first (ADR-014).
 export const digestDocument = (
   values: TinaDocument | undefined,
   fields: FieldSchema[],

--- a/packages/v4/@tinacms/tinacms/src/core/invariant.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/invariant.ts
@@ -1,8 +1,3 @@
-// Assert an invariant of the boot or of the config. It throws when `condition` is false,
-// and it then narrows the type with `asserts condition`. A caller therefore needs no
-// `if (!x) throw` at a guard. tiny-invariant removes its messages in production. This
-// function throws the `code` there instead. The code is stable, and a search finds it, so
-// a stripped error still points at its guard. Development gets `code: message` in full.
 const isProduction =
   typeof process !== 'undefined' && process.env.NODE_ENV === 'production';
 

--- a/packages/v4/@tinacms/tinacms/src/core/mount.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/mount.ts
@@ -5,10 +5,8 @@ import {
   isSingletonSliceCapability,
 } from './plugin';
 
-// Where a plugin mounts, on both sides of the boundary. The client store slice and the
-// server ops namespace resolve through this one rule, so that `get().media.*` and
-// `server.media.*` always agree. The isOverride flag records an `overrides` declaration,
-// which is the only way to replace another provider (ADR-006).
+// Where a plugin mounts, on both sides of the boundary: one rule so
+// `get().media.*` and `server.media.*` always agree.
 export interface CapabilityMount {
   namespace: string;
   isOverride: boolean;
@@ -26,9 +24,8 @@ export const declaresCapabilityOverride = (
   return false;
 };
 
-// A plugin that provides a singleton capability mounts at that key. Every other plugin
-// mounts under its own name. A change of provider, from tinaCloudAuth to auth0Auth,
-// therefore changes no reader of `get().auth` and no caller of `server.auth.*`.
+// Singleton providers mount at the capability key, everything else under its
+// own name, so a change of provider changes no reader.
 export const capabilityMountFor = (
   manifest: PluginManifest
 ): CapabilityMount => {
@@ -47,8 +44,7 @@ export const capabilityMountFor = (
       isOverride: declaresCapabilityOverride(manifest, capability),
     };
   }
-  // A feature plugin must not take a capability namespace by its name alone. The peers
-  // read the capability state, and call the capability ops, at these keys.
+  // A feature plugin must not squat a capability namespace by name alone.
   invariant(
     !isSingletonSliceCapability(manifest.name),
     'plugin-name-squats-capability',

--- a/packages/v4/@tinacms/tinacms/src/core/overridable-registry.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/overridable-registry.test.ts
@@ -1,8 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { composeOverridableRegistry } from './overridable-registry';
 
-// A conflict factory that writes the kind and the key, so a test can assert which
-// conflict happened.
 const conflict = (kind: string, key: string) => new Error(`${kind}:${key}`);
 
 const base = (key: string, value: string) => ({
@@ -50,8 +48,6 @@ describe('composeOverridableRegistry', () => {
   });
 
   it('an override does not mask a base-vs-base collision', () => {
-    // Two plugins both provide a base at "a", and a third one overrides it. The
-    // override wins its key, and it must not hide the collision between the two bases.
     expect(() =>
       composeOverridableRegistry(
         [base('a', '1'), override('a', 'over'), base('a', '2')],

--- a/packages/v4/@tinacms/tinacms/src/core/overridable-registry.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/overridable-registry.ts
@@ -1,17 +1,7 @@
-// A registry with string keys, composed from the entries that the plugins supply. Each
-// entry is a built-in, which this file calls a base, or an `overrides` declaration from a
-// plugin. The composition does not depend on the order. An override wins its key, whether
-// it resolves before the base or after it. Two bases at one key are a conflict, and so are
-// two overrides. The caller writes the message for that conflict.
-//
-// The field registry holds the field descriptors by type. The slice composer of the store
-// holds the slices by namespace. Both resolve in this way, so the rule lives here once.
 
 export interface RegistryEntry<TValue> {
   key: string;
   value: TValue;
-  // True when the plugin declares an `overrides` for `key`. The entry then replaces a
-  // base at that key, and does not collide with it.
   isOverride: boolean;
 }
 
@@ -28,10 +18,6 @@ export const composeOverridableRegistry = <TValue>(
   conflictError: (conflict: RegistryConflict, key: string) => Error
 ): Map<string, TValue> => {
   const registry = new Map<string, TValue>();
-  // An override wins its key in any order. Two bases at one key collide, and so do two
-  // overrides. Two sets record this, and not one. A second base is therefore still a
-  // duplicate base when an override already holds the key. An override must not hide a
-  // real collision between two other plugins.
   const overriddenKeys = new Set<string>();
   const baseKeys = new Set<string>();
 
@@ -39,7 +25,6 @@ export const composeOverridableRegistry = <TValue>(
     if (isOverride) {
       if (overriddenKeys.has(key))
         throw conflictError(REGISTRY_CONFLICTS.duplicateOverride, key);
-      // An override takes its key, whether or not a base has resolved.
       registry.set(key, value);
       overriddenKeys.add(key);
       continue;
@@ -47,7 +32,6 @@ export const composeOverridableRegistry = <TValue>(
     if (baseKeys.has(key))
       throw conflictError(REGISTRY_CONFLICTS.duplicateBase, key);
     baseKeys.add(key);
-    // A base fills its key only when no override holds it.
     if (!overriddenKeys.has(key)) registry.set(key, value);
   }
   return registry;

--- a/packages/v4/@tinacms/tinacms/src/core/plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/plugin.ts
@@ -5,23 +5,11 @@ import type { AdminScreen } from './screen/contract';
 
 export type Capability = 'field' | 'content' | 'auth' | 'media' | 'search';
 
-// The one keyed capability. There are many field types, but one registry. Runtime
-// checks read this constant instead of a repeated literal.
 export const FIELD_CAPABILITY = 'field' as const satisfies Capability;
 
-// The provider of this capability also carries the RPC transport hooks. Refer to
-// AuthTransportHooks in server/index.ts. The naming rule is the same as
-// FIELD_CAPABILITY.
 export const AUTH_CAPABILITY = 'auth' as const satisfies Capability;
 
-// The provider of each of these capabilities owns one client store namespace. Its slice
-// mounts at the capability key, and not at the plugin name. Refer to
-// store-architecture.md. The store composer reads this list instead of repeating it.
-// The list holds `content`, which has no client slice yet. It does not hold `field`,
-// because `field` is keyed and the form state is core (ADR-010).
-//
-// TODO(v4): give each capability a descriptor with a kind of 'singleton-slice',
-// 'keyed', or 'backend'. Then derive this list from those descriptors.
+// TODO(v4): derive this list from per-capability descriptors.
 export const SINGLETON_SLICE_CAPABILITIES = [
   'auth',
   'content',
@@ -32,61 +20,30 @@ export const SINGLETON_SLICE_CAPABILITIES = [
 export type SingletonSliceCapability =
   (typeof SINGLETON_SLICE_CAPABILITIES)[number];
 
-// The one guard over that list. It takes a plain string, so the namespace checks can
-// also use it.
 export const isSingletonSliceCapability = (
   value: string
 ): value is SingletonSliceCapability =>
   (SINGLETON_SLICE_CAPABILITIES as readonly string[]).includes(value);
 
-// The static half of a `field` provider. It holds the schema type the provider renders,
-// and the contract version of the shape of that type. Both sit on the manifest, and not
-// on the descriptor, because the schema compile runs in Node. A read of the type key
-// from the client segment would pull React into the build. For rich text it would also
-// pull in Plate (ADR-016 §2).
 export interface FieldProvision {
   type: string;
-  // Only a breaking change to the schema shape of this field type increases this
-  // number. A committed lock that holds an older major version stops the build. It
-  // does not break quietly (ADR-016 §3).
   contractVersion: number;
 }
 
-// A declaration that the segment of a plugin replaces a built-in segment. The `field`
-// capability is keyed, so its override names the field type. A singleton capability has
-// one slot, so the union gives it no key.
 export type CapabilityOverride =
   | { capability: typeof FIELD_CAPABILITY; key: string }
   | { capability: SingletonSliceCapability };
 
-// The full client store, composed at boot. It is a flat set of namespaces, and each
-// namespace holds the state of one slice. The shape is open, because a plugin can
-// register any namespace at boot. Core slices and plugin slices both mount here, and a
-// slice reads its peers from here. The store modules import this one definition.
 export type TinaStoreState = Record<string, SliceState>;
 
-// The state of one slice. The slice returns this object, and the runtime mounts it at
-// the namespace of the slice. It holds the data fields of the slice and its action
-// functions, for example `{ items: [], add: (item) => … }`. The author of the slice
-// defines the keys and the value shapes.
 export type SliceState = Record<string, unknown>;
 
-// The `set` function of a slice, scoped to the namespace of that slice. It takes the
-// next partial state, or a function that computes the next state from the current
-// state. These are the two forms of `set` in Zustand. It also takes a devtools action
-// label. A write lands in the namespace of the slice only, and never in the whole store.
 export type SliceSet = (
   partial: Partial<SliceState> | ((current: SliceState) => Partial<SliceState>),
   replace?: boolean,
   action?: string
 ) => void;
 
-// The store slice of a client segment. Refer to store-architecture.md. It receives the
-// scoped `set` and the whole-store `get`, and it returns the state and the actions. The
-// runtime mounts them at the namespace of the plugin. The `get` function reads the peers
-// by namespace, for example `get().auth.user`. A slice never sees the devtools
-// middleware or the persist middleware of the host. A field plugin supplies no slice,
-// because the form state is core (ADR-010).
 export type ClientSlice = (
   set: SliceSet,
   get: StoreApi<TinaStoreState>['getState']
@@ -95,47 +52,28 @@ export type ClientSlice = (
 export interface ClientSegment {
   field?: FieldDescriptor;
   slice?: ClientSlice;
-  // Screens this plugin adds to the admin, beside the collection views the schema
-  // generates. They compose into the screen registry at boot. Refer to
-  // core/screen/registry. A plugin declares no capability for these: a screen is a
-  // contribution, and not a slot that one provider fills.
   screens?: AdminScreen[];
 }
 
-// One operation in a server segment (ADR-007). The whole contract is a flat record of
-// `(input) => Promise<result>` functions. An `import type` carries the same shape to the
-// client for the typed RPC proxy. The `never` input keeps every concrete operation
-// assignable, and it avoids `any`. The transport casts the input at its one dispatch
-// site.
 export type ServerOp = (input: never) => Promise<unknown>;
 
 export type ServerSegment = Record<string, ServerOp>;
 
-// A manifest with its loaded server segment. The RPC handler composes these in
-// rpc/handler.ts. ResolvedSegment is the equivalent shape on the client.
 export interface ResolvedServerSegment {
   manifest: PluginManifest;
   ops: ServerSegment;
 }
 
-// A manifest with its loaded client segment. Both registries compose from these units:
-// the field type registry and the store slice registry.
 export interface ResolvedSegment {
   manifest: PluginManifest;
   segment: ClientSegment;
 }
 
-// Load the client segment of each plugin once. This is the one resolution pass at boot.
-// Its result feeds createFieldRegistry and createTinaStore, so the two compose from the
-// same segments and cannot diverge.
 export const resolveClientSegments = async (
   plugins: PluginManifest[]
 ): Promise<ResolvedSegment[]> => {
   const resolved: ResolvedSegment[] = [];
   for (const manifest of plugins) {
-    // A field provider with no client segment never reaches the registry's paired
-    // check below, so it would compile into the lock and then resolve to nothing at
-    // render. Caught here, where the segment list is built.
     invariant(
       !(manifest.field && !manifest.client),
       'field-plugin-no-client',
@@ -153,37 +91,21 @@ export const resolveClientSegments = async (
   return resolved;
 };
 
-// The shape an author passes to definePlugin. The list fields are optional, so a plugin
-// declares only what it uses. definePlugin fills them in, so every consumer reads the
-// PluginManifest below and needs no `?? []` guard.
 export interface PluginManifestInput {
   name: string;
-  // The runtime reads `name`, `client`, `server`, `provides` for the mount key,
-  // `dependsOn` for the graph order in core/resolve.ts, `overrides`, and `requires` for
-  // the RPC transport gate. It does not read `permissions` yet. That field waits for
-  // the typed Permission union from codegen (ADR-008 §3).
   provides?: Capability[];
   dependsOn?: Capability[];
-  // A `field` provider must set this field, and no other plugin may set it. It names
-  // the keyed slot that the plugin fills. The client segment supplies the descriptor
-  // for that slot.
   field?: FieldProvision;
   client?: () => Promise<{ default: ClientSegment }>;
   server?: () => Promise<{ default: ServerSegment }>;
+  // TODO(ADR-008 §3): type `permissions` against codegen's Permission union once it lands.
   permissions?: { name: string; description?: string }[];
   requires?: { permission: string };
   overrides?: CapabilityOverride[];
-  // The plugin lifecycle (ADR-006). The runtime runs these once at each boot, in
-  // dependency order. Refer to initializePlugins in core/resolve.ts. It does not run
-  // them for each UI instance. They take no context argument yet. PluginInitContext
-  // carries the resolved config and nothing else. It arrives with defineConfig
-  // (ADR-024), and it adds to this shape without a breaking change.
   onInit?: () => void | Promise<void>;
   onDestroy?: () => void | Promise<void>;
 }
 
-// The normalized manifest that every consumer reads. definePlugin has filled the list
-// fields, so `provides`, `dependsOn`, and `overrides` are always arrays.
 export interface PluginManifest extends PluginManifestInput {
   provides: Capability[];
   dependsOn: Capability[];

--- a/packages/v4/@tinacms/tinacms/src/core/resolve.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/resolve.ts
@@ -12,8 +12,6 @@ import {
   type ResolvedServerSegment,
 } from './plugin';
 
-// Load the server segment of each plugin once. This is the server equivalent of
-// resolveClientSegments. The RPC handler calls it after the graph is valid.
 export const resolveServerSegments = async (
   plugins: PluginManifest[]
 ): Promise<ResolvedServerSegment[]> => {
@@ -31,11 +29,9 @@ export const resolveServerSegments = async (
   return resolved;
 };
 
-// Only the plugins in the config take part (ADR-006). A plugin cannot add itself. Every
-// error in a config fails here, before any segment import, so a bad config never boots
-// part-way. Those errors are duplicate names, singleton conflicts, missing providers,
-// and dependency cycles. The `field` capability is keyed (ADR-009), so many providers
-// are correct. The field registry finds a conflict on one field type.
+// Every config error fails here, before any segment import, so a bad config
+// never boots part-way (ADR-006). `field` is keyed, so many providers are
+// correct; the field registry finds per-type conflicts.
 export const validateCapabilityGraph = (plugins: PluginManifest[]): void => {
   const names = new Set<string>();
   for (const plugin of plugins) {
@@ -48,10 +44,8 @@ export const validateCapabilityGraph = (plugins: PluginManifest[]): void => {
     names.add(plugin.name);
   }
 
-  // A singleton capability resolves through the same override rule as a field type and
-  // a store slice. That rule does not depend on the order. Two bases at one capability
-  // throw, and so do two overrides. An `overrides` declaration is the only way to
-  // replace a provider.
+  // Singleton capabilities resolve through the same order-independent override
+  // rule as field types and store slices.
   const capabilityEntries = plugins.flatMap((plugin) => {
     const singletonCapabilities = plugin.provides.filter(
       (capability) => capability !== FIELD_CAPABILITY
@@ -79,10 +73,8 @@ export const validateCapabilityGraph = (plugins: PluginManifest[]): void => {
   orderPluginsByDependencies(plugins);
 };
 
-// The init order (ADR-006). A provider runs before the plugins that depend on it. The
-// config order decides between plugins that are otherwise equal. A plugin that satisfies
-// its own dependency makes no edge. A cycle is an error, and the message names its
-// members. The scan for ready plugins is O(n²), which is enough for tens of plugins.
+// Init order (ADR-006): providers before dependents, config order breaks ties,
+// a cycle is an error. The ready scan is O(n²), enough for tens of plugins.
 const orderPluginsByDependencies = (
   plugins: PluginManifest[]
 ): PluginManifest[] => {
@@ -128,16 +120,13 @@ const orderPluginsByDependencies = (
   return ordered;
 };
 
-// The onInit lifecycle (ADR-006). Each hook runs once at each boot, in dependency order,
-// and this function waits for it. It returns the teardown. The teardown runs onDestroy in
-// the reverse order, and only for the plugins that ran their init. A failure part-way
-// through tears those plugins down, and then throws the cause again.
+// Runs each onInit once per boot in dependency order and returns the teardown,
+// which runs onDestroy in reverse for the plugins that ran their init (ADR-006).
 export const initializePlugins = async (
   plugins: PluginManifest[]
 ): Promise<() => Promise<void>> => {
   const initialized: PluginManifest[] = [];
-  // This drains the list, so a second call destroys nothing. Every hook runs, even when
-  // one throws. The first failure then throws again.
+  // Drains the list, so a second call destroys nothing.
   const destroyInitialized = async () => {
     const failures: unknown[] = [];
     for (const plugin of initialized.splice(0).reverse()) {
@@ -147,8 +136,6 @@ export const initializePlugins = async (
         failures.push(cause);
       }
     }
-    // Report every teardown failure, and not the first one alone. A later onDestroy
-    // must not hide an earlier failure.
     if (failures.length === 1) throw failures[0];
     if (failures.length > 1) {
       throw new AggregateError(failures, 'Plugin teardown failed.');
@@ -159,9 +146,8 @@ export const initializePlugins = async (
       await plugin.onInit?.();
       initialized.push(plugin);
     } catch (cause) {
-      // The rollback failure must not replace the failure that caused it, but it must
-      // not vanish either: a half-torn-down plugin can leave a handle open, and the
-      // thrown `cause` says nothing about that.
+      // The rollback failure must not replace the failure that caused it, but
+      // must not vanish either.
       await destroyInitialized().catch((rollbackFailure) => {
         console.error(
           '[tinacms] Plugin teardown failed while rolling back a failed init:',

--- a/packages/v4/@tinacms/tinacms/src/core/screen/contract.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/screen/contract.ts
@@ -1,42 +1,15 @@
-// A screen a plugin adds to the admin, beside the collection views the schema generates.
-//
-// The admin shell renders exactly one thing: the content model. A media library, a
-// branch view, a settings screen, and a search result are none of them a collection, and
-// nothing in the shell should have to name them. A plugin contributes one of these and
-// the shell routes to it, lists it in the navigation, and otherwise knows nothing about
-// it.
-//
-// A screen is not a UI slot (ADR-013). A slot is fan-in: many plugins stack chrome into
-// one named region, and the hard question is ordering. A screen is the inverse — one
-// component owns one route, and two plugins claiming one name is a collision to report.
-// That is the cardinality of a keyed capability, which is why the screen registry
-// composes through composeOverridableRegistry and a slot registry will not.
 
 import type { ComponentType } from 'react';
 
 export interface AdminScreenProps {
-  // The route segments after the screen name. `#/screens/media/photos/2026` gives
-  // `['photos', '2026']`. A screen with one view ignores this; a screen that navigates
-  // within itself reads it, and calls `navigate` from useAdminRoute to write it. The
-  // segments are decoded, so a segment may hold a slash.
   segments: string[];
 }
 
 export interface AdminScreen {
-  // The route key, and the segment this screen mounts at under `#/screens/`. It must be
-  // a single segment: no slashes, because the segments after it belong to the screen.
   name: string;
-  // The navigation entry.
   label: string;
-  // Where this sits in the navigation, low to high. Explicit, because the order two
-  // plugins appear in must not depend on the order they were installed (ADR-006, and
-  // ADR-013 §6 for the same rule applied to slots). Screens that share an order — which
-  // is every screen that declares none — sort by name, so the arrangement is the same
-  // whichever way the plugin list is written.
   order?: number;
   component: ComponentType<AdminScreenProps>;
 }
 
-// The order of a screen that declares none. Zero and not Infinity, so a plugin can sit a
-// screen above the default set with a negative number as well as below it.
 export const DEFAULT_SCREEN_ORDER = 0;

--- a/packages/v4/@tinacms/tinacms/src/core/screen/registry.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/screen/registry.test.ts
@@ -47,8 +47,6 @@ describe('admin screen registry', () => {
     ).toBe(0);
   });
 
-  // Both would mount at the same hash, and there is no `overrides` for a screen to say
-  // which one wins.
   it('rejects two plugins claiming one screen name', () => {
     expect(() =>
       createScreenRegistry([
@@ -58,8 +56,6 @@ describe('admin screen registry', () => {
     ).toThrow(/both contribute an admin screen named "media"/);
   });
 
-  // A name holding a slash parses as a screen name plus a segment, so the screen would
-  // never match its own route. Caught at boot, and not as a dead navigation entry.
   it('rejects a screen name that holds a slash', () => {
     expect(() =>
       createScreenRegistry([
@@ -86,8 +82,6 @@ describe('screen navigation order', () => {
     ).toEqual(['First', 'Second', 'Third']);
   });
 
-  // The whole point of an explicit order: which plugin was installed first must not
-  // decide what the editor sees (ADR-006).
   it('gives the same order whichever way the plugin list is written', () => {
     const media = segmentOf('media-plugin', [
       screen('media', { label: 'Media' }),
@@ -107,7 +101,6 @@ describe('screen navigation order', () => {
     ).toEqual(['Apple', 'Zebra']);
   });
 
-  // Zero is the default, so a negative order sits a screen above the undeclared ones.
   it('lets a negative order sit above the default', () => {
     expect(
       labelsOf([

--- a/packages/v4/@tinacms/tinacms/src/core/screen/registry.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/screen/registry.ts
@@ -1,11 +1,3 @@
-// The admin screens, composed at boot from the client segments of the plugins.
-//
-// This is a registry and not a store slice, for the reason the field registry is one
-// (refer to TinaRuntime in editor/context.ts): it is a fixed map of React components,
-// which is config and not state. It is decided at boot from the plugin list, nothing
-// mutates it afterwards, and the devtools could not serialize a component. What *is*
-// state — which screen is open — lives in the route, where a reload and a shared link
-// both keep it.
 
 import { invariant } from '../invariant';
 import {
@@ -24,10 +16,6 @@ const screenConflictError = (_conflict: RegistryConflict, key: string): Error =>
       `at \`#/screens/${key}\`. Rename one of them.`
   );
 
-// The name is a route segment, so the router has to be able to give it back. A name
-// holding a slash would parse as a screen name plus a segment, and the screen would
-// never match its own route. Caught at boot, where the author can act on it, and not as
-// a navigation entry that leads to a blank view.
 const validateScreenName = (pluginName: string, screen: AdminScreen): void => {
   invariant(
     screen.name.length > 0,
@@ -49,22 +37,12 @@ export const createScreenRegistry = (
     resolved.flatMap(({ manifest, segment }) =>
       (segment.screens ?? []).map((screen) => {
         validateScreenName(manifest.name, screen);
-        // No screen takes an override. `overrides` replaces a *capability* provider,
-        // and a screen is not one — two plugins wanting the same screen name is a
-        // collision to report, not one to resolve silently in favour of whoever
-        // declared it.
         return { key: screen.name, value: screen, isOverride: false };
       })
     ),
     screenConflictError
   );
 
-// The screens in navigation order: by `order`, then by name.
-//
-// Never in registration order. That is the order the plugins happen to be listed in, so
-// moving one line in a config array would reshuffle the navigation — the "load order
-// never silently decides" rule of ADR-006. Sorting the ties by name instead makes the
-// arrangement a property of the screens themselves.
 export const screenList = (registry: ScreenRegistry): AdminScreen[] =>
   [...registry.values()].sort((left, right) => {
     const byOrder =

--- a/packages/v4/@tinacms/tinacms/src/editor/active-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/active-field.test.tsx
@@ -15,8 +15,6 @@ import {
   useActiveField,
 } from './index';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -28,8 +26,6 @@ const collection: CollectionSchema = {
   ],
 };
 
-// This drives the activation path in the same way as the click listener of the preview.
-// It calls useActiveField, and it needs no postMessage.
 function ActivateProbe() {
   const { setActive } = useActiveField();
   return (
@@ -39,15 +35,11 @@ function ActivateProbe() {
   );
 }
 
-// The view of this form on the active field, as a field plugin would read it.
 function ActiveReadout() {
   const { active } = useActiveField();
   return <span data-testid='active'>{active ?? 'none'}</span>;
 }
 
-// Records every new activation entry, by identity. The echo test needs the count of
-// entries, which no rendered value can show: a second entry for the same address
-// renders the same text.
 function ActivationLog({ entries }: { entries: string[] }) {
   const active = useFormStore((state) => state.active);
   const last = useRef<unknown>(null);
@@ -106,8 +98,6 @@ describe('active-field rail', () => {
     await userEvent.click(screen.getByText('activate'));
     expect(input).toHaveFocus();
 
-    // Blur the field, as a click elsewhere does, and then activate the same field
-    // again.
     (input as HTMLInputElement).blur();
     expect(input).not.toHaveFocus();
     await userEvent.click(screen.getByText('activate'));

--- a/packages/v4/@tinacms/tinacms/src/editor/content-queries.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/content-queries.test.tsx
@@ -13,8 +13,6 @@ const ENTRIES: DocumentEntry[] = [
   { path: 'content/posts/second.mdx', document: { title: 'Second' } },
 ];
 
-// The runtime these hooks read: a store with a content namespace, and nothing else they
-// touch. The registry and the schema are not on this path.
 const renderWithContent = (provider: ContentProvider) => {
   const store = createStore<TinaStoreState>()(() => ({
     content: provider as unknown as Record<string, unknown>,
@@ -55,7 +53,6 @@ describe('useCollectionDocuments', () => {
     expect(provider.list).toHaveBeenCalledWith('post');
   });
 
-  // No collection is a real state — nothing is open — and not a read of one named ''.
   it('reads nothing and reports no load without a collection', async () => {
     const provider = stubProvider();
     const { wrapper } = renderWithContent(provider);
@@ -68,8 +65,6 @@ describe('useCollectionDocuments', () => {
     expect(provider.list).not.toHaveBeenCalled();
   });
 
-  // The list renders straight from this, so a new array each render would re-render
-  // every consumer of it.
   it('returns the same empty list identity across renders', () => {
     const { wrapper } = renderWithContent(stubProvider());
     const { result, rerender } = renderHook(
@@ -100,8 +95,6 @@ describe('useCollectionDocuments', () => {
 });
 
 describe('useSaveDocument', () => {
-  // The stored entry can hold more than the value that was sent, and the cached list
-  // has to show what was stored rather than what the form had.
   it('replaces the cached entry with what the data layer stored', async () => {
     const persisted: DocumentEntry = {
       path: 'content/posts/hello.mdx',
@@ -127,8 +120,6 @@ describe('useSaveDocument', () => {
     await waitFor(() =>
       expect(result.current.list.documents).toEqual([persisted, ENTRIES[1]])
     );
-    // Written into the cache, not refetched: the stored entry is already the
-    // authoritative result of the write.
     expect(provider.list).toHaveBeenCalledTimes(1);
   });
 
@@ -159,8 +150,6 @@ describe('useSaveDocument', () => {
     );
   });
 
-  // useFormSave marks the form clean only after the save resolves, so the rejection has
-  // to reach it.
   it('rejects when the write does', async () => {
     const provider = stubProvider({
       update: vi.fn(async () => {

--- a/packages/v4/@tinacms/tinacms/src/editor/content-queries.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/content-queries.ts
@@ -1,17 +1,3 @@
-// The cache over the content capability. The capability itself is a transport of plain
-// promises (ContentSlice), and this file is the one consumer that decides policy:
-// deduplicate concurrent reads, when a read goes stale, what a failed one does, and what
-// a save writes back.
-//
-// The split matters because ContentSlice is the plugin contract. TinaCloud, the
-// self-hosted layer, and the v3 shim each implement it, and none of them should have to
-// ship a caching strategy — or take a dependency on this query client — to be a data
-// layer. React Query stays on this side of that boundary.
-//
-// These hooks return their own shapes rather than the React Query result. The components
-// need the data, the pending flag, and the error, and nothing else; returning the result
-// object would also mean spreading it, which reads every tracked property and re-renders
-// the caller on query state it never used.
 
 import {
   skipToken,
@@ -23,9 +9,6 @@ import type { DocumentEntry } from '../core/content/contract';
 import type { TinaDocument } from '../core/schema/types';
 import { useContentSlice } from './hooks';
 
-// One namespace for every content read, so an invalidation can reach the whole
-// capability or one collection of it. The functions build on each other, so
-// invalidating `all()` reaches every key below it.
 export const contentKeys = {
   all: () => ['tina', 'content'] as const,
   list: (collection: string) => [...contentKeys.all(), 'list', collection],
@@ -37,13 +20,8 @@ export const contentKeys = {
   ],
 };
 
-// Content changes underneath the editor — someone edits the file in their IDE, or a
-// teammate pushes — but not on the timescale of a click. Half a minute keeps navigation
-// between collections instant without serving a list from the morning.
 export const CONTENT_STALE_TIME = 30_000;
 
-// A stable fallback, so a caller that renders the list does not see a new array on every
-// render while the first read is in flight.
 const EMPTY_DOCUMENTS: DocumentEntry[] = [];
 
 export interface CollectionDocuments {
@@ -52,17 +30,6 @@ export interface CollectionDocuments {
   error: Error | null;
 }
 
-/**
- * The documents of one collection.
- *
- * Passing no collection is a real state — nothing is open — and not a load of one named
- * ''. `skipToken` models that as a query with no function: nothing is fetched, and the
- * result is an empty list that never reports itself as loading.
- *
- * Two components asking for the same collection share one request. The sidebar's
- * document list and the open document's scope both call this, so before the cache each
- * ran its own effect and its own fetch of the same collection.
- */
 export const useCollectionDocuments = (
   collection: string | undefined
 ): CollectionDocuments => {
@@ -74,30 +41,17 @@ export const useCollectionDocuments = (
   });
   return {
     documents: query.data ?? EMPTY_DOCUMENTS,
-    // `isLoading`, and not `isPending`. A skipped query is pending forever, because it
-    // has no data and never will; `isLoading` is that pending state narrowed to a read
-    // actually in flight, which is what a caller renders a spinner for.
     isLoading: query.isLoading,
     error: query.error,
   };
 };
 
 export interface DocumentRead {
-  // One absent case, and not three. A read that has not run, a skipped one, and a
-  // document that does not exist all have no entry, and `isLoading` is what separates a
-  // read in flight from a settled one.
   entry: DocumentEntry | null;
   isLoading: boolean;
   error: Error | null;
 }
 
-/**
- * One document, read directly rather than out of its collection list.
- *
- * The admin shell does not use this. It reads the open document from the list it already
- * holds, so that two reads of one document cannot disagree and seed the form from the
- * older one. A page plugin that opens a document without its collection list needs this.
- */
 export const useDocument = (
   collection: string | undefined,
   path: string | undefined
@@ -134,21 +88,10 @@ export interface SaveDocumentInput {
 }
 
 export interface DocumentSave {
-  // Rejects when the write does, so useFormSave leaves the form dirty.
   save: (input: SaveDocumentInput) => Promise<DocumentEntry>;
   isSaving: boolean;
 }
 
-/**
- * The save. It writes the stored entry back into the cached list, so the sidebar shows
- * the save without a refetch, and it does not invalidate that list.
- *
- * Not invalidating is deliberate. The stored entry is the authoritative result of this
- * write, so a refetch could only return the same thing — or, against a data layer that
- * reads its own write late, something older. Refer to usePinnedDocument in
- * document-scope.tsx for why re-seeding the open form off a fresh list is the failure
- * this avoids.
- */
 export const useSaveDocument = (): DocumentSave => {
   const content = useContentSlice();
   const queryClient = useQueryClient();
@@ -158,9 +101,6 @@ export const useSaveDocument = (): DocumentSave => {
     onSuccess: (entry, { collection }) => {
       queryClient.setQueryData<DocumentEntry[]>(
         contentKeys.list(collection),
-        // Only a list that was read. Seeding an unread one writes a fresh single-
-        // document list, which the next useCollectionDocuments mount reads as the whole
-        // collection and skips its fetch. Returning undefined leaves the key unset.
         (cached) => (cached ? upsertByPath(cached, entry) : undefined)
       );
       queryClient.setQueryData(
@@ -169,16 +109,9 @@ export const useSaveDocument = (): DocumentSave => {
       );
     },
   });
-  // `mutateAsync` is stable across renders, so a caller can hold it in a stable save
-  // handler. Refer to the FormProvider scope memo in document-scope.tsx.
   return { save: mutation.mutateAsync, isSaving: mutation.isPending };
 };
 
-/**
- * Drop every cached content read, so the next render fetches again. The editorial
- * workflow needs this on a branch switch: the documents of the last branch are not the
- * documents of this one.
- */
 export const useInvalidateContent = (): (() => Promise<void>) => {
   const queryClient = useQueryClient();
   return () => queryClient.invalidateQueries({ queryKey: contentKeys.all() });

--- a/packages/v4/@tinacms/tinacms/src/editor/context.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/context.ts
@@ -12,85 +12,26 @@ import type {
 import type { ScreenRegistry } from '../core/screen/registry';
 import type { FormId } from '../form/form-store';
 
-/**
- * The point where the content capability joins the save flow (ADR-018 and ADR-019). The
- * host gives FormProvider a handler that stores the digested document.
- *
- * A rejection leaves the form dirty. useFormSave marks the form clean only after the
- * handler resolves.
- */
 export type SaveHandler = (document: TinaDocument) => void | Promise<void>;
 
-// There is one context for each scope in the tree: the app, the form, and the field.
-// There is not one context for each value. Each scope has one provider and one lifetime.
-// No context here holds state that changes often. RHF holds the values, and the form
-// store holds the status and the active field. More contexts would therefore save no
-// render.
-
-/**
- * The app scope, from TinaProvider. It holds the runtime composed at boot, from one
- * resolveClientSegments pass that feeds both halves.
- *
- * The registry stays out of the store. It is a fixed map of React components, which is
- * config and not state. The devtools could also not serialize it.
- */
 export interface TinaRuntime {
   registry: FieldRegistry;
   store: StoreApi<TinaStoreState>;
-  /**
-   * The content model that the admin navigates. It is config, and not state. It comes
-   * from the build (ADR-016), so it sits beside the registry and not in the store.
-   */
   schema: TinaSchema;
-  /**
-   * The screens that the plugins add to the admin. It is a fixed map of components
-   * composed at boot, so it sits here for the same reason the field registry does.
-   */
   screens: ScreenRegistry;
 }
 export const TinaRuntimeContext = createContext<TinaRuntime | null>(null);
 
-/**
- * The form scope, from FormProvider. It holds the identity of the open document, its
- * schema, and the save handler. It changes only when the document changes.
- *
- * The `collection` and the save handler become reads from the store, or from a
- * capability, when the data layer arrives (ADR-019). This scope then holds the id alone.
- */
 export interface FormScope {
   formId: FormId;
-  /**
-   * The path of the open document, beside the form id derived from it. The save needs
-   * the path to build the transform context that the ingest used. Refer to
-   * FieldTransformContext. A form id cannot give the path back.
-   */
   path: string;
   collection: CollectionSchema;
   onSave: SaveHandler | null;
-  /**
-   * The identity of the values that the form is seeded from. A field that hosts an
-   * editor owning its own state keys on this. RHF reseeds in place, and such an editor
-   * has to mount again to read a new seed.
-   *
-   * It changes on a discard, and when the document changes under the form. Refer to
-   * FormProvider.
-   */
   seedKey: string;
-  /**
-   * Throw the edits away and put the form back on its baseline. The provider owns this,
-   * and not the store, because RHF and the mounted editors move with the store.
-   */
   discardEdits: () => void;
 }
 export const FormScopeContext = createContext<FormScope | null>(null);
 
-/**
- * The field scope. A field receives its address from `Field` (ADR-009).
- */
 export const FieldAddressContext = createContext<FieldAddress | null>(null);
 
-/**
- * The resolved schema node of the field, also passed by `Field`. It holds the config
- * that the field renders from. The declarative validation stays on the validation path.
- */
 export const FieldSchemaContext = createContext<FieldSchema | null>(null);

--- a/packages/v4/@tinacms/tinacms/src/editor/continuity.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/continuity.test.tsx
@@ -21,9 +21,6 @@ import {
 } from '../form/form-store';
 import { t } from '../index';
 
-// A pristine form has never been validated, so the store gives it no error map at all,
-// and not an empty one. Refer to form-store.ts. This narrowing keeps that shape, so no
-// assertion reaches through the union.
 const errorsOf = (forms: FormStore['forms'], formId: FormId) => {
   const scope = forms[formId];
   return isEdited(scope) ? scope.errors : undefined;
@@ -41,13 +38,8 @@ import {
   useFormStatus,
 } from './index';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
-// The same shape as the post collection of the playground. The min of 3 gives these
-// tests one validation failure to keep across a change of document. The max of 20 gives
-// a second failure. A test for a leak between forms needs two different messages.
 const collection: CollectionSchema = {
   name: 'post',
   format: 'mdx',
@@ -88,16 +80,10 @@ function DiscardProbe() {
   );
 }
 
-// The seed key is what a field hosting its own editor keys on, so a test that reads it
-// is testing that such a field would mount again. No string field needs it.
 function SeedKeyProbe() {
   return <span data-testid='seed'>{useFormSeedKey()}</span>;
 }
 
-// A host that keys its FormProvider, so a change of path tears the form down and hosts
-// the other document. The store keeps the edits. The admin shell no longer keys its
-// provider — it switches in place, which the unkeyed describe below covers — but a host
-// that remounts is still supported, and ADR-012 must hold for it.
 const host = (path: string, document: TinaDocument, onSave?: SaveHandler) => (
   <TinaProvider
     config={asResolvedConfig({
@@ -180,14 +166,11 @@ describe('form continuity across mounts', () => {
     await userEvent.type(inputB, ' two');
     await userEvent.click(screen.getByText('save'));
     await waitFor(() => expect(onSave).toHaveBeenCalledTimes(1));
-    // The document of B only. The save does not change the scope of A.
     expect(onSave).toHaveBeenCalledWith({ title: 'Doc B two' });
 
     rerender(host(pathA, { title: 'Doc A' }, onSave));
     const backOnA = await screen.findByLabelText('title');
     await waitFor(() => expect(backOnA).toHaveValue('x'));
-    // RHF derives no error from defaultValues, so this message is here only because
-    // the provider validated the kept edits again.
     await screen.findByText('Title must be at least 3 characters');
     expect(screen.getByTestId('status')).toHaveTextContent('dirty');
   });
@@ -198,9 +181,6 @@ describe('form continuity across mounts', () => {
     expect(input).toHaveValue('Old content');
     unmount();
 
-    // No one edited this form, so the kept scope is pristine. The remount must adopt
-    // the incoming document, because a pristine form is never stale. It must not
-    // serve the old mirror.
     render(host(pathA, { title: 'New content' }));
     const revisited = await screen.findByLabelText('title');
     await waitFor(() => expect(revisited).toHaveValue('New content'));
@@ -212,9 +192,6 @@ describe('form continuity across mounts', () => {
     await userEvent.type(await screen.findByLabelText('title'), ' edited');
     unmount();
 
-    // This remounts onto the kept edits, and the host then changes the document prop
-    // under the same path. The edits win, because the store does nothing for an
-    // edited form, and the seed follows.
     const { rerender } = render(host(pathA, { title: 'Doc A' }));
     const revisited = await screen.findByLabelText('title');
     await waitFor(() => expect(revisited).toHaveValue('Doc A edited'));
@@ -236,11 +213,6 @@ describe('form continuity across mounts', () => {
     );
     unmount();
 
-    // Record every error state that the scope of A passes through during the
-    // remount. The new RHF instance derives an empty map before its first trigger,
-    // and that must not clear the kept errors, not even for one render. Such a gap
-    // makes the badge flicker, and it loses the errors when the form unmounts inside
-    // it.
     const seen: unknown[] = [];
     const unsubscribe = useFormStore.subscribe((state, previous) => {
       const errors = errorsOf(state.forms, formIdA);
@@ -269,7 +241,6 @@ describe('form continuity across mounts', () => {
       )
     );
 
-    // A correct value clears the mirror through the same path.
     await userEvent.type(inputA, 'yz');
     await waitFor(() =>
       expect(
@@ -284,8 +255,6 @@ describe('form continuity across mounts', () => {
       )
     );
 
-    // A is torn down, and its mirrored errors are still readable while B is hosted.
-    // This is the case that the collection badge needs.
     rerender(host(pathB, { title: 'Doc B' }));
     await waitFor(() =>
       expect(screen.getByLabelText('title')).toHaveValue('Doc B')
@@ -296,8 +265,6 @@ describe('form continuity across mounts', () => {
   });
 });
 
-// There is no key here, so one FormProvider instance hosts the other path. This is the
-// harder change. Nothing remounts, and each part must hold by itself.
 const unkeyedHost = (
   path: string,
   document: TinaDocument,
@@ -329,7 +296,6 @@ describe('unkeyed document switches (same FormProvider instance)', () => {
     const input = await screen.findByLabelText('title');
     await userEvent.type(input, ' edited');
 
-    // The same content, and a different path. Only the form id separates the two.
     rerender(unkeyedHost(pathB, { title: 'Same' }, onSave));
     await waitFor(() =>
       expect(screen.getByLabelText('title')).toHaveValue('Same')
@@ -343,14 +309,12 @@ describe('unkeyed document switches (same FormProvider instance)', () => {
 
   it('a switch never bleeds the outgoing form’s errors into the incoming scope', async () => {
     const formIdB = toFormId(pathB);
-    // B waits unhosted with its own invalid kept edit and mirrored error.
     useFormStore.getState().registerForm(formIdB, { [title]: 'Doc B' });
     useFormStore.getState().setFieldValue(formIdB, title, 'xy');
     useFormStore.getState().setFieldErrors(formIdB, {
       [title]: ['Title must be at least 3 characters'],
     });
 
-    // A carries a different error, max and not min, so a leak between the two shows.
     const { rerender } = render(unkeyedHost(pathA, { title: 'Doc A' }));
     const inputA = await screen.findByLabelText('title');
     await userEvent.type(inputA, ' with far too long a title');
@@ -372,7 +336,6 @@ describe('unkeyed document switches (same FormProvider instance)', () => {
     await screen.findByText('Title must be at least 3 characters');
     unsubscribe();
 
-    // The scope of B never held the error of A, and nothing cleared it.
     expect(
       seen.every(
         (errors) =>
@@ -384,13 +347,10 @@ describe('unkeyed document switches (same FormProvider instance)', () => {
     expect(errorsOf(useFormStore.getState().forms, formIdB)?.[title]).toEqual([
       'Title must be at least 3 characters',
     ]);
-    // The error of A is still on A.
     expect(
       errorsOf(useFormStore.getState().forms, toFormId(pathA))?.[title]
     ).toContain('Title must be at most 20 characters');
 
-    // The mirror works under the new owner. A new edit in B reaches the mirror. The
-    // ownership guard skips one run, and never the stream.
     const inputB = screen.getByLabelText('title');
     await userEvent.clear(inputB);
     await userEvent.type(inputB, 'now far too long for the max rule');
@@ -420,10 +380,6 @@ describe('useFormValues', () => {
   });
 });
 
-// Discarding an edit has to move three things at once: the store, RHF, and any editor
-// that owns its state. The last of those cannot be reset in place, so it keys on the seed
-// and mounts again. A string field needs none of that, so these tests read the seed key
-// directly — the rich-text e2e is what proves an editor follows it.
 describe('discarding edits', () => {
   it('puts RHF and the store back on the loaded content, under a new seed', async () => {
     render(host(pathA, { title: 'Hello' }));
@@ -435,7 +391,6 @@ describe('discarding edits', () => {
     await userEvent.click(screen.getByText('discard'));
 
     await waitFor(() => expect(input).toHaveValue('Hello'));
-    // Pristine, and not clean: a discarded form is the form a fresh load would give.
     expect(screen.getByTestId('status')).toHaveTextContent('pristine');
     expect(screen.getByTestId('seed').textContent).not.toBe(seed);
   });
@@ -498,7 +453,6 @@ describe('discarding edits', () => {
       expect(screen.getByLabelText('title')).toHaveValue('Doc B')
     );
 
-    // A's edits are its own. Discarding B did not touch them.
     rerender(host(pathA, { title: 'Doc A' }));
     await waitFor(() =>
       expect(screen.getByLabelText('title')).toHaveValue('Doc A edited')

--- a/packages/v4/@tinacms/tinacms/src/editor/field-errors.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/field-errors.ts
@@ -6,8 +6,6 @@ export interface FieldErrorEntry {
 
 export const toFieldErrorEntry = (messages: string[]): FieldErrorEntry => ({
   type: 'validation',
-  // The FieldError of RHF holds one `message`, which is the first error. The `types`
-  // member holds the full list, and useFieldErrors returns all of them.
   message: messages[0],
   types: Object.fromEntries(
     messages.map((message, index) => [String(index), message])

--- a/packages/v4/@tinacms/tinacms/src/editor/field.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/field.tsx
@@ -35,17 +35,6 @@ export function Field({ address }: FieldProps) {
 
   const fieldAddress = toFieldAddress(address);
 
-  // Focus in the form is a producer of the active field, beside the click in the
-  // preview. It sits here, on the one wrapper every field shares, so no field plugin
-  // carries it. It writes the store directly, as the preview connection does, because
-  // this component must not re-render on the value it writes.
-  //
-  // The guard is necessary. An activation focuses the field, and that focus arrives
-  // back here. An unguarded write would then hand every activation a second entry,
-  // and every consumer of the entry would run twice. A focus on the field that is
-  // already active therefore writes nothing. The re-activation path keeps its
-  // semantics, because setActive itself stays unguarded: activating the same address
-  // again is a new entry, and focuses the field again.
   const markActive = () => {
     const { active, setActive } = useFormStore.getState();
     if (active?.formId === scope.formId && active.address === fieldAddress) {
@@ -58,8 +47,6 @@ export function Field({ address }: FieldProps) {
   return (
     <FieldAddressContext value={fieldAddress}>
       <FieldSchemaContext value={node}>
-        {/* display: contents, because this wrapper exists for the focus listener
-            alone. It must not become a box in the layout of the form. */}
         <div style={{ display: 'contents' }} onFocus={markActive}>
           <Component />
         </div>

--- a/packages/v4/@tinacms/tinacms/src/editor/form-save.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/form-save.test.tsx
@@ -18,8 +18,6 @@ import {
   useFormStatus,
 } from './index';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -86,14 +84,6 @@ describe('useFormSave', () => {
   });
 });
 
-// A field whose value is a structure, and not a primitive. It uses a plain input, so a
-// test can simulate the edit. The rich-text field is the real case, but Plate needs a
-// browser to accept a keystroke, and the fault has nothing to do with Plate.
-//
-// The regression: the store reads the formState subscription of RHF, which sends a clone
-// of each value, but markSaved keeps the values that RHF holds as the baseline. Two
-// primitives compare equal across that split under `Object.is`. Two structures never do,
-// so the form stayed dirty through every save.
 const structureFieldPlugin = definePlugin({
   name: 'test:field:structure',
   provides: ['field'],
@@ -102,8 +92,6 @@ const structureFieldPlugin = definePlugin({
     default: {
       field: {
         Component: StructureField,
-        // This matches the rich-text field. The stored value is a string, the editor
-        // value is a structure, and each edit makes a new object.
         parse: (stored: unknown) => ({ text: String(stored ?? '') }),
         serialize: (value: unknown) => (value as { text: string }).text,
       },

--- a/packages/v4/@tinacms/tinacms/src/editor/form-store-wiring.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/form-store-wiring.test.tsx
@@ -13,8 +13,6 @@ import {
   useFormStatus,
 } from './index';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -52,8 +50,6 @@ describe('FormProvider form-store wiring', () => {
     await userEvent.type(input, '!');
     expect(screen.getByTestId('status')).toHaveTextContent('dirty');
 
-    // Back to the registered baseline. This proves that the status is a comparison,
-    // and not a flag.
     await userEvent.type(input, '{backspace}');
     expect(screen.getByTestId('status')).toHaveTextContent('clean');
   });

--- a/packages/v4/@tinacms/tinacms/src/editor/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/index.ts
@@ -1,20 +1,5 @@
-// The browser entry, `tinacms/react`. The host of the admin UI imports it, and so do the
-// client segments of the plugins. It must not import the server adapters, which are
-// next, express, astro, and hono, in the adapters/ folder.
-//
-// It holds the provider, the `<Field>` primitive that resolves a component (ADR-009),
-// the form hooks keyed by address (ADR-010), and the editor half of visual editing. That
-// half is usePreviewConnection, and the site half sits on the ./preview entry.
-// react-hook-form renders the field values. The form state store owns the pristine,
-// dirty, and clean status.
 
 export { type FieldAddress, toFieldAddress } from '../core/field/address';
-// The read-only surface of the form store. It gives the pristine, dirty, and clean
-// status, and the mirror of the values and the errors of any open form. useFormValues
-// and useFormErrors read that mirror, so a collection indicator works whether or not the
-// form is mounted. The store handle and its write functions stay inside the package,
-// because the editor owns the writes. A plugin client segment therefore cannot write the
-// form state (ADR-010 §6).
 export {
   type FieldErrors,
   type FormId,
@@ -38,9 +23,6 @@ export {
   type PreviewConnectionOptions,
   usePreviewConnection,
 } from './preview-connection';
-// The cache over the content capability. A plugin's client segment reads content
-// through these, and not through the slice: the slice is a transport, and these hold
-// the deduplication, the staleness policy, and the save's write-back.
 export {
   type CollectionDocuments,
   CONTENT_STALE_TIME,

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.test.tsx
@@ -23,8 +23,6 @@ import { FormScopeContext } from './context';
 import { Field, FormProvider, TinaProvider } from './index';
 import { usePreviewConnection } from './preview-connection';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -35,7 +33,6 @@ const collection: CollectionSchema = {
 const path = 'content/posts/preview.mdx';
 const formId = toFormId(path);
 
-// This stands in for the iframe. usePreviewConnection reads contentWindow only.
 const fakeIframe = () => {
   const contentWindow = { postMessage: vi.fn() };
   return {
@@ -55,8 +52,6 @@ function Connection({
   return null;
 }
 
-// The MessageEvent constructor of happy-dom does not always carry the origin and the
-// source, so this sets them. connection.test.ts uses the same helper.
 const messageFromPreview = (
   data: unknown,
   source: unknown,
@@ -170,8 +165,6 @@ describe('usePreviewConnection', () => {
 
   it('a ready before any form registers is silent until registration answers it', async () => {
     const iframe = fakeIframe();
-    // There is no <Field> here. This drives the hook against a store that is empty
-    // after the mount.
     function Bare() {
       const ref = useRef<HTMLIFrameElement | null>(null);
       ref.current = iframe.ref.current;
@@ -190,7 +183,6 @@ describe('usePreviewConnection', () => {
         </FormProvider>
       </TinaProvider>
     );
-    // TinaProvider mounts its children after the plugins resolve, so wait for that.
     await screen.findByText('bare');
     act(() => {
       useFormStore.setState({ forms: {}, active: null });
@@ -199,8 +191,6 @@ describe('usePreviewConnection', () => {
     messageFromPreview(readyMessage(), iframe.ref.current?.contentWindow);
     expect(iframe.postMessage).not.toHaveBeenCalled();
 
-    // The recovery. The registration fires the post from the subscription, so the
-    // early ready message needs no answer.
     act(() => {
       useFormStore
         .getState()
@@ -245,11 +235,6 @@ describe('usePreviewConnection', () => {
     await screen.findByLabelText('title');
     iframe.postMessage.mockClear();
 
-    // The iframe stays across the change, so there is no new ready message. The
-    // store also does nothing when an edited scope registers again. The post at
-    // connect time is therefore the only way to move the preview. The waitFor call
-    // also flushes the validation that the provider runs when it adopts the kept
-    // edits, which keeps act quiet.
     rerender(tree(otherPath));
     await waitFor(() =>
       expect(iframe.postMessage).toHaveBeenCalledWith(
@@ -261,8 +246,6 @@ describe('usePreviewConnection', () => {
 
   it("rejects '*' as targetOrigin at construction", () => {
     const iframe = fakeIframe();
-    // A FormScopeContext alone is enough. The invariant throws in the body of the
-    // hook, before an effect needs the runtime.
     const wrapper = ({ children }: { children: ReactNode }) => (
       <FormScopeContext
         value={{

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
@@ -10,30 +10,15 @@ import {
 import { useFormId } from './hooks';
 
 export interface PreviewConnectionOptions {
-  // The origin of the preview iframe. It defaults to the origin of the editor. A
-  // cross-origin embed is an explicit choice, and is never '*'.
   targetOrigin?: string;
 }
 
-// The editor half of visual editing (the v4 part of #6944). It streams the values of
-// the hosted form into the preview iframe, and it activates the field that a preview
-// click names. The form store is the source for the wire, and RHF is not. The store
-// replaces the `values` object at each registerForm and setFieldValue, and keeps it at
-// each markSaved and setActive. A reference compare therefore posts on a value change
-// alone. That includes the registration, which also covers a ready message that arrives
-// before the form exists. A values message carries the whole state, so a second message
-// does no harm and there is no send queue. Every ready message gets the current values,
-// which covers a reload of the iframe. A new connection posts the current scope, which
-// covers a move to a form that was already edited. This hook must sit under a
-// FormProvider, and the invariant in useFormId reports it otherwise.
 export function usePreviewConnection(
   iframeRef: RefObject<HTMLIFrameElement | null>,
   options?: PreviewConnectionOptions
 ): void {
   const formId = useFormId();
   const targetOrigin = options?.targetOrigin ?? window.origin;
-  // This check runs at construction. A '*' origin would stream the values of the
-  // document to any window that embeds the editor.
   invariant(
     targetOrigin !== '*',
     'preview-target-origin-wildcard',
@@ -46,8 +31,6 @@ export function usePreviewConnection(
       target()?.postMessage(valuesMessage(toDocument(values)), targetOrigin);
 
     const onMessage = (event: MessageEvent) => {
-      // The null check is necessary. With no iframe mounted, target() returns null,
-      // which would equal the null source of a stray message from the same origin.
       const source = target();
       if (!source || event.origin !== targetOrigin || event.source !== source)
         return;
@@ -55,9 +38,6 @@ export function usePreviewConnection(
         const scope = useFormStore.getState().forms[formId];
         if (scope) postValues(scope.values);
       } else if (isActivateMessage(event.data)) {
-        // The store directly, and not useActiveField. This hook writes the active
-        // field and never reads it, so subscribing would re-render the pane that
-        // holds the iframe on every activation for a value it does not use.
         useFormStore
           .getState()
           .setActive(formId, toFieldAddress(event.data.address));

--- a/packages/v4/@tinacms/tinacms/src/editor/resolver.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/resolver.ts
@@ -18,9 +18,6 @@ export const buildFormResolver =
         errors[node.name] = toFieldErrorEntry(fieldErrors);
       }
     }
-    // The resolver contract of RHF returns { values, errors }. After a failure,
-    // errors holds the field errors and values is empty. After a success, errors is
-    // empty and the values pass through.
     return Object.keys(errors).length > 0
       ? { values: {}, errors }
       : { values, errors: {} };

--- a/packages/v4/@tinacms/tinacms/src/form/form-store.hooks.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/form/form-store.hooks.test.tsx
@@ -9,10 +9,6 @@ import {
   useIsFormDirty,
 } from './form-store';
 
-// The exported hooks are the public surface of the store, and editor/index.ts re-exports
-// them. The getState() tests cover the reducer logic. These tests prove that the Zustand
-// selector subscribes, and that a consumer renders again when the status of the form
-// changes.
 const title = toFieldAddress('title');
 const postA = toFormId('posts/a.mdx');
 

--- a/packages/v4/@tinacms/tinacms/src/form/form-store.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/form/form-store.test.ts
@@ -34,7 +34,6 @@ describe('form-store registration', () => {
   it('re-registering an edited form keeps in-progress edits', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
     store.getState().setFieldValue(postA, title, 'Edited');
-    // A remount registers the original values again. The live edit must survive that.
     store.getState().registerForm(postA, { [title]: 'Hello' });
     expect(store.getState().forms[postA].values[title]).toBe('Edited');
     expect(statusOf(postA)).toBe('dirty');
@@ -70,16 +69,10 @@ describe('form-store dirty tracking', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
     store.getState().setFieldValue(postA, subtitle, 'x');
     expect(statusOf(postA)).toBe('dirty');
-    // RHF emits undefined when a field clears. An absent key and an undefined value
-    // are one state, because JSON cannot hold "present but undefined". This must
-    // therefore read clean.
     store.getState().setFieldValue(postA, subtitle, undefined);
     expect(statusOf(postA)).toBe('clean');
   });
 
-  // A composite value arrives as a fresh object on every edit, so a reference test
-  // holds it dirty for ever. The default equality compares structure, which is what
-  // makes the revert below read clean. Refer to sameValue in core/form/compare.ts.
   it('an object value that is edited and reverted is clean, not dirty', () => {
     const hero = toFieldAddress('hero');
     store.getState().registerForm(postA, { [hero]: { heading: 'Hello' } });
@@ -87,7 +80,6 @@ describe('form-store dirty tracking', () => {
     expect(statusOf(postA)).toBe('dirty');
     expect(fieldDirty(store.getState().forms[postA], hero)).toBe(true);
 
-    // A new object, equal to the baseline in structure alone.
     store.getState().setFieldValue(postA, hero, { heading: 'Hello' });
     expect(statusOf(postA)).toBe('clean');
     expect(fieldDirty(store.getState().forms[postA], hero)).toBe(false);
@@ -114,7 +106,6 @@ describe('form-store save reset', () => {
     store.getState().markSaved(postA);
     expect(statusOf(postA)).toBe('clean');
 
-    // The baseline is the saved value, so a return to the original value is dirty.
     store.getState().setFieldValue(postA, title, 'Hello');
     expect(statusOf(postA)).toBe('dirty');
   });
@@ -124,22 +115,15 @@ describe('form-store save reset', () => {
     store.getState().setFieldValue(postA, title, 'Saved value');
     const snapshot = { ...store.getState().forms[postA].values };
 
-    // An edit typed during the save. The baseline is the snapshot, and not the
-    // current values, so the newer edit still reads dirty.
     store.getState().setFieldValue(postA, title, 'Newer edit');
     store.getState().markSaved(postA, snapshot);
     expect(statusOf(postA)).toBe('dirty');
 
-    // Reverting to what was actually saved is clean against the new baseline.
     store.getState().setFieldValue(postA, title, 'Saved value');
     expect(statusOf(postA)).toBe('clean');
   });
 });
 
-// The store reads the formState subscription of RHF, which sends a clone of each value,
-// but markSaved keeps the values that RHF holds as the baseline. Two primitives compare
-// equal across that split. Two structures never do by reference, so a saved rich-text
-// document stayed dirty for ever until the comparison became structural.
 describe('form-store structural value equality', () => {
   const body = toFieldAddress('body');
   const ast = () => ({
@@ -160,7 +144,6 @@ describe('form-store structural value equality', () => {
     store.getState().setFieldValue(postA, body, edited);
     expect(statusOf(postA)).toBe('dirty');
 
-    // A different object holding the same content, as markSaved receives.
     const savedClone = JSON.parse(JSON.stringify(edited));
     store.getState().markSaved(postA, { [body]: savedClone });
     expect(statusOf(postA)).toBe('clean');
@@ -175,11 +158,6 @@ describe('form-store structural value equality', () => {
   });
 });
 
-// A field whose editor value is richer than its stored form answers for itself, through
-// isEqual on its descriptor (core/form/compare.ts). The rich-text field is the one that
-// does today: Plate adds an id to every node, so the tree in the editor never matches the
-// tree parsed from the file, and structure alone would hold such a document dirty for
-// ever. The equality here stands in for that, so this test needs no editor.
 describe('form-store field-supplied equality', () => {
   const body = toFieldAddress('body');
   type Body = { source: string; editorOnly: number };
@@ -208,8 +186,6 @@ describe('form-store field-supplied equality', () => {
     expect(statusOf(postA)).toBe('dirty');
     expect(fieldDirty(store.getState().forms[postA], body)).toBe(true);
 
-    // What the editor gives back is never the tree it was given, so this undo carries
-    // its own noise. Only the field can tell that the document is back where it was.
     store.getState().setFieldValue(postA, body, withSource('Prose.', 2));
     expect(statusOf(postA)).toBe('clean');
     expect(fieldDirty(store.getState().forms[postA], body)).toBe(false);
@@ -236,9 +212,6 @@ describe('form-store field-supplied equality', () => {
 });
 
 describe('form-store error mirror', () => {
-  // The `errors` map exists only on an edited scope. A pristine form has never been
-  // validated, so the store gives it no error map at all, and not an empty one. This
-  // narrowing asserts against the real shape.
   const scope = () => store.getState().forms[postA];
   const errorsOf = () => {
     const current = scope();
@@ -269,13 +242,9 @@ describe('form-store error mirror', () => {
     store.getState().setFieldErrors(postA, { [title]: ['Too short'] });
     const before = scope();
 
-    // The same content in new arrays. RHF builds these again at each keystroke.
     store.getState().setFieldErrors(postA, { [title]: ['Too short'] });
     expect(scope()).toBe(before);
 
-    // A write that differs replaces the errors, and it must keep the values
-    // reference. An error write must not look like a value change to the preview
-    // wire.
     store.getState().setFieldErrors(postA, {});
     expect(scope().values).toBe(before.values);
   });
@@ -334,8 +303,6 @@ describe('form-store discarded edits', () => {
 
     store.getState().discardEdits(postA);
     expect(store.getState().forms[postA].values[title]).toBe('Hello');
-    // Pristine, and not clean. A discarded form is the form a fresh load would give,
-    // so a remount adopts new content rather than keeping this one.
     expect(statusOf(postA)).toBe('pristine');
   });
 
@@ -424,7 +391,6 @@ describe('form-store reference stability', () => {
     store.getState().registerForm(postA, { [title]: 'Hello' });
     const before = store.getState().forms[postA];
     store.getState().setFieldValue(postA, title, 'Hello');
-    // Nothing changed. The scope is the same object, and it is still pristine.
     expect(store.getState().forms[postA]).toBe(before);
     expect(statusOf(postA)).toBe('pristine');
   });

--- a/packages/v4/@tinacms/tinacms/src/form/form-store.ts
+++ b/packages/v4/@tinacms/tinacms/src/form/form-store.ts
@@ -11,22 +11,6 @@ import {
 import { invariant } from '../core/invariant';
 import type { TinaDocument } from '../core/schema/types';
 
-// The form state store (ADR-010, issue #6909). It holds the status of each open
-// document: pristine, dirty, or clean. Save controls, navigation warnings, and the
-// editor indicators all read the status from here.
-//
-// Each open form keeps a flat map of values, keyed by its form id. After the first
-// edit, the store compares those values with a baseline. The baseline is the content
-// the form loaded, or the content it last saved. Open forms do not overwrite each
-// other, because each one has its own form id.
-//
-// RHF owns the values and the errors inside a mounted form. This store keeps a
-// one-way mirror of both, and the provider is the only writer. The mirror outlives
-// the mount, so a return to the form keeps the unsaved edits. Everything outside RHF
-// reads the mirror. The structure index (ADR-010) arrives with the composite fields.
-
-// There is one form per document (ADR-010), so the form id is the document path. The
-// brand keeps it distinct from a field address and from a plain string.
 export type FormId = Brand<string, 'FormId'>;
 
 export const toFormId = (path: string): FormId => {
@@ -38,12 +22,8 @@ export const toFormId = (path: string): FormId => {
   return path as FormId;
 };
 
-// The brand stops a plain string from seeding or indexing the values of a form.
 export type FormValues = Record<FieldAddress, unknown>;
 
-// The constructor for FormValues. It brands the keys of a flat document as field
-// addresses. It handles flat addresses only, which is what the editor field hooks
-// assume. Composite fields will need a path walk here.
 export const toFormValues = (document: TinaDocument): FormValues => {
   const values: FormValues = {};
   for (const [name, value] of Object.entries(document)) {
@@ -52,26 +32,12 @@ export const toFormValues = (document: TinaDocument): FormValues => {
   return values;
 };
 
-// The inverse of toFormValues. A flat address is a field name today, so the document
-// is a key-for-key copy.
 export const toDocument = (values: FormValues): TinaDocument => ({ ...values });
 
 export type FormStatus = 'pristine' | 'dirty' | 'clean';
 
-// The validation messages for each address, mirrored from RHF. RHF derives them, and
-// they exist only on an edited form. RHF validates on change, so a pristine form has
-// no errors yet.
 export type FieldErrors = Partial<Record<FieldAddress, string[]>>;
 
-// One open document's form. A pristine form has no baseline, because its values are
-// the baseline. A baseline appears when the form is edited or saved. The store then
-// compares the values with the baseline to tell dirty from clean. This shape makes a
-// pristine form with a different baseline impossible to build.
-// The name is OpenForm, not FormScope. FormScope is the form context of the editor in
-// editor/context.ts.
-// The `equal` of a form arrives with it, from the host that registered it, because the
-// answer belongs to the fields and the store holds no field registry. Refer to
-// core/form/compare.ts.
 type OpenForm =
   | {
       readonly status: 'pristine';
@@ -86,25 +52,14 @@ type OpenForm =
       readonly equal: FieldEquality;
     };
 
-// The only place that compares the discriminant. Every consumer calls this instead.
 export const isEdited = (
   scope: OpenForm | undefined
 ): scope is Extract<OpenForm, { status: 'edited' }> =>
   scope?.status === 'edited';
 
 export interface FormStore {
-  // Keyed by form id, so a missing key is a form that is not open.
   forms: Partial<Record<FormId, OpenForm>>;
-  // The one active field across all open forms (ADR-009, visual editing). A click in
-  // the preview activates a single field, and that field then focuses itself with
-  // useFieldActivation. It sits on the store, not on the form, because activation
-  // does not depend on the dirty state.
   active: { formId: FormId; address: FieldAddress } | null;
-  // Seed a form with the values it loaded. A second call on an edited form does
-  // nothing, so a return to the form keeps the unsaved edits (ADR-012). A second call
-  // on a pristine form adopts the new content, so a reload is never stale.
-  // The `equal` is the equality of this form's fields, from fieldEqualityFor. Without
-  // it, every field of the form compares as structure.
   registerForm: (
     formId: FormId,
     values: FormValues,
@@ -115,21 +70,10 @@ export interface FormStore {
     address: FieldAddress,
     value: unknown
   ) => void;
-  // The only write path for the error mirror. It replaces the whole map. The provider
-  // calls it each time RHF derives the errors again. It does nothing for a pristine
-  // form, and nothing for an equal map.
   setFieldErrors: (formId: FormId, errors: FieldErrors) => void;
   setActive: (formId: FormId, address: FieldAddress | null) => void;
-  // After a save, move the baseline to the values that were saved. The status becomes
-  // clean. The caller passes the snapshot it saved, so an edit made during the save
-  // stays dirty. Without a snapshot, the current values become the baseline.
   markSaved: (formId: FormId, savedValues?: FormValues) => void;
-  // Throw the edits away and put the form back on its baseline: the content it loaded,
-  // or the content it last saved. The form becomes pristine, and its mirrored errors go
-  // with the edits that raised them, because this is the form a fresh load would give.
-  // The host resets RHF alongside it. Refer to discardEdits in editor/provider.tsx.
   discardEdits: (formId: FormId) => void;
-  // Close the form and drop its state.
   removeForm: (formId: FormId) => void;
 }
 
@@ -138,10 +82,6 @@ const valuesEqual = (
   baseline: FormValues,
   equal: FieldEquality
 ): boolean => {
-  // Compare the union of both key sets, so an undefined value equals an absent key.
-  // JSON cannot hold "present but undefined", and a controlled input clears to
-  // undefined. The two are one state.
-  // Object.keys drops the brand. These keys arrived as field addresses.
   const keys = new Set([
     ...Object.keys(current),
     ...Object.keys(baseline),
@@ -156,8 +96,6 @@ export const formStatus = (scope: OpenForm | undefined): FormStatus => {
     : 'dirty';
 };
 
-// The dirty test for one field, behind the exported useIsFieldDirty. It compares
-// values like valuesEqual, and for the same reason.
 export const fieldDirty = (
   scope: OpenForm | undefined,
   address: FieldAddress
@@ -166,19 +104,9 @@ export const fieldDirty = (
     ? !scope.equal(address, scope.values[address], scope.baseline[address])
     : false;
 
-// RHF builds new message arrays each time it derives the errors. This compares their
-// content, so an unchanged write does not disturb the subscribers. The maps hold
-// arrays of strings, so JSON is safe here. A different key order costs one more write.
 const errorsEqual = (current: FieldErrors, next: FieldErrors): boolean =>
   JSON.stringify(current) === JSON.stringify(next);
 
-// Zustand composes its middleware at create() time. This store uses devtools only,
-// which sends the status changes to the Redux DevTools extension. Without the
-// extension, in production and in the tests, devtools does nothing. The store does
-// not use persist, because it loads the values from the document at each boot.
-//
-// The names below are the title of the store and its action labels in the DevTools
-// timeline. They are declared once, so the call sites cannot drift.
 const DEVTOOLS_STORE_NAME = 'TinaFormStore';
 const DEVTOOLS_ACTION = {
   register: 'form/register',
@@ -195,9 +123,6 @@ type DevtoolsActionLabel =
 export const useFormStore = create<FormStore>()(
   devtools(
     (set) => {
-      // Apply a labelled patch to the state. It calls the Zustand set(partial,
-      // replace, action) with replace set to false. Every action merges its patch
-      // into the state, and no action replaces the whole store.
       const apply = (
         patch: (state: FormStore) => FormStore | Partial<FormStore>,
         action: DevtoolsActionLabel
@@ -210,8 +135,6 @@ export const useFormStore = create<FormStore>()(
         registerForm: (formId, values, equal = STRUCTURAL_EQUALITY) =>
           apply((state) => {
             // TODO(v4): the edited state also covers a clean form, so a clean form
-            // does not adopt new content on a reload. The draft slice will choose
-            // between the new content and the kept edits.
             if (isEdited(state.forms[formId])) return state;
             return {
               forms: {
@@ -225,27 +148,16 @@ export const useFormStore = create<FormStore>()(
           apply((state) => {
             const scope = state.forms[formId];
             if (!scope) return state;
-            // A write that the document would not see does nothing, because a
-            // controlled input fires onChange again with the same value, and Plate
-            // rewrites its tree on a click alone. A field must send a new value, and
-            // must not change a value in place. This test drops a value that was
-            // changed in place.
             if (scope.equal(address, scope.values[address], value))
               return state;
-            // The first edit keeps the pristine values as the baseline.
             return {
               forms: {
                 ...state.forms,
                 [formId]: {
-                  // Spread, so a rebuild carries the `equal` of the form rather
-                  // than relisting it. A rebuild that forgot it would silently
-                  // compare every field of the form as structure.
                   ...scope,
                   status: 'edited',
                   values: { ...scope.values, [address]: value },
                   baseline: isEdited(scope) ? scope.baseline : scope.values,
-                  // A value write leaves the errors alone. RHF derives them
-                  // again, and setFieldErrors then updates the mirror.
                   errors: isEdited(scope) ? scope.errors : {},
                 },
               },
@@ -255,12 +167,8 @@ export const useFormStore = create<FormStore>()(
         setFieldErrors: (formId, errors) =>
           apply((state) => {
             const scope = state.forms[formId];
-            // A pristine form has no errors to mirror. RHF validates on change, so
-            // it derives no errors before the first edit.
             if (!isEdited(scope)) return state;
             if (errorsEqual(scope.errors, errors)) return state;
-            // Keep the values and the baseline references. An error write must not
-            // look like a value change to the preview wire or to the dirty test.
             return {
               forms: {
                 ...state.forms,
@@ -286,7 +194,6 @@ export const useFormStore = create<FormStore>()(
                   ...scope,
                   status: 'edited',
                   baseline: savedValues ?? scope.values,
-                  // A save changes no values, so it changes no errors.
                   errors: isEdited(scope) ? scope.errors : {},
                 },
               },
@@ -296,8 +203,6 @@ export const useFormStore = create<FormStore>()(
         discardEdits: (formId) =>
           apply((state) => {
             const scope = state.forms[formId];
-            // A form with no edits has nothing to discard. That covers a pristine
-            // form, and a form that is not open at all.
             if (!isEdited(scope)) return state;
             return {
               forms: {
@@ -326,11 +231,6 @@ export const useFormStore = create<FormStore>()(
   )
 );
 
-// A read of the store that does not subscribe, for the places that need the current
-// state and not a render on every change. Callers use this rather than
-// useFormStore.getState() when the read happens during a render: the hook is a value
-// there and not a call, which breaks the rules of React and makes the React Compiler
-// skip the whole component. At module scope it is a plain read.
 export const readFormStore = (): FormStore => useFormStore.getState();
 
 export const useFormStatus = (formId: FormId): FormStatus =>
@@ -344,11 +244,6 @@ export const useIsFieldDirty = (
   address: FieldAddress
 ): boolean => useFormStore((state) => fieldDirty(state.forms[formId], address));
 
-// The live values of any open form, mounted or not. The chrome, the collection views,
-// and the panels read the mirror. They do not touch the RHF instance of the form. The
-// selector returns a stable reference to the values. The memo then gives the caller a
-// stable document for each real change. This package ships its source, so a consumer
-// that holds the document in a dependency list sees this hook as written.
 export const useFormValues = (formId: FormId): TinaDocument | undefined => {
   const values = useFormStore((state) => state.forms[formId]?.values);
   return useMemo(() => (values ? toDocument(values) : undefined), [values]);
@@ -356,8 +251,6 @@ export const useFormValues = (formId: FormId): TinaDocument | undefined => {
 
 const NO_FIELD_ERRORS: FieldErrors = {};
 
-// The mirrored errors of any open form. A pristine form and an unopened form both
-// give an empty map. A collection view uses this to mark a document that has errors.
 export const useFormErrors = (formId: FormId): FieldErrors =>
   useFormStore((state) => {
     const scope = state.forms[formId];

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -1,14 +1,3 @@
-// The universal entry. The client code, the server code, and the framework adapters all
-// import it. It must not import from ./react, ./client, ./server, or ./adapters.
-//
-// It holds the surface for the config and the schema (ADR-024): definePlugin, the `t`
-// schema helpers, and the public contract types. Each field type supplies its own
-// `t.<type>` builder from its plugin. This entry is the composition root.
-
-// The schema compile is pure, and it runs in Node, because it reads the manifests and
-// never the segments. It therefore sits in the universal entry, next to the config that
-// it compiles. loadTinaConfig does not sit here. It needs Vite to resolve the TypeScript
-// of the user, so it stays on the build side.
 export {
   type LockCheck,
   LOCK_VERSION,

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.test.ts
@@ -90,8 +90,6 @@ describe('graphql (the v3 pipeline)', () => {
       title: 'Renamed',
       featured: true,
     });
-    // The query selects the body only, so the whole object must survive the round
-    // trip.
     const after = await dataLayer.graphql(query);
     expect(after.data).toEqual(before.data);
   });
@@ -107,9 +105,6 @@ describe('graphql (the v3 pipeline)', () => {
   });
 });
 
-// v3 indexes one extension for each collection, so a collection with mixed formats is
-// fully editable and only partly queryable. This test states that limit, so no one has
-// to find it in an empty query result.
 describe('a mixed-format collection through the v3 pipeline', () => {
   let mixed: LocalDataLayer;
   let warn: ReturnType<typeof vi.spyOn>;

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql-pipeline.ts
@@ -1,8 +1,6 @@
-// The v3 content pipeline, hosted by the local data layer. It runs in Node only. It is
-// the same Database and resolve stack from @tinacms/graphql that the v3 CLI ran. It
-// indexes the local files into an abstract-level store, through the sqlite-level adapter
-// that this project maintains. Every v3 GraphQL query therefore still works against the
-// content that v4 manages.
+// The v3 content pipeline, hosted by the local data layer (Node only): the same
+// Database and resolve stack from @tinacms/graphql, so every v3 GraphQL query
+// still works against the content v4 manages.
 
 import {
   FilesystemBridge,
@@ -22,36 +20,20 @@ export type GraphQLVariables = Record<string, unknown>;
 export interface GraphQLPipelineOptions {
   rootDir: string;
   collections: CollectionSchema[];
-  /**
-   * Any abstract-level store. It defaults to an in-memory sqlite-level store. Pass a
-   * store backed by a file to keep the index across restarts.
-   */
+  // Defaults to in-memory sqlite-level; pass a file-backed store to keep the
+  // index across restarts.
   level?: Level;
 }
 
 export interface GraphQLPipeline {
-  /**
-   * Run one v3 GraphQL request. It returns the standard `{ data, errors }` object.
-   */
   execute(query: string, variables?: GraphQLVariables): Promise<GraphQLResult>;
-  /**
-   * Index the saved documents again, so that the next execute sees them. The paths are
-   * posix paths from the project root.
-   */
+  // Paths are posix paths from the project root.
   reindexPaths(paths: string[]): Promise<void>;
 }
 
-/**
- * One v4 field, in the shape that the v3 schema builder reads.
- *
- * The schema validation of v3 rejects an unknown key, so only the properties that both
- * models share cross over. A property that belongs to v4 alone stays out. The validation
- * rules and the UI config are two examples.
- *
- * `templates` crosses over too. v3 models it under the same name. Without it, a body
- * that holds an embed indexes as MDX that the v3 parser cannot read, while the editor
- * renders that same body correctly.
- */
+// v3 schema validation rejects unknown keys, so only shared properties cross
+// over. `templates` must cross: without it a body holding an embed indexes as
+// MDX the v3 parser cannot read.
 const toV3Field = (field: FieldSchema) => ({
   type: field.type,
   name: field.name,
@@ -61,16 +43,9 @@ const toV3Field = (field: FieldSchema) => ({
   ...(field.templates ? { templates: field.templates } : {}),
 });
 
-/**
- * One v4 collection, in the shape that the v3 schema builder reads.
- *
- * v3 holds one format for each collection. It globs for `${path}/**.${format}`, and it
- * then compares the extension of each candidate file. Only the primary format therefore
- * reaches the index. A collection with mixed formats is fully editable, because the file
- * provider dispatches for each file, but it is only partly queryable.
- * warnUnindexedFormats reports that, instead of a half-index with no message. This ends
- * when v4 owns its index.
- */
+// v3 holds one format per collection, so only the primary format reaches the
+// index: a mixed collection is fully editable but only partly queryable, and
+// warnUnindexedFormats says so. Ends when v4 owns its index.
 const toV3Collection = (collection: CollectionSchema) => ({
   name: collection.name,
   label: collection.label,
@@ -107,19 +82,13 @@ export const createGraphQLPipeline = async (
   });
   const schema = { collections: options.collections.map(toV3Collection) };
   const { graphQLSchema, tinaSchema, lookup } = await buildDotTinaFiles({
-    /**
-     * buildDotTinaFiles reads config.schema only. The full v3 Config, with the branch,
-     * the client id, and the media, has no local equivalent.
-     */
+    // buildDotTinaFiles reads config.schema only.
     config: { schema },
     buildSDK: false,
   });
   await database.indexContent({ graphQLSchema, tinaSchema, lookup });
-  /**
-   * The queue of index runs. A reindex runs alone. Two saves at the same time must not
-   * interleave a read, a change, and a write on the shared index. A failed run does not
-   * block the next one.
-   */
+  // Serialises index runs: two saves must not interleave on the shared index.
+  // A failed run does not block the next one.
   let indexing: Promise<void> = Promise.resolve();
   return {
     execute: (query, variables = {}) =>

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.client.ts
@@ -1,9 +1,3 @@
-// The client segment of the localContentPlugin. It is the ContentSlice from contract.ts,
-// and it speaks the wire protocol of content-request.ts over fetch. The content goes from
-// the client to the data layer directly, and not through the capability RPC (ADR-018 §1).
-//
-// It is a transport, and holds no cache. The admin's query client caches these reads.
-// Refer to ContentSlice.
 
 import type {
   ContentProvider,
@@ -39,8 +33,6 @@ export const createContentSlice = (url: string): ClientSlice => {
         collection,
         path,
       }),
-    // The update returns the stored entry, which can hold more than the value that was
-    // sent. The unknown fields of the stored document merge into it.
     update: (collection, path, value) =>
       postContentRequest<DocumentEntry>(url, {
         op: 'update',
@@ -49,7 +41,5 @@ export const createContentSlice = (url: string): ClientSlice => {
         value,
       }),
   };
-  // The slice takes no `set`. It writes no state, so it ignores both arguments and
-  // returns the same operations at each boot.
   return () => ({ ...slice });
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.test.ts
@@ -11,7 +11,6 @@ const ENTRIES: DocumentEntry[] = [
   { path: 'content/posts/second.mdx', document: { title: 'Second' } },
 ];
 
-// A small harness for a slice. It is the scoped `set` that the store gives to a slice.
 const createSliceHarness = async (responseBody: unknown, ok = true) => {
   const requests: unknown[] = [];
   vi.stubGlobal(
@@ -46,9 +45,6 @@ const createSliceHarness = async (responseBody: unknown, ok = true) => {
 
 afterEach(() => vi.unstubAllGlobals());
 
-// The slice is a transport. It maps the ContentProvider operations onto the wire
-// protocol and returns what came back. The caching that used to live here belongs to the
-// query client now, and editor/content-queries.test.tsx covers it.
 describe('content slice', () => {
   it('posts a list op and returns the entries', async () => {
     const harness = await createSliceHarness(ENTRIES);
@@ -67,9 +63,6 @@ describe('content slice', () => {
   });
 
   it('posts an update op and returns the persisted entry', async () => {
-    // The server merges the unknown fields into the stored document, so the result
-    // holds more than the value that was sent. The caller gets that result, and not
-    // the raw form value.
     const persisted: DocumentEntry = {
       path: 'content/posts/hello.mdx',
       document: { title: 'Renamed', category: 'not-in-schema' },

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/local-content.plugin.ts
@@ -1,8 +1,3 @@
-// The client half of the local data layer. This plugin provides the `content` capability
-// during local development. Its slice mounts at the `content` namespace, from
-// SINGLETON_SLICE_CAPABILITIES, and it speaks the wire protocol of content-request.ts.
-// Refer to local-content.client.ts. A TinaCloud provider, or a v3 provider, replaces this
-// plugin and mounts a slice of the same shape.
 
 import { DEFAULT_CONTENT_URL } from '../../../core/content/contract';
 import { type PluginManifest, definePlugin } from '../../../core/plugin';

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/tinacms-graphql.d.ts
@@ -1,10 +1,3 @@
-// The local types for @tinacms/graphql. The tsconfig `paths` field maps them in. The
-// published d.ts file points into the v3 source, because tinacms-scripts emits
-// `export * from "../src/index"`. That pulls the whole v3 graphql and mdx source into
-// the tsc run of this package, with about 150 type errors that were already there. These
-// types cover the members that graphql-pipeline.ts uses, so the boundary has types and
-// tsc does not check the v3 source. graphql-pipeline.test.ts covers the runtime behaviour
-// against the real package.
 declare module '@tinacms/graphql' {
   import type { AbstractLevel } from 'abstract-level';
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.schema.ts
@@ -11,9 +11,6 @@ export const boolean = (
   config: Omit<BooleanFieldSchema, 'type'>
 ): BooleanFieldSchema => ({ ...config, type: BOOLEAN_FIELD_TYPE });
 
-// The field has two states. The value `false` is valid, and there is no empty state, so
-// this schema cannot enforce `required`. It checks the type of the value only, and `null`
-// passes as an absent value.
 export const booleanSchema = (_node: FieldSchema): ZodType =>
   z.preprocess(
     (value) => (value == null ? undefined : value),

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/boolean/boolean-field.test.tsx
@@ -16,8 +16,6 @@ import { Field, FormProvider, TinaProvider } from '../../../editor';
 import { t } from '../../../index';
 import booleanFieldPlugin from './boolean-field.plugin';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -92,8 +90,6 @@ describe('BooleanField value updates', () => {
 });
 
 describe('BooleanField validation', () => {
-  // The `required` flag does nothing for a boolean, by design. A checkbox has no empty
-  // state, and `false` is a real value, so neither true nor false is rejected.
   it('accepts both true and false even when the field is required', async () => {
     const registry = await resolveRegistry();
     const descriptor = registry.get('boolean');

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.client.tsx
@@ -5,12 +5,8 @@ import { DatetimeField } from './datetime-field.ui';
 export default defineClientPlugin({
   field: {
     Component: DatetimeField,
-    // No defaultValue: empty stays `undefined`, so an untouched field writes nothing.
     metadata: { layout: 'inline' },
     schema: datetimeSchema,
-    // A YAML frontmatter date arrives as a Date (js-yaml parses an unquoted date).
-    // Everything else stays the string that the file holds, so an untouched document
-    // digests back unchanged.
     parse: (stored) => {
       if (stored instanceof Date) return stored.toISOString();
       return stored == null ? undefined : String(stored);

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.schema.ts
@@ -14,9 +14,6 @@ export const datetime = (
 const labelOf = (field: DatetimeFieldSchema): string =>
   field.label ?? field.name;
 
-// The value is an ISO-shaped string, and the field does no zone math anywhere. A YAML
-// frontmatter date arrives as a Date, because js-yaml parses an unquoted date, so the
-// preprocess folds that case back to the string form before the checks.
 export const datetimeSchema = (node: FieldSchema): ZodType => {
   const field = node as DatetimeFieldSchema;
   const schema = z

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.test.tsx
@@ -15,8 +15,6 @@ import { Field, FormProvider, TinaProvider } from '../../../editor';
 import { t } from '../../../index';
 import datetimeFieldPlugin from './datetime-field.plugin';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -114,9 +112,9 @@ describe('DatetimeField validation', () => {
   it('rejects a string that is not a date', async () => {
     const registry = await resolveRegistry();
     const descriptor = registry.get('datetime');
-    expect(
-      validateField(publishedNode, descriptor, 'not-a-date')
-    ).not.toEqual([]);
+    expect(validateField(publishedNode, descriptor, 'not-a-date')).not.toEqual(
+      []
+    );
   });
 
   it('accepts an absent value as optional', async () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/datetime/datetime-field.ui.tsx
@@ -8,13 +8,7 @@ import {
   useFieldValue,
 } from '../../../editor';
 
-// The native input wants `YYYY-MM-DDTHH:mm` exactly. A stored value can be longer
-// (seconds, a zone) or shorter (a date with no time), and either shape would render
-// as an empty input. This normalises for display only. The stored value does not
-// change until the author edits.
-//
 // ponytail: no zone math — a stored `Z` time shows as wall clock. Convert to the
-// zone of the author when a team asks for it.
 const toInputValue = (stored: string | undefined): string => {
   if (!stored) return '';
   return stored.includes('T') ? stored.slice(0, 16) : `${stored}T00:00`;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -9,8 +9,6 @@ import { richText } from './rich-text/rich-text-field.schema';
 import stringFieldPlugin from './string/string-field.plugin';
 import { string } from './string/string-field.schema';
 
-// The built-in field plugins of TinaCMS. The check for a core plugin reads this list,
-// and not the name of the plugin.
 export const corePlugins = [
   stringFieldPlugin,
   booleanFieldPlugin,
@@ -19,12 +17,7 @@ export const corePlugins = [
   richTextFieldPlugin,
 ];
 
-// The schema helpers, one for each built-in field. Each one is written out, and none is
-// derived in a loop, so `t.string` keeps its static type. They sit beside corePlugins, so
-// the built-in set is in one place.
-// TODO: build `t` from the configured plugin set when defineConfig arrives (ADR-024). A
-// field plugin from a user then joins it, with its types. This list is the built-in
-// default until then.
+// TODO: build `t` from the configured plugin set when defineConfig arrives
 export const t = { string, boolean, number, datetime, richText };
 
 export type { BooleanFieldSchema } from './boolean/boolean-field.schema';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.client.tsx
@@ -5,13 +5,9 @@ import { NumberField } from './number-field.ui';
 export default defineClientPlugin({
   field: {
     Component: NumberField,
-    // No defaultValue: empty stays `undefined`, so `serialize` only ever sees a number.
     metadata: { layout: 'inline' },
     schema: numberSchema,
-    // Normalise a stored `null` to empty rather than "null"/`NaN`.
     parse: (stored) => (stored == null ? undefined : String(stored)),
-    // Malformed stored data coerces to `NaN` here; guarding that belongs to the save
-    // flow (validate before digest, ADR-018), not serialize (which stays `-> number`).
     serialize: (value) => Number(value),
   },
 });

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.schema.ts
@@ -16,17 +16,11 @@ export const number = (
 
 const labelOf = (node: NumberFieldSchema): string => node.label ?? node.name;
 
-// Convert the editor string before the validation. Test for an empty string, and for a
-// string of spaces, directly. The value `0` is valid, and a falsy test would read an
-// empty string as zero.
 const toNumber = (value: unknown): unknown => {
   const trimmed = typeof value === 'string' ? value.trim() : value;
   return trimmed === '' || trimmed == null ? undefined : Number(trimmed);
 };
 
-// The `min` and `max` values bound the number, and not the length of the string. A
-// string that is not a number becomes `NaN`. The `.finite()` check also rejects
-// `Infinity`, which JSON would write as `null`.
 export const numberSchema = (node: FieldSchema): ZodType => {
   const field = node as NumberFieldSchema;
   let schema = z
@@ -48,7 +42,6 @@ export const numberSchema = (node: FieldSchema): ZodType => {
     );
   }
   if (field.required) {
-    // An empty string becomes `undefined`, which fails a schema that is not optional.
     return z.preprocess(toNumber, schema);
   }
   return z.preprocess(toNumber, schema.optional());

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.test.tsx
@@ -16,8 +16,6 @@ import { Field, FormProvider, TinaProvider } from '../../../editor';
 import { t } from '../../../index';
 import numberFieldPlugin from './number-field.plugin';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -33,10 +31,7 @@ const collection: CollectionSchema = {
       max: 5,
       step: 0.5,
     }),
-    // Required, with no bounds. This proves that `0` is a present value, and not
-    // empty.
     t.number({ name: 'count', label: 'Count', required: true }),
-    // Optional, for the negative values, the decimals, and the empty case.
     t.number({ name: 'weight', label: 'Weight' }),
   ],
 };
@@ -183,9 +178,7 @@ describe('NumberField ingest and digest', () => {
     const registry = await resolveRegistry();
     const stored = { rating: 3, count: 0, weight: -1.5 };
     const ingested = ingestDocument(stored, collection.fields, registry);
-    // parse: stored number -> editor string
     expect(ingested).toEqual({ rating: '3', count: '0', weight: '-1.5' });
-    // serialize: editor string -> stored number (zero and decimal preserved)
     expect(digestDocument(ingested, collection.fields, registry)).toEqual(
       stored
     );

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/number/number-field.ui.tsx
@@ -11,37 +11,25 @@ import type { NumberFieldSchema } from './number-field.schema';
 export function NumberField() {
   const address = useFieldAddress();
   const field = useFieldSchema<NumberFieldSchema>();
-  // The stored value is a number, but the editor value is the string from the input.
-  // It is undefined when the input is empty. A partial entry such as `-` or `1.`
-  // therefore survives while the author types.
   const [value, setValue] = useFieldValue<string | undefined>(address);
   const errors = useFieldErrors(address);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useFieldActivation(() => inputRef.current?.focus());
 
-  // TODO(shadcn): replace this input and its markup with the shared components in
-  // src/ui/. Those are the shadcn Input, Label, and form field wrapper, added with the
-  // shadcn CLI. Every field then looks the same, and a new theme needs no change to a
-  // field.
+  // TODO(shadcn): replace with the shared components in src/ui/.
   return (
     <div>
       <input
         ref={inputRef}
         type='number'
-        // The default is 'any', so the browser does not report a decimal as a
-        // stepMismatch.
         step={field.step ?? 'any'}
         id={address}
         aria-label={address}
         value={value ?? ''}
-        // The browser reports an empty string here for bad input, such as "5e", so
-        // the value becomes empty. A report of that state needs the value model and
-        // the save flow, which come later.
         onChange={(event) =>
           setValue(event.target.value === '' ? undefined : event.target.value)
         }
-        // Stop a scroll over a focused input from changing the value.
         onWheel={(event) => event.currentTarget.blur()}
       />
       {errors.map((error) => (

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/markdown.codec.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/markdown.codec.ts
@@ -7,11 +7,6 @@ import {
 } from './mdx-parser';
 import type { RichTextCodec } from './rich-text-codec';
 
-// The codec for .md files. It uses the stricter `markdown` parser of @tinacms/mdx,
-// which reads no JSX. A .md file and a .mdx file are different formats, so a parse of
-// both as MDX is wrong in two ways. In .md prose, the MDX parser reads `{` as an
-// expression and `<` as a tag. In a .md file, an embed writes JSX that no markdown
-// reader can parse again.
 const markdownField = (node: FieldSchema): MdxField => ({
   ...asMdxField(node),
   parser: { type: 'markdown' as const },

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx-parser.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx-parser.ts
@@ -3,35 +3,12 @@ import { INVALID_MARKDOWN_TYPE } from '@tinacms/rich-text';
 import type { FieldSchema } from '../../../core/schema/types';
 import type { RichTextValue } from './rich-text-codec';
 
-// The calls into @tinacms/mdx, which both built-in codecs share. They differ only in the
-// shape of the field they hand to the parser, so that field is a parameter here and the
-// body of each call site is written once.
-
-// @tinacms/mdx resolves the media paths through this callback. v4 has no media
-// capability yet, because plugins/media/ is empty. The paths therefore pass through
-// with no change. Use the resolver of the media store when that store exists.
 const passthroughMedia = (url: string): string => url;
 
-// The registry gives each field its node as the base FieldSchema, but @tinacms/mdx
-// needs the v3 field type. The two hold the same data under the same names, and the
-// compiler cannot see it: v3 types a template field by a closed union of literal types,
-// and a v4 schema node types it as a string. So the conversion stays an assertion, and
-// this is the one place that makes it. The call sites do not repeat it. It becomes a
-// plain assignment when @tinacms/mdx declares the field shape that it reads.
 export type MdxField = Parameters<typeof parseMDX>[1];
 
 export const asMdxField = (node: FieldSchema): MdxField => node as MdxField;
 
-/**
- * Reads a body that @tinacms/mdx could not parse back as its original source.
- *
- * The parser keeps that source on the node it puts in place of the body, so the value
- * of the node is the file as it was. Returns undefined for every other tree.
- *
- * This guard belongs to the codec, and not to the parser. @tinacms/mdx makes the same
- * check, but only on its MDX branch. Its markdown branch returns before that check, so
- * a body that it could not parse would save as an empty string.
- */
 const unparsedSource = (value: RichTextValue): string | undefined => {
   const first = value.children[0] as
     | { type?: string; value?: string }
@@ -40,18 +17,9 @@ const unparsedSource = (value: RichTextValue): string | undefined => {
   return first.value ?? '';
 };
 
-/** Reads a body from the file into the document model of the editor. */
 export const parseWithMdx = (source: string, field: MdxField): RichTextValue =>
   parseMDX(source, field, passthroughMedia) as RichTextValue;
 
-/**
- * Writes the document model back as the contents of a body.
- *
- * An absent body arrives as EMPTY_RICH_TEXT, and not as null: the field normalises it
- * at the dispatch, so this holds the contract in rich-text-codec.ts and a codec of your
- * own takes a value of the declared type. The first guard below covers a tree with no
- * children.
- */
 export const serializeWithMdx = (
   value: RichTextValue,
   field: MdxField
@@ -64,6 +32,5 @@ export const serializeWithMdx = (
     field,
     passthroughMedia
   );
-  // serializeMDX returns undefined for an empty value, but a file holds a string.
   return typeof serialized === 'string' ? serialized : '';
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx.codec.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx.codec.ts
@@ -1,10 +1,6 @@
 import { asMdxField, parseWithMdx, serializeWithMdx } from './mdx-parser';
 import type { RichTextCodec } from './rich-text-codec';
 
-// The default codec. It reads and writes markdown and MDX through @tinacms/mdx. This
-// is the parser that v3 used, so a v3 content folder opens without a change. The codec
-// is the only part of the field that knows the storage format. A new codec gives the
-// field a new format.
 export const mdxCodec: RichTextCodec = {
   parse: (source, node) => parseWithMdx(source, asMdxField(node)),
   serialize: (value, node) => serializeWithMdx(value, asMdxField(node)),

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.test.ts
@@ -16,10 +16,6 @@ import richTextFieldPlugin from './rich-text-field.plugin';
 const resolveRegistry = (): Promise<FieldRegistry> =>
   resolveFieldPlugins([richTextFieldPlugin]);
 
-// This is the point of the codec boundary: a new format needs no change in the editor,
-// the schema, or the save flow. This codec stores the body as plain text in capitals.
-// That is nothing like markdown, so a test that passes with it proves that no assumption
-// about markdown left the codec.
 const shoutCodec: RichTextCodec = {
   parse: (source) => ({
     type: 'root',
@@ -45,8 +41,6 @@ describe('codec selection', () => {
   });
 });
 
-// One collection can hold .md and .mdx documents, so the parser follows the file and not
-// the collection. This is the Plate half of a collection with more than one format.
 describe('codec selection follows the document', () => {
   const body = t.richText({ name: 'body' });
 
@@ -59,9 +53,6 @@ describe('codec selection follows the document', () => {
     );
   });
 
-  // A .json file and a .yaml file hold rich text as a markdown string, as v3 does, and
-  // they name no format of their own. They therefore take the branch that returns an
-  // unparsed body, and does not blank it.
   it('falls back to MDX for a format with no markdown file of its own', () => {
     expect(codecFor(body, { documentPath: 'content/posts/a.json' })).toBe(
       mdxCodec
@@ -81,8 +72,6 @@ describe('codec selection follows the document', () => {
 
 describe('the two parsers genuinely differ', () => {
   const body = t.richText({ name: 'body' });
-  // A brace is an MDX expression, and an ordinary character in markdown. A price in
-  // .md prose is the common case, and MDX rejects the whole body over it.
   const PROSE_WITH_BRACES = 'Costs {100} dollars\n';
 
   it('reads braces in .md prose as text where MDX fails the whole body', () => {
@@ -107,11 +96,6 @@ describe('the two parsers genuinely differ', () => {
     ).toBe(source);
   });
 
-  // This is why the schema refuses a `parser: 'markdown'` option on a field. The
-  // markdown branch of serializeMDX returns before its check for invalid markdown, so
-  // a body that it could not parse would save as an empty string. The codec guards it
-  // instead. Without that guard, an author who opens a body that the parser rejected,
-  // and then saves, destroys the file.
   it('writes an unparsed body back as its original source, never blank', () => {
     const source = 'Body the parser could not read\n';
     const unparsed = {
@@ -180,8 +164,6 @@ describe('a field carries its content through its codec', () => {
       collection.fields,
       registry
     );
-    // The markdown parser would also produce a text node of "hello there", so this
-    // asserts the structure that this codec makes, and not the text alone.
     expect(values.body).toEqual({
       type: 'root',
       children: [

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.ts
@@ -1,8 +1,5 @@
 import type { FieldSchema } from '../../../core/schema/types';
 
-// The document model belongs to the editor package, which defines the shape that it
-// edits. A codec produces that shape. This file re-exports the model, so a codec author
-// imports the contract and the value from one place.
 export {
   EMPTY_RICH_TEXT,
   type RichTextNode,
@@ -10,20 +7,7 @@ export {
 } from '@tinacms/rich-text';
 import type { RichTextValue } from '@tinacms/rich-text';
 
-// The boundary between the contents of a file and the value that the editor edits.
-//
-// A codec owns the format. It reads a body from the disk, and it writes the body back.
-// The editor owns the shape below, and it knows nothing about markdown or MDX. A new
-// parser therefore changes nothing in the editor, which is why this file exists.
-//
-// This file has no dependency, and it holds one type import. A new codec must not pull in
-// the parser of the default codec.
-
 export interface RichTextCodec {
-  // The `node` is the schema of the field. The default codec reads `templates` from
-  // it to resolve the embeds. A codec that needs no config ignores it.
   parse(source: string, node: FieldSchema): RichTextValue;
-  // The return value goes into the file, so it is always a string. A codec with
-  // nothing to write returns an empty string.
   serialize(value: RichTextValue, node: FieldSchema): string;
 }

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codecs.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codecs.ts
@@ -12,30 +12,11 @@ import {
   isRichTextValue,
 } from './rich-text-field.schema';
 
-// This map is keyed by format, and not by extension. FORMAT_EXTENSIONS in
-// core/schema/types.ts owns the extensions. A key from the format union also makes a
-// new format visible to the compiler here. The map is partial, because a format needs
-// no codec. Refer to the fallback below.
 const codecsByFormat: Partial<Record<CollectionFormat, RichTextCodec>> = {
   mdx: mdxCodec,
   md: markdownCodec,
 };
 
-// The codec that a field uses. A field that declares a codec uses that codec. Every
-// other field uses the codec for the format of its document.
-//
-// The fallback covers the formats with no markdown file of their own. These are .json,
-// .yaml, and any path with an extension that this code does not know. MDX is the
-// correct default there, because v3 behaves in the same way. v3 selects a parser from
-// the `parser` option of the field, and not from the extension. Without that option,
-// v3 uses the MDX parser for every file. Refer to resolver/index.ts in
-// @tinacms/graphql, which calls parseMDX directly. v4 selects by extension where the
-// extension is clear, and keeps the answer of v3 where it is not.
-//
-// This function sits here, and not next to the contract, so that the contract holds no
-// implementation. It also sits here, and not on the schema, so that the universal entry
-// in src/index.ts never pulls a parser into the main bundle. A default for the whole
-// project belongs on defineConfig (ADR-024).
 export const codecFor = (
   node: FieldSchema,
   context: FieldTransformContext = {}
@@ -48,11 +29,6 @@ export const codecFor = (
   return codecsByFormat[format] ?? mdxCodec;
 };
 
-// The source of a value, kept against the value it came from. The store asks
-// writesSameSource for every subscriber of the form on every keystroke, and a serialize
-// of a long body is not free. Plate replaces the tree at each edit, so an entry falls out
-// with the tree it belongs to. The codec and the node are part of the entry, because both
-// decide what the source looks like, and one collection can hold more than one format.
 const sourceOfValue = new WeakMap<
   RichTextValue,
   { codec: RichTextCodec; node: FieldSchema; source: string }
@@ -72,14 +48,6 @@ const sourceOf = (
   return source;
 };
 
-// Whether two values would write the same source, which is the question the form store
-// asks through isEqual. It cannot compare the trees themselves: Plate normalizes the tree
-// it is given, with an id on every node and a trailing block, so the tree in the editor
-// never matches the tree parsed from the file. A body that its author typed and then
-// deleted again would stay dirty for ever, and a click alone would look like an edit.
-// A form seeds its values from the document, so a value here is a tree. A field with no
-// value at all is the exception: an absent key and an empty body are two states, and only
-// the identity above makes them one.
 export const writesSameSource = (
   a: unknown,
   b: unknown,
@@ -92,10 +60,6 @@ export const writesSameSource = (
   try {
     return sourceOf(a, codec, node) === sourceOf(b, codec, node);
   } catch {
-    // @tinacms/mdx throws for a tree it cannot write — a mark inside inline code, or a
-    // node it does not model. The store asks this on every keystroke, so a throw here
-    // would take the editor down mid-edit. Reporting "different" keeps the form dirty,
-    // which is the safe answer: it offers the save rather than dropping the edit.
     return false;
   }
 };

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.client.tsx
@@ -8,32 +8,18 @@ export default defineClientPlugin({
   field: {
     Component: RichTextField,
     defaultValue: EMPTY_RICH_TEXT,
-    // A body is its own section. It does not sit beside a text input.
-    // A contenteditable is not a labelable element, so a host's `for` cannot reach
-    // it; the editor carries its own accessible name.
     metadata: { layout: 'block', labelable: false },
     schema: richTextSchema,
-    // The document holds what the codec writes, which is markdown by default. The
-    // editor works on the document model. The codec is the only part that knows the
-    // format, so a new codec changes the contents of the file and nothing else. The
-    // codec resolves from the document, and not from the field alone, so one
-    // collection can hold .md and .mdx documents, each read with its own parser.
     parse: (stored, node, context) =>
       codecFor(node, context).parse(
         typeof stored === 'string' ? stored : '',
         node
       ),
-    // An absent body is resolved here, and not in each codec. digestDocument drops only
-    // `undefined`, and richTextSchema models an absent body as null, so a codec written
-    // to the declared contract — `serialize(value: RichTextValue)` — would receive a
-    // null it never agreed to.
     serialize: (value, node, context) =>
       codecFor(node, context).serialize(
         value == null ? EMPTY_RICH_TEXT : (value as RichTextValue),
         node
       ),
-    // Two trees are the same edit when they write the same source. The editor value is
-    // richer than the document, so the store cannot answer this by structure alone.
     isEqual: writesSameSource,
   },
 });

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.render.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.render.test.tsx
@@ -6,8 +6,6 @@ import { Field, FormProvider, TinaProvider } from '../../../editor';
 import { t } from '../../../index';
 import richTextFieldPlugin from './rich-text-field.plugin';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {
@@ -65,10 +63,6 @@ describe('RichTextField rendering', () => {
     expect(editable).toHaveTextContent('Some prose.');
   });
 
-  // The embed nodes read their templates from EditorContext, and the field component
-  // must provide it. Without it, `useTemplates()` returns the context default of `[]`,
-  // and every embed renders nothing. There is no message, because the toolbar reads
-  // another context and still looks correct.
   it('renders a configured embed, proving EditorContext is provided', async () => {
     render(
       <TinaProvider

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.schema.ts
@@ -6,8 +6,6 @@ import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
 
 export const RICH_TEXT_FIELD_TYPE = 'rich-text';
 
-// rich-text-codec.ts holds the document model and the format contract. This is a
-// type-only re-export, so a schema author imports from one place.
 import type { RichTextCodec, RichTextValue } from './rich-text-codec';
 
 export type {
@@ -18,50 +16,22 @@ export type {
 
 export interface RichTextFieldSchema extends BaseFieldSchema {
   type: typeof RICH_TEXT_FIELD_TYPE;
-  // This marks the field as the owner of the markdown body of the file, as the v3
-  // content model does. Without it, the field is frontmatter that holds markdown.
   isBody?: boolean;
-  // The MDX components that an author can embed. Each one becomes an entry in the
-  // slash menu, and a node that the author can edit. An edit to the props of an embed
-  // needs the object field, which does not exist yet. A template therefore renders,
-  // but its side panel is empty.
   templates?: MdxTemplate[];
-  // The toolbar buttons and the heading levels the editor shows. v3 also took a
-  // bare list of buttons under `toolbarOverride`. v4 takes `overrides.toolbar`
-  // alone, so there is one shape to read and one place to add an option to.
   overrides?: ToolbarOverrides;
-  // This changes how the field reads its body from the file, and how it writes the
-  // body back. Without it, the codec follows the extension of the document. That is
-  // MDX for .mdx, markdown for .md, and MDX for any other file that holds a markdown
-  // string. Refer to rich-text-codecs.ts. This is what lets one collection hold more
-  // than one format. Set a codec to hold this field to one format for every file, or
-  // to store the body in a format of your own.
   codec?: RichTextCodec;
-  // There is no `parser` option, although the codecs use the v3 parsers below. That
-  // option would reach the `markdown` branch of serializeMDX. That branch returns
-  // before its check for invalid markdown, so it would save a body that it could not
-  // parse as an empty string. The `slatejson` value has the same problem, because it
-  // returns the tree that this field would write as an empty body. markdownCodec takes
-  // that branch on purpose, and guards it first. Add the option again only behind the
-  // same guard.
 }
 
 export const richText = (
   config: Omit<RichTextFieldSchema, 'type'>
 ): RichTextFieldSchema => ({ ...config, type: RICH_TEXT_FIELD_TYPE });
 
-// The registry hands every field its node as the base FieldSchema, which declares no
-// codec. This is how the field reads its own config back off that node, and the reason
-// it is a test of the type rather than an assertion of it.
 export const isRichTextFieldSchema = (
   node: FieldSchema
 ): node is RichTextFieldSchema => node.type === RICH_TEXT_FIELD_TYPE;
 
 const labelOf = (node: BaseFieldSchema): string => node.label ?? node.name;
 
-// The one answer to "is this a RichTextValue". Validation asks it of a form value, and
-// writesSameSource in rich-text-codecs.ts asks it of the two values it is given, so a
-// second guard would let the two disagree about what the type means.
 export const isRichTextValue = (value: unknown): value is RichTextValue => {
   const candidate = value as RichTextValue | null;
   return (
@@ -72,18 +42,9 @@ export const isRichTextValue = (value: unknown): value is RichTextValue => {
   );
 };
 
-// This reports a body that @tinacms/mdx could not parse as a field error. Refer to
-// INVALID_MARKDOWN_TYPE. It reports, and it does not protect. A save does not run the
-// resolver, because useFormSave digests the values and calls onSave directly, so the
-// value still reaches the disk. The serializer keeps that safe. It writes the original
-// source back for this node, and not an empty body.
 const isUnparsedMarkdown = (value: RichTextValue): boolean =>
   value.children[0]?.type === INVALID_MARKDOWN_TYPE;
 
-// An empty body parses to a root with no children, so `required` counts the children and
-// does not test the value. An empty tree is present, but it holds nothing. The check for
-// an absent value must run before the shape check. Otherwise a missing required body
-// reports "must be rich text" instead of "is required".
 export const richTextSchema = (node: FieldSchema): ZodType => {
   const ast = z
     .custom<RichTextValue>(

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.test.tsx
@@ -58,9 +58,6 @@ describe('RichTextField ingest and digest', () => {
   });
 });
 
-// The tree holds no leading whitespace, so the serializer drops the blank line between
-// the frontmatter and the prose. The markdown adapter writes it back. Without that, an
-// open and a save of any v3 document would restyle it.
 describe('RichTextField round-trip through the format adapter', () => {
   const adapter = formatAdapterFor('mdx');
   const RAW = '---\ntitle: Hello World\n---\n\nBody prose.\n';
@@ -85,9 +82,6 @@ describe('RichTextField round-trip through the format adapter', () => {
   });
 });
 
-// The parse and serialize functions take the field node for one reason: the parser reads
-// `templates` from it. Without the node, an embed becomes a raw html node. This test
-// fails if anyone drops that argument again.
 describe('RichTextField templates through the node argument', () => {
   const withTemplates: CollectionSchema = {
     name: 'post',
@@ -143,8 +137,6 @@ describe('RichTextField templates through the node argument', () => {
   });
 });
 
-// A save is what makes an unparsed body dangerous. The validation reports it, and does
-// not block the write, so the serializer must return the source unchanged.
 describe('RichTextField unparseable markdown', () => {
   const BROKEN = '<Unclosed\n';
 
@@ -164,13 +156,7 @@ describe('RichTextField unparseable markdown', () => {
   });
 });
 
-// The form store asks the descriptor whether two values are the same edit. It cannot
-// compare the trees itself: Plate normalizes the tree it is given, so the tree in the
-// editor never matches the tree parsed from the file. Without this answer, a body that
-// its author typed and then deleted again would stay "Unsaved" for ever.
 describe('RichTextField equality', () => {
-  // What Plate hands back: NodeIdPlugin puts an id on every node, and TrailingBlockPlugin
-  // appends an empty paragraph.
   const normalized = (value: RichTextValue): RichTextValue => {
     const withIds = (node: Record<string, unknown>, index: number) => ({
       ...node,
@@ -271,8 +257,6 @@ describe('RichTextField metadata wrapping', () => {
   it('registers the rich-text descriptor as a block field', async () => {
     const registry = await resolveRegistry();
     const descriptor = registry.get('rich-text');
-    // labelable: false — a contenteditable is not a labelable element, so a host
-    // must not point a <label for> at it.
     expect(descriptor?.metadata).toEqual({ layout: 'block', labelable: false });
     expect(descriptor?.defaultValue).toEqual({ type: 'root', children: [] });
   });

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.ui.tsx
@@ -16,10 +16,8 @@ import {
 import { writesSameSource } from './rich-text-codecs';
 import type { RichTextFieldSchema } from './rich-text-field.schema';
 
-// The raw mode is not ported. v4 has no raw markdown editor to change to, so the
-// controls that would call this are hidden. Those controls are in
-// fixed-toolbar-buttons.tsx, and in the card for invalid markdown. This mode needs a raw
-// editor, and not this setter alone, so the context still carries the shape.
+// Raw mode is not ported: v4 has no raw markdown editor yet, so the controls
+// are hidden but the context still carries the shape.
 const RAW_MODE_UNAVAILABLE = false;
 const setRawModeUnavailable = () => {};
 
@@ -31,37 +29,20 @@ export function RichTextField() {
   const errors = useFieldErrors(address);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // The editor reports the embed that the author selected. The host turns that into
-  // the one active field of the store, so this code sits here and not in the editor
-  // package.
   const { setActive } = useActiveField();
   const activateEmbed = useCallback(
     (embedAddress: string) => setActive(toFieldAddress(embedAddress)),
     [setActive]
   );
 
-  // Plate fires onChange for a change of selection, and not for an edit alone. Its
-  // normalization also changes the document: NodeIdPlugin adds an `id` to every node,
-  // and TrailingBlockPlugin adds an empty paragraph. The mounted document therefore
-  // never matches the structure of the document on disk. A compare of the two
-  // documents would report an edit after a click. Ask the codec instead: would the file
-  // be different? The store asks the same question of the same codec, through
-  // `isEqual` on the descriptor, so this keeps a write out of RHF and the store keeps
-  // it out of the dirty state.
-  //
-  // The value comes from the disk, and it is seeded again when another document opens.
-  // This component stays mounted across that change, and only the editor below it has
-  // a key.
-  // The same context the ingest and the save build, so all three resolve one codec.
-  // Without the path, a .md body would be compared as MDX here and written as markdown
-  // by useFormSave.
+  // Same context the ingest and the save build, so all three resolve one codec:
+  // without the path, a .md body would be compared as MDX here and written as
+  // markdown by useFormSave.
   const documentPath = useDocumentPath();
 
-  // The value the editor last reported, which is what the next change is compared
-  // against. A tree, and not its source: writesSameSource caches the source of a tree
-  // against the tree itself, so the comparison costs one serialize per change rather
-  // than two, and a body the parser cannot write again reads as a change instead of
-  // taking the field down.
+  // Plate fires onChange on selection changes and its normalization rewrites the
+  // tree, so compare written source against the last reported value instead of
+  // trees — a click must not read as an edit.
   const lastValue = useRef<RichTextValue>(EMPTY_RICH_TEXT);
   const seededFor = useRef<string | null>(null);
   if (seededFor.current !== seedKey) {
@@ -82,25 +63,17 @@ export function RichTextField() {
   const editable = () =>
     containerRef.current?.querySelector<HTMLElement>('[role="textbox"]');
 
-  // Plate gives no ref for its contenteditable element, so the activation searches
-  // for it. Slate mounts one tick after this component, so the search waits.
+  // Plate gives no ref for its contenteditable, and Slate mounts one tick after
+  // this component, so the search waits.
   useFieldActivation(() => {
     setTimeout(() => editable()?.focus(), 0);
   });
 
   return (
     <FieldWrapper errors={errors}>
-      {/* Plate owns its state once it mounts, and it reads `value` as a seed only.
-          A new seed must therefore remount it. The provider resets react-hook-form
-          in place, and does not remount it, so the seed key changes for every one of
-          those resets: another document, a discarded edit, or content that changed
-          under the form. Without this key, the editor would keep the body it mounted
-          with, and save that back. */}
-      {/* The min-w-0 class is necessary. FieldWrapper lays its children out in a
-          grid, so this element is a grid item and defaults to `min-width: auto`. It
-          would then refuse to become narrower than the editor, and would spill out
-          of the sidebar. An indented list is enough to cause that. A width of zero
-          lets the grid track decide, and the editor then handles its own overflow. */}
+      {/* Plate reads `value` as a seed only, so a new seed must remount it via
+          the key. min-w-0: as a grid item this defaults to min-width:auto and
+          would spill out of the sidebar instead of shrinking. */}
       <div ref={containerRef} className='min-w-0'>
         <EditorContext.Provider
           key={seedKey}
@@ -109,9 +82,6 @@ export function RichTextField() {
             templates: field.templates ?? [],
             rawMode: RAW_MODE_UNAVAILABLE,
             setRawMode: setRawModeUnavailable,
-            // The editor reports the embed that was selected. The host decides what
-            // that means, which is why the editor package no longer imports the form
-            // store. Refer to activateEmbed above.
             onActivateField: activateEmbed,
           }}
         >

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.ui.tsx
@@ -16,8 +16,6 @@ import {
 import { writesSameSource } from './rich-text-codecs';
 import type { RichTextFieldSchema } from './rich-text-field.schema';
 
-// Raw mode is not ported: v4 has no raw markdown editor yet, so the controls
-// are hidden but the context still carries the shape.
 const RAW_MODE_UNAVAILABLE = false;
 const setRawModeUnavailable = () => {};
 
@@ -35,14 +33,8 @@ export function RichTextField() {
     [setActive]
   );
 
-  // Same context the ingest and the save build, so all three resolve one codec:
-  // without the path, a .md body would be compared as MDX here and written as
-  // markdown by useFormSave.
   const documentPath = useDocumentPath();
 
-  // Plate fires onChange on selection changes and its normalization rewrites the
-  // tree, so compare written source against the last reported value instead of
-  // trees — a click must not read as an edit.
   const lastValue = useRef<RichTextValue>(EMPTY_RICH_TEXT);
   const seededFor = useRef<string | null>(null);
   if (seededFor.current !== seedKey) {
@@ -63,17 +55,12 @@ export function RichTextField() {
   const editable = () =>
     containerRef.current?.querySelector<HTMLElement>('[role="textbox"]');
 
-  // Plate gives no ref for its contenteditable, and Slate mounts one tick after
-  // this component, so the search waits.
   useFieldActivation(() => {
     setTimeout(() => editable()?.focus(), 0);
   });
 
   return (
     <FieldWrapper errors={errors}>
-      {/* Plate reads `value` as a seed only, so a new seed must remount it via
-          the key. min-w-0: as a grid item this defaults to min-width:auto and
-          would spill out of the sidebar instead of shrinking. */}
       <div ref={containerRef} className='min-w-0'>
         <EditorContext.Provider
           key={seedKey}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/string/string-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/string/string-field.schema.ts
@@ -24,9 +24,6 @@ const compileRegExp = (pattern: string): RegExp | null => {
   }
 };
 
-// This validates one field, because `node` is that field alone. A rule across two fields
-// is not supported here yet. Such a rule arrives through useSiblingValue in the
-// component, through a refine at the form level, or through a server segment.
 export const stringSchema = (node: FieldSchema): ZodType => {
   const field = node as StringFieldSchema;
   let schema = z.string();

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/string/string-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/string/string-field.test.tsx
@@ -16,8 +16,6 @@ import { Field, FormProvider, TinaProvider } from '../../../editor';
 import { t } from '../../../index';
 import stringFieldPlugin from './string-field.plugin';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 const collection: CollectionSchema = {

--- a/packages/v4/@tinacms/tinacms/src/preview/connection.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/connection.test.ts
@@ -2,8 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { type PreviewConnection, connectToEditor } from './connection';
 import { activateMessage, readyMessage, valuesMessage } from './protocol';
 
-// The MessageEvent constructor of happy-dom does not always carry the origin and the
-// source, so this sets them. Every test needs both for the guards under test.
 const messageEvent = (data: unknown, origin: string, source: unknown) => {
   const event = new MessageEvent('message', { data });
   Object.defineProperty(event, 'origin', { value: origin });
@@ -84,8 +82,6 @@ describe('connectToEditor', () => {
     const child = document.createElement('span');
     marked.appendChild(child);
     document.body.appendChild(marked);
-    // A click also bubbles up from a child of the marked element, which closest()
-    // finds.
     child.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     expect(editor.postMessage).toHaveBeenCalledWith(
       activateMessage('title'),
@@ -135,7 +131,6 @@ describe('connectToEditor', () => {
       readyMessage(),
       editorOrigin
     );
-    // The origin of the preview is no longer the allowed origin.
     window.dispatchEvent(
       messageEvent(valuesMessage({ title: 'own' }), window.origin, editor)
     );

--- a/packages/v4/@tinacms/tinacms/src/preview/connection.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/connection.ts
@@ -8,10 +8,6 @@ import {
 } from './protocol';
 
 export interface ConnectToEditorOptions {
-  // The window of the preview, and the window of the editor that hosts it, which is
-  // window.parent. The caller passes them, and this code does not read the globals,
-  // so a test can drive the boundary. In happy-dom, window.parent equals window, and
-  // the embedded path would otherwise be unreachable.
   previewWindow: Window;
   editorWindow: Window;
   allowedOrigin: string;
@@ -22,20 +18,12 @@ export interface PreviewConnection {
   disconnect: () => void;
 }
 
-// The preview half of the wire protocol. It adopts every values message from the
-// editor. It sends a click on a marked element up as an activate message, which holds
-// the address and nothing else (ADR-009 §4). It announces that it is ready once it
-// listens. An incoming message must come from the editor window, at the allowed origin,
-// so another window cannot reach it.
 export const connectToEditor = ({
   previewWindow,
   editorWindow,
   allowedOrigin,
   onValues,
 }: ConnectToEditorOptions): PreviewConnection => {
-  // This check runs at construction. A '*' origin would post the ready and activate
-  // messages to any embedder, and would defeat the origin check on the incoming
-  // messages.
   invariant(
     allowedOrigin !== '*',
     'preview-allowed-origin-wildcard',
@@ -46,8 +34,6 @@ export const connectToEditor = ({
     if (isValuesMessage(event.data)) onValues(event.data.values);
   };
   const onClick = (event: MouseEvent) => {
-    // The target of a click is not always an Element, because a synthetic event can
-    // target the document. Only an Element has closest().
     if (!(event.target instanceof Element)) return;
     const marked = event.target.closest(`[${TINA_FIELD_ATTR}]`);
     const address = marked?.getAttribute(TINA_FIELD_ATTR);

--- a/packages/v4/@tinacms/tinacms/src/preview/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/index.ts
@@ -1,8 +1,1 @@
-// The public entry `@tinacms/tinacms/preview`. It holds the half of the site-side visual
-// editing that no framework owns (ADR-009 §4): the wire protocol and the tinaField
-// address marker. It uses neither React nor zustand. The bindings for each framework sit
-// under ./adapters/<framework>, and React is the first of them, at ./adapters/react. The
-// editor half is usePreviewConnection, on the ./react entry. connectToEditor, the message
-// constructors and createPreviewStore stay internal: a binding for a new framework lives
-// under ./adapters and imports the store directly, so it is not a published contract yet.
 export { TINA_FIELD_ATTR, tinaField } from './protocol';

--- a/packages/v4/@tinacms/tinacms/src/preview/protocol.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/protocol.ts
@@ -1,14 +1,5 @@
 import type { TinaDocument } from '../core/schema/types';
 
-// The wire protocol for visual editing (the v4 part of #6944). It carries three
-// messages across the boundary between the editor window and the preview window. The
-// `tina:activate` message holds the field address and nothing else (ADR-009 §4). The
-// `tina:ready` message is the handshake from the preview to the editor. The
-// `tina:values` message streams the whole state from the editor to the preview. This
-// package owns both of those messages, and it ships both halves together. There is
-// therefore no version field and no form id field. A new need becomes a new message
-// type.
-
 export const READY_MESSAGE_TYPE = 'tina:ready';
 export const VALUES_MESSAGE_TYPE = 'tina:values';
 export const ACTIVATE_MESSAGE_TYPE = 'tina:activate';
@@ -52,16 +43,11 @@ export const isValuesMessage = (data: unknown): data is ValuesMessage =>
   typeof (data as { values?: unknown }).values === 'object' &&
   (data as { values?: unknown }).values !== null;
 
-// This also validates the payload. toFieldAddress throws on an empty address, so a
-// damaged message must not pass this guard.
 export const isActivateMessage = (data: unknown): data is ActivateMessage =>
   hasMessageType(data, ACTIVATE_MESSAGE_TYPE) &&
   typeof (data as { address?: unknown }).address === 'string' &&
   (data as { address: string }).address.length > 0;
 
-// The marker half of the protocol. A site uses it to tag a rendered element with the
-// field address that a click activates. Spread it onto the element, for example
-// <h1 {...tinaField('title')}>.
 export const TINA_FIELD_ATTR = 'data-tina-field';
 
 export const tinaField = (address: string): { 'data-tina-field': string } => ({

--- a/packages/v4/@tinacms/tinacms/src/preview/store.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/store.test.ts
@@ -2,9 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import { readyMessage, valuesMessage } from './protocol';
 import { createPreviewStore } from './store';
 
-// No framework here. The store takes its windows as arguments, so these drive the
-// boundary directly instead of standing a component up around it.
-
 const fakeEditor = () =>
   ({ postMessage: vi.fn() }) as unknown as Window & { postMessage: any };
 
@@ -18,7 +15,6 @@ const streamValues = (editor: Window, values: Record<string, unknown>) => {
 describe('a preview outside the editor', () => {
   it('connects to nothing', () => {
     const listenerSpy = vi.spyOn(window, 'addEventListener');
-    // A page opened on its own is its own parent.
     const store = createPreviewStore({
       previewWindow: window,
       editorWindow: window,
@@ -73,8 +69,6 @@ describe('a preview embedded in the editor', () => {
     const { editor, store } = embedded();
     store.subscribe(vi.fn());
     streamValues(editor, { title: 'Edited live' });
-    // Referential stability is the contract a store consumer reads to decide whether
-    // anything happened.
     expect(store.getSnapshot()).toBe(store.getSnapshot());
   });
 

--- a/packages/v4/@tinacms/tinacms/src/preview/store.ts
+++ b/packages/v4/@tinacms/tinacms/src/preview/store.ts
@@ -1,34 +1,16 @@
-// The preview connection as a store, which is the shape every framework already knows how
-// to consume: subscribe to changes, read a snapshot.
-//
-// React reads it with useSyncExternalStore, Svelte with its store contract, Vue with a
-// shallowRef, a plain script by calling subscribe. The rules that would otherwise be
-// rewritten in each of those — that a page outside the editor connects to nothing, that
-// nothing has streamed until the editor says so, that the last subscriber closes the
-// connection — live here once.
 
 import type { TinaDocument } from '../core/schema/types';
 import { type PreviewConnection, connectToEditor } from './connection';
 
 export interface CreatePreviewStoreOptions {
-  // The origin of the editor. It defaults to the origin of the page. A cross-origin
-  // embed is an explicit choice, and is never '*'.
   allowedOrigin?: string;
-  // Both default to the globals. They are named so a test, or a host that renders
-  // somewhere other than a browser tab, can drive the boundary.
   previewWindow?: Window;
   editorWindow?: Window;
 }
 
 export interface PreviewStore {
-  // Start listening, and get back the unsubscribe. On a page that is not embedded in the
-  // editor this connects to nothing and the unsubscribe is a no-op.
   subscribe: (onChange: () => void) => () => void;
-  // The document the editor streamed most recently, or null if it has streamed none. The
-  // reference only changes when a new one arrives, which is what a store consumer needs
-  // to decide whether anything happened.
   getSnapshot: () => TinaDocument | null;
-  // Nothing has streamed during a server render, by definition.
   getServerSnapshot: () => null;
 }
 
@@ -39,8 +21,6 @@ export function createPreviewStore({
 }: CreatePreviewStoreOptions = {}): PreviewStore {
   const preview = previewWindow ?? globalThis.window;
   const editor = editorWindow ?? preview?.parent;
-  // A page opened on its own is its own parent. There is no editor to talk to, so the
-  // store never adds a listener and never announces itself.
   const embedded = Boolean(preview && editor && editor !== preview);
 
   let streamed: TinaDocument | null = null;
@@ -53,8 +33,6 @@ export function createPreviewStore({
     subscribe: (onChange) => {
       if (!embedded) return () => {};
       listeners.add(onChange);
-      // One connection for the store, opened by the first subscriber. Two views of the
-      // same preview should not each announce themselves to the editor.
       connection ??= connectToEditor({
         previewWindow: preview,
         editorWindow: editor,

--- a/packages/v4/@tinacms/tinacms/src/rich-text/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/index.ts
@@ -1,15 +1,3 @@
-// The rich-text renderer, minus a framework.
-//
-// `renderRichText(content, components, host)` is the whole render. A framework supplies
-// a RichTextHost — build an element, call a component, make text, join siblings — and
-// gets every node type, fallback and table for free. Adding one is a change here, not in
-// each binding. The React host is in adapters/react.
-//
-// `resolveRichTextNode` is the layer underneath, for a host that wants to drive the walk
-// itself rather than implement the interface.
-//
-// Nothing in here imports React, so this entry is safe from a server, a codec, or a
-// binding for any other framework.
 export { type RichTextHost, renderRichText } from './render';
 export { resolveRichTextNode } from './resolve';
 export type {

--- a/packages/v4/@tinacms/tinacms/src/rich-text/render.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/render.test.ts
@@ -2,11 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { type RichTextHost, renderRichText, styleToCss } from './render';
 import type { TinaMarkdownContent } from './types';
 
-// A second host, written here rather than shipped, to hold the interface honest. It
-// renders to an HTML string with no framework anywhere, and the markup it lands on is the
-// markup adapters/react lands on — the assertions below are the same literals that file
-// asserts. If a fallback ever drifts into one binding, this fails.
-
 const VOID_TAGS = new Set(['img', 'hr', 'br']);
 
 const escape = (value: string) =>

--- a/packages/v4/@tinacms/tinacms/src/rich-text/render.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/render.ts
@@ -1,14 +1,3 @@
-// The whole render, driven through one interface a framework implements.
-//
-// resolve.ts answers what a single node renders as. This file does everything built on
-// top of that answer: the recursion, the fallback markup for a node the site supplied no
-// component for, the nesting of marks on a leaf, and the shape of a table. All of it is
-// framework-free, so a new node type, a new fallback or a fix to a table lands once and
-// every framework has it.
-//
-// What is left for a framework is RichTextHost: four ways to build a value, and an
-// optional memo hook. The React binding in adapters/react is the reference; it is about
-// thirty lines.
 
 import { resolveRichTextNode } from './resolve';
 import type {
@@ -21,57 +10,32 @@ import type {
   TinaMarkdownContent,
 } from './types';
 
-// A style object, in the camelCase convention every framework already reads. A host that
-// writes markup as text runs it through styleToCss below.
 type Style = Record<string, string | undefined>;
 
-// The two elements a table cell can be. A header cell only exists on a table that told us
-// its first row is one.
 type CellTag = 'th' | 'td';
 
-/**
- * What a framework has to supply to render rich text. `Rendered` is whatever that
- * framework calls a renderable value — a React element, an HTML string, a vnode.
- *
- * Nothing here is about markdown. A host that can build an element, call a component,
- * make a text value and join a list can render every rich-text document there is.
- */
 export interface RichTextHost<Rendered> {
-  /** Build an element of the framework. `children` is null when the node takes none. */
   element(
     tag: string,
     props: Record<string, unknown>,
     children: Rendered | null
   ): Rendered;
-  /** Call a component the site supplied. `component` is the value out of its map. */
   component(
     component: unknown,
     props: Record<string, unknown>,
     children: Rendered | null
   ): Rendered;
-  /** A text value. Framework escaping applies: rich text never injects markup. */
   text(value: string): Rendered;
-  /** Join siblings. The host assigns whatever keys or separators it needs. */
   list(items: Rendered[]): Rendered;
-  /**
-   * Optional. Wrap the render of one node so the host can cache it against `cacheKey`,
-   * which is stable for as long as the node and its components are. React uses this to
-   * keep as-you-type editing responsive; a host that renders once should leave it out.
-   */
   memo?(render: () => Rendered, cacheKey: unknown): Rendered;
 }
 
 type RenderContext<Rendered> = {
   host: RichTextHost<Rendered>;
   components: SuppliedComponents;
-  // Set while rendering a table cell. A cell wraps its content in a paragraph, so the
-  // paragraph is what becomes the th or td.
   paragraphAs?: (children: Rendered | null) => Rendered;
 };
 
-/**
- * Render a rich-text value with the given components, through the given host.
- */
 export function renderRichText<Rendered>(
   content: TinaMarkdownContent | TinaMarkdownContent[] | undefined,
   components: SuppliedComponents,
@@ -80,7 +44,6 @@ export function renderRichText<Rendered>(
   return renderNodes(nodesOf(content), { host, components });
 }
 
-// A value is either the list of nodes itself or a node whose children are that list.
 const nodesOf = (
   content: TinaMarkdownContent | TinaMarkdownContent[] | undefined
 ): TinaMarkdownContent[] => {
@@ -160,8 +123,6 @@ function renderLeaf<Rendered>(
   context: RenderContext<Rendered>
 ): Rendered {
   const { host, components } = context;
-  // The marks arrive outermost first, so fold from the end to put the string at the
-  // centre and the first mark on the outside.
   let rendered = host.text(instruction.text);
   for (let index = instruction.marks.length - 1; index >= 0; index--) {
     const mark = instruction.marks[index];
@@ -173,17 +134,12 @@ function renderLeaf<Rendered>(
   return rendered;
 }
 
-// A highlight is the one mark whose fallback markup carries its own colour, and `mark`
-// has no attribute for it.
 const markStyle = (props: RichTextProps): RichTextProps =>
   props.color ? { style: { backgroundColor: props.color } } : {};
 
 const TABLE_BORDER = '1px solid #EDECF3';
 const TABLE_CELL_PADDING = '0.25rem';
 
-// The fallback look of a table, which is the one place the renderer has an opinion about
-// appearance. A pipe table gets the borders v3 drew on it; a table written as an MDX
-// element is left bare. Either is replaced wholesale by supplying table/tr/th/td.
 const TABLE_FALLBACK = {
   mdx: {
     table: undefined as Style | undefined,
@@ -222,9 +178,6 @@ function renderTable<Rendered>(
   const row = (cells: RichTextTableCell[], tag: CellTag): Rendered => {
     const rendered = host.list(
       cells.map((tableCell, index) =>
-        // A cell renders with no components but its own: v3 scoped the map down to the
-        // paragraph swap while rendering one, and a site's components do not reach inside
-        // a table today.
         renderNodes(nodesOf(tableCell.content), {
           host,
           components: {},
@@ -251,10 +204,6 @@ function renderTable<Rendered>(
     : host.element('table', { style: fallback.table }, inner);
 }
 
-/**
- * Serialise a style object from the fallback markup into a CSS declaration string, for a
- * host that writes markup as text rather than handing objects to a framework.
- */
 export function styleToCss(style: Style | undefined): string | undefined {
   if (!style) return undefined;
   const declarations = Object.entries(style)

--- a/packages/v4/@tinacms/tinacms/src/rich-text/resolve.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/resolve.test.ts
@@ -2,10 +2,6 @@ import { describe, expect, it } from 'vitest';
 import { resolveRichTextNode } from './resolve';
 import type { SuppliedComponents, TinaMarkdownContent } from './types';
 
-// The point of these tests is that they import no framework and render nothing. The walk
-// that v3 could only exercise through React is now a function from a node and a set of
-// supplied components to an instruction, so the branches are checkable directly.
-
 const node = (value: Record<string, unknown>) => value as TinaMarkdownContent;
 const none: SuppliedComponents = {};
 const supplying = (...keys: string[]): SuppliedComponents =>
@@ -311,8 +307,6 @@ describe('tables', () => {
     expect(instruction.rows).toEqual([[{ content: [] }]]);
   });
 
-  // Alignment is author content, and a pipe table writes a null for a column it did not
-  // align. Dropping those entries would shift every column after them.
   it('keeps a column position when its alignment is not one of the three keywords', () => {
     const instruction = resolveRichTextNode(
       node({

--- a/packages/v4/@tinacms/tinacms/src/rich-text/resolve.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/resolve.ts
@@ -1,10 +1,3 @@
-// The walk over a rich-text tree, with no framework in it.
-//
-// v3 kept this switch inside a React component, so Astro had to rewrite the whole thing
-// in `.astro` files to render the same content. Here the switch answers a question every
-// binding asks — what does this node render as, and did the site supply a component for
-// it — and a binding is left with the part that is genuinely its own: turning an
-// instruction into an element.
 
 import { sanitizeUrl } from '@tinacms/mdx/sanitize-url';
 import type {
@@ -20,8 +13,6 @@ import type {
   TinaMarkdownContent,
 } from './types';
 
-// Presence, not lookup. Matches the truthiness check the v3 renderer made, so a site that
-// passes `{ p: undefined }` still gets the default markup.
 const supplied = (components: SuppliedComponents, key: string): boolean =>
   Boolean(components[key]);
 
@@ -38,8 +29,6 @@ const PASSTHROUGH_TAGS = new Set([
   'li',
 ]);
 
-// The markup a mark falls back to when the site supplied no component for it. `text` is
-// absent on purpose: a text component wraps the string and has no markup to stand in for.
 const MARK_FALLBACK_TAG: Record<Exclude<RichTextMarkKey, 'text'>, string> = {
   bold: 'strong',
   italic: 'em',
@@ -58,10 +47,6 @@ export function resolveRichTextNode(
   const content: RichTextChildren = { kind: 'content', content: children };
   const noChildren: RichTextChildren = { kind: 'none' };
 
-  // The one decision this file makes, in the one place it is made: call the component the
-  // site supplied under `key`, or build `fallback` instead. The v3 renderer dropped the
-  // node's own props on the fallback path, and a site that never supplied a component has
-  // never seen them on the element, so the fallback carries only what it names.
   const componentOr = (
     key: string,
     fallback: { tag: string; props?: RichTextProps },
@@ -85,9 +70,6 @@ export function resolveRichTextNode(
       return componentOr('lic', { tag: 'div' }, content);
 
     case 'blockquote':
-      // Support both blockquote and block_quote (deprecated) for backwards compatibility.
-      // Naming the deprecated key second means it also carries the case where the site
-      // supplied neither, which falls back to the element.
       return componentOr(
         supplied(components, 'blockquote') ? 'blockquote' : 'block_quote',
         { tag: 'blockquote' },
@@ -182,8 +164,6 @@ export function resolveRichTextNode(
       return resolveGfmTable(fields);
 
     case 'maybe_mdx':
-      // We don't want to render this as it's only displayed while editing an mdx node and
-      // should be transformed before form submission
       return { kind: 'nothing' };
 
     case 'html':
@@ -196,9 +176,6 @@ export function resolveRichTextNode(
           children: noChildren,
         };
       }
-      // Escaped, not injected: v3 returned the string from the component and React
-      // rendered it as text. A site that wants the markup live supplies an `html`
-      // component and takes that decision itself.
       return { kind: 'text', text: fields.value ?? '' };
 
     case 'invalid_markdown':
@@ -233,14 +210,12 @@ function resolveLeaf(
     );
   };
 
-  // Pushed outermost first, in the order v3 nested them.
   if (fields.bold) mark('bold');
   if (fields.italic) mark('italic');
   if (fields.underline) mark('underline');
   if (fields.strikethrough) mark('strikethrough');
   if (fields.code) mark('code');
   if (fields.highlight) mark('highlight', { color: fields.highlightColor });
-  // A text component only ever wraps the string itself, so it is always innermost.
   if (supplied(components, 'text')) {
     marks.push({ kind: 'component', key: 'text', props: {} });
   }
@@ -249,7 +224,6 @@ function resolveLeaf(
 }
 
 function readCodeBlockValue(fields: RichTextNodeFields): string {
-  // Extract code string from children if present, else fallback to value
   if (Array.isArray(fields.children)) {
     return fields.children
       .map((line) =>
@@ -268,10 +242,6 @@ type MdxTableRow = { tableCells?: { value: TinaMarkdownContent }[] };
 
 const TABLE_ALIGNMENTS = new Set<string>(['left', 'right', 'center']);
 
-// The alignment of each column, by position. This is author content, and a pipe table
-// writes a null for a column it did not align, so anything that is not one of the three
-// keywords becomes "no alignment" rather than being dropped — dropping it would shift
-// the alignment of every column after it.
 const columnAlignments = (
   align: unknown
 ): (RichTextTableAlign | undefined)[] =>
@@ -303,8 +273,6 @@ function resolveGfmTable(fields: RichTextNodeFields): RichTextInstruction {
     kind: 'table',
     source: 'gfm',
     align: columnAlignments(fields.props?.align),
-    // A pipe table carries its header in the markup, not in a flag, and v3 rendered every
-    // row into the body. Keep that until the parser says which row is the header.
     header: null,
     rows: (fields.children ?? []).map((row) =>
       (row.children ?? []).map((cell) => ({ content: cell.children }))

--- a/packages/v4/@tinacms/tinacms/src/rich-text/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/types.ts
@@ -1,20 +1,13 @@
-// The vocabulary of a rich-text value, and of the components a site may supply to render
-// one. Nothing here names a framework. `Rendered` is whatever a binding produces, so the
-// React adapter fixes it to React.JSX.Element and a future adapter fixes it to its own.
+// The vocabulary of a rich-text value, framework-free. `Rendered` is whatever a
+// binding produces.
 
 export type TinaMarkdownContent = {
   type: string;
-  // Optional, because a leaf node has no children. A text node is
-  // `{ type: 'text', text: '…' }`. The parser emits that shape, and the renderer
-  // branches on it. A required field here would describe a tree that never exists,
-  // and every caller would cast around it.
   children?: TinaMarkdownContent[];
 };
 
-// The fields the resolver reads off a node beyond `type` and `children`. They are all
-// optional because the union of node shapes has never been written down; keeping the
-// reads in one named type is what lets the resolver drop the `@ts-ignore` per branch that
-// the v3 renderer carried.
+// All optional because the union of node shapes has never been written down;
+// this named type is what lets the resolver drop v3's per-branch `@ts-ignore`.
 export type RichTextNodeFields = TinaMarkdownContent & {
   text?: string;
   value?: string;
@@ -64,24 +57,17 @@ export type BaseComponents<Rendered> = {
   maybe_mdx?: { children: Rendered };
   html?: { value: string };
   html_inline?: { value: string };
-  // A cell carries the alignment of its own column, which is absent for a column the
-  // table did not align.
   th?: { align?: RichTextTableAlign; children: Rendered };
   td?: { align?: RichTextTableAlign; children: Rendered };
   tr?: { children: Rendered };
-  /**
-   * A table arrives in one of two shapes, because the two syntaxes carry different
-   * things. A table written as an MDX element hands over its own props, as every MDX
-   * embed does. A pipe table has no props, so it arrives already rendered into rows,
-   * like every other element. A site that supports both branches on `tableRows`.
-   */
+  // Two shapes: an MDX table hands over its own props, a pipe table arrives
+  // already rendered. A site that supports both branches on `tableRows`.
   table?:
   | {
     align?: RichTextTableAlign[];
     tableRows: { tableCells: { value: TinaMarkdownContent }[] }[];
   }
   | { children: Rendered };
-  // Provide a fallback when a JSX component wasn't provided
   component_missing?: { name: string };
 };
 
@@ -100,11 +86,10 @@ export type RichTextComponents<ComponentAndProps extends object, Rendered> = {
   [K in keyof ComponentAndProps]: (props: ComponentAndProps[K]) => Rendered;
 } & BaseComponentSignature<Rendered>;
 
-// The resolver only ever asks whether a key was supplied, never what it renders, so it
-// takes the map at its loosest useful type. A binding keeps the precise one.
+// The resolver only asks whether a key was supplied; a binding keeps the
+// precise type.
 export type SuppliedComponents = Record<string, unknown>;
 
-// The props a binding spreads onto whatever it builds.
 export type RichTextProps = Record<string, unknown>;
 
 export type RichTextMarkKey =
@@ -116,28 +101,20 @@ export type RichTextMarkKey =
   | 'highlight'
   | 'text';
 
-/**
- * One mark on a text leaf, in the same two shapes a node resolves to: the component the
- * site supplied, or the element to fall back to. Marks arrive outermost first, and that
- * order is the contract — v3 nested bold outside italic outside underline, and a site's
- * CSS may lean on it.
- */
+// Marks arrive outermost first, and that order is the contract: v3 nested bold
+// outside italic outside underline, and a site's CSS may lean on it.
 export type RichTextMark =
   | { kind: 'element'; tag: string; props: RichTextProps }
   | { kind: 'component'; key: RichTextMarkKey; props: RichTextProps };
 
 export type RichTextTableCell = {
-  // Left unresolved: the binding renders it back through the renderer with `p` swapped
-  // for the cell element, because a cell in the mdx tree wraps its text in a paragraph.
+  // Unresolved: the binding renders it back through the renderer with `p`
+  // swapped for the cell element.
   content: TinaMarkdownContent | TinaMarkdownContent[] | undefined;
 };
 
-/**
- * What to render for one node, said without naming a framework. Children stay
- * unresolved — a `content` child is a slice of the tree the binding feeds back through
- * its own renderer — so a binding keeps whatever memoisation it needs at the node
- * boundary instead of paying for a full walk on every render.
- */
+// Children stay unresolved so a binding keeps its memoisation at the node
+// boundary instead of paying for a full walk on every render.
 export type RichTextChildren =
   | { kind: 'none' }
   | { kind: 'text'; text: string }
@@ -162,13 +139,9 @@ export type RichTextInstruction =
   }
   | {
     kind: 'table';
-    // `mdx` is a table written as an MDX JSX element, `gfm` one written with pipes.
-    // They differ only in the markup a binding falls back to, so both arrive here
-    // already normalised into rows of cells.
+    // Differ only in fallback markup; both arrive normalised into rows.
     source: 'mdx' | 'gfm';
-    // One entry per column, in column order. An entry is absent for a column that
-    // carries no alignment: a pipe table writes a null for those, and the alignment
-    // of every column after it would shift if they were dropped.
+    // Per column; absent entries kept so later columns do not shift.
     align: (RichTextTableAlign | undefined)[];
     header: RichTextTableCell[] | null;
     rows: RichTextTableCell[][];

--- a/packages/v4/@tinacms/tinacms/src/rich-text/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/types.ts
@@ -1,13 +1,9 @@
-// The vocabulary of a rich-text value, framework-free. `Rendered` is whatever a
-// binding produces.
 
 export type TinaMarkdownContent = {
   type: string;
   children?: TinaMarkdownContent[];
 };
 
-// All optional because the union of node shapes has never been written down;
-// this named type is what lets the resolver drop v3's per-branch `@ts-ignore`.
 export type RichTextNodeFields = TinaMarkdownContent & {
   text?: string;
   value?: string;
@@ -60,14 +56,12 @@ export type BaseComponents<Rendered> = {
   th?: { align?: RichTextTableAlign; children: Rendered };
   td?: { align?: RichTextTableAlign; children: Rendered };
   tr?: { children: Rendered };
-  // Two shapes: an MDX table hands over its own props, a pipe table arrives
-  // already rendered. A site that supports both branches on `tableRows`.
   table?:
-  | {
-    align?: RichTextTableAlign[];
-    tableRows: { tableCells: { value: TinaMarkdownContent }[] }[];
-  }
-  | { children: Rendered };
+    | {
+        align?: RichTextTableAlign[];
+        tableRows: { tableCells: { value: TinaMarkdownContent }[] }[];
+      }
+    | { children: Rendered };
   component_missing?: { name: string };
 };
 
@@ -77,17 +71,10 @@ export type BaseComponentSignature<Rendered> = {
   ) => Rendered;
 };
 
-/**
- * The components a site supplies, generic over what a binding renders. A binding
- * re-exports this with `Rendered` pinned to its own element type — see the `Components`
- * alias in `adapters/react`.
- */
 export type RichTextComponents<ComponentAndProps extends object, Rendered> = {
   [K in keyof ComponentAndProps]: (props: ComponentAndProps[K]) => Rendered;
 } & BaseComponentSignature<Rendered>;
 
-// The resolver only asks whether a key was supplied; a binding keeps the
-// precise type.
 export type SuppliedComponents = Record<string, unknown>;
 
 export type RichTextProps = Record<string, unknown>;
@@ -101,20 +88,14 @@ export type RichTextMarkKey =
   | 'highlight'
   | 'text';
 
-// Marks arrive outermost first, and that order is the contract: v3 nested bold
-// outside italic outside underline, and a site's CSS may lean on it.
 export type RichTextMark =
   | { kind: 'element'; tag: string; props: RichTextProps }
   | { kind: 'component'; key: RichTextMarkKey; props: RichTextProps };
 
 export type RichTextTableCell = {
-  // Unresolved: the binding renders it back through the renderer with `p`
-  // swapped for the cell element.
   content: TinaMarkdownContent | TinaMarkdownContent[] | undefined;
 };
 
-// Children stay unresolved so a binding keeps its memoisation at the node
-// boundary instead of paying for a full walk on every render.
 export type RichTextChildren =
   | { kind: 'none' }
   | { kind: 'text'; text: string }
@@ -126,23 +107,21 @@ export type RichTextInstruction =
   | { kind: 'text'; text: string }
   | { kind: 'leaf'; text: string; marks: RichTextMark[] }
   | {
-    kind: 'element';
-    tag: string;
-    props: RichTextProps;
-    children: RichTextChildren;
-  }
+      kind: 'element';
+      tag: string;
+      props: RichTextProps;
+      children: RichTextChildren;
+    }
   | {
-    kind: 'component';
-    key: string;
-    props: RichTextProps;
-    children: RichTextChildren;
-  }
+      kind: 'component';
+      key: string;
+      props: RichTextProps;
+      children: RichTextChildren;
+    }
   | {
-    kind: 'table';
-    // Differ only in fallback markup; both arrive normalised into rows.
-    source: 'mdx' | 'gfm';
-    // Per column; absent entries kept so later columns do not shift.
-    align: (RichTextTableAlign | undefined)[];
-    header: RichTextTableCell[] | null;
-    rows: RichTextTableCell[][];
-  };
+      kind: 'table';
+      source: 'mdx' | 'gfm';
+      align: (RichTextTableAlign | undefined)[];
+      header: RichTextTableCell[] | null;
+      rows: RichTextTableCell[][];
+    };

--- a/packages/v4/@tinacms/tinacms/src/rpc/handler.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/handler.ts
@@ -1,7 +1,5 @@
-// The capability RPC transport (ADR-007 and ADR-008). Every server segment composes into
-// one handler that takes a Request and returns a Response, and the adapters mount that
-// handler. It carries JSON only. Binary data belongs to the media capability (ADR-022).
-// A codec for richer JSON is still an open question (ADR-007).
+// Capability RPC transport (ADR-007, ADR-008). All server segments compose into one
+// Request -> Response handler. JSON only; binary belongs to media (ADR-022).
 
 import { invariant } from '../core/invariant';
 import { capabilityMountFor } from '../core/mount';
@@ -28,34 +26,31 @@ import {
 } from '../server';
 
 export type RpcHandler = ((request: Request) => Promise<Response>) & {
-  // Tear the composed plugins down. A host that replaces a handler instead of ending
-  // with the process calls this on the old one, so every onInit keeps its onDestroy.
+  // Hosts that replace a handler (not end the process) call this so every
+  // onInit keeps its onDestroy.
   destroy: () => Promise<void>;
 };
 
 export interface RpcHandlerConfig {
   plugins: PluginManifest[];
-  // Where the adapter mounted this handler, such as `/api/tina`. Without it the route
-  // is the last two segments of the path, so any prefix reaches an operation and a
-  // proxy rule keyed on an exact path does not hold. Set it to pin the route.
+  // e.g. `/api/tina`. Without it the route is the last two path segments, so
+  // any prefix reaches an operation. Set it to pin the route.
   mountPath?: string;
 }
 
-// The composition runs once, at the first request. A failed composition leaves the
-// cache, so the next request tries again.
+// Composition runs once, at the first request. A failure is not cached.
 export const createRpcHandler = ({
   plugins,
   mountPath,
 }: RpcHandlerConfig): RpcHandler => {
   let runtimePromise: Promise<ServerRuntime> | null = null;
-  // The composition and the teardown of this handler run in one sequence. destroy()
-  // clears the cache before its onDestroy hooks finish, so a request arriving during a
-  // teardown composes again — and without this it would run onInit while onDestroy was
-  // still running. TinaProvider serialises the same pair on the client.
+  // Serialises compose/teardown: destroy() clears the cache before onDestroy
+  // finishes, so without this a request arriving mid-teardown would run onInit
+  // while onDestroy was still running.
   let lifecycleTurn: Promise<void> = Promise.resolve();
 
-  // Compose after the current turn, and become the next one, so a destroy that arrives
-  // mid-composition tears down what this composition initialized.
+  // Compose after the current turn, so a destroy arriving mid-composition tears
+  // down what this composition initialized.
   const composeAfterCurrentTurn = (): Promise<ServerRuntime> => {
     const composing = lifecycleTurn.then(() => composeServerRuntime(plugins));
     lifecycleTurn = composing.then(
@@ -70,9 +65,8 @@ export const createRpcHandler = ({
   };
 
   const handler = async (request: Request): Promise<Response> => {
-    // The route is settled before the runtime composes. Composing imports every
-    // plugin's server segment and runs its onInit, and a failed compose is not cached
-    // — so an unauthenticated GET would start that work again on every request.
+    // Refuse before composing: a failed compose is not cached, so an
+    // unauthenticated GET would otherwise re-run every plugin import per request.
     const refusal = refusalOf(request);
     if (refusal) return refusal;
     const route = routeOf(request, mountPath);
@@ -99,10 +93,8 @@ export const createRpcHandler = ({
     const composed = runtimePromise;
     runtimePromise = null;
     const currentTurn = lifecycleTurn;
-    // Nothing composed, or a composition that failed: there is no initialized plugin
-    // to tear down, and that failure already reached the request that triggered it. A
-    // failed onDestroy is another matter — it leaves a handle open — so it is logged
-    // here, as initializePlugins logs the teardown that rolls back a failed init.
+    // A failed composition has nothing to tear down; a failed onDestroy leaves
+    // a handle open, so it is logged.
     lifecycleTurn = (async () => {
       await currentTurn;
       const runtime = await composed?.catch(() => null);
@@ -133,20 +125,13 @@ const composeServerRuntime = async (
     serverConflictError
   );
   const authHooks = claimAuthTransportHooks(segmentsByNamespace);
-  // The init runs last, so a failed composition leaves no initialized plugin behind
-  // for the next attempt. The teardown travels on the runtime: a handler that is
-  // replaced rather than ending with the process — a dev server re-evaluating its
-  // route module — would otherwise run every onInit again with no matching onDestroy.
+  // Init runs last, so a failed composition leaves no initialized plugin behind.
   const destroy = await initializePlugins(plugins);
   return { segmentsByNamespace, authHooks, destroy };
 };
 
-// Read the transport hooks from the auth segment, and remove them from its routable
-// ops. The dispatch then returns 404 for their names through its normal lookup. Without
-// a callable getSession, this returns null, and every non-public op fails closed. A
-// rolePermissions that is not callable fails the composition. A silent change to the
-// built-in bundles would grant the wildcard of the admin role, which the provider did
-// not intend.
+// Pull the transport hooks off the auth segment so dispatch 404s them. Without a
+// callable getSession this returns null and every non-public op fails closed.
 const claimAuthTransportHooks = (
   segmentsByNamespace: Map<string, ResolvedServerSegment>
 ): AuthTransportHooks | null => {
@@ -174,19 +159,13 @@ interface RpcRoute {
   opName: string;
 }
 
-// Why a request is refused before it reaches an operation, or null when nothing here
-// refuses it: the method and the two CSRF gates. None of them needs a composed plugin
-// to answer, which is why they run before the runtime exists.
 const refusalOf = (request: Request): Response | null => {
   if (request.method !== 'POST') {
     return errorResponse(405, 'method-not-allowed', 'RPC operations are POST.');
   }
-  // The CSRF guard (ADR-008). A cross-origin fetch with application/json always
-  // starts a CORS preflight, and this server never answers one. A forged cross-site
-  // POST therefore cannot reach an operation that changes state, even when getSession
-  // reads a cookie. Compare the MIME essence, and not a substring. A safelisted type
-  // that holds the string as a parameter sends no preflight. One example is
-  // `text/plain; charset=application/json`.
+  // CSRF gate 1 (ADR-008): cross-origin application/json always preflights, and
+  // this server never answers OPTIONS. Compare the MIME essence, not a substring:
+  // `text/plain; charset=application/json` sends no preflight.
   const mimeEssence = request.headers
     .get('content-type')
     ?.replace(/;.*/, '')
@@ -199,9 +178,8 @@ const refusalOf = (request: Request): Response | null => {
       'RPC requests must be application/json.'
     );
   }
-  // The second gate. The preflight above holds only while nothing answers OPTIONS, and
-  // a host app that mounts a global CORS middleware voids it without touching this
-  // file. A browser that sends this header states the relationship itself.
+  // CSRF gate 2: a host app's global CORS middleware voids the preflight gate
+  // without touching this file.
   if (request.headers.get('sec-fetch-site') === 'cross-site') {
     return errorResponse(
       403,
@@ -212,11 +190,8 @@ const refusalOf = (request: Request): Response | null => {
   return null;
 };
 
-// The operation a path addresses, or null when it addresses none.
 const routeOf = (request: Request, mountPath?: string): RpcRoute | null => {
   const segments = new URL(request.url).pathname.split('/').filter(Boolean);
-  // Without a mount path the route is the last two segments, so any prefix reaches the
-  // operation. With one, the path has to be exactly the mount and those two.
   const routed = mountPath
     ? segmentsBelowMount(segments, mountPath)
     : segments.slice(-2);
@@ -240,10 +215,8 @@ const dispatch = async (
   request: Request,
   { namespace, opName }: RpcRoute
 ): Promise<Response> => {
-  // One catch covers all the code after the routing, because that code belongs to the
-  // plugins. A thrown error carries internal details, which must not reach an HTTP
-  // body. The runtime context covers the same region, so use() also resolves inside
-  // the auth hooks.
+  // One catch covers everything after routing: plugin code throws internal
+  // details that must not reach an HTTP body.
   try {
     return await serverRuntimeStorage.run(runtime, () =>
       authorizeAndInvokeOp(runtime, request, namespace, opName)
@@ -270,9 +243,8 @@ const authorizeAndInvokeOp = async (
     );
   }
 
-  // Secure by default (ADR-008 §1). Authenticate the caller before you invoke an
-  // operation. A publicOp is the one exception. It also skips the plugin-level
-  // `requires`, because a caller with no session has no permissions to check.
+  // Secure by default (ADR-008 §1): authenticate before invoking. publicOp is
+  // the one exception and also skips plugin-level `requires`.
   const meta = opMeta(op);
   if (!meta.public) {
     const session = runtime.authHooks
@@ -315,9 +287,8 @@ const authorizeAndInvokeOp = async (
   return Response.json(result ?? null);
 };
 
-// The own-property check and the function check keep the prototype members, such as
-// `toString`, and any value that is not an operation, off the routes. The auth hooks
-// need no rule here, because the composition already removed them from the ops.
+// Own-property + function checks keep prototype members like `toString` off the
+// routes.
 const routedOp = (
   mounted: ResolvedServerSegment,
   opName: string
@@ -327,8 +298,6 @@ const routedOp = (
   return typeof op === 'function' ? op : undefined;
 };
 
-// The one place that removes the `never` input of ServerOp for the call.
-// core/plugin.ts explains that choice.
 const invokeOp = (op: ServerOp, input: unknown): Promise<unknown> =>
   (op as (input: unknown) => Promise<unknown>)(input);
 
@@ -338,7 +307,6 @@ const hasPermission = async (
   permission: string
 ): Promise<boolean> => {
   for (const role of session.roles) {
-    // A provider that resolves the roles owns the whole map (ADR-008 §3 and §4).
     const permissions = authHooks?.rolePermissions
       ? await authHooks.rolePermissions(role)
       : (DEFAULT_ROLE_PERMISSIONS[role] ?? []);
@@ -349,9 +317,6 @@ const hasPermission = async (
   return false;
 };
 
-// Every response that is not a 2xx holds `{ error: { code, message } }`. The
-// specification in tinacmsv4 plans/007 records the code table, until the ADR for the
-// error model exists. The tests hold the literal values.
 const errorResponse = (
   status: number,
   code: string,

--- a/packages/v4/@tinacms/tinacms/src/rpc/proxy.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/proxy.test.ts
@@ -4,9 +4,6 @@ import { defineServerPlugin, publicOp } from '../server';
 import { createRpcHandler } from './handler';
 import { RpcError, createRpcClient } from './proxy';
 
-// The pattern that a real plugin uses. The type of the ops record crosses to the client,
-// as an `import type` does. Here it crosses directly, because both sides are one TS
-// project.
 const searchOps = defineServerPlugin({
   query: publicOp(async (input: { q: string }) => ({ hits: [input.q] })),
   reindex: async () => ({ started: true }),
@@ -22,8 +19,6 @@ const handler = createRpcHandler({ plugins: [searchPlugin] });
 
 const client = createRpcClient<{ search: typeof searchOps }>({
   url: 'http://tina.local/api/tina',
-  // The handler takes a Request and returns a Response, so it also serves as the fetch
-  // implementation.
   fetch: (input, init) => handler(new Request(input, init)),
 });
 
@@ -43,8 +38,6 @@ describe('createRpcClient', () => {
   });
 
   it('is not thenable and yields nothing for symbol keys', async () => {
-    // The `await` keyword reads `then` at both levels. A POST there would hang the
-    // caller.
     expect((client as unknown as Record<string, unknown>).then).toBeUndefined();
     expect(
       (client.search as unknown as Record<string, unknown>).then

--- a/packages/v4/@tinacms/tinacms/src/rpc/proxy.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/proxy.ts
@@ -1,11 +1,6 @@
-// Client half of the capability RPC (ADR-007): a typed Proxy that turns
-// `server.media.upload(input)` into one POST. Runs in the browser; must not
-// import from ../server or ./handler.
 
 export type RpcProxy<TSegments> = {
   [Namespace in keyof TSegments]: {
-    // Variadic inference so a zero-arg op stays callable with zero args —
-    // `(input: infer I)` would infer `unknown` and demand a dummy argument.
     [Op in keyof TSegments[Namespace]]: TSegments[Namespace][Op] extends (
       ...args: infer TArgs
     ) => Promise<infer TResult>
@@ -27,7 +22,6 @@ export class RpcError extends Error {
 
 export interface RpcClientConfig {
   url: string;
-  // Bearer token (ADR-023 §4). Without it, only a publicOp answers.
   getToken?: () => string | null | Promise<string | null>;
   fetch?: typeof fetch;
 }
@@ -45,16 +39,15 @@ export const createRpcClient = <TSegments>(
     }
   ) as RpcProxy<TSegments>;
 
-// Protocol keys must read as absent: `then` or `await client.media` hangs,
-// and string coercion (`${client.media}`, JSON.stringify) reads toString/
-// valueOf/toJSON — returning an op function there fires bogus POSTs.
 const RESERVED_PROXY_KEYS: ReadonlySet<string> = new Set([
   'then',
   'toString',
   'valueOf',
   'toJSON',
 ]);
-const isReservedProxyKey = (key: string | symbol): boolean =>
+const isReservedProxyKey = (
+  key: string | symbol
+): key is symbol | 'then' | 'toString' | 'valueOf' | 'toJSON' =>
   typeof key === 'symbol' || RESERVED_PROXY_KEYS.has(key);
 
 const createNamespaceProxy = (config: RpcClientConfig, namespace: string) =>
@@ -93,8 +86,6 @@ const unwrapRpcResponse = async (
   namespace: string,
   opName: string
 ): Promise<unknown> => {
-  // A 2xx that is not JSON is not a result: an SSO interstitial comes back 200,
-  // and parsing it as "null" would resolve the call as an empty success.
   const isJson = response.headers
     .get('content-type')
     ?.toLowerCase()

--- a/packages/v4/@tinacms/tinacms/src/rpc/proxy.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/proxy.ts
@@ -1,14 +1,15 @@
-// The client half of the capability RPC (ADR-007). It is a typed Proxy that turns
-// `server.media.upload(input)` into one POST. The types cross through an `import type`,
-// which the compiler erases, so no server code and no secret reaches the browser. This
-// file runs in the browser, and it must not import from ../server or from ./handler.
+// Client half of the capability RPC (ADR-007): a typed Proxy that turns
+// `server.media.upload(input)` into one POST. Runs in the browser; must not
+// import from ../server or ./handler.
 
 export type RpcProxy<TSegments> = {
   [Namespace in keyof TSegments]: {
+    // Variadic inference so a zero-arg op stays callable with zero args —
+    // `(input: infer I)` would infer `unknown` and demand a dummy argument.
     [Op in keyof TSegments[Namespace]]: TSegments[Namespace][Op] extends (
-      input: infer TInput
+      ...args: infer TArgs
     ) => Promise<infer TResult>
-      ? (input: TInput) => Promise<TResult>
+      ? (...args: TArgs) => Promise<TResult>
       : never;
   };
 };
@@ -25,18 +26,12 @@ export class RpcError extends Error {
 }
 
 export interface RpcClientConfig {
-  // The base URL where the handler is mounted, for example `/api/tina`.
   url: string;
-  // The session credential is a bearer token, and the transport attaches it
-  // (ADR-023 §4). Without it, in local development with no auth, a request carries no
-  // credential, and only a publicOp answers.
+  // Bearer token (ADR-023 §4). Without it, only a publicOp answers.
   getToken?: () => string | null | Promise<string | null>;
   fetch?: typeof fetch;
 }
 
-// The two levels of the proxy match the two levels of the call. There is no cache. Every
-// read of a property leads to a network call, and no caller can depend on the identity of
-// a property.
 export const createRpcClient = <TSegments>(
   config: RpcClientConfig
 ): RpcProxy<TSegments> =>
@@ -50,12 +45,17 @@ export const createRpcClient = <TSegments>(
     }
   ) as RpcProxy<TSegments>;
 
-// A get trap sees every read of a property, and not the operation calls alone. A symbol,
-// which an inspector reads, and `then`, which `await` reads, must therefore read as
-// absent. Without that, `await client.media` hangs, and an inspector sends POST requests
-// that no one wanted.
-const isReservedProxyKey = (key: string | symbol): key is symbol | 'then' =>
-  typeof key === 'symbol' || key === 'then';
+// Protocol keys must read as absent: `then` or `await client.media` hangs,
+// and string coercion (`${client.media}`, JSON.stringify) reads toString/
+// valueOf/toJSON — returning an op function there fires bogus POSTs.
+const RESERVED_PROXY_KEYS: ReadonlySet<string> = new Set([
+  'then',
+  'toString',
+  'valueOf',
+  'toJSON',
+]);
+const isReservedProxyKey = (key: string | symbol): boolean =>
+  typeof key === 'symbol' || RESERVED_PROXY_KEYS.has(key);
 
 const createNamespaceProxy = (config: RpcClientConfig, namespace: string) =>
   new Proxy(
@@ -93,9 +93,8 @@ const unwrapRpcResponse = async (
   namespace: string,
   opName: string
 ): Promise<unknown> => {
-  // A 2xx that is not JSON is not a result. An SSO interstitial or a proxy's own page
-  // comes back with 200, and parsing it as "null" would resolve the call as an empty
-  // success — the caller then writes that absence into the UI as though it were data.
+  // A 2xx that is not JSON is not a result: an SSO interstitial comes back 200,
+  // and parsing it as "null" would resolve the call as an empty success.
   const isJson = response.headers
     .get('content-type')
     ?.toLowerCase()

--- a/packages/v4/@tinacms/tinacms/src/server/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/server/index.ts
@@ -1,5 +1,4 @@
-// The server entry, `tinacms/server`. The server segments of the plugins import it, and
-// so do the framework adapters. It never reaches the browser bundle.
+// The server entry, `tinacms/server`. Never reaches the browser bundle.
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { invariant } from '../core/invariant';
@@ -11,38 +10,26 @@ import type {
 
 export type { ResolvedServerSegment, ServerOp, ServerSegment };
 
-// An identity function, like definePlugin and defineClientPlugin. It keeps `TOps`, so
-// the exported type of the segment is the type that `import type` carries to the client
-// for the RPC proxy (ADR-007). A wider Record type would erase the signature of every
-// operation.
+// Identity function that keeps `TOps`, so `import type` carries each op's
+// signature to the client RPC proxy (ADR-007).
 export const defineServerPlugin = <TOps extends ServerSegment>(
   ops: TOps
 ): TOps => ops;
 
-// The one primitive that every verifier needs (ADR-023 §1). The session carries the
-// roles. The core reads them at each request, and stores nothing (ADR-008).
 export interface Session {
   identity: { id: string; name?: string; email?: string };
   roles: string[];
 }
 
-// The transport hooks that the RPC handler needs from the provider of `auth`. They sit
-// on the server segment of the auth plugin, under these names. The composition removes
-// them from the routable ops in rpc/handler.ts. The handler then calls them directly,
-// and getSession receives the Request. The dispatch can never route them as RPC
-// operations.
+// Transport hooks the RPC handler pulls off the auth segment; the composition
+// removes them from the routable ops so dispatch can never route them.
 export interface AuthTransportHooks {
   getSession: (request: Request) => Promise<Session | null>;
-  // The auth provider owns the map from a role to its permissions (ADR-008 §3).
-  // Without this hook, the built-in defaults for editor and admin apply.
   rolePermissions?: (role: string) => Promise<string[]>;
 }
 
-// Tina supplies the editor role and the admin role, so that TinaCloud works with no
-// config (ADR-008 §4 and §5). A new permission goes to no role by default, except
-// through the wildcard of the admin role. The object has a null prototype, so a role
-// with the name of an Object.prototype member resolves to nothing. Two such names are
-// "constructor" and "__proto__".
+// Defaults so TinaCloud works with no config (ADR-008 §4, §5). Null prototype,
+// so a role named "constructor" or "__proto__" resolves to nothing.
 export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = Object.assign(
   Object.create(null),
   {
@@ -51,12 +38,8 @@ export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = Object.assign(
   }
 );
 
-// The authorization marks for an operation (ADR-008). A plain handler is protected by
-// default. `publicOp` is the one way to remove that protection, and a search finds it.
-// `protectedOp` names the permission that the operation needs. That name is a string
-// until codegen builds the typed union. These functions wrap the handler, and do not
-// change it, so two wrappers on one handler cannot share a tag. The key uses
-// `Symbol.for`, so two copies of this module agree on the tag.
+// Authorization marks (ADR-008): plain handlers are protected by default,
+// `publicOp` opts out. `Symbol.for`, so two copies of this module agree on the tag.
 const OP_META = Symbol.for('tinacms.op-meta');
 
 interface OpMeta {
@@ -85,25 +68,18 @@ export const protectedOp = <TOp extends ServerOp>(
 export const opMeta = (handler: ServerOp): OpMeta =>
   (handler as TaggedOp)[OP_META] ?? {};
 
-// The composed server runtime. rpc/handler.ts builds it once for each handler. It holds
-// the segments by mount namespace, and the auth hooks from the composition. A null value
-// there fails closed.
 export interface ServerRuntime {
   segmentsByNamespace: Map<string, ResolvedServerSegment>;
   authHooks: AuthTransportHooks | null;
-  // The teardown from initializePlugins. It runs every onDestroy that its matching
-  // onInit paired with, and a second call destroys nothing.
   destroy: () => Promise<void>;
 }
 
-// This carries the runtime through a dispatch, so that the module-level `use()`
-// resolves against the handler that dispatched it. It stays correct when requests
-// overlap.
+// Carries the runtime through a dispatch so module-level `use()` resolves
+// against the dispatching handler, even when requests overlap.
 export const serverRuntimeStorage = new AsyncLocalStorage<ServerRuntime>();
 
-// The in-process accessor for a capability on the server (ADR-007). One example is
-// `use('content').listAll()`. The typed contract for each capability arrives with
-// ADR-019, ADR-021, and ADR-022. Until then, a caller casts the result.
+// In-process capability accessor, e.g. `use('content').listAll()` (ADR-007).
+// Untyped until the capability contracts land; callers cast.
 export const use = (capability: string): ServerSegment => {
   const runtime = serverRuntimeStorage.getStore();
   invariant(

--- a/packages/v4/@tinacms/tinacms/src/store/compose-slices.ts
+++ b/packages/v4/@tinacms/tinacms/src/store/compose-slices.ts
@@ -10,15 +10,8 @@ import {
   isSingletonSliceCapability,
 } from '../core/plugin';
 
-// A map from a namespace to the slice creator that mounts there. It is composed once at
-// boot from the resolved client segments. createFieldRegistry reads the same input, and
-// composeOverridableRegistry resolves the overrides for both. That resolution does not
-// depend on the order.
 export type SliceRegistry = Map<string, ClientSlice>;
 
-// A namespace is a singleton capability key, such as `media`, or a plugin name, such as
-// `editorial-workflow`. The two collide for different reasons, so the message differs.
-// Only a capability accepts an override, so a duplicate override is always a capability.
 const sliceConflictError = (
   conflict: RegistryConflict,
   namespace: string

--- a/packages/v4/@tinacms/tinacms/src/store/create-store.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/store/create-store.test.ts
@@ -9,8 +9,6 @@ import {
 import { composePluginSlices } from './compose-slices';
 import { createTinaStore, pickPersistableNamespaces } from './create-store';
 
-// The field registry resolves these from the manifests at boot. The store composes the
-// same { manifest, segment } shape, so these tests build it inline.
 const resolved = (
   spec: {
     name: string;
@@ -27,8 +25,6 @@ const get = (store: ReturnType<typeof createTinaStore>) =>
   store.getState() as Record<string, any>;
 
 beforeEach(() => {
-  // Every store persists under the same key, so clear it. The durable state of one
-  // test must not rehydrate into the next test.
   localStorage.clear();
 });
 
@@ -55,12 +51,9 @@ describe('composePluginSlices namespacing', () => {
   });
 
   it('rejects a plugin named after a capability it does not provide', () => {
-    // A peer reads the capability state at `get().media`, so a feature plugin must
-    // not take that namespace by its name alone.
     expect(() =>
       composePluginSlices([resolved({ name: 'media' }, () => ({}))])
     ).toThrow(/does not provide it/);
-    // A real provider can carry the capability name.
     const registry = composePluginSlices([
       resolved({ name: 'media', provides: ['media'] }, () => ({})),
     ]);
@@ -133,7 +126,6 @@ describe('composePluginSlices conflicts', () => {
         ) as any
       )?.from;
 
-    // base-first and override-first both resolve to the override.
     expect(winner(composePluginSlices([base, override]))).toBe('s3');
     expect(winner(composePluginSlices([override, base]))).toBe('s3');
   });
@@ -197,9 +189,7 @@ describe('createTinaStore composition', () => {
     get(store).media.add('hero.png');
 
     expect(get(store).media.items).toEqual(['hero.png']);
-    // a scoped write never leaks to the top level …
     expect(get(store).items).toBeUndefined();
-    // … and a peer read resolves through the namespace.
     expect(get(store).media.uploaderId()).toBe('u1');
   });
 
@@ -207,8 +197,6 @@ describe('createTinaStore composition', () => {
     const authSlice: ClientSlice = () => ({ user: { id: 'u1' } });
     const mediaSlice: ClientSlice = (set) => ({
       items: ['a', 'b'],
-      // With replace set to true, this replaces the state of the slice, and does
-      // not merge into it.
       reset: () => set({ items: [] }, true),
     });
 
@@ -219,9 +207,7 @@ describe('createTinaStore composition', () => {
 
     get(store).media.reset();
 
-    // the slice was replaced (reset method dropped) …
     expect(get(store).media).toEqual({ items: [] });
-    // … but the peers and the core namespaces stay. Nothing clears the whole store.
     expect(get(store).auth.user.id).toBe('u1');
     expect(get(store).ui).toEqual({});
   });
@@ -262,12 +248,9 @@ describe('createTinaStore persistence round-trip', () => {
       media: { items: ['stale'] },
     } as any);
 
-    // A fresh boot reads the persisted storage written above.
     const rebooted = get(boot());
     expect(rebooted.ui).toEqual({ theme: 'dark' });
     expect(rebooted.branch).toEqual({ current: 'feat' });
-    // The documents, and every plugin namespace, are volatile. The store computes
-    // them again at boot, and does not rehydrate them.
     expect(rebooted.documents).toEqual({});
     expect(rebooted.media).toEqual({ items: [] });
   });

--- a/packages/v4/@tinacms/tinacms/src/store/create-store.ts
+++ b/packages/v4/@tinacms/tinacms/src/store/create-store.ts
@@ -4,30 +4,9 @@ import { invariant } from '../core/invariant';
 import type { ResolvedSegment, SliceSet, TinaStoreState } from '../core/plugin';
 import { composePluginSlices } from './compose-slices';
 
-// The built-in namespaces of the store. They are empty for now. This increment delivers
-// the registration mechanism and the middleware stack. It does not deliver the shapes of
-// ui, branch, and documents. Those arrive later as core slices, composed at boot by
-// createUiSlice, createBranchSlice, and createDocumentsSlice. Refer to
-// store-architecture.md. These namespaces are core, and not plugins. isCoreNamespace
-// reserves these keys, and the store rejects a plugin that mounts on one of them.
 const CORE_NAMESPACES = ['ui', 'branch', 'documents'] as const;
 type CoreNamespace = (typeof CORE_NAMESPACES)[number];
 
-// The core namespaces that survive a reload. They hold the theme, the sidebar, and the
-// branch selection. The type is a subset of CORE_NAMESPACES, so the two cannot drift.
-// All other state is volatile, and the store computes it again at each boot. That state
-// includes the document selection and every plugin namespace, such as the form values
-// and the media lists. This is the one place that decides what persists. Refer to
-// store-architecture.md and persistence.md.
-//
-// Note: the persist middleware does a shallow merge, which replaces a whole namespace
-// at rehydration. That is correct while these namespaces hold plain data. A core slice
-// that carries action functions needs a custom `merge`, so that rehydration keeps the
-// composed slice.
-//
-// Note: persistence.md keeps the branch list and the dirty state volatile. Only the
-// selection survives. Persistence of the whole namespace is correct while `branch` is
-// empty. The real branch slice needs a partialize function for each key.
 const PERSISTED_NAMESPACES: readonly CoreNamespace[] = ['ui', 'branch'];
 
 export const pickPersistableNamespaces = (
@@ -43,30 +22,18 @@ export const pickPersistableNamespaces = (
 const createCoreSlices = (): TinaStoreState =>
   Object.fromEntries(CORE_NAMESPACES.map((namespace) => [namespace, {}]));
 
-// The whole-store `set` that the middleware stack gives to the initializer. This code
-// always calls it with replace set to false, so a patch to one namespace cannot remove
-// its peers.
 type RootSet = (
   updater: (store: TinaStoreState) => Partial<TinaStoreState>,
   replace: false,
   action?: string
 ) => void;
 
-// Build the `set` for one slice, scoped to the namespace of that slice. The slice reads
-// and updates its own state only. This function then writes the result under the
-// namespace key, and merges it into the whole store. The peer namespaces do not change.
-//
-// The `replace` flag belongs to the slice. It replaces the state of the slice instead of
-// a merge into it. This function does not pass the flag to the root set. The root set
-// always merges the patch for one namespace, or it would drop every peer.
 const createNamespacedSet =
   (namespace: string, setStore: RootSet): SliceSet =>
   (partial, replace = false, action) =>
     setStore(
       (store) => {
         const currentSliceState = store[namespace] ?? {};
-        // SliceSet has the two forms of the Zustand set(): set(partial) and
-        // set(current => partial). The second form reads the current slice state.
         const nextSliceState =
           typeof partial === 'function' ? partial(currentSliceState) : partial;
         return {
@@ -82,15 +49,9 @@ const createNamespacedSet =
 const isCoreNamespace = (namespace: string): namespace is CoreNamespace =>
   (CORE_NAMESPACES as readonly string[]).includes(namespace);
 
-// The fixed names of the store. There is one store for each app boot (ADR-003), so one
-// storage key and one devtools title are correct. They cannot collide.
 const PERSIST_STORAGE_KEY = 'tina-store';
 const DEVTOOLS_STORE_NAME = 'TinaStore';
 
-// Compose the client store once at boot from the resolved plugin segments. It holds the
-// core slices, and each plugin slice at its own namespace. The fixed middleware stack
-// wraps them: devtools, and then persist. The plugin list is static, so the store has no
-// extend function at runtime.
 export const createTinaStore = (resolved: ResolvedSegment[]) => {
   const pluginSlices = composePluginSlices(resolved);
   return create<TinaStoreState>()(
@@ -106,8 +67,6 @@ export const createTinaStore = (resolved: ResolvedSegment[]) => {
                 `store namespace (${CORE_NAMESPACES.join('/')}). Rename the plugin ` +
                 'or the capability it provides.'
             );
-            // The `set as RootSet` cast narrows the wide middleware type of Zustand to
-            // the merge-only root set. The slice itself receives the SliceSet type.
             const scopedSet = createNamespacedSet(namespace, set as RootSet);
             state[namespace] = slice(scopedSet, get);
           }

--- a/packages/v4/@tinacms/tinacms/src/test/setup.ts
+++ b/packages/v4/@tinacms/tinacms/src/test/setup.ts
@@ -3,15 +3,8 @@ import { configure } from '@testing-library/dom';
 import { beforeEach } from 'vitest';
 import { useFormStore } from '../form/form-store';
 
-// findBy* and waitFor default to one second, which is too short for the async boot of
-// TinaProvider.
-// (plugin graph + lazy segment imports) on loaded CI runners.
 configure({ asyncUtilTimeout: 5000 });
 
-// The form-store is a module-level singleton, so its state bleeds across tests.
-// Reset it here for every test file rather than mandating a beforeEach per file.
-// localStorage too: every createTinaStore persists/rehydrates the shared
-// 'tina-store' key, so durable namespaces would otherwise leak between tests.
 beforeEach(() => {
   useFormStore.setState({ forms: {}, active: null });
   localStorage.clear();

--- a/packages/v4/@tinacms/tinacms/vitest.config.ts
+++ b/packages/v4/@tinacms/tinacms/vitest.config.ts
@@ -3,20 +3,13 @@ import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  // The suite runs the compiled output, not the source. The compiler's memoisation
-  // is only sound while the components stay pure, so a component that mutates in
-  // render should fail here rather than go stale in someone's editor.
   plugins: [react({ babel: { plugins: ['babel-plugin-react-compiler'] } })],
   test: {
     globals: true,
     environment: 'happy-dom',
-    // Must exceed setup.ts's 5s asyncUtilTimeout, or a failing findBy* dies as
-    // a generic vitest timeout with no testing-library DOM dump. 30s, not 10 —
-    // the Plate suites sit at the 10s edge on 2-core CI runners.
     testTimeout: 30_000,
     poolOptions: {
       forks: {
-        // node ≥23 otherwise injects a broken globalThis.localStorage that shadows happy-dom's
         execArgv: ['--no-experimental-webstorage'],
       },
     },

--- a/packages/v4/@tinacms/ui/src/components/alert-dialog.tsx
+++ b/packages/v4/@tinacms/ui/src/components/alert-dialog.tsx
@@ -3,10 +3,6 @@ import type * as React from 'react';
 
 import { cn } from '@tinacms/ui/lib/utils';
 
-// The dialog for an action that cannot be undone. It differs from Sheet in what it
-// refuses to do: it has no close button, and a click outside it or the Escape key does
-// not dismiss it. The choice has to be made.
-
 function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
   return <AlertDialogPrimitive.Root data-slot='alert-dialog' {...props} />;
 }

--- a/packages/v4/@tinacms/ui/src/components/field-wrapper.tsx
+++ b/packages/v4/@tinacms/ui/src/components/field-wrapper.tsx
@@ -3,9 +3,6 @@ import type * as React from 'react';
 import { Label } from '@tinacms/ui/components/label';
 import { cn } from '@tinacms/ui/lib/utils';
 
-// The shared field shell (hand-written, not CLI-managed): label, control slot,
-// error messages. Purely presentational — the editor package owns form state and
-// passes errors in, so this stays reusable outside a form context.
 export interface FieldWrapperProps {
   label?: string;
   htmlFor?: string;

--- a/packages/v4/@tinacms/ui/src/hooks/use-mobile.ts
+++ b/packages/v4/@tinacms/ui/src/hooks/use-mobile.ts
@@ -2,14 +2,8 @@ import * as React from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 
-// The one query. The seed and the listener both answer from it, so they cannot disagree
-// about the viewport that is exactly the breakpoint wide.
 const MOBILE_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
-// Seeded from matchMedia rather than from `undefined`. Starting undefined reports
-// desktop on the first render, so on a narrow viewport the Sidebar rendered its desktop
-// branch and then swapped to the Sheet branch, remounting the whole subtree. The
-// initializer runs once, and guards `window` for the server render.
 const matchesMobile = () =>
   typeof window !== 'undefined' && window.matchMedia(MOBILE_QUERY).matches;
 


### PR DESCRIPTION
**TLDR:** Comments that restate the code are deleted across the v4 packages; pragmas, TODOs and FIXMEs stay.

**Feats:**
- The comment strip across @tinacms/tinacms, @tinacms/rich-text and @tinacms/ui
- AGENTS.md states the two standards: comments are a last resort, and error narrowing is an if
- The error-narrowing rule applied where the strip found violations
- TINA_E2E_PORT is validated as an integer

**How to test:** The suites confirm nothing moved.
- Run `pnpm test` and `pnpm types` in `packages/v4/@tinacms/tinacms`.
- Run `pnpm test` and `pnpm types` in `packages/v4/@tinacms/rich-text`.
