### PR TITLE
feat(v4): the lock carries the tinacms version; the runtime validates the plugin graph harder

### DIFF
--- a/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
+++ b/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "schema": {
     "collections": [
       {
@@ -28,7 +28,13 @@
           }
         ]
       }
-    ]
+    ],
+    "version": {
+      "fullVersion": "4.0.0-alpha.0",
+      "major": "4",
+      "minor": "0",
+      "patch": "0-alpha"
+    }
   },
   "primitives": {
     "boolean": 1,

--- a/packages/v4/@tinacms/tinacms/src/codegen/compile-schema.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/compile-schema.test.ts
@@ -4,9 +4,6 @@ import { definePlugin } from '../core/plugin';
 import type { FieldSchema } from '../core/schema/types';
 import { LOCK_VERSION, checkLock, compileSchema } from './compile-schema';
 
-// This config is built by hand, and not by defineConfig. The compile reads the manifests
-// only. A fixed field set here also keeps these tests independent of the built-ins that
-// ship.
 const fieldPlugin = (type: string, contractVersion: number) =>
   definePlugin({
     name: `test:field:${type}`,
@@ -42,13 +39,14 @@ describe('compileSchema', () => {
     });
   });
 
-  // The definitions resolve at build time from the installed plugins. The lock
-  // therefore holds a version number, and nothing that a change without a break could
-  // make stale.
-  // The previous version of this asserted `not.toContain('Component')` against
-  // manifests that carry no client segment, so it could not fail. What the ADR
-  // actually promises is that the lock holds a version number and nothing that the
-  // installed plugin resolves at build.
+  it('stamps schema.version with the package version, in the v3 shape', () => {
+    const lock = compileSchema(configWith([{ name: 'title', type: 'string' }]));
+    const { fullVersion, major, minor, patch } = lock.schema.version;
+    expect(fullVersion).toMatch(/^\d+\.\d+\.\d+/);
+    expect(fullVersion.startsWith(`${major}.${minor}.${patch}`)).toBe(true);
+    expect([major, minor].every((part) => /^\d+$/.test(part))).toBe(true);
+  });
+
   it('references primitives by key and version without inlining them', () => {
     const lock = compileSchema(configWith([{ name: 'title', type: 'string' }]));
     expect(lock.primitives).toEqual({ string: 1 });
@@ -60,7 +58,6 @@ describe('compileSchema', () => {
     expect(lock.primitives).not.toHaveProperty('rich-text');
   });
 
-  // The file is committed, so the iteration order alone must not change it.
   it('orders primitives stably', () => {
     const lock = compileSchema(
       configWith([
@@ -87,8 +84,6 @@ describe('checkLock', () => {
     });
   });
 
-  // An edit to the schema is the common case. Write the lock again, and do not stop
-  // the build.
   it('reports a lock that lags the schema as stale', () => {
     const lock = compileSchema(config);
     const check = checkLock(
@@ -101,8 +96,23 @@ describe('checkLock', () => {
     expect(check.status).toBe('stale');
   });
 
-  // This is the case that ADR-016 covers. The primitive changed its shape under a
-  // committed lock, and a silent repair must not happen.
+  it('reports a lock stamped by an older tinacms as stale', () => {
+    const lock = compileSchema(config);
+    const stamped = {
+      ...lock,
+      schema: {
+        ...lock.schema,
+        version: {
+          fullVersion: '4.0.0-alpha.-1',
+          major: '4',
+          minor: '0',
+          patch: '0-alpha',
+        },
+      },
+    };
+    expect(checkLock(stamped, config).status).toBe('stale');
+  });
+
   it('stops on a pinned contract version the installed plugin no longer matches', () => {
     const lock = compileSchema(config);
     const check = checkLock(
@@ -120,9 +130,6 @@ describe('checkLock', () => {
   });
 });
 
-// A rich-text field carries templates whose fields have their own types. They render
-// like any other field, so they need the same build gate and the same contract pin —
-// reading only the top level let them through both.
 const withFields = (fields: FieldSchema[]): ResolvedConfig =>
   asResolvedConfig({
     plugins: [fieldPlugin('rich-text', 1), fieldPlugin('string', 3)],
@@ -158,8 +165,6 @@ describe('compileSchema with nested template fields', () => {
     );
   });
 
-  // A template can nest a field that carries templates of its own, and those fields
-  // render too. Stopping at the first level let them past the gate.
   it('rejects a field type nested inside a template of a template', () => {
     expect(() =>
       compileSchema(
@@ -192,8 +197,6 @@ describe('compileSchema with nested template fields', () => {
 });
 
 describe('compileSchema provider conflicts', () => {
-  // The field registry refuses to boot this config; last-wins here would still write
-  // a lock, pinning whichever plugin happened to be last.
   it('rejects two plugins providing the same field type', () => {
     expect(() =>
       compileSchema(
@@ -209,8 +212,6 @@ describe('compileSchema provider conflicts', () => {
 describe('checkLock across lock formats', () => {
   const config = configWith([{ name: 'title', type: 'string' }]);
 
-  // A lock from a newer tinacms differs only by stringify, so it read as stale and was
-  // rewritten in the older format — a silent downgrade of a committed file.
   it('refuses a lock written in a newer format instead of downgrading it', () => {
     const lock = { ...compileSchema(config), version: LOCK_VERSION + 1 };
     const check = checkLock(lock, config);
@@ -218,15 +219,11 @@ describe('checkLock across lock formats', () => {
     expect(check).toHaveProperty('message', expect.stringContaining('Upgrade'));
   });
 
-  // The opposite case: this package can write the newer format, so the lock is merely
-  // out of date. Telling the author to upgrade tinacms would leave them stuck.
   it('reports a lock written in an older format as stale', () => {
     const lock = { ...compileSchema(config), version: LOCK_VERSION - 1 };
     expect(checkLock(lock, config).status).toBe('stale');
   });
 
-  // `primitives` is parsed JSON, so an inherited key would otherwise resolve against
-  // Object.prototype and compare as a pinned version nobody wrote.
   it('does not read prototype keys as pinned versions', () => {
     const lock = compileSchema(
       configWith(

--- a/packages/v4/@tinacms/tinacms/src/codegen/compile-schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/compile-schema.ts
@@ -1,64 +1,42 @@
-// The schema compile (ADR-016). It takes the schema from defineConfig, and it writes
-// tina-lock.json.
-//
-// It is pure, and it runs in Node. It reads the manifests, and never the client
-// segments. FieldProvision on the manifest makes that possible. Every consumer that
-// needs the content model, and cannot run the build of the user, reads this artifact.
-// The client reads it to build the forms. The data layer reads it for its generated API.
-// TinaCloud reads it to validate.
 
 import type { ResolvedConfig, TinaSchema } from '../config';
+import { fieldConflictError, overridesFieldKey } from '../core/field/registry';
 import { invariant } from '../core/invariant';
+import { composeOverridableRegistry } from '../core/overridable-registry';
 import type { FieldProvision, PluginManifest } from '../core/plugin';
 import type {
   CollectionSchema,
   FieldSchema,
   TemplateSchema,
 } from '../core/schema/types';
+import { type PackageVersion, packageVersion } from './package-version';
 
-// The format version of the artifact. It increases when the shape of the file changes.
-// It is not the contract version of a primitive, which the file also holds.
-export const LOCK_VERSION = 4;
+export const LOCK_VERSION = 5;
 
 export interface TinaLock {
   version: number;
-  schema: TinaSchema;
-  /**
-   * The field types that the schema uses. Each one holds the contract version of its
-   * plugin. The file does not hold the definitions (ADR-016 §2). They resolve at build
-   * time from the installed plugins. A change to a primitive that breaks nothing
-   * therefore leaves this file alone. The file changes only when the schema of the
-   * user changes, or when a contract version changes.
-   *
-   * Only the types that the schema uses appear here. An unrelated field plugin makes
-   * no change to this file.
-   */
+  schema: TinaSchema & { version: PackageVersion };
   primitives: Record<string, number>;
 }
 
 const fieldProvisionsOf = (
   plugins: PluginManifest[]
-): Map<string, FieldProvision> => {
-  const provisions = new Map<string, FieldProvision>();
-  for (const plugin of plugins) {
-    if (!plugin.field) continue;
-    // Last-wins would pin whichever plugin happened to be last, for a config the
-    // field registry refuses to boot at all. Same rule, same point of failure.
-    invariant(
-      !provisions.has(plugin.field.type),
-      'schema-duplicate-field-type',
-      `Two plugins provide the \`field\` capability at type "${plugin.field.type}". ` +
-      'Declare `overrides: [{ capability: "field", key }]` to replace a built-in.'
-    );
-    provisions.set(plugin.field.type, plugin.field);
-  }
-  return provisions;
-};
+): Map<string, FieldProvision> =>
+  composeOverridableRegistry(
+    plugins.flatMap((plugin) =>
+      plugin.field
+        ? [
+            {
+              key: plugin.field.type,
+              value: plugin.field,
+              isOverride: overridesFieldKey(plugin, plugin.field.type),
+            },
+          ]
+        : []
+    ),
+    fieldConflictError
+  );
 
-// A field whose schema node carries its own templates (rich-text embeds) nests further
-// field types inside it. They render like any other field, so they need the same
-// build gate and the same contract pin — reading only the top level let them through
-// both. A nested field can carry templates of its own, so this walks the whole tree.
 const templateFieldTypesIn = (templates: TemplateSchema[] = []): string[] =>
   templates.flatMap((template) =>
     (template.fields ?? []).flatMap((nested) => [
@@ -82,50 +60,33 @@ const usedFieldTypes = (collections: CollectionSchema[]): string[] => [
 export const compileSchema = (config: ResolvedConfig): TinaLock => {
   const provisions = fieldProvisionsOf(config.plugins);
   const primitives: Record<string, number> = {};
-  // Sort the types, so that the artifact holds the same bytes at each run. This file
-  // is committed, and an unsorted object would change with the iteration order alone.
   for (const type of usedFieldTypes(config.schema.collections).sort()) {
     const provision = provisions.get(type);
-    // The build gate (ADR-020). A field type that no plugin renders is a broken
-    // schema. It fails here, and not as an empty field in the editor.
     invariant(
       provision,
       'schema-unknown-field-type',
       `The schema uses the field type "${type}", but no installed plugin provides ` +
-      'the `field` capability at that type.'
+        'the `field` capability at that type.'
     );
     primitives[type] = provision.contractVersion;
   }
-  return { version: LOCK_VERSION, schema: config.schema, primitives };
+  return {
+    version: LOCK_VERSION,
+    schema: { ...config.schema, version: packageVersion() },
+    primitives,
+  };
 };
 
 export type LockCheck =
   | { status: 'current' }
-  // The lock was written in a format this package does not know. It is newer, not
-  // stale — rewriting it would silently downgrade a committed file.
   | { status: 'unreadable'; message: string }
-  // The lock is older than a change to the schema, or to the installed field set.
-  // Every contract version in it still matches. Write the lock again, and do not stop
-  // the build.
   | { status: 'stale'; message: string }
-  // A primitive changed its shape under a committed lock. A silent repair is the
-  // failure that ADR-016 prevents, so this stops and gives a migration path.
   | { status: 'incompatible'; message: string };
 
-/**
- * Compare a committed lock with the output that the installed plugins would compile.
- * The lock is committed, so it can be older than the package. This function turns that
- * difference into a warning, or into a migration. It does not let it become a silent
- * break (ADR-016 §3).
- */
 export const checkLock = (
   lock: TinaLock,
   config: ResolvedConfig
 ): LockCheck => {
-  // A lock from a newer tinacms cannot be compared field by field: it would differ only
-  // by stringify, read as merely stale, and be rewritten in the older format.
-  // LOCK_VERSION existed and nothing read it. A lock from an older tinacms is the
-  // opposite case — this package can write it again, so it falls through to `stale`.
   if (lock.version > LOCK_VERSION) {
     return {
       status: 'unreadable',
@@ -136,9 +97,6 @@ export const checkLock = (
     };
   }
   const fresh = compileSchema(config);
-  // Object.create(null): a lock is parsed JSON, so a `constructor` or `toString` key
-  // in `primitives` would otherwise resolve against Object.prototype and compare as a
-  // pinned version that was never written.
   const pinned: Record<string, number> = Object.assign(
     Object.create(null),
     lock.primitives
@@ -164,8 +122,8 @@ export const checkLock = (
     return {
       status: 'stale',
       message:
-        'tina-lock.json is out of date with your schema and installed plugins. ' +
-        'Regenerating it.',
+        'tina-lock.json is out of date with your schema, your installed plugins, ' +
+        'or your tinacms version. Regenerating it.',
     };
   }
   return { status: 'current' };

--- a/packages/v4/@tinacms/tinacms/src/codegen/package-version.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/package-version.ts
@@ -1,9 +1,7 @@
-
-import { createRequire } from 'node:module';
-
-const packageJson: { version: string } = createRequire(import.meta.url)(
-  '../../package.json'
-);
+// A JSON import, not createRequire: the main entry reaches this file through
+// compile-schema, and a browser imports that entry for defineConfig, so nothing
+// here may touch a node builtin.
+import packageJson from '../../package.json';
 
 export interface PackageVersion {
   fullVersion: string;

--- a/packages/v4/@tinacms/tinacms/src/config.ts
+++ b/packages/v4/@tinacms/tinacms/src/config.ts
@@ -14,14 +14,30 @@ export const defineCollection = (
   collection: CollectionSchema
 ): CollectionSchema => collection;
 
+export interface TinaBuildConfig {
+  publicFolder?: string;
+  outputFolder?: string;
+}
+
+export const DEFAULT_BUILD: Required<TinaBuildConfig> = {
+  publicFolder: 'public',
+  outputFolder: 'admin',
+};
+
+export const resolveBuild = (
+  build?: TinaBuildConfig
+): Required<TinaBuildConfig> => ({ ...DEFAULT_BUILD, ...build });
+
 export interface TinaConfig {
   plugins?: PluginManifest[];
   schema: TinaSchema;
+  build?: TinaBuildConfig;
 }
 
 export interface ComposedConfig {
   plugins: PluginManifest[];
   schema: TinaSchema;
+  build?: Required<TinaBuildConfig>;
 }
 
 export type ResolvedConfig = Brand<ComposedConfig, 'ResolvedConfig'>;
@@ -53,5 +69,9 @@ export const defineConfig = (config: TinaConfig): ResolvedConfig => {
       'provider to `plugins` — `localContentPlugin()` for local development.'
   );
   validateCapabilityGraph(plugins);
-  return asResolvedConfig({ plugins, schema: config.schema });
+  return asResolvedConfig({
+    plugins,
+    schema: config.schema,
+    build: resolveBuild(config.build),
+  });
 };

--- a/packages/v4/@tinacms/tinacms/src/core/field/registry.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/field/registry.ts
@@ -14,13 +14,19 @@ import type { FieldDescriptor } from './contract';
 
 export type FieldRegistry = Map<string, FieldDescriptor>;
 
-const overridesFieldKey = (manifest: PluginManifest, key: string): boolean =>
+export const overridesFieldKey = (
+  manifest: PluginManifest,
+  key: string
+): boolean =>
   manifest.overrides.some(
     (override) =>
       override.capability === FIELD_CAPABILITY && override.key === key
   );
 
-const fieldConflictError = (conflict: RegistryConflict, key: string): Error => {
+export const fieldConflictError = (
+  conflict: RegistryConflict,
+  key: string
+): Error => {
   if (conflict === REGISTRY_CONFLICTS.duplicateOverride) {
     return new Error(
       `Two plugins both declare an \`overrides\` for the \`field\` type "${key}". ` +
@@ -33,10 +39,6 @@ const fieldConflictError = (conflict: RegistryConflict, key: string): Error => {
   );
 };
 
-// A field plugin declares itself in two places. The type key sits on the manifest, and
-// the descriptor sits on the client segment. One half alone is an error by the author.
-// Without this check, it would fail as a missing field type at the render, far from its
-// cause.
 const fieldEntryOf = ({ manifest, segment }: ResolvedSegment) => {
   if (!(manifest.field || segment.field)) return [];
   invariant(

--- a/packages/v4/@tinacms/tinacms/src/core/mount.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/mount.ts
@@ -5,8 +5,6 @@ import {
   isSingletonSliceCapability,
 } from './plugin';
 
-// Where a plugin mounts, on both sides of the boundary: one rule so
-// `get().media.*` and `server.media.*` always agree.
 export interface CapabilityMount {
   namespace: string;
   isOverride: boolean;
@@ -15,17 +13,9 @@ export interface CapabilityMount {
 export const declaresCapabilityOverride = (
   manifest: PluginManifest,
   capability: Capability
-): boolean => {
-  for (const override of manifest.overrides) {
-    if (override.capability === capability) {
-      return true;
-    }
-  }
-  return false;
-};
+): boolean =>
+  manifest.overrides.some((override) => override.capability === capability);
 
-// Singleton providers mount at the capability key, everything else under its
-// own name, so a change of provider changes no reader.
 export const capabilityMountFor = (
   manifest: PluginManifest
 ): CapabilityMount => {
@@ -44,7 +34,6 @@ export const capabilityMountFor = (
       isOverride: declaresCapabilityOverride(manifest, capability),
     };
   }
-  // A feature plugin must not squat a capability namespace by name alone.
   invariant(
     !isSingletonSliceCapability(manifest.name),
     'plugin-name-squats-capability',

--- a/packages/v4/@tinacms/tinacms/src/core/resolve.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/resolve.ts
@@ -1,3 +1,4 @@
+import { fieldConflictError, overridesFieldKey } from './field/registry';
 import { invariant } from './invariant';
 import { declaresCapabilityOverride } from './mount';
 import {
@@ -7,9 +8,9 @@ import {
 } from './overridable-registry';
 import {
   type Capability,
-  FIELD_CAPABILITY,
   type PluginManifest,
   type ResolvedServerSegment,
+  isSingletonSliceCapability,
 } from './plugin';
 
 export const resolveServerSegments = async (
@@ -29,9 +30,6 @@ export const resolveServerSegments = async (
   return resolved;
 };
 
-// Every config error fails here, before any segment import, so a bad config
-// never boots part-way (ADR-006). `field` is keyed, so many providers are
-// correct; the field registry finds per-type conflicts.
 export const validateCapabilityGraph = (plugins: PluginManifest[]): void => {
   const names = new Set<string>();
   for (const plugin of plugins) {
@@ -44,11 +42,43 @@ export const validateCapabilityGraph = (plugins: PluginManifest[]): void => {
     names.add(plugin.name);
   }
 
-  // Singleton capabilities resolve through the same order-independent override
-  // rule as field types and store slices.
+  for (const plugin of plugins) {
+    for (const override of plugin.overrides) {
+      invariant(
+        plugin.provides.includes(override.capability),
+        'override-without-provides',
+        `Plugin "${plugin.name}" declares \`overrides\` for "${override.capability}" ` +
+          `but does not declare \`provides: ["${override.capability}"]\`, so it ` +
+          'would never replace the built-in.'
+      );
+    }
+  }
+
+  composeOverridableRegistry(
+    plugins.flatMap((plugin) =>
+      plugin.field
+        ? [
+            {
+              key: plugin.field.type,
+              value: plugin,
+              isOverride: overridesFieldKey(plugin, plugin.field.type),
+            },
+          ]
+        : []
+    ),
+    fieldConflictError
+  );
+
   const capabilityEntries = plugins.flatMap((plugin) => {
     const singletonCapabilities = plugin.provides.filter(
-      (capability) => capability !== FIELD_CAPABILITY
+      isSingletonSliceCapability
+    );
+    invariant(
+      singletonCapabilities.length <= 1,
+      'plugin-multiple-singleton-slices',
+      `Plugin "${plugin.name}" provides ${singletonCapabilities.length} ` +
+        `singleton capabilities (${singletonCapabilities.join(', ')}), but a ` +
+        'plugin mounts at only one namespace. Split it into one plugin per capability.'
     );
     return singletonCapabilities.map((capability) => ({
       key: capability,
@@ -73,8 +103,6 @@ export const validateCapabilityGraph = (plugins: PluginManifest[]): void => {
   orderPluginsByDependencies(plugins);
 };
 
-// Init order (ADR-006): providers before dependents, config order breaks ties,
-// a cycle is an error. The ready scan is O(n²), enough for tens of plugins.
 const orderPluginsByDependencies = (
   plugins: PluginManifest[]
 ): PluginManifest[] => {
@@ -120,13 +148,10 @@ const orderPluginsByDependencies = (
   return ordered;
 };
 
-// Runs each onInit once per boot in dependency order and returns the teardown,
-// which runs onDestroy in reverse for the plugins that ran their init (ADR-006).
 export const initializePlugins = async (
   plugins: PluginManifest[]
 ): Promise<() => Promise<void>> => {
   const initialized: PluginManifest[] = [];
-  // Drains the list, so a second call destroys nothing.
   const destroyInitialized = async () => {
     const failures: unknown[] = [];
     for (const plugin of initialized.splice(0).reverse()) {
@@ -146,8 +171,6 @@ export const initializePlugins = async (
       await plugin.onInit?.();
       initialized.push(plugin);
     } catch (cause) {
-      // The rollback failure must not replace the failure that caused it, but
-      // must not vanish either.
       await destroyInitialized().catch((rollbackFailure) => {
         console.error(
           '[tinacms] Plugin teardown failed while rolling back a failed init:',

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.test.ts
@@ -1,14 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { FORMAT_EXTENSIONS, formatForPath } from './types';
 
-// There is one map, and two consumers that must agree. The format adapters choose the
-// adapter for a file, and the rich-text codecs choose the parser for a body. Both read
-// the same constant, so they cannot drift. These tests pin the matching itself.
 describe('formatForPath', () => {
   it('tells .md and .mdx apart', () => {
-    // The string '.md' is a prefix of '.mdx'. A looser match, with includes or with
-    // a cut at the first dot, therefore reads every .mdx file as markdown, and drops
-    // the embeds at the save.
     expect(formatForPath('content/posts/hello.mdx')).toBe('mdx');
     expect(formatForPath('content/posts/hello.md')).toBe('md');
   });
@@ -17,14 +11,18 @@ describe('formatForPath', () => {
     expect(formatForPath('content/posts/2026.01.02-release.md')).toBe('md');
   });
 
+  it('reads the format whatever the case of the extension', () => {
+    expect(formatForPath('content/posts/Hello.MDX')).toBe('mdx');
+    expect(formatForPath('content/posts/Hello.Md')).toBe('md');
+    expect(formatForPath('content/posts/DATA.JSON')).toBe('json');
+  });
+
   it('returns undefined for a format it does not know', () => {
     expect(formatForPath('content/posts/hello.markdown')).toBeUndefined();
     expect(formatForPath('content/posts/LICENSE')).toBeUndefined();
   });
 
   it('names an extension for every format in the union', () => {
-    // The Record<CollectionFormat, string> type makes this a compile error, and not a
-    // fault at runtime. The test asserts it too, so the intent survives a wider type.
     expect(
       Object.values(FORMAT_EXTENSIONS).every((ext) => ext.startsWith('.'))
     ).toBe(true);

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
@@ -4,26 +4,11 @@ export interface BaseFieldSchema {
   required?: boolean;
 }
 
-/**
- * A field declared inside a template. Its `type` is optional, because a template is
- * author-written config and the editor carries a template's fields through to the
- * nested-form panel without reading them.
- */
 export interface TemplateFieldSchema extends BaseFieldSchema {
   type?: string;
   templates?: TemplateSchema[];
 }
 
-/**
- * One shape that a field's value can take, for a field that offers several. A rich-text
- * embed is the only case today.
- *
- * It is declared here, and not on the rich-text field alone, because three consumers
- * read it off a plain schema node: the compile step gates and pins the field types
- * nested inside it, the v3 GraphQL pipeline hands it to the v3 schema builder, and the
- * editor renders the embed. The editor's own MdxTemplate is the narrower of the two, and
- * satisfies this structurally.
- */
 export interface TemplateSchema {
   name: string;
   label?: string;
@@ -34,11 +19,6 @@ export interface TemplateSchema {
 
 export interface FieldSchema extends BaseFieldSchema {
   type: string;
-  /**
-   * Marks the field that holds the markdown body of the file. The body is markdown
-   * on disk, and an MDX tree in memory. The format adapter reads and writes the
-   * string, and the rich-text field edits the tree.
-   */
   isBody?: boolean;
   templates?: TemplateSchema[];
 }
@@ -47,12 +27,6 @@ export const COLLECTION_FORMATS = ['md', 'mdx', 'json', 'yaml'] as const;
 
 export type CollectionFormat = (typeof COLLECTION_FORMATS)[number];
 
-/**
- * The file extension of each format. It is declared once, because two consumers must
- * agree on it. The format adapters use it to find the adapter for a file. The
- * rich-text codecs use it to find the parser for a body. The record covers the whole
- * union, so a new format does not compile until it names its extension.
- */
 export const FORMAT_EXTENSIONS: Record<CollectionFormat, string> = {
   md: '.md',
   mdx: '.mdx',
@@ -60,40 +34,21 @@ export const FORMAT_EXTENSIONS: Record<CollectionFormat, string> = {
   yaml: '.yaml',
 };
 
-/**
- * The format of a document, read from the name of that document. The file decides its
- * format, and the collection does not. One collection can therefore hold more than one
- * format.
- */
 export const formatForPath = (
   documentPath: string
-): CollectionFormat | undefined =>
-  COLLECTION_FORMATS.find((format) =>
-    documentPath.endsWith(FORMAT_EXTENSIONS[format])
+): CollectionFormat | undefined => {
+  const lowerPath = documentPath.toLowerCase();
+  return COLLECTION_FORMATS.find((format) =>
+    lowerPath.endsWith(FORMAT_EXTENSIONS[format])
   );
+};
 
 export interface CollectionSchema {
   name: string;
   label?: string;
   path?: string;
-  /**
-   * One format, or several formats for a collection with mixed files. An `.mdx`
-   * document and a `.json` document can share a list and a form. The extension of
-   * each file names the adapter that reads it.
-   *
-   * The first entry is the primary format. Today that has one meaning only. The v3
-   * GraphQL pipeline reads the primary format and no other, until v4 owns its index.
-   * graphql-pipeline.ts warns about the other formats. The primary format is not yet
-   * the format of a new document. The data layer writes the path that it receives, so
-   * the caller chooses the extension. The primary format becomes the default when code
-   * above the data layer starts to name new files.
-   */
   format: CollectionFormat | CollectionFormat[];
   fields: FieldSchema[];
 }
 
-/**
- * An open set of field values, keyed by field name. The plugins supply the value
- * types, and no static type can describe them. The type is therefore `unknown`.
- */
 export type TinaDocument = Record<string, unknown>;

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -9,6 +9,7 @@ export {
   defineCollection,
   defineConfig,
   type ResolvedConfig,
+  type TinaBuildConfig,
   type TinaConfig,
   type TinaSchema,
 } from './config';

--- a/packages/v4/@tinacms/tinacms/src/rpc/handler.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/handler.test.ts
@@ -9,11 +9,14 @@ import {
 } from '../server';
 import { createRpcHandler } from './handler';
 
-const sessionsByToken: Record<string, Session> = {
-  'admin-token': { identity: { id: 'ada' }, roles: ['admin'] },
-  'editor-token': { identity: { id: 'eli' }, roles: ['editor'] },
-  'proto-token': { identity: { id: 'mal' }, roles: ['constructor'] },
-};
+const sessionsByToken: Record<string, Session> = Object.assign(
+  Object.create(null),
+  {
+    'admin-token': { identity: { id: 'ada' }, roles: ['admin'] },
+    'editor-token': { identity: { id: 'eli' }, roles: ['editor'] },
+    'proto-token': { identity: { id: 'mal' }, roles: ['constructor'] },
+  }
+);
 
 const authPlugin = (rolePermissions?: (role: string) => Promise<string[]>) =>
   definePlugin({
@@ -44,8 +47,6 @@ const mediaPlugin = definePlugin({
         { permission: 'media:delete' },
         async (input: { path: string }) => ({ removed: input.path })
       ),
-      // This covers the in-process accessor between two server segments, inside a
-      // dispatch.
       viaAuth: async () => (use('auth').whoami as () => Promise<unknown>)(),
       explode: async () => {
         throw new Error('secret internals');
@@ -83,9 +84,6 @@ const post = (
       (opts.body === undefined ? undefined : JSON.stringify(opts.body)),
   });
 
-// Sec-Fetch-Site is a forbidden header name, so happy-dom refuses to put it on a real
-// Request — which is the property the guard rests on: a page cannot forge it either.
-// The handler reads only these four members, so a double states the header instead.
 const postStatingFetchSite = (path: string, site: string): Request =>
   ({
     method: 'POST',
@@ -201,8 +199,6 @@ describe('createRpcHandler', () => {
       server: async () => ({
         default: defineServerPlugin({
           getSession: async (request: Request) => {
-            // A provider that composes a capability can read its peers during a
-            // verification.
             await (use('media').health as () => Promise<unknown>)();
             return request.headers.get('authorization')
               ? { identity: { id: 'ada' }, roles: ['admin'] }
@@ -428,8 +424,6 @@ describe('createRpcHandler', () => {
   });
 });
 
-// The guards that need no runtime run before the runtime composes, so a request that
-// never reaches an operation cannot make every plugin import and initialize.
 describe('createRpcHandler composition', () => {
   const countingPlugin = (onInit: () => void) =>
     definePlugin({
@@ -505,10 +499,7 @@ describe('createRpcHandler composition', () => {
     await handler(post('/search/ping'));
     const teardown = handler.destroy();
     await started;
-    // The destroy has cleared the cache, so this request composes again. It must not
-    // run onInit while the onDestroy above is still running.
     const duringTeardown = handler(post('/search/ping'));
-    // Long enough for an unserialised composition to reach its onInit.
     await new Promise((resolve) => setTimeout(resolve, 20));
     releaseOnDestroy();
     await teardown;
@@ -563,8 +554,6 @@ describe('createRpcHandler composition', () => {
   });
 });
 
-// Without a mountPath the route is the last two segments, so any prefix reaches the
-// operation. With one, the path has to be the mount and exactly those two.
 describe('createRpcHandler mountPath', () => {
   const plugins = [mediaPlugin, authPlugin()];
 

--- a/packages/v4/@tinacms/tinacms/src/rpc/handler.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/handler.ts
@@ -1,5 +1,3 @@
-// Capability RPC transport (ADR-007, ADR-008). All server segments compose into one
-// Request -> Response handler. JSON only; binary belongs to media (ADR-022).
 
 import { invariant } from '../core/invariant';
 import { capabilityMountFor } from '../core/mount';
@@ -26,31 +24,21 @@ import {
 } from '../server';
 
 export type RpcHandler = ((request: Request) => Promise<Response>) & {
-  // Hosts that replace a handler (not end the process) call this so every
-  // onInit keeps its onDestroy.
   destroy: () => Promise<void>;
 };
 
 export interface RpcHandlerConfig {
   plugins: PluginManifest[];
-  // e.g. `/api/tina`. Without it the route is the last two path segments, so
-  // any prefix reaches an operation. Set it to pin the route.
   mountPath?: string;
 }
 
-// Composition runs once, at the first request. A failure is not cached.
 export const createRpcHandler = ({
   plugins,
   mountPath,
 }: RpcHandlerConfig): RpcHandler => {
   let runtimePromise: Promise<ServerRuntime> | null = null;
-  // Serialises compose/teardown: destroy() clears the cache before onDestroy
-  // finishes, so without this a request arriving mid-teardown would run onInit
-  // while onDestroy was still running.
   let lifecycleTurn: Promise<void> = Promise.resolve();
 
-  // Compose after the current turn, so a destroy arriving mid-composition tears
-  // down what this composition initialized.
   const composeAfterCurrentTurn = (): Promise<ServerRuntime> => {
     const composing = lifecycleTurn.then(() => composeServerRuntime(plugins));
     lifecycleTurn = composing.then(
@@ -65,8 +53,6 @@ export const createRpcHandler = ({
   };
 
   const handler = async (request: Request): Promise<Response> => {
-    // Refuse before composing: a failed compose is not cached, so an
-    // unauthenticated GET would otherwise re-run every plugin import per request.
     const refusal = refusalOf(request);
     if (refusal) return refusal;
     const route = routeOf(request, mountPath);
@@ -93,8 +79,6 @@ export const createRpcHandler = ({
     const composed = runtimePromise;
     runtimePromise = null;
     const currentTurn = lifecycleTurn;
-    // A failed composition has nothing to tear down; a failed onDestroy leaves
-    // a handle open, so it is logged.
     lifecycleTurn = (async () => {
       await currentTurn;
       const runtime = await composed?.catch(() => null);
@@ -125,13 +109,10 @@ const composeServerRuntime = async (
     serverConflictError
   );
   const authHooks = claimAuthTransportHooks(segmentsByNamespace);
-  // Init runs last, so a failed composition leaves no initialized plugin behind.
   const destroy = await initializePlugins(plugins);
   return { segmentsByNamespace, authHooks, destroy };
 };
 
-// Pull the transport hooks off the auth segment so dispatch 404s them. Without a
-// callable getSession this returns null and every non-public op fails closed.
 const claimAuthTransportHooks = (
   segmentsByNamespace: Map<string, ResolvedServerSegment>
 ): AuthTransportHooks | null => {
@@ -163,9 +144,6 @@ const refusalOf = (request: Request): Response | null => {
   if (request.method !== 'POST') {
     return errorResponse(405, 'method-not-allowed', 'RPC operations are POST.');
   }
-  // CSRF gate 1 (ADR-008): cross-origin application/json always preflights, and
-  // this server never answers OPTIONS. Compare the MIME essence, not a substring:
-  // `text/plain; charset=application/json` sends no preflight.
   const mimeEssence = request.headers
     .get('content-type')
     ?.replace(/;.*/, '')
@@ -178,8 +156,6 @@ const refusalOf = (request: Request): Response | null => {
       'RPC requests must be application/json.'
     );
   }
-  // CSRF gate 2: a host app's global CORS middleware voids the preflight gate
-  // without touching this file.
   if (request.headers.get('sec-fetch-site') === 'cross-site') {
     return errorResponse(
       403,
@@ -215,8 +191,6 @@ const dispatch = async (
   request: Request,
   { namespace, opName }: RpcRoute
 ): Promise<Response> => {
-  // One catch covers everything after routing: plugin code throws internal
-  // details that must not reach an HTTP body.
   try {
     return await serverRuntimeStorage.run(runtime, () =>
       authorizeAndInvokeOp(runtime, request, namespace, opName)
@@ -243,13 +217,12 @@ const authorizeAndInvokeOp = async (
     );
   }
 
-  // Secure by default (ADR-008 §1): authenticate before invoking. publicOp is
-  // the one exception and also skips plugin-level `requires`.
   const meta = opMeta(op);
   if (!meta.public) {
-    const session = runtime.authHooks
-      ? await runtime.authHooks.getSession(request)
-      : null;
+    if (!runtime.authHooks) {
+      return errorResponse(401, 'unauthenticated', 'No CMS session.');
+    }
+    const session = await runtime.authHooks.getSession(request);
     if (!session) {
       return errorResponse(401, 'unauthenticated', 'No CMS session.');
     }
@@ -287,8 +260,6 @@ const authorizeAndInvokeOp = async (
   return Response.json(result ?? null);
 };
 
-// Own-property + function checks keep prototype members like `toString` off the
-// routes.
 const routedOp = (
   mounted: ResolvedServerSegment,
   opName: string
@@ -302,12 +273,12 @@ const invokeOp = (op: ServerOp, input: unknown): Promise<unknown> =>
   (op as (input: unknown) => Promise<unknown>)(input);
 
 const hasPermission = async (
-  authHooks: AuthTransportHooks | null,
+  authHooks: AuthTransportHooks,
   session: Session,
   permission: string
 ): Promise<boolean> => {
   for (const role of session.roles) {
-    const permissions = authHooks?.rolePermissions
+    const permissions = authHooks.rolePermissions
       ? await authHooks.rolePermissions(role)
       : (DEFAULT_ROLE_PERMISSIONS[role] ?? []);
     if (permissions.includes('*') || permissions.includes(permission)) {

--- a/packages/v4/@tinacms/tinacms/src/rpc/proxy.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/proxy.test.ts
@@ -29,7 +29,7 @@ describe('createRpcClient', () => {
   });
 
   it('throws RpcError carrying the transport code and status', async () => {
-    const rejection = client.search.reindex(undefined);
+    const rejection = client.search.reindex();
     await expect(rejection).rejects.toBeInstanceOf(RpcError);
     await expect(rejection).rejects.toMatchObject({
       status: 401,

--- a/packages/v4/@tinacms/tinacms/src/rpc/proxy.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/proxy.test.ts
@@ -37,6 +37,20 @@ describe('createRpcClient', () => {
     });
   });
 
+  it('throws rpc-not-json for an ok response whose body is not JSON', async () => {
+    const broken = createRpcClient<{ search: typeof searchOps }>({
+      url: 'http://tina.local/api/tina',
+      fetch: async () =>
+        new Response('<!doctype html>', {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+    });
+    const rejection = broken.search.query({ q: 'x' });
+    await expect(rejection).rejects.toBeInstanceOf(RpcError);
+    await expect(rejection).rejects.toMatchObject({ code: 'rpc-not-json' });
+  });
+
   it('is not thenable and yields nothing for symbol keys', async () => {
     expect((client as unknown as Record<string, unknown>).then).toBeUndefined();
     expect(

--- a/packages/v4/@tinacms/tinacms/src/rpc/proxy.ts
+++ b/packages/v4/@tinacms/tinacms/src/rpc/proxy.ts
@@ -86,19 +86,28 @@ const unwrapRpcResponse = async (
   namespace: string,
   opName: string
 ): Promise<unknown> => {
-  const isJson = response.headers
+  const mimeEssence = response.headers
     .get('content-type')
-    ?.toLowerCase()
-    .includes('application/json');
-  if (response.ok && !isJson) {
-    throw new RpcError(
-      response.status,
-      'rpc-not-json',
-      `RPC ${namespace}/${opName} returned ${response.status} but not JSON.`
-    );
+    ?.replace(/;.*/, '')
+    .trim()
+    .toLowerCase();
+  if (response.ok) {
+    if (mimeEssence !== 'application/json') {
+      throw new RpcError(
+        response.status,
+        'rpc-not-json',
+        `RPC ${namespace}/${opName} returned ${response.status} but not JSON.`
+      );
+    }
+    return response.json().catch(() => {
+      throw new RpcError(
+        response.status,
+        'rpc-not-json',
+        `RPC ${namespace}/${opName} returned ${response.status} with a body that is not JSON.`
+      );
+    });
   }
   const payload = await response.json().catch(() => null);
-  if (response.ok) return payload;
   const error = (payload as { error?: { code?: string; message?: string } })
     ?.error;
   throw new RpcError(

--- a/packages/v4/@tinacms/tinacms/src/server/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/server/index.ts
@@ -1,4 +1,3 @@
-// The server entry, `tinacms/server`. Never reaches the browser bundle.
 
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { invariant } from '../core/invariant';
@@ -10,8 +9,6 @@ import type {
 
 export type { ResolvedServerSegment, ServerOp, ServerSegment };
 
-// Identity function that keeps `TOps`, so `import type` carries each op's
-// signature to the client RPC proxy (ADR-007).
 export const defineServerPlugin = <TOps extends ServerSegment>(
   ops: TOps
 ): TOps => ops;
@@ -21,25 +18,20 @@ export interface Session {
   roles: string[];
 }
 
-// Transport hooks the RPC handler pulls off the auth segment; the composition
-// removes them from the routable ops so dispatch can never route them.
 export interface AuthTransportHooks {
   getSession: (request: Request) => Promise<Session | null>;
   rolePermissions?: (role: string) => Promise<string[]>;
 }
 
-// Defaults so TinaCloud works with no config (ADR-008 §4, §5). Null prototype,
-// so a role named "constructor" or "__proto__" resolves to nothing.
-export const DEFAULT_ROLE_PERMISSIONS: Record<string, string[]> = Object.assign(
-  Object.create(null),
-  {
-    admin: ['*'],
-    editor: [],
-  }
+export const DEFAULT_ROLE_PERMISSIONS: Readonly<
+  Record<string, readonly string[]>
+> = Object.freeze(
+  Object.assign(Object.create(null), {
+    admin: Object.freeze(['*']),
+    editor: Object.freeze([]),
+  })
 );
 
-// Authorization marks (ADR-008): plain handlers are protected by default,
-// `publicOp` opts out. `Symbol.for`, so two copies of this module agree on the tag.
 const OP_META = Symbol.for('tinacms.op-meta');
 
 interface OpMeta {
@@ -52,6 +44,11 @@ interface TaggedOp {
 }
 
 const tagOp = <TOp extends ServerOp>(handler: TOp, meta: OpMeta): TOp => {
+  invariant(
+    (handler as TaggedOp)[OP_META] === undefined,
+    'op-already-tagged',
+    'This handler already carries an authorization mark; wrap the bare handler instead.'
+  );
   const wrapped = ((input: never) => handler(input)) as TOp & TaggedOp;
   wrapped[OP_META] = meta;
   return wrapped;
@@ -74,12 +71,8 @@ export interface ServerRuntime {
   destroy: () => Promise<void>;
 }
 
-// Carries the runtime through a dispatch so module-level `use()` resolves
-// against the dispatching handler, even when requests overlap.
 export const serverRuntimeStorage = new AsyncLocalStorage<ServerRuntime>();
 
-// In-process capability accessor, e.g. `use('content').listAll()` (ADR-007).
-// Untyped until the capability contracts land; callers cast.
 export const use = (capability: string): ServerSegment => {
   const runtime = serverRuntimeStorage.getStore();
   invariant(


### PR DESCRIPTION
**TLDR:** tina-lock.json stamps the installed tinacms version (LOCK_VERSION 5), and the runtime rejects more invalid plugin graphs at boot.

**Feats:**
- compileSchema stamps schema.version from the installed package
- An overrides entry without a matching provides is rejected; so is a plugin with two singleton slices
- The compile and the boot compose the field registry the same way, so they fail the same way
- The RPC handler answers 401 when no auth hooks are mounted; DEFAULT_ROLE_PERMISSIONS is frozen; a handler cannot be tagged twice
- Document extension matching is case-insensitive

**How to test:** The compile, resolve and RPC suites cover each rule.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test` and `pnpm types`.
