### PR TITLE
feat(v4): tinacms init, and the barebones example that runs its output

### DIFF
--- a/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
+++ b/packages/v4/@tinacms/tinacms/bin/tinacms.mjs
@@ -1,22 +1,13 @@
 #!/usr/bin/env node
-// The bin is JavaScript, and the CLI that it runs is TypeScript. Vite loads that
-// TypeScript, and node does not strip the types. Node can strip the types, but it cannot
-// follow the relative imports of this package, which have no extension. The `exports`
-// field still points at the raw source, because ADR-001 has not decided the dist build.
-//
-// This server loads the CLI, and only the CLI. It is rooted at this package, so it must
-// not also read the user's tina/config.ts: that config resolves its relative imports and
-// tsconfig paths against the project, which `--root` can put anywhere. The CLI therefore
-// opens its own server for the config, rooted at the directory the config sits in.
+// The CLI is TypeScript with extensionless relative imports, so node needs Vite
+// to load it until ADR-001 lands a dist build. This server loads only the CLI;
+// the CLI opens its own server for the user's tina/config.ts.
 
 import { fileURLToPath } from 'node:url';
 
-// Vite is an optional peer, because the browser runtime of this package does not need a
-// build tool and should not install one. The bin does need it, for the reason above, so
-// this reports the missing peer as the instruction it is. The `catch` goes when ADR-001
-// lands the dist build: from then the bin loads compiled JavaScript, and only the config
-// read needs a loader.
-const { createServer } = await import('vite').catch(() => {
+// Vite is an optional peer: report it missing with the fix, rethrow anything else.
+const { createServer } = await import('vite').catch((cause) => {
+  if (cause?.code !== 'ERR_MODULE_NOT_FOUND') throw cause;
   console.error(
     'tinacms: this command needs Vite to read tina/config.ts.\n' +
       'Install it in your project:  npm i -D vite'
@@ -27,10 +18,8 @@ const { createServer } = await import('vite').catch(() => {
 const server = await createServer({
   configFile: false,
   logLevel: 'warn',
-  // `ws: false` is required, and `hmr: false` alone is not enough. In middleware mode
-  // Vite has no HTTP server for the HMR socket, falls through, and binds its default
-  // port 24678 on every interface — so running the CLI would claim a fixed global
-  // port and two runs at once would race. load-config.ts guards the same way.
+  // ws: false, or middleware-mode Vite binds its default HMR port 24678 globally
+  // and two CLI runs race. load-config.ts guards the same way.
   server: { middlewareMode: true, hmr: false, ws: false, watch: null },
 });
 

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.test.ts
@@ -2,13 +2,16 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { LOCK_VERSION } from '../../codegen/compile-schema';
 import { type ResolvedConfig, asResolvedConfig } from '../../config';
 import { definePlugin } from '../../core/plugin';
-import { LOCK_FILENAME, TINA_DIRECTORY, runCodegen } from './codegen';
+import {
+  LOCK_FILENAME,
+  TINA_DIRECTORY,
+  findConfigPath,
+  runCodegen,
+} from './codegen';
 
-// These tests use a real temporary directory, and not a mock file system. The behaviour
-// under test is what reaches the disk. An unchanged lock is not written again, and a
-// failed run leaves the committed file as it is.
 let rootDir: string;
 let lockPath: string;
 
@@ -29,8 +32,6 @@ const config = (fields: { name: string; type: string }[]): ResolvedConfig =>
     },
   });
 
-// This stands in for the Vite server that the bin lends to the CLI. These tests then
-// cover the disk behaviour of runCodegen, and start no server for each case.
 const loaderFor = (resolved: ResolvedConfig) => ({
   ssrLoadModule: async () => ({ default: resolved }),
 });
@@ -61,8 +62,6 @@ describe('runCodegen', () => {
     expect((await readLock()).primitives).toEqual({ string: 1 });
   });
 
-  // The lock is committed. A write of an identical file would put it in `git status`
-  // after every build.
   it('leaves an already-current lock untouched', async () => {
     const schema = config([{ name: 'title', type: 'string' }]);
     await codegen(schema);
@@ -103,8 +102,6 @@ describe('runCodegen', () => {
     expect(await readFile(lockPath, 'utf8')).toBe(committed);
   });
 
-  // A hand edit, or a bad merge, leaves nothing to compare against. The command
-  // therefore compiles again, and does not fail in JSON.parse.
   it('recompiles over an unparseable lock', async () => {
     await writeFile(lockPath, '{ not json');
     const result = await codegen(config([{ name: 'title', type: 'string' }]));
@@ -119,9 +116,34 @@ describe('runCodegen', () => {
   });
 });
 
+describe('findConfigPath', () => {
+  it.each(['config.ts', 'config.tsx', 'config.js', 'config.mjs'])(
+    'finds %s',
+    async (name) => {
+      await writeFile(
+        path.join(rootDir, TINA_DIRECTORY, name),
+        'export default {}'
+      );
+      expect(await findConfigPath(rootDir)).toBe(
+        path.join(rootDir, TINA_DIRECTORY, name)
+      );
+    }
+  );
+
+  it('prefers config.ts when several candidates exist', async () => {
+    for (const name of ['config.mjs', 'config.tsx', 'config.ts']) {
+      await writeFile(
+        path.join(rootDir, TINA_DIRECTORY, name),
+        'export default {}'
+      );
+    }
+    expect(await findConfigPath(rootDir)).toBe(
+      path.join(rootDir, TINA_DIRECTORY, 'config.ts')
+    );
+  });
+});
+
 describe('runCodegen on a lock it cannot trust', () => {
-  // These parse but are not a lock. The cast alone let them reach checkLock, which
-  // then threw a TypeError on `lock.primitives[type]` instead of recompiling.
   it.each([
     ['an array', '[]'],
     ['a number', '3'],
@@ -148,7 +170,6 @@ describe('runCodegen on a lock it cannot trust', () => {
     expect(await readFile(lockPath, 'utf8')).toBe(committed);
   });
 
-  // --config can point outside tina/, so the lock's directory is not a given.
   it('creates the lock directory when it does not exist', async () => {
     await rm(path.join(rootDir, TINA_DIRECTORY), {
       recursive: true,
@@ -157,5 +178,99 @@ describe('runCodegen on a lock it cannot trust', () => {
     const result = await codegen(config([{ name: 'title', type: 'string' }]));
     expect(result.outcome).toBe('created');
     expect((await readLock()).primitives).toEqual({ string: 1 });
+  });
+});
+
+describe('runCodegen and the admin route', () => {
+  const outcomeOf = (
+    result: Awaited<ReturnType<typeof codegen>>,
+    suffix: string
+  ) => result.admin.find((file) => file.path.endsWith(suffix))?.outcome;
+
+  it('writes public/admin/index.html and scaffolds the entry on a first run', async () => {
+    const result = await codegen(config([{ name: 'title', type: 'string' }]));
+
+    expect(outcomeOf(result, path.join('public', 'admin', 'index.html'))).toBe(
+      'created'
+    );
+    expect(outcomeOf(result, path.join('tina', 'admin.tsx'))).toBe('created');
+    expect(outcomeOf(result, path.join('tina', 'admin.css'))).toBe('created');
+    const html = await readFile(
+      path.join(rootDir, 'public', 'admin', 'index.html'),
+      'utf8'
+    );
+    expect(html).toContain('<script type="module" src="/tina/admin.tsx">');
+    const entry = await readFile(
+      path.join(rootDir, 'tina', 'admin.tsx'),
+      'utf8'
+    );
+    expect(entry).toContain('<TinaAdmin config={config}');
+  });
+
+  it('honours build.publicFolder and build.outputFolder from the config', async () => {
+    const custom = asResolvedConfig({
+      ...config([{ name: 'title', type: 'string' }]),
+      build: { publicFolder: 'static', outputFolder: 'cms' },
+    });
+    const result = await codegen(custom);
+    expect(outcomeOf(result, path.join('static', 'cms', 'index.html'))).toBe(
+      'created'
+    );
+  });
+
+  it('keeps every admin file the project edited', async () => {
+    const schema = config([{ name: 'title', type: 'string' }]);
+    await codegen(schema);
+    const entryPath = path.join(rootDir, 'tina', 'admin.tsx');
+    const htmlPath = path.join(rootDir, 'public', 'admin', 'index.html');
+    const cssPath = path.join(rootDir, 'tina', 'admin.css');
+    const edited = '// The project edited this file.\n';
+    const editedHtml = '<!doctype html>custom shell';
+    const editedCss = '/* The project edited this file. */\n';
+    await writeFile(entryPath, edited);
+    await writeFile(htmlPath, editedHtml);
+    await writeFile(cssPath, editedCss);
+
+    const result = await codegen(schema);
+
+    expect(outcomeOf(result, path.join('tina', 'admin.tsx'))).toBe('kept');
+    expect(await readFile(entryPath, 'utf8')).toBe(edited);
+    expect(outcomeOf(result, path.join('public', 'admin', 'index.html'))).toBe(
+      'kept'
+    );
+    expect(await readFile(htmlPath, 'utf8')).toBe(editedHtml);
+    expect(outcomeOf(result, path.join('tina', 'admin.css'))).toBe('kept');
+    expect(await readFile(cssPath, 'utf8')).toBe(editedCss);
+  });
+
+  it('scaffolds no admin files when the lock check fails', async () => {
+    await writeFile(
+      lockPath,
+      JSON.stringify({ version: LOCK_VERSION + 1, primitives: { string: 1 } })
+    );
+
+    await expect(
+      codegen(config([{ name: 'title', type: 'string' }]))
+    ).rejects.toThrow(/Upgrade tinacms/);
+
+    for (const file of [
+      path.join(rootDir, 'public', 'admin', 'index.html'),
+      path.join(rootDir, 'tina', 'admin.tsx'),
+      path.join(rootDir, 'tina', 'admin.css'),
+    ]) {
+      await expect(readFile(file, 'utf8')).rejects.toThrow();
+    }
+  });
+
+  it('writes nothing under public in check mode', async () => {
+    await runCodegen({
+      rootDir,
+      configPath: path.join(rootDir, TINA_DIRECTORY, 'config.ts'),
+      load: { loader: loaderFor(config([{ name: 'title', type: 'string' }])) },
+      write: false,
+    });
+    await expect(
+      readFile(path.join(rootDir, 'public', 'admin', 'index.html'), 'utf8')
+    ).rejects.toThrow();
   });
 });

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -1,7 +1,5 @@
-// `tinacms codegen`: compiles the schema and writes tina-lock.json (ADR-016).
-
 import { constants } from 'node:fs';
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import {
   type TinaLock,
@@ -12,42 +10,45 @@ import {
   type LoadTinaConfigOptions,
   loadTinaConfig,
 } from '../../codegen/load-config';
+import { type ResolvedConfig, resolveBuild } from '../../config';
 import { invariant } from '../../core/invariant';
 
 export const TINA_DIRECTORY = 'tina';
 export const LOCK_FILENAME = 'tina-lock.json';
 
-// `.tsx` included: a collection with a custom field component holds JSX.
 const CONFIG_FILENAMES = ['config.ts', 'config.tsx', 'config.js', 'config.mjs'];
 
 export interface CodegenOptions {
   rootDir: string;
   configPath?: string;
   load?: LoadTinaConfigOptions;
-  // Defaults to true. `--check` passes false: in CI a differing lock is the
-  // failure to report, not a file to repair.
   write?: boolean;
 }
 
-export type CodegenOutcome =
+export type CodegenOutcome = 'created' | 'updated' | 'unchanged';
+
+export type AdminFileOutcome =
   | 'created'
-  | 'updated'
-  // Same bytes as the committed file; nothing written.
-  | 'unchanged';
+  // The file exists and belongs to the project, so codegen left it alone.
+  | 'kept';
+
+export interface AdminFile {
+  path: string;
+  outcome: AdminFileOutcome;
+}
 
 export interface CodegenResult {
   configPath: string;
   lockPath: string;
   outcome: CodegenOutcome;
   lock: TinaLock;
+  admin: AdminFile[];
   warning?: string;
 }
 
 const firstExisting = async (candidates: string[]): Promise<string | null> => {
   for (const candidate of candidates) {
     try {
-      // access, not readFile: an unreadable config must surface as a fault, not
-      // read as missing.
       await access(candidate, constants.R_OK);
       return candidate;
     } catch (cause) {
@@ -74,8 +75,6 @@ export const findConfigPath = async (rootDir: string): Promise<string> => {
 const readExistingLock = async (lockPath: string): Promise<TinaLock | null> => {
   try {
     const parsed: unknown = JSON.parse(await readFile(lockPath, 'utf8'));
-    // A lock that parses to `[]` or `3` after a bad merge must not reach
-    // checkLock and TypeError on `lock.primitives[type]`.
     const lock = parsed as TinaLock | null;
     if (!lock || typeof lock !== 'object' || Array.isArray(lock)) return null;
     if (typeof lock.primitives !== 'object' || lock.primitives === null) {
@@ -83,14 +82,104 @@ const readExistingLock = async (lockPath: string): Promise<TinaLock | null> => {
     }
     return lock;
   } catch {
-    // Absent and unparsable are one situation: nothing to compare, compile again.
     return null;
   }
 };
 
-// Formatted with a trailing newline: a committed file people read in a diff.
 const serializeLock = (lock: TinaLock): string =>
   `${JSON.stringify(lock, null, 2)}\n`;
+
+const writeLock = async (lockPath: string, lock: TinaLock): Promise<void> => {
+  const tempPath = `${lockPath}.${process.pid}.tmp`;
+  await writeFile(tempPath, serializeLock(lock));
+  await rename(tempPath, lockPath);
+};
+
+// The admin route, in the v3 shape. Codegen writes an index.html into the public
+// folder. The dev server of the project then serves the admin on /admin/ with no
+// route of its own. The html is a shell: the module script points at tina/admin.tsx,
+// which the dev server transforms like any source file. The entry and its css cannot
+// live in public/ — the dev server serves public/ files raw, and both need the
+// pipeline. Codegen scaffolds all three files once; they then belong to the project.
+// A project can change the shell, the preview route, or the styles without fighting
+// the generator.
+const ADMIN_HTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TinaCMS</title>
+    <style>
+      body { margin: 0; font-family: system-ui, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/${TINA_DIRECTORY}/admin.tsx"></script>
+  </body>
+</html>
+`;
+
+const ADMIN_ENTRY = `import { TinaAdmin } from '@tinacms/tinacms/admin';
+import { createRoot } from 'react-dom/client';
+import config from './config';
+import './admin.css';
+
+// The admin route. TinaAdmin supplies the whole editor: the collections, the document
+// form, the save button, and the preview pane. \`preview\` names the page of this site
+// that renders the open document.
+const root = document.getElementById('root');
+if (!root) throw new Error('admin/index.html is missing #root');
+createRoot(root).render(<TinaAdmin config={config} preview='/' />);
+`;
+
+const ADMIN_CSS = `@import "@tinacms/ui/globals.css";
+
+/* Tailwind skips node_modules, and the alpha releases the editor as source (ADR-001),
+   so name the package sources here. These lines go when the dist build lands. */
+@source "../node_modules/@tinacms/tinacms/src";
+@source "../node_modules/@tinacms/ui/src";
+@source "../node_modules/@tinacms/rich-text/src";
+`;
+
+const scaffoldOnce = async (
+  target: string,
+  content: string
+): Promise<AdminFile> => {
+  await mkdir(path.dirname(target), { recursive: true });
+  try {
+    // The 'wx' flag makes the existence check and the write one operation.
+    await writeFile(target, content, { flag: 'wx' });
+    return { path: target, outcome: 'created' };
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== 'EEXIST') throw cause;
+    return { path: target, outcome: 'kept' };
+  }
+};
+
+const writeAdminFiles = async (
+  rootDir: string,
+  config: ResolvedConfig
+): Promise<AdminFile[]> => {
+  const build = resolveBuild(config.build);
+  const htmlPath = path.join(
+    rootDir,
+    build.publicFolder,
+    build.outputFolder,
+    'index.html'
+  );
+  return [
+    await scaffoldOnce(htmlPath, ADMIN_HTML),
+    await scaffoldOnce(
+      path.join(rootDir, TINA_DIRECTORY, 'admin.tsx'),
+      ADMIN_ENTRY
+    ),
+    await scaffoldOnce(
+      path.join(rootDir, TINA_DIRECTORY, 'admin.css'),
+      ADMIN_CSS
+    ),
+  ];
+};
 
 export const runCodegen = async (
   options: CodegenOptions
@@ -103,32 +192,45 @@ export const runCodegen = async (
   const config = await loadTinaConfig(configPath, options.load);
   const lock = compileSchema(config);
   const existing = await readExistingLock(lockPath);
+  const scaffoldAdmin = async (): Promise<AdminFile[]> =>
+    write ? writeAdminFiles(options.rootDir, config) : [];
 
   if (!existing) {
     if (write) {
       await mkdir(path.dirname(lockPath), { recursive: true });
-      await writeFile(lockPath, serializeLock(lock));
+      await writeLock(lockPath, lock);
     }
-    return { configPath, lockPath, outcome: 'created', lock };
+    return {
+      configPath,
+      lockPath,
+      outcome: 'created',
+      lock,
+      admin: await scaffoldAdmin(),
+    };
   }
 
   const check = checkLock(existing, config);
   if (check.status === 'current') {
-    return { configPath, lockPath, outcome: 'unchanged', lock };
+    return {
+      configPath,
+      lockPath,
+      outcome: 'unchanged',
+      lock,
+      admin: await scaffoldAdmin(),
+    };
   }
-  // The one failure: a field type changed shape under a committed lock. A write
-  // here would be the silent break ADR-016 prevents.
   invariant(
     check.status === 'stale',
     check.status === 'unreadable' ? 'lock-unreadable' : 'lock-incompatible',
     check.message
   );
-  if (write) await writeFile(lockPath, serializeLock(lock));
+  if (write) await writeLock(lockPath, lock);
   return {
     configPath,
     lockPath,
     outcome: 'updated',
     lock,
+    admin: await scaffoldAdmin(),
     warning: check.message,
   };
 };

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/init.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/init.test.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { INIT_FILES, runInit } from './init';
+
+let rootDir: string;
+
+beforeEach(async () => {
+  rootDir = await mkdtemp(path.join(tmpdir(), 'tina-init-'));
+});
+
+afterEach(async () => {
+  await rm(rootDir, { recursive: true, force: true });
+});
+
+describe('runInit', () => {
+  it('writes every starter file into an empty directory', async () => {
+    const result = await runInit({ rootDir });
+
+    expect(result.files).toHaveLength(INIT_FILES.length);
+    for (const file of result.files) {
+      expect(file.outcome).toBe('created');
+    }
+    const config = await readFile(
+      path.join(rootDir, 'tina', 'config.ts'),
+      'utf8'
+    );
+    expect(config).toContain('export default defineConfig(');
+    expect(config).toContain('localContentPlugin()');
+    const document = await readFile(
+      path.join(rootDir, 'content', 'posts', 'hello-world.mdx'),
+      'utf8'
+    );
+    expect(document).toContain('title: Hello World');
+  });
+
+  it('keeps a file that exists, byte for byte', async () => {
+    const configPath = path.join(rootDir, 'tina', 'config.ts');
+    await runInit({ rootDir });
+    const edited = '// The project edited this file.\n';
+    await writeFile(configPath, edited);
+
+    const result = await runInit({ rootDir });
+
+    const config = result.files.find((file) => file.path === configPath);
+    expect(config?.outcome).toBe('kept');
+    expect(await readFile(configPath, 'utf8')).toBe(edited);
+    for (const file of result.files) {
+      expect(file.outcome).toBe('kept');
+    }
+  });
+
+  it('reports every path under the root it was given', async () => {
+    const result = await runInit({ rootDir });
+    for (const file of result.files) {
+      expect(file.path.startsWith(rootDir)).toBe(true);
+    }
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/init.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/init.ts
@@ -1,0 +1,99 @@
+// The `tinacms init` command. It writes the files that a v4 project commits (the CLI
+// rule in packages/v4/README.md): the starter tina/config.ts with the plugin
+// registration, and one document to open. It does not wrap a process, and it does not
+// edit a file that exists. A file belongs to the project once it is written, so a
+// second run keeps every one of them. The admin route is codegen's, not init's.
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const CONFIG_TEMPLATE = `// The content model of this project. Two consumers import it: the Vite plugin runs it
+// in node to serve the local data layer, and the admin imports it in the browser. One
+// declaration serves both, so the two cannot drift.
+
+import {
+  type CollectionSchema,
+  defineConfig,
+  localContentPlugin,
+  t,
+} from '@tinacms/tinacms';
+
+export const postCollection = {
+  name: 'post',
+  label: 'Posts',
+  path: 'content/posts',
+  format: 'mdx',
+  fields: [
+    t.string({ name: 'title', label: 'Title', required: true }),
+    t.richText({ name: 'body', label: 'Body', isBody: true }),
+  ],
+} satisfies CollectionSchema;
+
+export default defineConfig({
+  plugins: [localContentPlugin()],
+  schema: { collections: [postCollection] },
+});
+`;
+
+const FIRST_DOCUMENT_TEMPLATE = `---
+title: Hello World
+---
+
+Write your first post here. A save in the admin writes this file back to disk.
+`;
+
+export const INIT_FILES: { relativePath: string; content: string }[] = [
+  { relativePath: path.join('tina', 'config.ts'), content: CONFIG_TEMPLATE },
+  {
+    relativePath: path.join('content', 'posts', 'hello-world.mdx'),
+    content: FIRST_DOCUMENT_TEMPLATE,
+  },
+];
+
+// The admin route itself comes from codegen, not init: `tinacms codegen` (and the
+// Vite plugin on dev) scaffolds public/admin/index.html, tina/admin.tsx, and
+// tina/admin.css once. After that the project owns them.
+export const INIT_NEXT_STEPS = `
+Next steps:
+
+  1. Mount Tina in vite.config.ts:
+
+       import { tinaLocalDataLayerVitePlugin } from '@tinacms/tinacms/local-data-layer/vite';
+       // ...
+       plugins: [
+         tinaLocalDataLayerVitePlugin({ rootDir, config: tina }),
+       ],
+
+  2. Run the dev server of your framework, and open /admin/. There is no \`tinacms dev\`.
+     Dev runs codegen for you: it scaffolds public/admin/index.html, tina/admin.tsx,
+     and tina/admin.css (yours to edit), and refreshes tina/tina-lock.json — commit them.
+`;
+
+export interface InitOptions {
+  rootDir: string;
+}
+
+export type InitFileOutcome =
+  | 'created'
+  // The file exists, so init left it as it is. The project owns it.
+  | 'kept';
+
+export interface InitResult {
+  files: { path: string; outcome: InitFileOutcome }[];
+}
+
+export const runInit = async (options: InitOptions): Promise<InitResult> => {
+  const files: InitResult['files'] = [];
+  for (const { relativePath, content } of INIT_FILES) {
+    const target = path.join(options.rootDir, relativePath);
+    await mkdir(path.dirname(target), { recursive: true });
+    try {
+      await writeFile(target, content, { flag: 'wx' });
+      files.push({ path: target, outcome: 'created' });
+    } catch (cause) {
+      if ((cause as NodeJS.ErrnoException).code !== 'EEXIST') throw cause;
+      files.push({ path: target, outcome: 'kept' });
+    }
+  }
+  return { files };
+};

--- a/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.test.ts
@@ -29,7 +29,6 @@ const resolved = asResolvedConfig({
   },
 });
 
-// This captures what a developer sees, and keeps it out of the test runner output.
 const capture = () => {
   const out: string[] = [];
   const err: string[] = [];
@@ -57,8 +56,6 @@ beforeEach(async () => {
 describe('runCli', () => {
   it('runs codegen against the working directory', async () => {
     const { out, context } = capture();
-    // The lookup for the config file reads the directory, and does not trust the
-    // loader. The file must therefore exist.
     await writeFile(
       path.join(rootDir, 'tina', 'config.ts'),
       'export default {}'
@@ -70,6 +67,32 @@ describe('runCli', () => {
       await readFile(path.join(rootDir, 'tina', 'tina-lock.json'), 'utf8')
     );
     expect(lock.primitives).toEqual({ string: 1 });
+  });
+
+  it('runs init against the working directory, and a second run keeps the files', async () => {
+    const { out, context } = capture();
+
+    expect(await runCli(['init'], context)).toBe(0);
+    const output = out.join('\n');
+    expect(output).toMatch(/Wrote .*tina[/\\]config\.ts/);
+    expect(output).toMatch(/Wrote .*hello-world\.mdx/);
+    expect(output).toContain('/admin/');
+    expect(
+      await readFile(path.join(rootDir, 'tina', 'config.ts'), 'utf8')
+    ).toContain('defineConfig(');
+
+    const second = capture();
+    expect(await runCli(['init'], second.context)).toBe(0);
+    expect(second.out.join('\n')).toMatch(/Kept .*tina[/\\]config\.ts/);
+  });
+
+  it('resolves init --root relative to the working directory', async () => {
+    const { context } = capture();
+
+    expect(await runCli(['init', '--root', 'site'], context)).toBe(0);
+    expect(
+      await readFile(path.join(rootDir, 'site', 'tina', 'config.ts'), 'utf8')
+    ).toContain('defineConfig(');
   });
 
   it('resolves --root relative to the working directory', async () => {
@@ -87,8 +110,21 @@ describe('runCli', () => {
     );
   });
 
-  // Every throw on this path carries an explanation, so the developer reads that and
-  // not a stack trace.
+  it('reads the config named by --config and writes the lock under tina/', async () => {
+    const { out, context } = capture();
+    await rm(path.join(rootDir, 'tina'), { recursive: true, force: true });
+    await writeFile(path.join(rootDir, 'cms.config.ts'), 'export default {}');
+
+    expect(
+      await runCli(['codegen', '--config', 'cms.config.ts'], context)
+    ).toBe(0);
+    expect(out.join('\n')).toMatch(/Wrote .*tina-lock\.json/);
+    const lock = JSON.parse(
+      await readFile(path.join(rootDir, 'tina', 'tina-lock.json'), 'utf8')
+    );
+    expect(lock.primitives).toEqual({ string: 1 });
+  });
+
   it('reports a missing config as a message, not a crash', async () => {
     const { err, context } = capture();
     expect(await runCli(['codegen'], context)).toBe(1);
@@ -107,8 +143,6 @@ describe('runCli', () => {
     expect(out.join('\n')).toContain('tinacms <command>');
   });
 
-  // A call with no command is a mistake, and not a request for help. Print the usage,
-  // and exit with a non-zero code.
   it('exits non-zero when given no command', async () => {
     const { out, context } = capture();
     expect(await runCli([], context)).toBe(1);
@@ -116,9 +150,6 @@ describe('runCli', () => {
   });
 });
 
-// The pipeline of a project never runs this bin, so a config that changed without its
-// lock reaches CI unnoticed. --check is the guard, and it must never repair the file it
-// is checking: a CI run that rewrites the lock reports success and commits nothing.
 describe('runCli codegen --check', () => {
   const writeConfig = () =>
     writeFile(path.join(rootDir, 'tina', 'config.ts'), 'export default {}');
@@ -146,8 +177,6 @@ describe('runCli codegen --check', () => {
   it('exits 1 and leaves a stale lock untouched', async () => {
     const { context } = capture();
     await writeConfig();
-    // A lock that parses and carries a different schema digest is the drift this
-    // command exists to catch.
     await runCli(['codegen'], context);
     const committed = JSON.parse(await readFile(lockPath(), 'utf8'));
     committed.schema.collections[0].fields.push({
@@ -165,8 +194,6 @@ describe('runCli codegen --check', () => {
 });
 
 describe('runCli argument handling', () => {
-  // parseArgs sat outside the try/catch, so a bad flag escaped as a stack trace —
-  // against this file's own "a message, not a crash" contract.
   it('reports an unknown flag as a message rather than throwing', async () => {
     const { err, context } = capture();
     await writeFile(
@@ -182,14 +209,12 @@ describe('runCli argument handling', () => {
     await expect(runCli(['codegen', '--root'], context)).resolves.toBe(1);
   });
 
-  // A typo'd command used to exit 0 whenever --help was also passed.
   it('exits non-zero for an unknown command even with --help', async () => {
     const { err, context } = capture();
     expect(await runCli(['publish', '--help'], context)).toBe(1);
     expect(err.join('\n')).toMatch(/Unknown command "publish"/);
   });
 
-  // startsWith('/') called C:\site relative and concatenated it onto cwd.
   it('treats an absolute --root as absolute', async () => {
     const { out, context } = capture();
     const elsewhere = await mkdtemp(path.join(tmpdir(), 'tina-abs-'));

--- a/packages/v4/@tinacms/tinacms/src/cli/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/index.ts
@@ -1,14 +1,10 @@
-// Command dispatch of the `tinacms` bin. The CLI lives in the runtime package
-// (ADR-001); four flags do not need an argument-parsing dependency.
-
 import path from 'node:path';
 import { parseArgs } from 'node:util';
 import type { ModuleLoader } from '../codegen/load-config';
 import { type CodegenResult, runCodegen } from './commands/codegen';
+import { INIT_NEXT_STEPS, runInit } from './commands/init';
 
 export interface CliContext {
-  // The Vite server the bin used to load this module, so the config read does
-  // not start a second one.
   loader?: ModuleLoader;
   cwd?: string;
   log?: (message: string) => void;
@@ -18,17 +14,18 @@ export interface CliContext {
 const USAGE = `tinacms <command> [options]
 
 Commands:
+  init        Write the starter tina/config.ts and a first document
   codegen     Compile the schema in tina/config.ts to tina/tina-lock.json
 
 Options:
   --root <dir>      Project root (default: the working directory)
-  --config <path>   Path to the config, when it is not under tina/
-  --check           Write nothing; exit 1 when the committed lock is stale
+  --config <path>   Path to the config, when it is not under tina/ (codegen)
+  --check           Write nothing; exit 1 when the committed lock is stale (codegen)
   -h, --help        Show this message
 `;
 
 const describe = (result: CodegenResult): string => {
-  const target = `${result.lockPath}`;
+  const target = result.lockPath;
   if (result.outcome === 'created') return `Wrote ${target}`;
   if (result.outcome === 'updated') return `Updated ${target}`;
   return `${target} is up to date`;
@@ -46,8 +43,6 @@ const codegenCommand = async (
     load: { loader: context.loader },
     write: !values.check,
   });
-  // Under --check the lock on disk is the answer: this is how CI catches a
-  // config that changed without its lock.
   if (values.check) {
     if (result.outcome === 'unchanged') {
       context.log(`${result.lockPath} is up to date`);
@@ -58,13 +53,33 @@ const codegenCommand = async (
     );
     return 1;
   }
-  // A stale lock is rewritten without failing the build, so state the reason.
   if (result.warning) context.log(result.warning);
   context.log(describe(result));
+  for (const file of result.admin) {
+    if (file.outcome === 'created') context.log(`Wrote ${file.path}`);
+  }
   return 0;
 };
 
-// path.resolve, not a `/` test: `C:\site` is absolute on Windows.
+const initCommand = async (
+  values: { root?: string },
+  context: Required<Pick<CliContext, 'cwd' | 'log'>>
+): Promise<number> => {
+  const rootDir = values.root
+    ? resolveFrom(context.cwd, values.root)
+    : context.cwd;
+  const result = await runInit({ rootDir });
+  for (const file of result.files) {
+    context.log(
+      file.outcome === 'created'
+        ? `Wrote ${file.path}`
+        : `Kept ${file.path} (it already exists)`
+    );
+  }
+  context.log(INIT_NEXT_STEPS);
+  return 0;
+};
+
 const resolveFrom = (cwd: string, target: string): string =>
   path.resolve(cwd, target);
 
@@ -84,7 +99,6 @@ export const runCli = async (
   }
 
   try {
-    // Inside the try: an unknown flag makes parseArgs throw.
     const { values } = parseArgs({
       args: rest,
       options: {
@@ -93,11 +107,8 @@ export const runCli = async (
         check: { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
       },
-      allowPositionals: true,
     });
-    // Command before --help, so a typo does not exit 0 just because the user
-    // also asked for usage.
-    if (command !== 'codegen') {
+    if (command !== 'codegen' && command !== 'init') {
       logError(`Unknown command "${command}".\n\n${USAGE}`);
       return 1;
     }
@@ -105,9 +116,11 @@ export const runCli = async (
       log(USAGE);
       return 0;
     }
+    if (command === 'init') {
+      return await initCommand(values, { cwd, log });
+    }
     return await codegenCommand(values, { ...context, cwd, log, logError });
   } catch (cause) {
-    // A message for the developer, not a stack trace.
     logError(cause instanceof Error ? cause.message : String(cause));
     return 1;
   }

--- a/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
+++ b/packages/v4/@tinacms/tinacms/src/codegen/load-config.ts
@@ -1,8 +1,3 @@
-// Node-only: loads `tina/config.ts` through a temporary Vite server rather than
-// importing it. Node can strip the types itself, but the config imports
-// `@tinacms/tinacms`, whose `exports` point at raw `.ts` files with
-// extensionless relative specifiers — the node resolver does not follow them,
-// the Vite resolver does.
 
 import path from 'node:path';
 import type { ResolvedConfig } from '../config';
@@ -14,32 +9,34 @@ export interface ModuleLoader {
 
 export interface LoadTinaConfigOptions {
   alias?: { find: string; replacement: string }[];
-  // Use the caller's server instead of starting one (~1s per run).
   loader?: ModuleLoader;
 }
 
-// Vite is an optional peer, imported dynamically so a browser-only consumer
-// never pulls it into the module graph.
+const importOptionalVite = async (): Promise<typeof import('vite') | null> => {
+  try {
+    return await import('vite');
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException)?.code === 'ERR_MODULE_NOT_FOUND') {
+      return null;
+    }
+    throw cause;
+  }
+};
+
 const startLoadingServer = async (
   configPath: string,
   alias: LoadTinaConfigOptions['alias']
 ) => {
-  const vite = await import('vite').catch(() => null);
+  const vite = await importOptionalVite();
   invariant(
     vite,
     'config-loader-missing',
     'Reading tina/config.ts needs Vite. Install vite as a dev dependency, or pass `loader` to use the module graph you already have.'
   );
   return vite.createServer({
-    // Ignore any vite.config in scope: a project's plugins would run its whole
-    // dev pipeline, and in a workspace would re-enter this config load.
     configFile: false,
-    // Root at the config, not process.cwd(), so relative imports and tsconfig
-    // paths resolve against the project.
     root: path.dirname(configPath),
     logLevel: 'warn',
-    // `ws: false` is required: `hmr: false` alone still binds the HMR socket on
-    // port 24678, so two concurrent loads would race on a global port.
     server: { middlewareMode: true, hmr: false, ws: false, watch: null },
     resolve: { alias: alias ?? [] },
   });
@@ -49,10 +46,12 @@ export const loadTinaConfig = async (
   configPath: string,
   options: LoadTinaConfigOptions = {}
 ): Promise<ResolvedConfig> => {
-  const server =
-    options.loader ?? (await startLoadingServer(configPath, options.alias));
+  const ownServer = options.loader
+    ? undefined
+    : await startLoadingServer(configPath, options.alias);
+  const server = options.loader ?? ownServer;
   try {
-    const loaded = await server.ssrLoadModule(configPath);
+    const loaded = await server!.ssrLoadModule(configPath);
     const config = loaded.default as ResolvedConfig | undefined;
     invariant(
       config?.plugins && config.schema,
@@ -61,7 +60,6 @@ export const loadTinaConfig = async (
     );
     return config;
   } finally {
-    // Close only the server this function opened.
-    if (!options.loader) await (server as { close(): Promise<void> }).close();
+    await ownServer?.close().catch(() => {});
   }
 };

--- a/packages/v4/AGENTS.md
+++ b/packages/v4/AGENTS.md
@@ -1,0 +1,151 @@
+# TinaCMS v4
+
+Instructions for agents working under `packages/v4/`.
+
+## Read first
+
+- [`README.md`](./README.md) — the package map: what v4 releases, publish
+  rules, and why the CLI stays out of the build pipeline.
+- The full v4 architecture spec lives in a separate repo:
+  [tinacms/tinacmsv4-docs](https://github.com/tinacms/tinacmsv4-docs)
+  (start at `CONTEXT.md`, then the ADR set).
+- The source of truth for the final shape of v4 live in `@tinacms/tinacms/_docs/`
+  (architecture, plugins, field plugins, per-field specs).
+
+## Packages in this directory
+
+| Package | Path | What it is |
+|---|---|---|
+| `@tinacms/tinacms` | `@tinacms/tinacms` | The v4 runtime + CLI in one package. `private: true`, `4.0.0-alpha.x`. Subpath exports for `/react`, `/client`, `/server`, `/local-data-layer`, and framework adapters (`/adapters/next`, `/express`, `/astro`, `/hono`). |
+| `@tinacms/rich-text` | `@tinacms/rich-text` | Plate rich-text editor. A value contract separates the editor from the storage format — keep that boundary (see `src/boundary.test.ts`). |
+| `@tinacms/ui` | `@tinacms/ui` | Shared UI components from shadcn/ui. |
+
+## Commands (run inside the package directory)
+
+```
+pnpm dev        # @tinacms/tinacms only — vite playground (playground/)
+pnpm test       # vitest
+pnpm test:e2e   # @tinacms/tinacms only — playwright
+pnpm types      # tsc + tsconfig.test.json
+pnpm build      # tinacms-scripts build
+pnpm codegen    # @tinacms/tinacms only — regenerates playground tina-lock
+```
+
+The playground (`@tinacms/tinacms/playground/`) is the manual test bed —
+use it to verify runtime/editor changes in a browser.
+
+## Hard rules
+
+- **The `tinacms` bin only writes files a person commits** (`init`,
+  `codegen`). It must never wrap a process, open a port, or produce a build
+  artifact. No `dev` or `build` commands. (See "The CLI stays out of the
+  pipeline" in `README.md`.)
+- **`tina-lock.json` is committed, not built.** CI never runs the bin;
+  `codegen --check` is an opt-in drift guard.
+- **Don't touch v3 packages for v4 features.** v3 (`packages/tinacms`,
+  `packages/@tinacms/*`) is in support mode: bug and security fixes only.
+- **Don't move level adapters or external integrations into this repo** —
+  the README lists where they live.
+- **shadcn components:** add or update via
+  `pnpm dlx shadcn@latest add <component>` run in `@tinacms/ui/` — don't
+  hand-write new primitives that shadcn already provides.
+
+## Types
+
+- **No `any`.** Not as an annotation, not as a cast. Use `unknown` and
+  narrow, or write the real type. `@tinacms/tinacms/src` has zero `any` —
+  keep it that way. (The `any`s in `rich-text/src/plate` are inherited Plate
+  code; do not add more, and remove them when you touch those files.)
+- **Identifiers get a concrete branded type, not a bare `string`.** Use
+  `Brand` from `core/brand.ts` and give each ID a `to*` constructor that
+  validates at the boundary — the cast lives in the constructor and nowhere
+  else:
+
+  ```ts
+  // core/brand.ts
+  export type Brand<T, K extends string> = T & { readonly __brand: K };
+
+  // core/field/address.ts
+  export type FieldAddress = Brand<string, 'FieldAddress'>;
+
+  export const toFieldAddress = (path: string): FieldAddress => {
+    invariant(path.length > 0, 'field-address-empty', '...');
+    return path as FieldAddress;
+  };
+  ```
+
+  Existing examples: `FormId` (`form/form-store.ts`), `FieldAddress`
+  (`core/field/address.ts`), `ResolvedConfig` (`config.ts`). A branded ID
+  cannot be swapped for another string by accident — a `FormId` does not
+  pass where a `FieldAddress` is expected.
+
+## Comments & prose (ASD-STE100)
+
+All v4 prose — code comments, `_docs/`, READMEs — follows **Simplified
+Technical English (ASD-STE100)**. The `README.md` in this directory is the
+reference for the register.
+
+The STE rules that matter most here:
+
+- **Active voice, present tense.** "The bin writes files", not "files are
+  written by the bin".
+- **One instruction or one fact per sentence.** Keep sentences short
+  (about 20 words or fewer).
+- **One word, one meaning.** Use the same term for the same thing every
+  time — a document is a document, not a "page", "entry", or "record"
+  depending on the file.
+- **No filler.** No "simply", "just", "note that", "in order to".
+
+Comment policy (a prior cleanup pass established this):
+
+- **Only comment traps, invariants, and ADR pointers.** Strip comments that
+  restate the code.
+- Reference ADRs by number when a decision explains the code:
+
+  ```ts
+  // TODO(ADR-008 §3): type `permissions` against codegen's Permission union once it lands.
+
+  // TODO: move this schema validation to defineConfig (ADR-024) so every
+  ```
+
+## Error handling
+
+- **Caught values are `unknown` — never assume they're an `Error`.** Name the
+  caught variable `cause` (the codebase convention), narrow with
+  `instanceof Error`, and fall back to `String(cause)`:
+
+  ```ts
+  try {
+    await save(document);
+  } catch (cause) {
+    if(cause instanceof Error){
+      logError(cause.message)
+    }else{
+      logError(String(cause))
+    }
+  }
+  ```
+
+- **Distinguish known failures with custom error classes**, not by matching
+  message strings. Extend `Error` and check with `instanceof` (see `RpcError`
+  in `src/rpc/proxy.ts`, `RequestBodyTooLargeError` in
+  `local-data-layer.vite.ts`):
+
+  ```ts
+  if (cause instanceof RequestBodyTooLargeError) {
+    res.statusCode = 413;
+  }
+  ```
+
+## React / JSX
+
+- **Don't use `&&` for conditional rendering.** Use a ternary with an explicit
+  `null` instead:
+
+  ```tsx
+  // ❌ Bad — renders "0" when items is empty, leaks falsy values into the DOM
+  {items.length && <List items={items} />}
+
+  // ✅ Good
+  {items.length > 0 ? <List items={items} /> : null}
+  ```

--- a/packages/v4/CLAUDE.md
+++ b/packages/v4/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/v4/examples/barebones/README.md
+++ b/packages/v4/examples/barebones/README.md
@@ -1,0 +1,43 @@
+# Barebones v4 example
+
+The smallest TinaCMS v4 app. One Vite project holds everything:
+
+| Piece | File | v4 rule it shows |
+|---|---|---|
+| The content model | `tina/config.ts` | One declaration. The data layer and the forms both read it. |
+| The pipeline | `vite.config.ts` | The project owns its pipeline. `pnpm dev` runs Vite; there is no `tinacms dev`. Tina mounts as one Vite plugin. |
+| The admin | `public/admin/index.html` → `tina/admin.tsx` | Codegen scaffolds the shell in `public/` (the v3 shape, at the `build` folders from `defineConfig`), the entry, and `tina/admin.css` once. The admin serves on `/admin/` with no route of the project's own. After that, all three files belong to the project. |
+| The site | `index.html` → `src/preview/` | Visual editing with `useTina`, `tinaField`, and `TinaMarkdown` from `@tinacms/tinacms/adapters/react`. The admin's preview pane renders this page. |
+| A custom field | `tina/rating-field.tsx` | A whole field plugin in one `definePlugin({...})` call, in one project-owned file. The config registers it next to `localContentPlugin()`. |
+| The content | `content/posts/*.mdx` | Files in the repository. A save in the admin writes them back to disk. |
+| The lock | `tina/tina-lock.json` | Committed, not built (ADR-016). Dev refreshes it. |
+
+A fresh project does not write these files by hand: `tinacms init` writes the
+starter `tina/config.ts` and a first document, and the first `vite` run (or
+`tinacms codegen`) generates the admin. All a project needs is `tinacms`, a
+`tina/config.ts`, and the Vite plugin — then open `/admin/`.
+
+## Run it
+
+From the repository root:
+
+```sh
+pnpm install
+pnpm --filter @examples/v4-barebones dev
+```
+
+Open the printed URL. The site renders at `/`, and the admin at `/admin/`
+(dev codegen scaffolds `public/admin/index.html` once; the project commits
+it). A schema change in `tina/config.ts` refreshes `tina/tina-lock.json` on
+the next dev run or `pnpm codegen` — commit the lock.
+
+## What is not real yet
+
+The two node-side imports in `vite.config.ts` reach into the package source with
+a relative path, because the alpha releases raw `.ts` through `exports`
+(ADR-001) and node cannot follow its extensionless relative imports outside a
+Vite module graph. Every browser-side import already uses the public specifiers
+(`@tinacms/tinacms`, `/admin`, `/react`, `/adapters/react`) resolved through
+`node_modules`, exactly as an installed app would. The `@source` lines in
+`tina/admin.css` exist for the same reason: Tailwind must scan the package
+sources until the dist build lands.

--- a/packages/v4/examples/barebones/content/posts/hello-world.mdx
+++ b/packages/v4/examples/barebones/content/posts/hello-world.mdx
@@ -1,0 +1,8 @@
+---
+title: Hello World
+featured: true
+stars: 4
+---
+
+This is the barebones v4 example. Edit this prose in the admin, and the save
+writes this file back to disk.

--- a/packages/v4/examples/barebones/index.html
+++ b/packages/v4/examples/barebones/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TinaCMS v4 Barebones Site</title>
+    <!-- The site page. The admin lives at /admin/ — codegen writes it into public/. -->
+
+    <style>
+      body { margin: 0; font-family: Georgia, serif; }
+      /* Discoverable click-to-edit targets. */
+      [data-tina-field]:hover { outline: 2px dashed #0084ff; cursor: pointer; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/preview/main.tsx"></script>
+  </body>
+</html>

--- a/packages/v4/examples/barebones/package.json
+++ b/packages/v4/examples/barebones/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@examples/v4-barebones",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The smallest TinaCMS v4 app: one Vite project, one collection, the admin on one route, and the local data layer mounted as a Vite plugin.",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "codegen": "tinacms codegen",
+    "types": "tsc"
+  },
+  "dependencies": {
+    "@tinacms/rich-text": "workspace:*",
+    "@tinacms/tinacms": "workspace:*",
+    "@tinacms/ui": "workspace:*",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.4",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "catalog:",
+    "tailwindcss": "^4.3.2",
+    "typescript": "^5.7.3",
+    "vite": "^5.4.0"
+  }
+}

--- a/packages/v4/examples/barebones/public/admin/index.html
+++ b/packages/v4/examples/barebones/public/admin/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>TinaCMS</title>
+    <style>
+      body { margin: 0; font-family: system-ui, sans-serif; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/tina/admin.tsx"></script>
+  </body>
+</html>

--- a/packages/v4/examples/barebones/src/content.ts
+++ b/packages/v4/examples/barebones/src/content.ts
@@ -1,0 +1,20 @@
+import type { TinaDocument } from '@tinacms/tinacms';
+
+// The static seed for the site page at /, when a browser opens it by itself. A real
+// site would render the document it fetched at build time. This uses `satisfies`, not a
+// type annotation: useTina is generic, so the literal shape lets the preview read `body`
+// as the MDX tree, and not cast it out of `unknown`.
+export const sampleDocument = {
+  title: 'Hello World',
+  featured: false,
+  stars: 4,
+  body: {
+    type: 'root',
+    children: [
+      {
+        type: 'p',
+        children: [{ type: 'text', text: 'Body prose, edited as markdown.' }],
+      },
+    ],
+  },
+} satisfies TinaDocument;

--- a/packages/v4/examples/barebones/src/preview/main.tsx
+++ b/packages/v4/examples/barebones/src/preview/main.tsx
@@ -1,0 +1,6 @@
+import { createRoot } from 'react-dom/client';
+import { PostPreview } from './post-preview';
+
+const root = document.getElementById('root');
+if (!root) throw new Error('index.html is missing #root');
+createRoot(root).render(<PostPreview />);

--- a/packages/v4/examples/barebones/src/preview/post-preview.tsx
+++ b/packages/v4/examples/barebones/src/preview/post-preview.tsx
@@ -1,0 +1,47 @@
+import {
+  TinaMarkdown,
+  tinaField,
+  useTina,
+} from '@tinacms/tinacms/adapters/react';
+import { sampleDocument } from '../content';
+
+// The site side of visual editing, written as a real site would write it. useTina seeds
+// from the document that the site rendered, which is the whole document when a browser
+// opens / directly. Inside the editor, useTina adopts the values that
+// arrive. tinaField marks the elements that an author can click.
+export function PostPreview() {
+  const { data: post, isEditing } = useTina({ data: sampleDocument });
+
+  return (
+    <article style={{ maxWidth: '42rem', margin: '0 auto', padding: '3rem' }}>
+      <span
+        {...tinaField('featured')}
+        style={{
+          display: 'inline-block',
+          padding: '0.2rem 0.6rem',
+          borderRadius: '999px',
+          fontSize: '0.8rem',
+          fontFamily: 'system-ui, sans-serif',
+          background: post.featured ? '#fef3c7' : '#f3f4f6',
+          color: post.featured ? '#92400e' : '#6b7280',
+        }}
+      >
+        {post.featured ? '★ Featured' : '☆ Not featured'}
+      </span>
+      <h1 {...tinaField('title')}>{String(post.title ?? '')}</h1>
+      {/* The custom field renders like any other: click the stars to focus it. */}
+      <p {...tinaField('stars')} aria-label='Stars' style={{ color: '#f59e0b' }}>
+        {'★'.repeat(post.stars ?? 0)}
+        {'☆'.repeat(5 - (post.stars ?? 0))}
+      </p>
+      <p style={{ color: '#6b7280' }}>
+        {isEditing
+          ? 'This preview renders the document streamed from the editor. Click the title or the badge to focus its field in the sidebar.'
+          : 'Standalone preview — rendering the static document.'}
+      </p>
+      <div {...tinaField('body')}>
+        <TinaMarkdown content={post.body} />
+      </div>
+    </article>
+  );
+}

--- a/packages/v4/examples/barebones/tina/admin.css
+++ b/packages/v4/examples/barebones/tina/admin.css
@@ -1,0 +1,7 @@
+@import "@tinacms/ui/globals.css";
+
+/* Tailwind skips node_modules, and the alpha releases the editor as source (ADR-001),
+   so name the package sources here. These lines go when the dist build lands. */
+@source "../node_modules/@tinacms/tinacms/src";
+@source "../node_modules/@tinacms/ui/src";
+@source "../node_modules/@tinacms/rich-text/src";

--- a/packages/v4/examples/barebones/tina/admin.tsx
+++ b/packages/v4/examples/barebones/tina/admin.tsx
@@ -1,0 +1,11 @@
+import { TinaAdmin } from '@tinacms/tinacms/admin';
+import { createRoot } from 'react-dom/client';
+import config from './config';
+import './admin.css';
+
+// The admin route. TinaAdmin supplies the whole editor: the collections, the document
+// form, the save button, and the preview pane. `preview` names the page of this site
+// that renders the open document.
+const root = document.getElementById('root');
+if (!root) throw new Error('admin/index.html is missing #root');
+createRoot(root).render(<TinaAdmin config={config} preview='/' />);

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -1,0 +1,31 @@
+// The one declaration of the content model. Two consumers import it: vite.config.ts
+// runs it in node to start the local data layer, and tina/admin.tsx (scaffolded by
+// codegen) imports it in the browser to render the admin. Node can import it, because
+// the universal entry keeps the browser code behind lazy segments.
+
+import {
+  type CollectionSchema,
+  defineConfig,
+  localContentPlugin,
+  t,
+} from '@tinacms/tinacms';
+import { rating, ratingFieldPlugin } from './rating-field';
+
+export const postCollection = {
+  name: 'post',
+  label: 'Posts',
+  path: 'content/posts',
+  format: 'mdx',
+  fields: [
+    t.string({ name: 'title', label: 'Title', required: true }),
+    t.boolean({ name: 'featured', label: 'Featured' }),
+    // The custom field of this project. tina/rating-field.tsx is the whole plugin.
+    rating({ name: 'stars', label: 'Stars' }),
+    t.richText({ name: 'body', label: 'Body', isBody: true }),
+  ],
+} satisfies CollectionSchema;
+
+export default defineConfig({
+  plugins: [localContentPlugin(), ratingFieldPlugin],
+  schema: { collections: [postCollection] },
+});

--- a/packages/v4/examples/barebones/tina/rating-field.tsx
+++ b/packages/v4/examples/barebones/tina/rating-field.tsx
@@ -1,0 +1,72 @@
+import { definePlugin } from '@tinacms/tinacms';
+import { defineClientPlugin } from '@tinacms/tinacms/client';
+import {
+  useFieldAddress,
+  useFieldErrors,
+  useFieldValue,
+} from '@tinacms/tinacms/react';
+
+// TODO: this won't be needed once we are building 't' from all plugins.
+export const rating = (config: { name: string; label?: string }) => ({
+  ...config,
+  type: 'rating' as const,
+});
+
+export const ratingFieldPlugin = definePlugin({
+  name: 'example:field:rating',
+  provides: ['field'],
+  field: { type: 'rating', contractVersion: 1 },
+  client: async () => ({
+    default: defineClientPlugin({
+      field: {
+        Component: function RatingField() {
+          const address = useFieldAddress();
+          const [value, setValue] = useFieldValue<number>(address);
+          const errors = useFieldErrors(address);
+          const current = value ?? 0;
+
+          return (
+            <div className='grid gap-1.5'>
+              <div
+                role='radiogroup'
+                aria-label={address}
+                className='flex gap-0.5'
+              >
+                {[1, 2, 3, 4, 5].map((star) => (
+                  <button
+                    key={star}
+                    type='button'
+                    role='radio'
+                    aria-checked={star === current}
+                    aria-label={`${star} star${star === 1 ? '' : 's'}`}
+                    onClick={() => setValue(star === current ? 0 : star)}
+                    className='text-xl leading-none text-amber-500'
+                  >
+                    {star <= current ? '★' : '☆'}
+                  </button>
+                ))}
+              </div>
+              {errors.map((error) => (
+                <span
+                  key={error}
+                  role='alert'
+                  className='text-sm text-destructive'
+                >
+                  {error}
+                </span>
+              ))}
+            </div>
+          );
+        },
+        defaultValue: 0,
+        metadata: { layout: 'inline' },
+        validate: (value) => {
+          const stars = value as number | undefined;
+          if (stars === undefined) return null;
+          if (Number.isInteger(stars) && stars >= 0 && stars <= 5) return null;
+          return 'A rating is 0 to 5 whole stars.';
+        },
+      },
+    }),
+  }),
+});

--- a/packages/v4/examples/barebones/tina/tina-lock.json
+++ b/packages/v4/examples/barebones/tina/tina-lock.json
@@ -1,0 +1,49 @@
+{
+  "version": 5,
+  "schema": {
+    "collections": [
+      {
+        "name": "post",
+        "label": "Posts",
+        "path": "content/posts",
+        "format": "mdx",
+        "fields": [
+          {
+            "name": "title",
+            "label": "Title",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "featured",
+            "label": "Featured",
+            "type": "boolean"
+          },
+          {
+            "name": "stars",
+            "label": "Stars",
+            "type": "rating"
+          },
+          {
+            "name": "body",
+            "label": "Body",
+            "isBody": true,
+            "type": "rich-text"
+          }
+        ]
+      }
+    ],
+    "version": {
+      "fullVersion": "4.0.0-alpha.0",
+      "major": "4",
+      "minor": "0",
+      "patch": "0-alpha"
+    }
+  },
+  "primitives": {
+    "boolean": 1,
+    "rating": 1,
+    "rich-text": 1,
+    "string": 1
+  }
+}

--- a/packages/v4/examples/barebones/tsconfig.json
+++ b/packages/v4/examples/barebones/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../../../base.tsconfig.json",
+  "compilerOptions": {
+    "emitDeclarationOnly": false,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["vite/client"],
+    "baseUrl": ".",
+    "paths": {
+      "@tinacms/graphql": [
+        "./node_modules/@tinacms/tinacms/src/plugins/content/local/graphql/tinacms-graphql.d.ts"
+      ],
+      // The repo root still resolves @types/react 18 (v3 is a React 18 package).
+      // Pin this project to its own React 19 types, as the v4 packages do, so the
+      // compilation sees one React type identity.
+      "react": ["./node_modules/@types/react"],
+      "react/*": ["./node_modules/@types/react/*"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-dom/*": ["./node_modules/@types/react-dom/*"]
+    }
+  },
+  "include": ["src", "tina", "vite.config.ts"]
+}

--- a/packages/v4/examples/barebones/vite.config.ts
+++ b/packages/v4/examples/barebones/vite.config.ts
@@ -1,0 +1,37 @@
+// The Vite config of the app. It shows the v4 shape: the project owns its pipeline, and
+// Tina mounts into it. `pnpm dev` runs Vite, and only Vite. There is no `tinacms dev`.
+//
+// The config loads tina/config.ts in node, and hands the collections to the local data
+// layer plugin. The browser code imports the same file, so the schema is declared once.
+
+import { fileURLToPath } from 'node:url';
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+// TEMPORARY (ADR-001). These two run in node, and node cannot load them through the
+// package name yet: `exports` points at raw .ts whose relative imports carry no
+// extension, and Vite externalizes every bare import of this file to node. A relative
+// import is bundled by esbuild instead, which follows those imports. When the dist build
+// lands, these become:
+//   import { loadTinaConfig } from '@tinacms/tinacms/...';
+//   import { tinaLocalDataLayerVitePlugin } from '@tinacms/tinacms/local-data-layer/vite';
+import { loadTinaConfig } from '../../@tinacms/tinacms/src/codegen/load-config';
+import { tinaLocalDataLayerVitePlugin } from '../../@tinacms/tinacms/src/plugins/content/local/server/local-data-layer.vite';
+
+const tina = await loadTinaConfig(
+  fileURLToPath(new URL('./tina/config.ts', import.meta.url))
+);
+
+export default defineConfig({
+  plugins: [
+    react(),
+    tailwindcss(),
+    // The whole Tina setup. The plugin serves the local data layer, and on dev it
+    // runs codegen: public/admin/index.html (the admin shell), the tina/admin.tsx
+    // entry, and tina/tina-lock.json. Open /admin/ — nothing else to mount.
+    tinaLocalDataLayerVitePlugin({
+      rootDir: fileURLToPath(new URL('.', import.meta.url)),
+      config: tina,
+    }),
+  ],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1380,7 +1380,7 @@ importers:
         version: link:../search
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
       altair-express-middleware:
         specifier: 'catalog:'
         version: 7.3.6
@@ -1476,7 +1476,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.3
-        version: 6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
       yup:
         specifier: ^1.6.1
         version: 1.7.1
@@ -2778,9 +2778,6 @@ importers:
       '@tinacms/ui':
         specifier: workspace:*
         version: link:../ui
-      abstract-level:
-        specifier: 'catalog:'
-        version: 1.0.4
       gray-matter:
         specifier: 'catalog:'
         version: 4.0.3
@@ -2830,6 +2827,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0))
+      abstract-level:
+        specifier: 'catalog:'
+        version: 1.0.4
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -2891,6 +2891,46 @@ importers:
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+
+  packages/v4/examples/barebones:
+    dependencies:
+      '@tinacms/rich-text':
+        specifier: workspace:*
+        version: link:../../@tinacms/rich-text
+      '@tinacms/tinacms':
+        specifier: workspace:*
+        version: link:../../@tinacms/tinacms
+      '@tinacms/ui':
+        specifier: workspace:*
+        version: link:../../@tinacms/ui
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.4
+        version: 4.2.4(vite@5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0))
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: 'catalog:'
+        version: 4.7.0(vite@5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0))
+      tailwindcss:
+        specifier: ^4.3.2
+        version: 4.3.2
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vite:
+        specifier: ^5.4.0
+        version: 5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
 
   playwright/astro-init:
     devDependencies:
@@ -19244,10 +19284,6 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  '@heroicons/react@1.0.6(react@19.2.7)':
-    dependencies:
-      react: 19.2.7
-
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
@@ -23493,7 +23529,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -23501,7 +23537,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -30913,10 +30949,22 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-router: 6.30.3(react@18.3.1)
 
+  react-router-dom@6.30.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@remix-run/router': 1.23.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-router: 6.30.3(react@19.2.7)
+
   react-router@6.30.3(react@18.3.1):
     dependencies:
       '@remix-run/router': 1.23.2
       react: 18.3.1
+
+  react-router@6.30.3(react@19.2.7):
+    dependencies:
+      '@remix-run/router': 1.23.2
+      react: 19.2.7
 
   react-style-singleton@2.2.3(@types/react@18.3.27)(react@18.3.1):
     dependencies:
@@ -33218,15 +33266,16 @@ snapshots:
       - supports-color
       - terser
 
-  vite-node@3.2.4(@types/node@22.19.17)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0):
+  vite-node@3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 5.4.21(@types/node@22.19.17)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
+      vite: 6.4.3(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
+      - jiti
       - less
       - lightningcss
       - sass
@@ -33235,6 +33284,8 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+      - tsx
+      - yaml
 
   vite@4.5.14(@types/node@22.19.17)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0):
     dependencies:
@@ -33347,7 +33398,7 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.2
 
-  vite@6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2):
+  vite@6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -33358,7 +33409,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 1.21.7
       lightningcss: 1.32.0
       sass: 1.97.3
       terser: 5.46.0
@@ -33577,7 +33628,7 @@ snapshots:
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
       vite: 6.4.1(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@22.19.17)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
+      vite-node: 3.2.4(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2778,6 +2778,9 @@ importers:
       '@tinacms/ui':
         specifier: workspace:*
         version: link:../ui
+      abstract-level:
+        specifier: 'catalog:'
+        version: 1.0.4
       gray-matter:
         specifier: 'catalog:'
         version: 4.0.3
@@ -2827,9 +2830,6 @@ importers:
       '@vitejs/plugin-react':
         specifier: 'catalog:'
         version: 4.7.0(vite@5.4.21(@types/node@25.1.0)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0))
-      abstract-level:
-        specifier: 'catalog:'
-        version: 1.0.4
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
     - packages/*
     - packages/@tinacms/*
     - packages/v4/@tinacms/*
+    - packages/v4/examples/*
     - examples/*/*
     - e2e/*
     - playwright/*


### PR DESCRIPTION
**TLDR:** `tinacms init` scaffolds a project — config, admin route, first document — and the new barebones example is that output, running.

**Feats:**
- init writes the starter tina/config.ts, the admin route and a first document; it keeps every file that already exists
- codegen writes the admin files beside the lock, so a fresh project boots from two commands
- packages/v4/examples/barebones: one Vite app, one collection, a custom field, a preview, no framework
- The pnpm workspace gains packages/v4/examples/*; load-config imports vite optionally

**How to test:** Run the example, then run init against an empty folder.
- Run `pnpm install`.
- Go to `packages/v4/examples/barebones`.
- Run `pnpm dev`, open the admin, and edit the post.
- Go to `packages/v4/@tinacms/tinacms`.
- Run `node bin/tinacms.mjs init --root /tmp/tina-init-test`.
- Confirm it lists the files it wrote.
