### PR TITLE
feat(v4): TinaAdmin mounts its own provider and router

### DIFF
--- a/packages/v4/@tinacms/tinacms/_docs/architecture.md
+++ b/packages/v4/@tinacms/tinacms/_docs/architecture.md
@@ -9,6 +9,8 @@ hooks → validation → digest.
 
 ## 1. Resolve the plugins into a registry
 
+`<TinaAdmin config>` (`admin/admin.tsx`) mounts `<TinaProvider>` itself, so an
+app renders one component and does not compose the provider by hand.
 `<TinaProvider plugins={[...]}>` (`editor/provider.tsx`) calls
 `resolveFieldPlugins` (`core/field/registry.ts`). `resolveFieldPlugins` awaits
 the `client()` import of each manifest. Then it builds the `FieldRegistry`, a

--- a/packages/v4/@tinacms/tinacms/e2e/rich-text-field.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/rich-text-field.spec.ts
@@ -4,24 +4,15 @@ import { fileURLToPath } from 'node:url';
 import { expect, test } from '@playwright/test';
 import { setColumnWidth, toolbar } from './form-column';
 
-// Two guarantees of the rich-text field that only a real browser can check. Both of them
-// shipped broken, and a person found them by hand. These tests stop that.
-
 const body = (page: import('@playwright/test').Page) =>
   page.getByRole('textbox', { name: 'body' });
 
-// The admin shell marks the open document in the header of its form, and it marks every
-// other document in the document list. This locator reads the header only, so the two
-// never cross. The match is exact, because the document list marks an edited document
-// "Unsaved". That word holds "Save", so a substring match would also find the list entry.
 const saveButton = (page: import('@playwright/test').Page) =>
-  page.getByRole('button', { name: 'Save', exact: true });
+  page.locator('aside').getByRole('button', { name: 'Save', exact: true });
 
 const status = (page: import('@playwright/test').Page) =>
   page.locator('aside header').getByText(/^(No changes|Unsaved|Saved)$/);
 
-// The admin opens on the collection list, so a test must navigate to a document. A deep
-// link is the shortest way in, and it also exercises the route.
 const openDocument = async (
   page: import('@playwright/test').Page,
   name: string
@@ -32,8 +23,6 @@ const openDocument = async (
   await expect(body(page)).toBeVisible();
 };
 
-// These tests save, so they write to the content of the playground. Copy that content
-// first, and write it back after, or a test run leaves the repository dirty.
 const CONTENT_DIR = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   '../playground/content/posts'
@@ -58,10 +47,6 @@ test.beforeEach(async ({ page }) => {
 });
 
 test.describe('rich-text layout', () => {
-  // FieldWrapper is a grid, so the wrapper of the editor is a grid item and defaults
-  // to `min-width: auto`. Without min-w-0, it refuses to become narrower than Plate,
-  // and it spills out of the sidebar. One paragraph fits in both cases. An indented
-  // list shows the fault, so this test opens the document that has one.
   test('the editor stays inside the sidebar, even with nested lists', async ({
     page,
   }) => {
@@ -74,7 +59,6 @@ test.describe('rich-text layout', () => {
     }));
     expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
 
-    // The editor fits the grid track, and does not set its width.
     const fits = await body(page).evaluate((editor) => {
       const track = editor.closest('aside') as HTMLElement;
       return editor.clientWidth <= track.clientWidth;
@@ -82,12 +66,6 @@ test.describe('rich-text layout', () => {
     expect(fits).toBe(true);
   });
 
-  // The toolbar decides how many tools to show from a table of pixel widths, one entry
-  // per control. Nothing derives that table from the buttons, so it drifts the moment a
-  // button changes. When it does, the row runs past its container and `overflow-hidden`
-  // takes the last control off screen — silently, because a clipped button still reports
-  // as rendered and still answers a click that lands where it used to be. This asserts
-  // the property the table exists to hold, at the widths the column can take.
   test('the toolbar fits its column at every width the column can take', async ({
     page,
   }) => {
@@ -119,29 +97,13 @@ test.describe('rich-text layout', () => {
 });
 
 test.describe('rich-text save lifecycle', () => {
-  // Both of these tests write hello-world.mdx. In parallel, they would race on that
-  // one file. The layout test opens another document, so it stays parallel.
   test.describe.configure({ mode: 'serial' });
 
-  // This test also guards the pinned document entry of the admin shell. A save writes
-  // the stored document back into the list cache of the content slice. Without the
-  // pin, that read ingests the document again and resets RHF, and the form never
-  // becomes clean. It happens only for a field whose stored form differs from its
-  // editor value. The rich-text field parses markdown into a tree, and Plate then
-  // normalizes that tree. A unit test on a plain field cannot see it, so this test is
-  // the guard.
-  //
-  // The store compares values by reference, but it receives the clone from RHF. A
-  // structured value could therefore never compare equal, and a saved document stayed
-  // dirty for ever. Plate also emits a normalized tree, with node ids and a trailing
-  // block, which never matches the tree parsed from the disk. A click alone then
-  // looked like an edit. This test types real text, so it covers both faults.
   test('goes pristine -> dirty on a real edit -> clean once saved', async ({
     page,
   }) => {
     await expect(status(page)).toHaveText('No changes');
 
-    // A focus, and a move of the caret, are not an edit.
     await body(page).click();
     await expect(status(page)).toHaveText('No changes');
 
@@ -152,11 +114,6 @@ test.describe('rich-text save lifecycle', () => {
     await expect(status(page)).toHaveText('Saved');
   });
 
-  // Typing and then deleting what was typed leaves the file it would write unchanged,
-  // so the document is not edited any more. The tree Plate holds is not the tree the
-  // document was parsed from — Plate adds node ids and a trailing block — so a compare
-  // of the two trees answers "edited" for a document that has returned to its contents
-  // on disk, and the badge then never leaves "Unsaved".
   test('typing and then deleting it returns the document to clean', async ({
     page,
   }) => {
@@ -166,8 +123,6 @@ test.describe('rich-text save lifecycle', () => {
     await body(page).pressSequentially('Edited.');
     await expect(status(page)).toHaveText('Unsaved');
 
-    // "Saved", and not "No changes": the form has been edited, and its values match the
-    // file again. Only a form that was never edited is pristine.
     for (const _ of 'Edited.') await page.keyboard.press('Backspace');
     await expect(status(page)).toHaveText('Saved');
   });

--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -81,6 +81,7 @@
     "@tinacms/mdx": "workspace:*",
     "@tinacms/rich-text": "workspace:*",
     "@tinacms/ui": "workspace:*",
+    "react-router-dom": "catalog:",
     "abstract-level": "catalog:",
     "gray-matter": "catalog:",
     "react-hook-form": "^7.80.0",

--- a/packages/v4/@tinacms/tinacms/playground/src/app.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/app.tsx
@@ -1,25 +1,6 @@
 import { TinaAdmin } from '@tinacms/tinacms/admin';
-import { TinaProvider, usePreviewConnection } from '@tinacms/tinacms/react';
-import { useRef } from 'react';
 import config from '../tina/config';
 
-function PreviewPane() {
-  const iframeRef = useRef<HTMLIFrameElement>(null);
-  usePreviewConnection(iframeRef);
-  return (
-    <iframe
-      ref={iframeRef}
-      src='/preview.html'
-      title='Preview'
-      className='size-full border-none'
-    />
-  );
-}
-
 export function App() {
-  return (
-    <TinaProvider config={config}>
-      <TinaAdmin preview={<PreviewPane />} />
-    </TinaProvider>
-  );
+  return <TinaAdmin config={config} preview='/preview.html' />;
 }

--- a/packages/v4/@tinacms/tinacms/src/admin/admin.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/admin.test.tsx
@@ -8,14 +8,11 @@ import { definePlugin } from '../core/plugin';
 import type { TinaDocument } from '../core/schema/types';
 import type { AdminScreenProps } from '../core/screen/contract';
 import { useFormId } from '../editor/hooks';
-import { TinaProvider } from '../editor/provider';
 import { useFormStore } from '../form/form-store';
 import stringFieldPlugin from '../plugins/fields/string/string-field.plugin';
 import { TinaAdmin } from './admin';
 import { useAdminRoute } from './use-admin-route';
 
-// A content provider in memory, which stands in for the local data layer. The admin
-// talks to the capability, so the code behind it does not affect these tests.
 const saved: { path: string; value: TinaDocument }[] = [];
 
 const store: Record<string, DocumentEntry[]> = {
@@ -38,9 +35,6 @@ const provider: ContentProvider = {
     (store[collection] ?? []).find((entry) => entry.path === path) ?? null,
   update: async (collection, path, value) => {
     saved.push({ path, value });
-    // Re-parsed, not echoed. The real slice returns what the data layer read back off
-    // disk, which is a different object with a normalised value — echoing the form's
-    // own value made the re-seed this file guards against unreachable.
     const entry = { path, document: { ...value } };
     store[collection] = (store[collection] ?? []).map((candidate) =>
       candidate.path === path ? entry : candidate
@@ -49,8 +43,6 @@ const provider: ContentProvider = {
   },
 };
 
-// Counted, so a test can assert that two components reading one collection share a
-// single request rather than each running their own.
 const listCalls: string[] = [];
 
 const contentPlugin = definePlugin({
@@ -58,8 +50,6 @@ const contentPlugin = definePlugin({
   provides: ['content'],
   client: async () => ({
     default: {
-      // The slice is the transport, and holds no cache. The query client caches, so a
-      // stub only has to answer.
       slice: () => ({
         list: (collection: string) => {
           listCalls.push(collection);
@@ -72,8 +62,6 @@ const contentPlugin = definePlugin({
   }),
 });
 
-// A screen a plugin contributes, to prove the shell routes to a view it knows nothing
-// about. It reads its own route segments.
 function MediaScreen({ segments }: AdminScreenProps) {
   const { navigate } = useAdminRoute();
   return (
@@ -122,22 +110,17 @@ const config = asResolvedConfig({
   },
 });
 
-// A client per render, so no cached list crosses between tests, and no retry hides a
-// rejection behind a delay.
 const renderAdmin = (preview?: React.ReactNode) =>
   render(
-    <TinaProvider
+    <TinaAdmin
       config={config}
       queryClient={
         new QueryClient({ defaultOptions: { queries: { retry: false } } })
       }
-    >
-      <TinaAdmin preview={preview} />
-    </TinaProvider>
+      preview={preview}
+    />
   );
 
-// A component that reads the open form from the main pane. usePreviewConnection is the
-// real one. This is the smallest component with the same requirement.
 function PreviewProbe() {
   return <p>previewing {useFormId()}</p>;
 }
@@ -161,8 +144,6 @@ beforeEach(() => {
   listCalls.length = 0;
   window.location.hash = '';
   useFormStore.setState({ forms: {} });
-  // provider.update mutates `store`, and nothing reset it, so a test that saved
-  // changed the fixture every later test read.
   for (const [collection, entries] of Object.entries(FIXTURES)) {
     store[collection] = entries.map((entry) => ({ ...entry }));
   }
@@ -171,8 +152,6 @@ beforeEach(() => {
 describe('TinaAdmin', () => {
   it('lists every collection the schema declares, and nothing else', async () => {
     renderAdmin();
-    // A SidebarMenu is a <ul>, so the menu is a labelled list and not a navigation
-    // landmark. The sidebar as a whole is the landmark.
     const menu = await screen.findByRole('list', { name: 'Collections' });
     expect(
       within(menu)
@@ -199,10 +178,12 @@ describe('TinaAdmin', () => {
       path: 'content/posts/hello.mdx',
       value: { title: 'Hello!' },
     });
+    await waitFor(() =>
+      expect(screen.getByRole('status')).toHaveTextContent('Saved')
+    );
+    expect(input).toHaveValue('Hello!');
   });
 
-  // The route is the state, so a deep link must open the document at the first paint,
-  // and not after a click.
   it('opens the document a deep link names', async () => {
     window.location.hash = '#/collections/post/content%2Fposts%2Fsecond.mdx';
     renderAdmin();
@@ -218,18 +199,12 @@ describe('TinaAdmin', () => {
     );
   });
 
-  // A stale link, or a collection with a new name. Say so, and do not show the list
-  // with no message.
   it('reports a collection the schema does not have', async () => {
     window.location.hash = '#/collections/ghost';
     renderAdmin();
     expect(await screen.findByText(/No collection named/)).toBeInTheDocument();
   });
 
-  // The preview renders in the main pane, and it reads the open form. The form scope
-  // must therefore sit above the whole layout, and not around the fields in the
-  // sidebar. A scope around the sidebar threw at runtime, and only in a browser. The
-  // vitest suite passed no preview, so nothing ran that path.
   it('renders the preview inside the open document form scope', async () => {
     window.location.hash = '#/collections/post/content%2Fposts%2Fhello.mdx';
     renderAdmin(<PreviewProbe />);
@@ -242,8 +217,6 @@ describe('TinaAdmin', () => {
     expect(screen.queryByText(/^previewing /)).not.toBeInTheDocument();
   });
 
-  // The store keeps an unsaved form after its scope unmounts (ADR-012), and the
-  // document list reads that store. The badge therefore stays after a move away.
   it('still badges a document as unsaved after navigating away from it', async () => {
     const user = userEvent.setup();
     renderAdmin();
@@ -255,6 +228,7 @@ describe('TinaAdmin', () => {
     await user.click(
       await screen.findByRole('button', { name: /second\.mdx/ })
     );
+    expect(await screen.findByLabelText('title')).toHaveValue('Second');
 
     const helloEntry = await screen.findByRole('button', {
       name: /hello\.mdx/,
@@ -264,9 +238,6 @@ describe('TinaAdmin', () => {
 });
 
 describe('TinaAdmin content reads', () => {
-  // The sidebar's document list and the open document's scope both read the collection.
-  // Each ran its own effect and its own fetch before the query client, so opening a
-  // collection listed it twice.
   it('reads a collection once when two components ask for it', async () => {
     const user = userEvent.setup();
     renderAdmin();
@@ -277,7 +248,6 @@ describe('TinaAdmin content reads', () => {
     expect(listCalls.filter((name) => name === 'post')).toEqual(['post']);
   });
 
-  // Returning to a collection inside the stale window serves the cache.
   it('does not read a collection again on returning to it', async () => {
     const user = userEvent.setup();
     renderAdmin();
@@ -292,8 +262,6 @@ describe('TinaAdmin content reads', () => {
     expect(listCalls).toEqual(['post', 'page']);
   });
 
-  // A failed read and an empty collection are different answers. The failure used to
-  // reach console.error alone, and the sidebar said "No documents yet".
   it('reports a collection that failed to load', async () => {
     const user = userEvent.setup();
     const failing = vi
@@ -308,8 +276,6 @@ describe('TinaAdmin content reads', () => {
     failing.mockRestore();
   });
 
-  // The save writes the stored entry into the cached list, so the sidebar shows it
-  // without a second read of the collection.
   it('shows a save in the document list without re-reading the collection', async () => {
     const user = userEvent.setup();
     renderAdmin();
@@ -345,8 +311,6 @@ describe('TinaAdmin screens', () => {
     await waitFor(() => expect(window.location.hash).toBe('#/screens/media'));
   });
 
-  // The screen owns the segments below its name, so it can navigate within itself and
-  // stay linkable.
   it('gives a screen its own route segments', async () => {
     window.location.hash = '#/screens/media/photos/2026';
     renderAdmin();
@@ -372,16 +336,12 @@ describe('TinaAdmin screens', () => {
     );
   });
 
-  // A stale link, or a screen whose plugin is no longer installed.
   it('reports a screen no plugin registered', async () => {
     window.location.hash = '#/screens/ghost';
     renderAdmin();
     expect(await screen.findByText(/No screen named/)).toBeInTheDocument();
   });
 
-  // A screen names no collection, so opening one closes the document list. The route is
-  // the state: `#/screens/media` has no collection in it, and a sidebar that kept one
-  // would be showing something a reload could not restore.
   it('closes the open collection when a screen opens', async () => {
     const user = userEvent.setup();
     renderAdmin();
@@ -397,8 +357,6 @@ describe('TinaAdmin screens', () => {
     ).not.toBeInTheDocument();
   });
 
-  // The form store keeps an unsaved form after its scope unmounts (ADR-012), and a
-  // screen unmounts that scope.
   it('keeps unsaved edits across a visit to a screen', async () => {
     const user = userEvent.setup();
     renderAdmin();
@@ -418,8 +376,6 @@ describe('TinaAdmin screens', () => {
 });
 
 describe('TinaAdmin form continuity', () => {
-  // Swapping the element type at the scope's position rebuilt everything below it, so
-  // the sidebar's document list re-fetched on every open and close.
   it('keeps the collection list mounted across opening a document', async () => {
     const user = userEvent.setup();
     renderAdmin();

--- a/packages/v4/@tinacms/tinacms/src/admin/admin.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/admin.tsx
@@ -1,6 +1,4 @@
-// The admin shell. The compiled schema drives all of it: no code here names a
-// collection or a field type (ADR-016 §1).
-
+import type { QueryClient } from '@tanstack/react-query';
 import {
   Sidebar,
   SidebarContent,
@@ -21,12 +19,17 @@ import {
   startTransition,
   use,
   useEffect,
+  useRef,
   useState,
 } from 'react';
+import { HashRouter } from 'react-router-dom';
+import type { ResolvedConfig } from '../config';
 import type { CollectionSchema } from '../core/schema/types';
 import type { AdminScreen } from '../core/screen/contract';
 import { useCollectionDocuments } from '../editor/content-queries';
 import { FormScopeContext } from '../editor/context';
+import { usePreviewConnection } from '../editor/preview-connection';
+import { TinaProvider } from '../editor/provider';
 import { toFormId } from '../form/form-store';
 import { DocumentForm } from './document-form';
 import { DocumentScope } from './document-scope';
@@ -36,7 +39,6 @@ import { type AdminRoute, COLLECTIONS_ROUTE } from './routing';
 import { useAdminRoute } from './use-admin-route';
 import { useFormColumnWidth } from './use-form-column-width';
 
-// Wider than the 16rem default: the entries are file paths.
 const SHELL_WIDTH = { '--sidebar-width': '18rem' } as CSSProperties;
 
 const documentName = (path: string) => path.split('/').at(-1) ?? path;
@@ -72,7 +74,6 @@ function CollectionMenu({
   );
 }
 
-// Separate component: a hook higher in the tree would load every collection.
 function DocumentMenu({
   collection,
   activePath,
@@ -86,7 +87,6 @@ function DocumentMenu({
     collection.name
   );
   const label = collection.label ?? collection.name;
-  // A failed read and an empty collection are different answers.
   if (error) {
     return (
       <p className='px-2 py-1.5 text-sm text-destructive'>
@@ -112,6 +112,7 @@ function DocumentMenu({
         <SidebarMenuItem key={path}>
           <SidebarMenuButton
             isActive={path === activePath}
+            aria-label={documentName(path)}
             onClick={() =>
               navigate({ view: 'document', collection: collection.name, path })
             }
@@ -168,7 +169,6 @@ function ScreenOutlet({
       </div>
       <div className='min-h-0 flex-1 overflow-y-auto'>
         {screen ? (
-          // Keyed so moving between screens remounts.
           <screen.component key={screen.name} segments={segments} />
         ) : (
           <Placeholder>No screen named “{name}”.</Placeholder>
@@ -178,13 +178,24 @@ function ScreenOutlet({
   );
 }
 
-// Tests the form scope, not the route: on a deep link the two differ for one
-// frame, and a preview mounted in that gap would read a form that does not
-// exist yet.
+function PreviewFrame({ src }: { src: string }) {
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+  usePreviewConnection(iframeRef);
+  return (
+    <iframe
+      ref={iframeRef}
+      src={src}
+      title='Preview'
+      className='size-full border-none'
+    />
+  );
+}
+
 function PreviewSlot({ preview }: { preview?: ReactNode }) {
   if (!use(FormScopeContext)) {
     return <Placeholder>Select a document to edit.</Placeholder>;
   }
+  if (typeof preview === 'string') return <PreviewFrame src={preview} />;
   return <>{preview ?? <Placeholder>No preview configured.</Placeholder>}</>;
 }
 
@@ -204,10 +215,6 @@ function FormColumn({ openPath }: { openPath?: string }) {
   const scope = use(FormScopeContext);
   const seedKey = scope?.seedKey;
 
-  // The field mount is deferred behind a transition: building the rich-text
-  // editor is the most expensive render in the admin, and long prose froze the
-  // shell for most of a second in the urgent pass. The urgent pass commits the
-  // skeleton, which also unmounts the outgoing editor at once.
   const [mountedSeedKey, setMountedSeedKey] = useState<string | undefined>(
     undefined
   );
@@ -219,7 +226,8 @@ function FormColumn({ openPath }: { openPath?: string }) {
   return (
     <>
       <aside
-        className='flex min-w-0 shrink-0 flex-col overflow-y-auto border-r border-sidebar-border p-4'
+        aria-label='Document form'
+        className='flex min-w-0 shrink-0 flex-col overflow-y-auto border-r border-border p-4'
         style={{ width }}
       >
         <div className='mb-2 flex items-center gap-1'>
@@ -231,23 +239,17 @@ function FormColumn({ openPath }: { openPath?: string }) {
           ) : null}
         </div>
         {mountedSeedKey === seedKey ? (
-          /* Keyed on the seed key: Plate reads its value at mount only. The key
-             stays here — on FormProvider it remounted the preview iframe on
-             every switch. */
           <DocumentForm key={seedKey} />
         ) : (
           <FormColumnSkeleton />
         )}
       </aside>
 
-      {/* Grab area wider than the line it draws: a 1px target is a miss. */}
       <div
         className='-ml-1 z-10 w-2 shrink-0 cursor-col-resize touch-none select-none focus-visible:outline-none'
         {...handleProps}
       />
 
-      {/* Holds the resize cursor over the panes and stops the drag selecting
-          their text. */}
       {isResizing ? (
         <div className='fixed inset-0 z-50 cursor-col-resize' />
       ) : null}
@@ -256,12 +258,24 @@ function FormColumn({ openPath }: { openPath?: string }) {
 }
 
 export interface TinaAdminProps {
-  // The site preview. A prop, not a UI slot: the slot names are a first-party
-  // set the core has not defined yet (ADR-013).
+  config: ResolvedConfig;
   preview?: ReactNode;
+  queryClient?: QueryClient;
 }
 
-export function TinaAdmin({ preview }: TinaAdminProps) {
+export function TinaAdmin({ config, preview, queryClient }: TinaAdminProps) {
+  return (
+    <TinaProvider config={config} queryClient={queryClient}>
+      <HashRouter
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
+        <AdminShell preview={preview} />
+      </HashRouter>
+    </TinaProvider>
+  );
+}
+
+function AdminShell({ preview }: { preview?: ReactNode }) {
   const schema = useTinaSchema();
   const screens = useAdminScreens();
   const { route, navigate } = useAdminRoute();
@@ -275,7 +289,6 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
   );
   const openPath = route.view === 'document' ? route.path : undefined;
   const activeScreen = route.view === 'screen' ? route : undefined;
-  // A route naming a collection outside the schema is stale, not broken.
   const isStaleCollectionRoute =
     activeCollectionName !== undefined && collection === undefined;
 
@@ -336,9 +349,6 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
         </SidebarContent>
       </Sidebar>
 
-      {/* A screen replaces the editor panes. That unmounts the form scope, but
-          unsaved edits survive it: the store keeps a form after its scope goes
-          (ADR-012). */}
       {activeScreen ? (
         <ScreenOutlet
           name={activeScreen.screen}
@@ -348,9 +358,6 @@ export function TinaAdmin({ preview }: TinaAdminProps) {
           segments={activeScreen.segments}
         />
       ) : (
-        /* The scope wraps only the panes that read the open form: wrapping the
-           whole layout reset the sidebar and re-fetched the document list on
-           every open and close. */
         <DocumentScope collection={collection} path={openPath}>
           <SidebarInset className='flex-row'>
             <FormColumn openPath={openPath} />

--- a/packages/v4/@tinacms/tinacms/src/admin/document-status.tsx
+++ b/packages/v4/@tinacms/tinacms/src/admin/document-status.tsx
@@ -6,10 +6,6 @@ import {
   useFormStatus,
 } from '../form/form-store';
 
-// These map onto the variants that the design system has. globals.css holds no success
-// colour and no warning colour, and a badge is the wrong place to add them. The order
-// still reads correctly. The state that needs action is the loudest, and the two settled
-// states are quiet.
 const STATUS_VARIANTS = {
   pristine: 'secondary',
   dirty: 'default',
@@ -22,9 +18,6 @@ const STATUS_LABELS: Record<FormStatus, string> = {
   clean: 'Saved',
 };
 
-// This reads the status of any form, mounted or not. The document list marks a closed
-// document with it. This is why the store owns the pristine, dirty, and clean status
-// (ADR-010), and RHF does not.
 export function FormStatusBadge({ formId }: { formId: FormId }) {
   const status = useFormStatus(formId);
   return (
@@ -33,5 +26,9 @@ export function FormStatusBadge({ formId }: { formId: FormId }) {
 }
 
 export function DocumentStatus() {
-  return <FormStatusBadge formId={useFormId()} />;
+  return (
+    <span role='status'>
+      <FormStatusBadge formId={useFormId()} />
+    </span>
+  );
 }

--- a/packages/v4/@tinacms/tinacms/src/admin/use-admin-route.ts
+++ b/packages/v4/@tinacms/tinacms/src/admin/use-admin-route.ts
@@ -1,17 +1,6 @@
-import { useMemo, useSyncExternalStore } from 'react';
+import { useCallback, useMemo } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { type AdminRoute, formatAdminRoute, parseAdminRoute } from './routing';
-
-const subscribe = (onChange: () => void) => {
-  window.addEventListener('hashchange', onChange);
-  return () => window.removeEventListener('hashchange', onChange);
-};
-
-const readHash = () => window.location.hash;
-const readHashOnServer = () => '';
-
-const navigate = (route: AdminRoute) => {
-  window.location.hash = formatAdminRoute(route);
-};
 
 export interface AdminNavigation {
   route: AdminRoute;
@@ -19,7 +8,15 @@ export interface AdminNavigation {
 }
 
 export const useAdminRoute = (): AdminNavigation => {
-  const hash = useSyncExternalStore(subscribe, readHash, readHashOnServer);
-  const route = useMemo(() => parseAdminRoute(hash), [hash]);
+  const location = useLocation();
+  const routerNavigate = useNavigate();
+  const route = useMemo(
+    () => parseAdminRoute(`#${location.pathname}`),
+    [location.pathname]
+  );
+  const navigate = useCallback(
+    (next: AdminRoute) => routerNavigate(formatAdminRoute(next).slice(1)),
+    [routerNavigate]
+  );
   return { route, navigate };
 };

--- a/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
@@ -6,7 +6,7 @@ import type { FieldAddress } from '../core/field/address';
 import type { FieldRegistry } from '../core/field/registry';
 import { digestDocument } from '../core/form/ingest';
 import { invariant } from '../core/invariant';
-import type { TinaStoreState } from '../core/plugin';
+import type { SliceState, TinaStoreState } from '../core/plugin';
 import type { FieldSchema, TinaDocument } from '../core/schema/types';
 import { type FormId, toFormValues, useFormStore } from '../form/form-store';
 import {
@@ -40,16 +40,21 @@ export function useTinaStore<Selected>(
   return useStore(runtime.store, selector);
 }
 
-// The `content` namespace has the open SliceState type, until codegen produces the
-// typed capability reads. The one cast is here.
+const isContentSlice = (
+  slice: SliceState
+): slice is SliceState & ContentSlice =>
+  typeof slice.get === 'function' &&
+  typeof slice.list === 'function' &&
+  typeof slice.update === 'function';
+
 export function useContentSlice(): ContentSlice {
   const slice = useTinaStore((state) => state.content);
   invariant(
-    slice,
+    slice && isContentSlice(slice),
     'content-capability-missing',
-    'No content capability is mounted — pass a content plugin (e.g. localContentPlugin()) to <TinaProvider plugins>'
+    'No content capability with get, list and update is mounted — pass a content plugin (e.g. localContentPlugin()) to <TinaProvider plugins>'
   );
-  return slice as unknown as ContentSlice;
+  return slice;
 }
 
 function useFormScope(hookCode: string, hookName: string): FormScope {
@@ -62,24 +67,15 @@ export function useFormId(): FormId {
   return useFormScope('form-id-outside-provider', 'useFormId').formId;
 }
 
-// The path of the open document. A field whose behaviour depends on the storage format
-// builds its FieldTransformContext from this, so it resolves the same codec that the
-// ingest and the save resolve. Reading it any other way lets the three disagree.
 export function useDocumentPath(): string {
   return useFormScope('document-path-outside-provider', 'useDocumentPath').path;
 }
 
-// The identity of the values the form was seeded from. A field whose editor owns its own
-// state keys on this, so that a reseed of RHF mounts it again on the new values. Every
-// other field reads its value through useFieldValue and needs nothing here.
 export function useFormSeedKey(): string {
   return useFormScope('form-seed-key-outside-provider', 'useFormSeedKey')
     .seedKey;
 }
 
-// Throw the edits of this form away and put it back on its baseline: the content it
-// loaded, or the content it last saved. It cannot be undone, so the caller confirms
-// first. No control in the admin calls this yet.
 export function useDiscardEdits(): () => void {
   return useFormScope('discard-edits-outside-provider', 'useDiscardEdits')
     .discardEdits;
@@ -90,19 +86,11 @@ export interface ActiveField {
   setActive: (address: FieldAddress | null) => void;
 }
 
-// The view of this form on the one active field in the store (ADR-009, visual editing).
-// The `active` value is the address that a click in the preview activated. It is null
-// when the active field belongs to another form. The `setActive` function sets that
-// address, or clears it.
 export function useActiveField(): ActiveField {
   const formId = useFormId();
   const active = useFormStore((state) =>
     state.active?.formId === formId ? state.active.address : null
   );
-  // Memoised by hand. Only the playground and the test config run the React Compiler,
-  // and this package ships its source — so a consumer's bundler sees these hooks
-  // uncompiled, and a fresh identity here re-runs their `[setActive]` effects on every
-  // render.
   const setActive = useCallback(
     (address: FieldAddress | null) =>
       useFormStore.getState().setActive(formId, address),
@@ -111,22 +99,13 @@ export function useActiveField(): ActiveField {
   return useMemo(() => ({ active, setActive }), [active, setActive]);
 }
 
-// Build the document again from the values of the form, and give it to the save handler
-// of the host (ADR-018 and ADR-019). Only a save that resolves moves the baseline and
-// makes the form clean. A save that rejects leaves the form dirty. The baseline is the
-// snapshot from before the save, and not the latest values in the store. An edit made
-// during the save therefore stays dirty.
 export function useFormSave(): () => Promise<void> {
   const registry = useFieldRegistry();
   const scope = useFormScope('form-save-outside-provider', 'useFormSave');
   const { getValues } = useFormContext<TinaDocument>();
-  // Memoised for the same reason as useActiveField above: consumers hold this in
-  // `[save]` dependencies, and this package ships uncompiled source.
   return useCallback(async () => {
     const { formId, path, collection, onSave } = scope;
     const values = getValues();
-    // The same context that the ingest parsed with, so one codec reads and writes
-    // the value. Without it, a value read as .md could be written as .mdx.
     const digested = digestDocument(values, collection.fields, registry, {
       documentPath: path,
     });
@@ -145,7 +124,6 @@ export function useFieldAddress(): FieldAddress {
   return address;
 }
 
-// The resolved schema node of the field, which holds its config. The caller asserts `T`.
 export function useFieldSchema<T extends FieldSchema = FieldSchema>(): T {
   const node = use(FieldSchemaContext);
   if (node == null) {
@@ -163,9 +141,6 @@ export function useFieldValue<T = unknown>(
 
 export function useFieldErrors(address: FieldAddress): string[] {
   const { errors } = useFormState({ name: address });
-  // The `errors` value of RHF has a complex mapped type. Cast it once, and index it by
-  // field name. This assumes flat addresses, because there are no nested fields yet. A
-  // nested path would need a path walk here.
   const fieldErrors = errors as Record<string, FieldErrorEntry | undefined>;
   return fieldErrorMessages(fieldErrors[address]);
 }
@@ -173,14 +148,7 @@ export function useFieldErrors(address: FieldAddress): string[] {
 export function useFieldActivation(handler: () => void): void {
   const address = use(FieldAddressContext);
   const formId = use(FormScopeContext)?.formId ?? null;
-  // Subscribe to the activation entry, and not to a boolean. setActive writes a new
-  // object at each call, so a second activation of the same field calls the handler
-  // again. A boolean would hold its value, and the second click would do nothing.
   const active = useFormStore((state) => state.active);
-  // The activation entry is the reactive half, and the handler is not. Every call site
-  // passes a new closure on each render, so a handler in the dependencies would fire on
-  // each render instead of on an activation. An Effect Event reads the latest closure
-  // without joining them.
   const onActivate = useEffectEvent(handler);
   useEffect(() => {
     if (

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
@@ -6,8 +6,6 @@ import { definePlugin } from '../core/plugin';
 import { useFieldRegistry, useTinaStore } from './hooks';
 import { TinaProvider } from './provider';
 
-// These tests render a runtime directly, and not a configured app. They therefore pass
-// TinaProvider the resolved shape, and do not call defineConfig.
 const NO_COLLECTIONS = { collections: [] };
 
 function BootProbe() {
@@ -26,9 +24,6 @@ function BootProbe() {
 }
 
 describe('TinaProvider boot', () => {
-  // This goes through defineConfig, so it covers the whole path of a real app. The
-  // built-ins that defineConfig adds must reach the registry and the store, and not
-  // the plugin list alone.
   it('mounts the built-in fields a bare config installs: resolved registry, composed boot store', async () => {
     const config = defineConfig({
       plugins: [definePlugin({ name: 'test:content', provides: ['content'] })],
@@ -66,5 +61,64 @@ describe('TinaProvider boot', () => {
     expect(onDestroy).not.toHaveBeenCalled();
     unmount();
     await waitFor(() => expect(onDestroy).toHaveBeenCalledTimes(1));
+  });
+
+  it('holds an unmounting provider onDestroy until a peer provider onInit finishes', async () => {
+    const lifecycle: string[] = [];
+    let secondInitStarted: () => void = () => {};
+    let releaseSecondInit: () => void = () => {};
+    const started = new Promise<void>((resolve) => {
+      secondInitStarted = resolve;
+    });
+    const released = new Promise<void>((resolve) => {
+      releaseSecondInit = resolve;
+    });
+    let inits = 0;
+    const shared = definePlugin({
+      name: 'shared-lifecycle',
+      onInit: async () => {
+        inits += 1;
+        lifecycle.push('init:start');
+        if (inits === 2) {
+          secondInitStarted();
+          await released;
+        }
+        lifecycle.push('init:end');
+      },
+      onDestroy: async () => {
+        lifecycle.push('destroy:start');
+        lifecycle.push('destroy:end');
+      },
+    });
+    const config = asResolvedConfig({
+      plugins: [shared],
+      schema: NO_COLLECTIONS,
+    });
+    const first = render(
+      <TinaProvider config={config}>
+        <BootProbe />
+      </TinaProvider>
+    );
+    await first.findByTestId('field-types');
+    const second = render(
+      <TinaProvider config={config}>
+        <BootProbe />
+      </TinaProvider>
+    );
+    await started;
+    first.unmount();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    releaseSecondInit();
+    await second.findByTestId('field-types');
+    await waitFor(() => expect(lifecycle).toContain('destroy:end'));
+    expect(lifecycle).toEqual([
+      'init:start',
+      'init:end',
+      'init:start',
+      'init:end',
+      'destroy:start',
+      'destroy:end',
+    ]);
+    second.unmount();
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.tsx
@@ -43,55 +43,16 @@ import {
 import { buildFormResolver } from './resolver';
 
 export interface TinaProviderProps {
-  /**
-   * The output of defineConfig. It already holds the composed plugin list, with the
-   * built-ins folded in and the graph validated. This provider only imports and mounts.
-   * A test that is not a configured app can pass the object directly.
-   */
   config: ResolvedConfig;
-  /**
-   * The cache for the content reads (content-queries.ts). One is created if none is
-   * passed, so a host needs no setup. Pass one to share the cache with the surrounding
-   * app, or to control the retry and staleness policy in a test.
-   *
-   * A nested QueryClientProvider is supported, so an app with its own client keeps it.
-   * The client here shadows that one for the editor's queries only. A passed client
-   * must come from the same @tanstack/react-query install, or its context is a
-   * different one.
-   */
   queryClient?: QueryClient;
   children: ReactNode;
 }
 
-/**
- * The editor's default cache policy. It retries once. A content read crosses a dev
- * server that restarts, and one retry covers that without sitting on a real failure.
- */
 const createDefaultQueryClient = () =>
   new QueryClient({ defaultOptions: { queries: { retry: 1 } } });
 
-/**
- * The result of the async boot. The tree sees this result and the schema. The schema
- * needs no boot.
- */
 type BootedRuntime = Omit<TinaRuntime, 'schema'>;
 
-/**
- * A boot token that changes when the plugin set does: the names, in order.
- *
- * The names are compared member by member, and not by array reference. A config object
- * that is rebuilt on each render holds an equal plugin set, and must not boot again.
- * They are not compared by identity either. A host that calls defineConfig inside a
- * component mints a new manifest for every plugin on every render, so an identity check
- * makes the token climb for ever, and each setBooted schedules the next destroy and
- * init.
- *
- * The cost is a config swapped at runtime for one that keeps every plugin name and
- * changes a plugin's config. `localContentPlugin({ url })` puts that config on the
- * instance. The boot does not run again, and the manifests and client segments of the
- * first config stay. Build the config once, outside the component, and remount the
- * provider to change it.
- */
 const usePluginsKey = (plugins: PluginManifest[]): number => {
   const previous = useRef<PluginManifest[] | null>(null);
   const token = useRef(0);
@@ -108,15 +69,6 @@ const usePluginsKey = (plugins: PluginManifest[]): number => {
   return token.current;
 };
 
-/**
- * This puts the plugin lifecycle of all provider instances into one sequence. It covers
- * the mount, unmount, and remount of StrictMode, and a change of the plugin key. The
- * onInit of the next boot waits for the teardown of the last instance, so an onDestroy
- * never runs after the onInit that follows it.
- *
- * It is module level because the manifests are module singletons, so their lifecycle is
- * global state.
- */
 let lifecycleTurn: Promise<void> = Promise.resolve();
 
 export function TinaProvider({
@@ -124,20 +76,8 @@ export function TinaProvider({
   queryClient,
   children,
 }: TinaProviderProps) {
-  /**
-   * Created once per provider, and never during render of the tree below it. A client
-   * built inline would be replaced on every render, and discard the cache each time.
-   */
   const [ownQueryClient] = useState(createDefaultQueryClient);
   const activeQueryClient = queryClient ?? ownQueryClient;
-  /**
-   * One resolveClientSegments pass feeds both halves of the runtime (ADR-003). One
-   * state object holds them, so the registry and the store always appear together.
-   *
-   * The schema stays out of that object. The boot is keyed on the plugin set, so a
-   * schema held here would go stale when the schema changed and the plugin names did
-   * not.
-   */
   const [booted, setBooted] = useState<BootedRuntime | null>(null);
   const [error, setError] = useState<Error | null>(null);
   const composedPlugins = config.plugins;
@@ -145,12 +85,6 @@ export function TinaProvider({
 
   useEffect(() => {
     let mounted = true;
-    // The graph pass (ADR-006) validates the manifests before it imports a
-    // segment. A config with a conflict, or with a missing provider, fails here.
-    // It does not fail part-way through the boot. The composition runs before the
-    // init, because a field type conflict appears only in createFieldRegistry, and
-    // it must not leave initialized plugins behind. The onInit runs last, before
-    // the runtime is exposed, so no consumer sees a half-initialized plugin set.
     const boot = lifecycleTurn.then(async () => {
       validateCapabilityGraph(composedPlugins);
       const resolved = await resolveClientSegments(composedPlugins);
@@ -163,10 +97,6 @@ export function TinaProvider({
       if (mounted) setBooted(runtime);
       return destroyPlugins;
     });
-    // Advance the shared turn at the mount, and not only at the teardown. A
-    // second provider that mounts in the same commit then chains its onInit after
-    // this boot. It does not race this boot on the module singleton manifests.
-    // The teardown replaces the turn again with the destroy.
     lifecycleTurn = boot.then(
       () => undefined,
       () => undefined
@@ -181,31 +111,17 @@ export function TinaProvider({
     });
     return () => {
       mounted = false;
-      // The teardown waits for the boot, and then becomes the next lifecycle
-      // turn. The init sequence cannot be cancelled, so an unmount during the
-      // boot still destroys the plugins that completed their init. A failed boot
-      // has nothing to destroy. initializePlugins already tore down its partial
-      // sequence, and setError reported the cause. A failed destroy is logged and
-      // not thrown again, because an unmount has no error boundary.
       const destroyBootedPlugins = async () => {
         const destroyPlugins = await boot.catch(() => null);
         await destroyPlugins?.();
       };
-      lifecycleTurn = destroyBootedPlugins().catch((cause) => {
+      const previousTurn = lifecycleTurn;
+      lifecycleTurn = previousTurn.then(destroyBootedPlugins).catch((cause) => {
         console.error('[tinacms] plugin teardown failed:', cause);
       });
     };
   }, [pluginsKey]);
 
-  /**
-   * Held, and not rebuilt. Every use(TinaRuntimeContext) consumer re-renders when this
-   * object changes identity. Only the playground and the test config run the React
-   * Compiler, and this package ships its source, so a consumer's bundler sees this hook
-   * as written.
-   *
-   * A config rebuilt on each render still churns here, through `config.schema`.
-   * usePluginsKey absorbs that for the plugin list only.
-   */
   const runtime = useMemo(
     () => (booted ? { ...booted, schema: config.schema } : null),
     [booted, config.schema]
@@ -222,10 +138,6 @@ export function TinaProvider({
 
 export interface FormProviderProps {
   collection: CollectionSchema;
-  /**
-   * The path of the open document. There is one form for each document (ADR-010), so
-   * this path identifies the form in the form state store.
-   */
   path: string;
   document?: TinaDocument;
   onSave?: SaveHandler;
@@ -246,47 +158,16 @@ export function FormProvider({
   const { registry } = runtime;
 
   const formId = toFormId(path);
-  /**
-   * The path of the document travels with its values. A field transform that depends on
-   * the storage format reads the path from here. The rich-text field selects its codec
-   * in this way. A collection with more than one format therefore resolves for each
-   * document, and not for the whole collection.
-   */
   const transformContext = useMemo(() => ({ documentPath: path }), [path]);
-  /**
-   * Held, and not rebuilt. Rebuilt on each render, this parses every field again — for
-   * the rich-text field that is a whole parseMDX of the body — and hands the seed effect
-   * below a new object, which reseeds the form on every render.
-   *
-   * Only the playground and the test config run the React Compiler, and this package
-   * ships its source, so a consumer's bundler sees these hooks as written.
-   */
   const ingested = useMemo(
     () =>
       ingestDocument(document, collection.fields, registry, transformContext),
     [document, collection, registry, transformContext]
   );
-  /**
-   * The store compares values, and the fields own the answer. This is where the two
-   * meet. The registry lives on the runtime, and the store must not import it.
-   */
   const equal = useMemo(
     () => fieldEqualityFor(collection.fields, registry, transformContext),
     [collection, registry, transformContext]
   );
-  /**
-   * The kept edits win over the incoming document. The store keeps an unsaved form
-   * after the teardown (ADR-012). A new host of the same form id therefore adopts the
-   * kept values and their mirrored errors into the new RHF instance, and does not seed
-   * from the document. This applies to edited forms only. A kept pristine form adopts
-   * the incoming document, because a pristine form is never stale.
-   *
-   * The hook reads the store once for each hosted form, keyed on the form id alone.
-   * While this instance hosts the form, the store mirrors RHF, so a read of that mirror
-   * during the mount would make a cycle. A change of document under kept edits keeps
-   * the edits, which matches the store. The draft slice will later choose between the
-   * new content and the kept edits.
-   */
   const kept = useMemo(() => {
     const scope = readFormStore().forms[formId];
     if (!isEdited(scope)) return { seed: null, errors: {} };
@@ -300,67 +181,21 @@ export function FormProvider({
   const resolver = buildFormResolver(collection, registry);
   const methods = useForm<TinaDocument>({
     defaultValues: seedValues,
-    /**
-     * The kept errors seed like the kept values. RHF adopts the whole map in its errors
-     * effect, so an invalid form shows its errors again after a remount. It needs no
-     * call to trigger().
-     *
-     * This is always an object. On a switch between forms, the new identity makes RHF
-     * replace the errors of the last host. An empty object clears them. A null would
-     * skip the effect and leak them.
-     */
     errors: kept.errors,
     resolver,
     mode: 'onChange',
-    /**
-     * The error seeding must not take the focus. RHF focuses the first field with an
-     * error each time its errors prop arrives. A save does not call handleSubmit, so
-     * nothing else uses this flag.
-     */
     shouldFocusError: false,
   });
 
-  /**
-   * A counter, so that two seeds of the same form id still give two different keys.
-   */
   const reseeds = useRef(0);
-  /**
-   * The identity of the seed that the mounted fields read. RHF resets its values in
-   * place, and a field that hosts an editor owning its own state cannot follow that. It
-   * has to mount again. Plate is that editor. This key changes whenever this provider
-   * reseeds RHF — a discard below, a document that changed under the form, or a switch
-   * of document — and it holds the form id of that seed. Refer to useFormSeedKey.
-   *
-   * It is state updated when the reseed lands, and not a value computed from the formId
-   * of the render. Computed, the key changed on the switch render itself — one render
-   * before the reset below replaces the values — so an editor keyed on it mounted once
-   * on the old document's values and again after the reset. The seed the fields read
-   * does not change until the reset runs, so the key must not claim that it has.
-   */
   const [seedKey, setSeedKey] = useState(() => `${formId}#${reseeds.current}`);
   const advanceSeedKey = useCallback((seededFormId: FormId) => {
     reseeds.current += 1;
     setSeedKey(`${seededFormId}#${reseeds.current}`);
   }, []);
 
-  /**
-   * The signature of the seed that RHF holds. The effect below adopts a new seed.
-   *
-   * The useForm hook of RHF reads defaultValues at the mount only, so a new seed must
-   * reset the form. A JSON signature detects the change, and that signature holds the
-   * form id. The form id is part of it because a switch between two documents with
-   * equal content must still reset the form. Without that reset, the RHF edits of the
-   * old form would render, and save, under the path of the new form. A re-render with
-   * the same content clears no edit in progress.
-   *
-   * The first run registers the form only, because defaultValues already seeded RHF.
-   *
-   * One gap remains. A document that changes under a mounted and edited form resets
-   * RHF, while the store keeps the edits. The draft slice will resolve this.
-   */
   const seededSignature = useRef<string | null>(null);
   useEffect(() => {
-    // The unmount does not call removeForm (ADR-012). A move away keeps the edits.
     useFormStore
       .getState()
       .registerForm(formId, toFormValues(seedValues), equal);
@@ -371,22 +206,11 @@ export function FormProvider({
     }
     if (seededSignature.current !== signature) {
       seededSignature.current = signature;
-      // A kept seed arrives with its errors in place, because the errors effect
-      // of RHF runs before this one. The reset must keep them. Any other seed is
-      // new content, so its old errors must go.
       methods.reset(seedValues, { keepErrors: kept.seed !== null });
       advanceSeedKey(formId);
     }
   }, [formId, seedValues, kept, methods, equal, advanceSeedKey]);
 
-  /**
-   * Throw the edits away and put the form back on its baseline: the content it loaded,
-   * or the content it last saved.
-   *
-   * Three places hold a value, and they move together — the store, RHF, and any editor
-   * that owns its state. The store goes first, so the reset that RHF broadcasts lands
-   * on a form that is already pristine.
-   */
   const discardEdits = useCallback(() => {
     const store = readFormStore();
     const scope = store.forms[formId];
@@ -397,19 +221,11 @@ export function FormProvider({
     advanceSeedKey(formId);
   }, [formId, methods, advanceSeedKey]);
 
-  // A one-way sync from RHF to the form store, with the values and the errors on one
-  // subscription. RHF owns the values and the render. The form store owns the
-  // pristine, dirty, and clean status (ADR-010). The methods.subscribe call is the one
-  // place that reads RHF. A wrapper around field.onChange would miss reset() and
-  // setValue(), and a raw useController could go around it. The subscription lives as
-  // long as the hosted form, so an update never lands under the id of another form.
-  // Every update it receives also comes after the error seeding above.
   useEffect(() => {
     const unsubscribe = methods.subscribe({
       formState: { values: true, errors: true },
       callback: ({ values, errors, name }) => {
         const store = useFormStore.getState();
-        // The name is undefined on a reset. registerForm adopts the baseline.
         if (name !== undefined) {
           store.setFieldValue(formId, toFieldAddress(name), values[name]);
         }
@@ -426,10 +242,6 @@ export function FormProvider({
     return () => unsubscribe();
   }, [formId, methods]);
 
-  /**
-   * Held, and it has to be. editor/context.ts documents this scope as changing only
-   * when the document changes, and useFormSave keys its own useCallback on it.
-   */
   const formScope = useMemo(
     () => ({
       formId,
@@ -445,9 +257,6 @@ export function FormProvider({
   return (
     <FormScopeContext value={formScope}>
       <RhfFormProvider {...methods}>
-        {/* The fragment makes the children a ReactElement. The children type of
-            the RHF FormProvider is older than the bigint in the ReactNode of
-            React 19. */}
         <>{children}</>
       </RhfFormProvider>
     </FormScopeContext>

--- a/packages/v4/@tinacms/ui/src/components/sidebar.tsx
+++ b/packages/v4/@tinacms/ui/src/components/sidebar.tsx
@@ -77,8 +77,6 @@ function SidebarProvider({
   const isMobile = useIsMobile();
   const [openMobile, setOpenMobile] = React.useState(false);
 
-  // This is the internal state of the sidebar.
-  // We use openProp and setOpenProp for control from outside the component.
   const [_open, _setOpen] = React.useState(defaultOpen);
   const open = openProp ?? _open;
   const setOpen = React.useCallback(
@@ -90,27 +88,15 @@ function SidebarProvider({
         _setOpen(openState);
       }
 
-      // This sets the cookie to keep the sidebar state.
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
     },
     [setOpenProp, open]
   );
 
-  // Helper to toggle the sidebar.
   const toggleSidebar = React.useCallback(() => {
     return isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open);
   }, [isMobile, setOpen, setOpenMobile]);
 
-  // Adds a keyboard shortcut to toggle the sidebar.
-  //
-  // Local change to the registry component: the shortcut yields to an editable target.
-  // Cmd/Ctrl+B is Bold in every text editor, and this listener is on `window` with a
-  // preventDefault, so hosting a rich-text field inside a sidebar layout silently killed
-  // it. A shortcut for chrome should not outrank the field the chrome exists to edit.
-  //
-  // The listener is also bound once rather than on every `toggleSidebar`, which the
-  // registry rebuilds whenever `open` or `isMobile` changes — so opening and closing
-  // the sidebar used to detach and re-attach a window listener each time.
   const handleKeyDown = React.useEffectEvent((event: KeyboardEvent) => {
     if (
       event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
@@ -127,8 +113,6 @@ function SidebarProvider({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  // We add a state so that we can do data-state="expanded" or "collapsed".
-  // This makes it easier to style the sidebar with Tailwind classes.
   const state = open ? 'expanded' : 'collapsed';
 
   const contextValue = React.useMemo<SidebarContextProps>(
@@ -198,9 +182,6 @@ function Sidebar({
   }
 
   if (isMobile) {
-    // `props` go to SheetContent, and not to Sheet. Sheet is Dialog.Root, which renders
-    // no element — so the aria-label and role a caller puts on <Sidebar> would land
-    // nowhere on mobile.
     return (
       <Sheet open={openMobile} onOpenChange={setOpenMobile}>
         <SheetContent
@@ -236,7 +217,6 @@ function Sidebar({
       data-side={side}
       data-slot='sidebar'
     >
-      {/* This is what handles the sidebar gap on desktop */}
       <div
         data-slot='sidebar-gap'
         className={cn(
@@ -251,9 +231,9 @@ function Sidebar({
       <div
         data-slot='sidebar-container'
         data-side={side}
+        inert={state === 'collapsed' && collapsible === 'offcanvas'}
         className={cn(
           'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear data-[side=left]:left-0 data-[side=left]:group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)] data-[side=right]:right-0 data-[side=right]:group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)] md:flex',
-          // Adjust the padding for floating and inset variants.
           variant === 'floating' || variant === 'inset'
             ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)+(--spacing(4))+2px)]'
             : 'group-data-[collapsible=icon]:w-(--sidebar-width-icon) group-data-[side=left]:border-r group-data-[side=right]:border-l',
@@ -626,7 +606,6 @@ function SidebarMenuSkeleton({
 }: React.ComponentProps<'div'> & {
   showIcon?: boolean;
 }) {
-  // Random width between 50 to 90%.
   const [width] = React.useState(() => {
     return `${Math.floor(Math.random() * 40) + 50}%`;
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2787,6 +2787,9 @@ importers:
       react-hook-form:
         specifier: ^7.80.0
         version: 7.80.0(react@19.2.7)
+      react-router-dom:
+        specifier: 'catalog:'
+        version: 6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       sqlite-level:
         specifier: 'catalog:'
         version: 2.1.0


### PR DESCRIPTION
**TLDR:** TinaAdmin takes the config and mounts TinaProvider and HashRouter itself, so an app renders one component.

**Feats:**
- TinaAdmin takes config and queryClient; no hand-composed provider
- A string preview prop renders the preview iframe with the connection wired
- useAdminRoute reads react-router instead of raw hashchange events
- The save badge is a status landmark; the collapsed sidebar goes inert; document buttons carry accessible names
- Provider teardown chains on the previous lifecycle turn, so overlapping mounts cannot interleave

**How to test:** The admin suite runs against the new mount; the playground uses it.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `pnpm test`.
- Run `pnpm dev` and open the admin.
- Confirm the admin boots and the preview renders.
