### PR TITLE
feat(media): add a Rename action to the Media Manager (local media store)

### DIFF
--- a/.changeset/media-manager-rename-local.md
+++ b/.changeset/media-manager-rename-local.md
@@ -1,0 +1,14 @@
+---
+"tinacms": minor
+"@tinacms/cli": minor
+---
+
+Add a Rename action to the Media Manager, backed by the local dev server.
+
+Selecting a file in the media preview now offers Rename alongside Insert and Delete. The modal edits the basename, keeps the extension, previews the sanitised result using the same rules uploads apply, and reports collisions and missing files specifically instead of a generic failure. Every open media picker refreshes afterwards, and pickers previewing the renamed file follow it to its new path.
+
+Renaming does **not** update content that already references the old path — the modal says so explicitly.
+
+The action only appears when the media store implements `rename`. `TinaMediaStore` implements it for local development via a new `POST /media/rename` route on the CLI dev server; TinaCloud, static and self-hosted repo-media stores do not advertise it, so the action stays hidden there rather than failing on click. Third-party stores (S3, Cloudinary, DigitalOcean Spaces, Azure) can opt in by implementing `MediaStore.rename`.
+
+`MediaManager.rename()` dispatches `media:rename:start`, `media:rename:success` and `media:rename:failure`.

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -446,11 +446,9 @@ describe('MediaModel (Vite dev server)', () => {
       const move = jest.spyOn(fs, 'move');
       // staging move succeeds, the move onto the new casing fails, and the
       // restore falls through to the real implementation
-      move
-        .mockImplementationOnce(realMove)
-        .mockImplementationOnce(async () => {
-          throw new Error('boom');
-        });
+      move.mockImplementationOnce(realMove).mockImplementationOnce(async () => {
+        throw new Error('boom');
+      });
 
       const result = await model.renameMedia({
         from: 'photo.jpg',

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -340,6 +340,212 @@ describe('MediaModel (Vite dev server)', () => {
       ).rejects.toThrow(PathTraversalError);
     });
   });
+
+  describe('renameMedia', () => {
+    let mediaDir: string;
+
+    beforeEach(() => {
+      mediaDir = path.join(tmpDir, 'public', 'uploads');
+    });
+
+    it('renames a file within the media root', async () => {
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'content');
+      const model = new MediaModel(config);
+
+      const result = await model.renameMedia({
+        from: 'old.txt',
+        to: 'new.txt',
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(await fs.pathExists(path.join(mediaDir, 'old.txt'))).toBe(false);
+      expect(await fs.readFile(path.join(mediaDir, 'new.txt'), 'utf8')).toBe(
+        'content'
+      );
+    });
+
+    it('renames a file inside a subdirectory', async () => {
+      await fs.mkdirp(path.join(mediaDir, 'products'));
+      await fs.writeFile(path.join(mediaDir, 'products', 'old.txt'), 'x');
+      const model = new MediaModel(config);
+
+      const result = await model.renameMedia({
+        from: 'products/old.txt',
+        to: 'products/new.txt',
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(
+        await fs.pathExists(path.join(mediaDir, 'products', 'new.txt'))
+      ).toBe(true);
+    });
+
+    it('returns NOT_FOUND when the source is missing', async () => {
+      const model = new MediaModel(config);
+      const result = await model.renameMedia({
+        from: 'ghost.txt',
+        to: 'new.txt',
+      });
+      expect(result).toMatchObject({ ok: false, code: 'NOT_FOUND' });
+    });
+
+    it('returns NAME_COLLISION when the destination exists', async () => {
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
+      await fs.writeFile(path.join(mediaDir, 'taken.txt'), 'b');
+      const model = new MediaModel(config);
+
+      const result = await model.renameMedia({
+        from: 'old.txt',
+        to: 'taken.txt',
+      });
+
+      expect(result).toMatchObject({ ok: false, code: 'NAME_COLLISION' });
+      // the source must survive a rejected rename
+      expect(await fs.readFile(path.join(mediaDir, 'old.txt'), 'utf8')).toBe(
+        'a'
+      );
+      expect(await fs.readFile(path.join(mediaDir, 'taken.txt'), 'utf8')).toBe(
+        'b'
+      );
+    });
+
+    it('returns UNSUPPORTED when the source is a directory', async () => {
+      await fs.mkdirp(path.join(mediaDir, 'a-folder'));
+      const model = new MediaModel(config);
+
+      const result = await model.renameMedia({
+        from: 'a-folder',
+        to: 'renamed-folder',
+      });
+
+      expect(result).toMatchObject({ ok: false, code: 'UNSUPPORTED' });
+      expect(await fs.pathExists(path.join(mediaDir, 'a-folder'))).toBe(true);
+    });
+
+    it('performs a case-only rename and leaves no staging file behind', async () => {
+      await fs.writeFile(path.join(mediaDir, 'photo.jpg'), 'bytes');
+      const model = new MediaModel(config);
+
+      const result = await model.renameMedia({
+        from: 'photo.jpg',
+        to: 'Photo.jpg',
+      });
+
+      expect(result).toEqual({ ok: true });
+      const entries = await fs.readdir(mediaDir);
+      expect(entries).toEqual(['Photo.jpg']);
+      expect(await fs.readFile(path.join(mediaDir, 'Photo.jpg'), 'utf8')).toBe(
+        'bytes'
+      );
+    });
+
+    it('restores the source when the second staged move fails', async () => {
+      await fs.writeFile(path.join(mediaDir, 'photo.jpg'), 'bytes');
+      const model = new MediaModel(config);
+      const realMove = fs.move;
+      const move = jest.spyOn(fs, 'move');
+      // staging move succeeds, the move onto the new casing fails, and the
+      // restore falls through to the real implementation
+      move
+        .mockImplementationOnce(realMove)
+        .mockImplementationOnce(async () => {
+          throw new Error('boom');
+        });
+
+      const result = await model.renameMedia({
+        from: 'photo.jpg',
+        to: 'Photo.jpg',
+      });
+
+      expect(result).toMatchObject({ ok: false, code: 'BACKEND_FAILURE' });
+      const entries = await fs.readdir(mediaDir);
+      expect(entries).toEqual(['photo.jpg']);
+      move.mockRestore();
+    });
+
+    it('maps a racing destination write to NAME_COLLISION', async () => {
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
+      const model = new MediaModel(config);
+      const move = jest.spyOn(fs, 'move').mockImplementationOnce(async () => {
+        // what fs-extra raises when overwrite is false and dest appeared
+        throw new Error('dest already exists.');
+      });
+
+      const result = await model.renameMedia({
+        from: 'old.txt',
+        to: 'new.txt',
+      });
+
+      expect(result).toMatchObject({ ok: false, code: 'NAME_COLLISION' });
+      move.mockRestore();
+    });
+
+    it('throws PathTraversalError for traversal in "from"', async () => {
+      const model = new MediaModel(config);
+      await expect(
+        model.renameMedia({ from: '../../etc/passwd', to: 'safe.txt' })
+      ).rejects.toThrow(PathTraversalError);
+    });
+
+    it('throws PathTraversalError for traversal in "to"', async () => {
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
+      const model = new MediaModel(config);
+      await expect(
+        model.renameMedia({ from: 'old.txt', to: '../../escaped.txt' })
+      ).rejects.toThrow(PathTraversalError);
+    });
+
+    it('throws PathTraversalError for still-encoded traversal', async () => {
+      const model = new MediaModel(config);
+      await expect(
+        model.renameMedia({ from: '..%2f..%2fpasswd', to: 'safe.txt' })
+      ).rejects.toThrow(PathTraversalError);
+    });
+
+    it('rejects the media root itself as a destination', async () => {
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
+      const model = new MediaModel(config);
+      await expect(
+        model.renameMedia({ from: 'old.txt', to: '' })
+      ).rejects.toThrow(PathTraversalError);
+    });
+  });
+
+  describe('renameMedia symlink traversal', () => {
+    let outsideDir: string;
+
+    beforeEach(async () => {
+      outsideDir = path.join(
+        process.env.TMPDIR || '/tmp',
+        `tina-outside-rename-${Date.now()}`
+      );
+      await fs.mkdirp(outsideDir);
+      await fs.writeFile(path.join(outsideDir, 'secret.txt'), 'sensitive');
+      await fs.symlink(
+        outsideDir,
+        path.join(tmpDir, 'public', 'uploads', 'escape')
+      );
+    });
+
+    afterEach(async () => {
+      await fs.remove(outsideDir);
+    });
+
+    it('rejects a source that escapes via symlink', async () => {
+      const model = new MediaModel(config);
+      await expect(
+        model.renameMedia({ from: 'escape/secret.txt', to: 'stolen.txt' })
+      ).rejects.toThrow(PathTraversalError);
+    });
+
+    it('rejects a destination that escapes via symlink', async () => {
+      await fs.writeFile(path.join(tmpDir, 'public', 'uploads', 'a.txt'), 'a');
+      const model = new MediaModel(config);
+      await expect(
+        model.renameMedia({ from: 'a.txt', to: 'escape/planted.txt' })
+      ).rejects.toThrow(PathTraversalError);
+    });
+  });
 });
 
 describe('createMediaRouter', () => {
@@ -364,11 +570,137 @@ describe('createMediaRouter', () => {
     await fs.remove(tmpDir);
   });
 
-  it('returns handleList, handleDelete, handlePost functions', () => {
+  it('returns handleList, handleDelete, handlePost, handleRename functions', () => {
     const router = createMediaRouter(config);
     expect(typeof router.handleList).toBe('function');
     expect(typeof router.handleDelete).toBe('function');
     expect(typeof router.handlePost).toBe('function');
+    expect(typeof router.handleRename).toBe('function');
+  });
+
+  describe('handleRename', () => {
+    const callRename = async (router: any, body: unknown) => {
+      let statusCode = 0;
+      let responseBody = '';
+      const res = {
+        set statusCode(code: number) {
+          statusCode = code;
+        },
+        end(data: string) {
+          responseBody = data;
+        },
+      };
+      await router.handleRename({ url: '/media/rename', body } as any, res);
+      return { statusCode, body: JSON.parse(responseBody || '{}') };
+    };
+
+    it('returns 200 and moves the file', async () => {
+      const mediaDir = path.join(tmpDir, 'public', 'uploads');
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'data');
+      const router = createMediaRouter(config);
+
+      const res = await callRename(router, {
+        from: 'old.txt',
+        to: 'new.txt',
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toEqual({
+        success: true,
+        from: 'old.txt',
+        to: 'new.txt',
+      });
+      expect(await fs.pathExists(path.join(mediaDir, 'new.txt'))).toBe(true);
+    });
+
+    it('ignores an extra branch field for parity with the cloud contract', async () => {
+      const mediaDir = path.join(tmpDir, 'public', 'uploads');
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'data');
+      const router = createMediaRouter(config);
+
+      const res = await callRename(router, {
+        from: 'old.txt',
+        to: 'new.txt',
+        branch: 'main',
+      });
+
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('returns 400 INVALID_FILENAME when from/to are missing', async () => {
+      const router = createMediaRouter(config);
+      const res = await callRename(router, { from: 'old.txt' });
+      expect(res.statusCode).toBe(400);
+      expect(res.body.code).toBe('INVALID_FILENAME');
+    });
+
+    it('returns 400 INVALID_FILENAME when the body is absent', async () => {
+      const router = createMediaRouter(config);
+      const res = await callRename(router, undefined);
+      expect(res.statusCode).toBe(400);
+      expect(res.body.code).toBe('INVALID_FILENAME');
+    });
+
+    it('returns 404 NOT_FOUND for a missing source', async () => {
+      const router = createMediaRouter(config);
+      const res = await callRename(router, {
+        from: 'ghost.txt',
+        to: 'new.txt',
+      });
+      expect(res.statusCode).toBe(404);
+      expect(res.body.code).toBe('NOT_FOUND');
+    });
+
+    it('returns 409 NAME_COLLISION when the destination is taken', async () => {
+      const mediaDir = path.join(tmpDir, 'public', 'uploads');
+      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
+      await fs.writeFile(path.join(mediaDir, 'taken.txt'), 'b');
+      const router = createMediaRouter(config);
+
+      const res = await callRename(router, {
+        from: 'old.txt',
+        to: 'taken.txt',
+      });
+
+      expect(res.statusCode).toBe(409);
+      expect(res.body.code).toBe('NAME_COLLISION');
+      expect(res.body.message).toContain('taken.txt');
+    });
+
+    it('returns 400 UNSUPPORTED when the source is a folder', async () => {
+      await fs.mkdirp(path.join(tmpDir, 'public', 'uploads', 'a-folder'));
+      const router = createMediaRouter(config);
+
+      const res = await callRename(router, {
+        from: 'a-folder',
+        to: 'b-folder',
+      });
+
+      expect(res.statusCode).toBe(400);
+      expect(res.body.code).toBe('UNSUPPORTED');
+    });
+
+    it('returns 403 INVALID_PATH for traversal', async () => {
+      const router = createMediaRouter(config);
+      const res = await callRename(router, {
+        from: '../../etc/passwd',
+        to: 'safe.txt',
+      });
+      expect(res.statusCode).toBe(403);
+      expect(res.body.code).toBe('INVALID_PATH');
+      expect(res.body.message).toContain('Path traversal detected');
+    });
+
+    it('returns 403 INVALID_PATH when the destination escapes the media root', async () => {
+      await fs.writeFile(path.join(tmpDir, 'public', 'uploads', 'a.txt'), 'a');
+      const router = createMediaRouter(config);
+      const res = await callRename(router, {
+        from: 'a.txt',
+        to: '../../evil.txt',
+      });
+      expect(res.statusCode).toBe(403);
+      expect(res.body.code).toBe('INVALID_PATH');
+    });
   });
 
   describe('handleList', () => {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.test.ts
@@ -461,6 +461,36 @@ describe('MediaModel (Vite dev server)', () => {
       move.mockRestore();
     });
 
+    it('names the staging file when the source cannot be restored', async () => {
+      await fs.writeFile(path.join(mediaDir, 'photo.jpg'), 'bytes');
+      const model = new MediaModel(config);
+      const realMove = fs.move;
+      const move = jest.spyOn(fs, 'move');
+      // stage succeeds, the move onto the new casing fails, and so does the
+      // attempt to put the file back
+      move
+        .mockImplementationOnce(realMove)
+        .mockImplementationOnce(async () => {
+          throw new Error('boom');
+        })
+        .mockImplementationOnce(async () => {
+          throw new Error('restore failed');
+        });
+
+      const result = await model.renameMedia({
+        from: 'photo.jpg',
+        to: 'Photo.jpg',
+      });
+
+      const entries = await fs.readdir(mediaDir);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatch(/^\.tina-rename-/);
+      // the surviving file is named in the message so it can be recovered
+      expect(result).toMatchObject({ ok: false, code: 'BACKEND_FAILURE' });
+      expect((result as { message: string }).message).toContain(entries[0]);
+      move.mockRestore();
+    });
+
     it('maps a racing destination write to NAME_COLLISION', async () => {
       await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
       const model = new MediaModel(config);
@@ -500,13 +530,16 @@ describe('MediaModel (Vite dev server)', () => {
       ).rejects.toThrow(PathTraversalError);
     });
 
-    it('rejects the media root itself as a destination', async () => {
-      await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
-      const model = new MediaModel(config);
-      await expect(
-        model.renameMedia({ from: 'old.txt', to: '' })
-      ).rejects.toThrow(PathTraversalError);
-    });
+    it.each(['', '.', './'])(
+      'rejects the media root itself as a destination (%j)',
+      async (to) => {
+        await fs.writeFile(path.join(mediaDir, 'old.txt'), 'a');
+        const model = new MediaModel(config);
+        await expect(
+          model.renameMedia({ from: 'old.txt', to })
+        ).rejects.toThrow(PathTraversalError);
+      }
+    );
   });
 
   describe('renameMedia symlink traversal', () => {
@@ -611,7 +644,9 @@ describe('createMediaRouter', () => {
       expect(await fs.pathExists(path.join(mediaDir, 'new.txt'))).toBe(true);
     });
 
-    it('ignores an extra branch field for parity with the cloud contract', async () => {
+    // Guards the contract, not the handler: unknown keys must not start
+    // 400ing if body validation is ever tightened.
+    it('accepts and ignores unknown fields in the body', async () => {
       const mediaDir = path.join(tmpDir, 'public', 'uploads');
       await fs.writeFile(path.join(mediaDir, 'old.txt'), 'data');
       const router = createMediaRouter(config);

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -64,9 +64,7 @@ export const createMediaRouter = (config: PathConfig) => {
     // Body is populated by the bodyParser.json middleware registered ahead of
     // this router, the same way the /graphql route consumes it.
     const body = (req as unknown as { body?: unknown }).body;
-    const { from, to, ...rest } =
-      (body as { from?: unknown; to?: unknown }) || {};
-    void rest; // `branch` is accepted for parity with the cloud contract
+    const { from, to } = (body as { from?: unknown; to?: unknown }) || {};
 
     if (typeof from !== 'string' || typeof to !== 'string' || !from || !to) {
       res.statusCode = 400;
@@ -213,6 +211,17 @@ const RENAME_ERROR_STATUS: Record<RenameFailureCode, number> = {
   UNSUPPORTED: 400,
   BACKEND_FAILURE: 500,
 };
+
+/**
+ * Raised when a staged rename cannot put the file back where it started, so
+ * the file is left under the staging name. Carries that name so the response
+ * can tell the editor where to find it.
+ */
+class StagedRenameError extends Error {
+  constructor(public readonly stagingName: string) {
+    super(`Left the file as "${stagingName}" in the same folder.`);
+  }
+}
 
 /** fs-extra's move rejects an existing destination with a bare message. */
 const isDestinationExistsError = (error: unknown) =>
@@ -624,22 +633,33 @@ export class MediaModel {
       return {
         ok: false,
         code: 'BACKEND_FAILURE',
-        message: 'Failed to rename the file.',
+        message:
+          error instanceof StagedRenameError
+            ? `Failed to rename the file. ${error.message}`
+            : 'Failed to rename the file.',
       };
     }
   }
 
   /**
    * A case-insensitive filesystem can treat `a.jpg` -> `A.jpg` as a no-op, so
-   * hop through a unique sibling name. On failure the source is put back.
+   * hop through a unique sibling name. On failure the source is put back; if
+   * even that fails the file survives under the staging name, which
+   * StagedRenameError reports rather than leaving it to be found by accident.
    */
   private async renameViaStaging(source: string, destination: string) {
-    const staging = join(path.dirname(source), `.tina-rename-${randomUUID()}`);
+    const stagingName = `.tina-rename-${randomUUID()}`;
+    const staging = join(path.dirname(source), stagingName);
     await fs.move(source, staging, { overwrite: false });
     try {
       await fs.move(staging, destination, { overwrite: false });
     } catch (error) {
-      await fs.move(staging, source, { overwrite: false }).catch(() => {});
+      try {
+        await fs.move(staging, source, { overwrite: false });
+      } catch (restoreError) {
+        console.error(restoreError);
+        throw new StagedRenameError(stagingName);
+      }
       throw error;
     }
   }

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import type { ServerResponse } from 'http';
 import path, { join } from 'path';
 import busboy from 'busboy';
@@ -59,6 +60,48 @@ export const createMediaRouter = (config: PathConfig) => {
     }
   };
 
+  const handleRename = async (req: Connect.IncomingMessage, res) => {
+    // Body is populated by the bodyParser.json middleware registered ahead of
+    // this router, the same way the /graphql route consumes it.
+    const body = (req as unknown as { body?: unknown }).body;
+    const { from, to, ...rest } =
+      (body as { from?: unknown; to?: unknown }) || {};
+    void rest; // `branch` is accepted for parity with the cloud contract
+
+    if (typeof from !== 'string' || typeof to !== 'string' || !from || !to) {
+      res.statusCode = 400;
+      res.end(
+        JSON.stringify({
+          code: 'INVALID_FILENAME',
+          message: 'Both "from" and "to" are required.',
+        })
+      );
+      return;
+    }
+
+    try {
+      const result = await mediaModel.renameMedia({ from, to });
+      // `in` rather than `result.ok`: this repo compiles with `strict: false`,
+      // where boolean-literal discriminants do not narrow.
+      if ('code' in result) {
+        res.statusCode = RENAME_ERROR_STATUS[result.code];
+        res.end(JSON.stringify({ code: result.code, message: result.message }));
+        return;
+      }
+      res.statusCode = 200;
+      res.end(JSON.stringify({ success: true, from, to }));
+    } catch (error) {
+      if (error instanceof PathTraversalError) {
+        res.statusCode = 403;
+        res.end(
+          JSON.stringify({ code: 'INVALID_PATH', message: error.message })
+        );
+        return;
+      }
+      throw error;
+    }
+  };
+
   const handlePost = async function (
     req: Connect.IncomingMessage,
     res: ServerResponse
@@ -107,7 +150,7 @@ export const createMediaRouter = (config: PathConfig) => {
     req.pipe(bb);
   };
 
-  return { handleList, handleDelete, handlePost };
+  return { handleList, handleDelete, handlePost, handleRename };
 };
 
 export const parseMediaFolder = (str: string) => {
@@ -153,6 +196,28 @@ export interface PathConfig {
 }
 
 type SuccessRecord = { ok: true } | { ok: false; message: string };
+
+export type RenameFailureCode =
+  | 'NOT_FOUND'
+  | 'NAME_COLLISION'
+  | 'UNSUPPORTED'
+  | 'BACKEND_FAILURE';
+
+type RenameRecord =
+  | { ok: true }
+  | { ok: false; code: RenameFailureCode; message: string };
+
+const RENAME_ERROR_STATUS: Record<RenameFailureCode, number> = {
+  NOT_FOUND: 404,
+  NAME_COLLISION: 409,
+  UNSUPPORTED: 400,
+  BACKEND_FAILURE: 500,
+};
+
+/** fs-extra's move rejects an existing destination with a bare message. */
+const isDestinationExistsError = (error: unknown) =>
+  (error as { code?: string })?.code === 'EEXIST' ||
+  /dest already exists/i.test((error as Error)?.message || '');
 
 /**
  * Detects URL-encoded path-traversal sequences that should have been
@@ -495,6 +560,91 @@ export class MediaModel {
       cursor:
         files.length > offset + pageSize ? String(offset + pageSize) : null,
     };
+  }
+
+  /**
+   * @security Both paths go through `resolveStrictlyWithinBase`, which rejects
+   * traversal, symlink escapes and the media root itself.
+   */
+  async renameMedia(args: { from: string; to: string }): Promise<RenameRecord> {
+    const mediaBase = join(this.rootPath, this.publicFolder, this.mediaRoot);
+    const source = resolveStrictlyWithinBase(args.from, mediaBase);
+    const destination = resolveStrictlyWithinBase(args.to, mediaBase);
+
+    try {
+      const stats = await fs.stat(source);
+      if (stats.isDirectory()) {
+        return {
+          ok: false,
+          code: 'UNSUPPORTED',
+          message: 'Renaming folders is not supported.',
+        };
+      }
+    } catch {
+      return {
+        ok: false,
+        code: 'NOT_FOUND',
+        message: `"${args.from}" does not exist.`,
+      };
+    }
+
+    // On case-insensitive filesystems the destination of a case-only rename
+    // reports as existing because it *is* the source.
+    const isCaseOnlyRename =
+      source !== destination &&
+      source.toLowerCase() === destination.toLowerCase();
+
+    if (!isCaseOnlyRename && (await fs.pathExists(destination))) {
+      return {
+        ok: false,
+        code: 'NAME_COLLISION',
+        message: `"${args.to}" already exists.`,
+      };
+    }
+
+    try {
+      await fs.ensureDir(path.dirname(destination));
+      if (isCaseOnlyRename) {
+        await this.renameViaStaging(source, destination);
+      } else {
+        await fs.move(source, destination, { overwrite: false });
+      }
+      return { ok: true };
+    } catch (error) {
+      // pathExists above is advisory only; the move stays overwrite-free so a
+      // racing writer still surfaces as a collision rather than data loss.
+      if (isDestinationExistsError(error)) {
+        return {
+          ok: false,
+          code: 'NAME_COLLISION',
+          message: `"${args.to}" already exists.`,
+        };
+      }
+      console.error(error);
+      return {
+        ok: false,
+        code: 'BACKEND_FAILURE',
+        message: 'Failed to rename the file.',
+      };
+    }
+  }
+
+  /**
+   * A case-insensitive filesystem can treat `a.jpg` -> `A.jpg` as a no-op, so
+   * hop through a unique sibling name. On failure the source is put back.
+   */
+  private async renameViaStaging(source: string, destination: string) {
+    const staging = join(
+      path.dirname(source),
+      `.tina-rename-${randomUUID()}`
+    );
+    await fs.move(source, staging, { overwrite: false });
+    try {
+      await fs.move(staging, destination, { overwrite: false });
+    } catch (error) {
+      await fs.move(staging, source, { overwrite: false }).catch(() => {});
+      throw error;
+    }
   }
 
   async deleteMedia(args: MediaArgs): Promise<SuccessRecord> {

--- a/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
+++ b/packages/@tinacms/cli/src/next/commands/dev-command/server/media.ts
@@ -634,10 +634,7 @@ export class MediaModel {
    * hop through a unique sibling name. On failure the source is put back.
    */
   private async renameViaStaging(source: string, destination: string) {
-    const staging = join(
-      path.dirname(source),
-      `.tina-rename-${randomUUID()}`
-    );
+    const staging = join(path.dirname(source), `.tina-rename-${randomUUID()}`);
     await fs.move(source, staging, { overwrite: false });
     try {
       await fs.move(staging, destination, { overwrite: false });

--- a/packages/@tinacms/cli/src/next/vite/plugins.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.test.ts
@@ -19,6 +19,10 @@ const mockHandleDelete = jest.fn(async (_req: any, res: any) => {
   res.end(JSON.stringify({ ok: true }));
 });
 const mockHandleList = jest.fn();
+const mockHandleRename = jest.fn(async (_req: any, res: any) => {
+  res.statusCode = 200;
+  res.end(JSON.stringify({ success: true }));
+});
 const mockSearchPut = jest.fn(async (_req: any, res: any) => {
   res.statusCode = 200;
   res.end('{}');
@@ -29,6 +33,7 @@ jest.mock('../commands/dev-command/server/media', () => ({
     handlePost: mockHandlePost,
     handleDelete: mockHandleDelete,
     handleList: mockHandleList,
+    handleRename: mockHandleRename,
   }),
   parseMediaFolder: (s: string) => s,
 }));
@@ -143,6 +148,21 @@ describe('devServerEndPointsPlugin cross-origin gate', () => {
       expect(mockHandleDelete).not.toHaveBeenCalled();
     });
 
+    it('rejects cross-origin POST /media/rename before reaching the handler', async () => {
+      const mw = getRequestMiddleware();
+      const { res, next } = await invoke(mw, {
+        url: '/media/rename',
+        method: 'POST',
+        headers: { origin: 'http://evil.test:8000' },
+        body: { from: 'a.txt', to: 'b.txt' },
+      });
+
+      expect(res.statusCode).toBe(403);
+      expect(res.body).toContain('Origin not allowed');
+      expect(mockHandleRename).not.toHaveBeenCalled();
+      expect(next).not.toHaveBeenCalled();
+    });
+
     it('rejects cross-origin POST /searchIndex before reaching the handler', async () => {
       const mw = getRequestMiddleware();
       const { res } = await invoke(mw, {
@@ -180,6 +200,21 @@ describe('devServerEndPointsPlugin cross-origin gate', () => {
 
       expect(res.statusCode).not.toBe(403);
       expect(mockHandlePost).toHaveBeenCalledTimes(1);
+    });
+
+    it('routes a localhost POST /media/rename to the rename handler', async () => {
+      const mw = getRequestMiddleware();
+      const { res } = await invoke(mw, {
+        url: '/media/rename',
+        method: 'POST',
+        headers: { origin: 'http://localhost:3000' },
+        body: { from: 'a.txt', to: 'b.txt' },
+      });
+
+      expect(res.statusCode).toBe(200);
+      expect(mockHandleRename).toHaveBeenCalled();
+      expect(mockHandlePost).not.toHaveBeenCalled();
+      expect(mockHandleDelete).not.toHaveBeenCalled();
     });
 
     it('allows a localhost Origin', async () => {

--- a/packages/@tinacms/cli/src/next/vite/plugins.test.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.test.ts
@@ -293,3 +293,58 @@ describe('devServerEndPointsPlugin cross-origin gate', () => {
     });
   });
 });
+
+describe('devServerEndPointsPlugin media route matching', () => {
+  it('routes DELETE of a "rename"-prefixed file to the delete handler', async () => {
+    const mw = getRequestMiddleware();
+    const { res } = await invoke(mw, {
+      url: '/media/renamed-hero.jpg',
+      method: 'DELETE',
+      headers: { origin: 'http://localhost:3000' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockHandleDelete).toHaveBeenCalledTimes(1);
+    expect(mockHandleRename).not.toHaveBeenCalled();
+  });
+
+  it('routes DELETE of a file named exactly "rename" to the delete handler', async () => {
+    const mw = getRequestMiddleware();
+    const { res } = await invoke(mw, {
+      url: '/media/rename',
+      method: 'DELETE',
+      headers: { origin: 'http://localhost:3000' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockHandleDelete).toHaveBeenCalledTimes(1);
+    expect(mockHandleRename).not.toHaveBeenCalled();
+  });
+
+  it('still gates a cross-origin DELETE of a "rename"-prefixed file', async () => {
+    const mw = getRequestMiddleware();
+    const { res, next } = await invoke(mw, {
+      url: '/media/renamed-hero.jpg',
+      method: 'DELETE',
+      headers: { origin: 'http://evil.test:8000' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(mockHandleDelete).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('matches the rename route with a query string attached', async () => {
+    const mw = getRequestMiddleware();
+    const { res } = await invoke(mw, {
+      url: '/media/rename?branch=main',
+      method: 'POST',
+      headers: { origin: 'http://localhost:3000' },
+      body: { from: 'a.txt', to: 'b.txt' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mockHandleRename).toHaveBeenCalledTimes(1);
+    expect(mockHandleDelete).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -47,6 +47,9 @@ export const transformTsxPlugin = ({
   return plug;
 };
 
+const isMediaRenameRequest = (req: { url?: string; method?: string }) =>
+  req.method === 'POST' && (req.url || '').split('?')[0] === '/media/rename';
+
 export const devServerEndPointsPlugin = ({
   configManager,
   apiURL,
@@ -72,7 +75,7 @@ export const devServerEndPointsPlugin = ({
   const isStateChangingRequest = (req: { url?: string; method?: string }) => {
     const url = req.url || '';
     if (url.startsWith('/media/upload')) return true;
-    if (url.startsWith('/media/rename')) return true;
+    if (isMediaRenameRequest(req)) return true;
     if (url.startsWith('/media') && req.method === 'DELETE') return true;
     if (url.startsWith('/graphql') && req.method === 'POST') return true;
     if (
@@ -120,7 +123,7 @@ export const devServerEndPointsPlugin = ({
           await mediaRouter.handlePost(req, res);
           return;
         }
-        if (req.url.startsWith('/media/rename')) {
+        if (isMediaRenameRequest(req)) {
           await mediaRouter.handleRename(req, res);
           return;
         }

--- a/packages/@tinacms/cli/src/next/vite/plugins.ts
+++ b/packages/@tinacms/cli/src/next/vite/plugins.ts
@@ -72,6 +72,7 @@ export const devServerEndPointsPlugin = ({
   const isStateChangingRequest = (req: { url?: string; method?: string }) => {
     const url = req.url || '';
     if (url.startsWith('/media/upload')) return true;
+    if (url.startsWith('/media/rename')) return true;
     if (url.startsWith('/media') && req.method === 'DELETE') return true;
     if (url.startsWith('/graphql') && req.method === 'POST') return true;
     if (
@@ -117,6 +118,10 @@ export const devServerEndPointsPlugin = ({
 
         if (req.url.startsWith('/media/upload')) {
           await mediaRouter.handlePost(req, res);
+          return;
+        }
+        if (req.url.startsWith('/media/rename')) {
+          await mediaRouter.handleRename(req, res);
           return;
         }
         if (req.url.startsWith('/media')) {

--- a/packages/tinacms/src/toolkit/components/media/media-manager.test.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.test.tsx
@@ -142,6 +142,38 @@ describe('MediaPicker rename action', () => {
     );
   });
 
+  // A search hit reports its folder inside `filename` and leaves `directory`
+  // empty, unlike a file reached by browsing into that folder.
+  it('keeps a searched file in its folder when renamed', async () => {
+    const rename = vi.fn().mockResolvedValue(file('new.jpg', 'nested'));
+    const { cms } = buildCms({ rename }, [file('nested/old.jpg')]);
+    renderPicker(cms);
+
+    await openPreview('nested/old.jpg');
+    await submitRename('new');
+
+    await waitFor(() =>
+      expect(rename).toHaveBeenCalledWith('nested/old.jpg', 'nested/new.jpg')
+    );
+  });
+
+  it('offers only the base name of a searched file for editing', async () => {
+    const rename = vi.fn();
+    const { cms } = buildCms({ rename }, [file('nested/old.jpg')]);
+    renderPicker(cms);
+
+    await openPreview('nested/old.jpg');
+    fireEvent.click(await screen.findByText('Rename'));
+
+    const input = screen.getByPlaceholderText('File name') as HTMLInputElement;
+    expect(input.value).toBe('old');
+
+    // Submitting an untouched name is not a rename, so the folder cannot be
+    // dropped just by opening the modal and confirming.
+    fireEvent.click(modal().getByText('Rename').closest('button'));
+    expect(rename).not.toHaveBeenCalled();
+  });
+
   it('reloads the list and re-points the preview at the renamed file', async () => {
     const renamed = file('new.jpg');
     let current = [file('old.jpg')];

--- a/packages/tinacms/src/toolkit/components/media/media-manager.test.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.test.tsx
@@ -1,0 +1,198 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { EventBus } from '@toolkit/core/event';
+import { MediaManager as MediaManagerCore } from '@toolkit/core/media';
+import type { Media, MediaStore } from '@toolkit/core/media';
+import { CMSContext } from '@toolkit/react-core/use-cms';
+import { ModalProvider } from '@toolkit/react-modals';
+import React from 'react';
+import { MediaPicker } from './media-manager';
+
+vi.mock('../../../lib/posthog/posthogProvider', () => ({
+  captureEvent: vi.fn(),
+}));
+
+const file = (filename: string, directory = ''): Media => ({
+  type: 'file',
+  id: filename,
+  filename,
+  directory,
+  src: `/uploads/${directory ? `${directory}/` : ''}${filename}`,
+  thumbnails: {
+    '75x75': `/uploads/${filename}`,
+    '400x400': `/uploads/${filename}`,
+    '1000x1000': `/uploads/${filename}`,
+  },
+});
+
+const buildCms = (
+  storeOverrides: Partial<MediaStore> = {},
+  items = [file('photo.jpg')]
+) => {
+  const events = new EventBus();
+  const store: MediaStore = {
+    accept: '*',
+    async persist() {
+      return [];
+    },
+    async delete() {},
+    async list() {
+      return { items, nextOffset: undefined };
+    },
+    ...storeOverrides,
+  };
+  const media = new MediaManagerCore(store, events);
+  const cms = {
+    media,
+    events,
+    alerts: { error: vi.fn(), success: vi.fn(), warn: vi.fn(), info: vi.fn() },
+    api: {
+      tina: {
+        isLocalMode: true,
+        schema: { schema: { config: { media: { tina: {} } } } },
+        getProject: vi.fn().mockResolvedValue({ mediaBranch: 'main' }),
+        appDashboardLink: 'https://app.tina.io',
+      },
+    },
+  };
+  return { cms, events, store, media };
+};
+
+const withCms = (cms: any, children: React.ReactNode) => (
+  <ModalProvider>
+    <CMSContext.Provider value={{ cms, dispatch: vi.fn(), state: {} } as any}>
+      {children}
+    </CMSContext.Provider>
+  </ModalProvider>
+);
+
+const renderPicker = (cms: any, props: any = {}) =>
+  render(withCms(cms, <MediaPicker allowDelete={true} {...props} />));
+
+const openPreview = async (filename: string) => {
+  const item = await screen.findByTitle(filename);
+  fireEvent.click(item);
+};
+
+// The picker and the open modal both render a "Rename" label; modals portal
+// into #modal-root, so scope to it to tell them apart.
+const modal = () => within(document.getElementById('modal-root'));
+
+const submitRename = async (newBase: string) => {
+  fireEvent.click(await screen.findByText('Rename'));
+  fireEvent.change(screen.getByPlaceholderText('File name'), {
+    target: { value: newBase },
+  });
+  fireEvent.click(modal().getByText('Rename').closest('button'));
+};
+
+describe('MediaPicker rename action', () => {
+  it('shows Rename when the store implements it', async () => {
+    const { cms } = buildCms({ rename: vi.fn() });
+    renderPicker(cms);
+
+    await openPreview('photo.jpg');
+    expect(await screen.findByText('Rename')).toBeDefined();
+  });
+
+  it('hides Rename when the store does not implement it', async () => {
+    const { cms } = buildCms();
+    renderPicker(cms);
+
+    await openPreview('photo.jpg');
+    await screen.findByText('Delete');
+    expect(screen.queryByText('Rename')).toBeNull();
+  });
+
+  it('hides Rename for a static store', async () => {
+    const { cms } = buildCms({ rename: vi.fn(), isStatic: true });
+    renderPicker(cms);
+
+    await openPreview('photo.jpg');
+    expect(screen.queryByText('Rename')).toBeNull();
+  });
+
+  it('hides Rename when the caller disallows destructive actions', async () => {
+    const { cms } = buildCms({ rename: vi.fn() });
+    renderPicker(cms, { allowDelete: false });
+
+    await openPreview('photo.jpg');
+    expect(screen.queryByText('Rename')).toBeNull();
+  });
+
+  it('sends media-root-relative from/to paths for a nested file', async () => {
+    const renamed = file('new.jpg', 'products');
+    const rename = vi.fn().mockResolvedValue(renamed);
+    const { cms } = buildCms({ rename }, [file('old.jpg', 'products')]);
+    renderPicker(cms);
+
+    await openPreview('old.jpg');
+    await submitRename('new');
+
+    await waitFor(() =>
+      expect(rename).toHaveBeenCalledWith(
+        'products/old.jpg',
+        'products/new.jpg'
+      )
+    );
+  });
+
+  it('reloads the list and re-points the preview at the renamed file', async () => {
+    const renamed = file('new.jpg');
+    let current = [file('old.jpg')];
+    const rename = vi.fn().mockImplementation(async () => {
+      current = [renamed];
+      return renamed;
+    });
+    const list = vi.fn().mockImplementation(async () => ({ items: current }));
+    const { cms } = buildCms({ rename, list });
+    renderPicker(cms);
+
+    await openPreview('old.jpg');
+    const callsBefore = list.mock.calls.length;
+    await submitRename('new');
+
+    // the preview heading follows the renamed file
+    expect(
+      await screen.findByRole('heading', { name: 'new.jpg' })
+    ).toBeDefined();
+    await waitFor(() =>
+      expect(list.mock.calls.length).toBeGreaterThan(callsBefore)
+    );
+    await waitFor(() => expect(screen.queryByTitle('old.jpg')).toBeNull());
+  });
+
+  it('keeps a second picker in sync through the event bus', async () => {
+    const renamed = file('new.jpg');
+    let current = [file('old.jpg')];
+    const rename = vi.fn().mockImplementation(async () => {
+      current = [renamed];
+      return renamed;
+    });
+    const list = vi.fn().mockImplementation(async () => ({ items: current }));
+    const { cms } = buildCms({ rename, list });
+
+    render(
+      withCms(
+        cms,
+        <>
+          <MediaPicker allowDelete={true} />
+          <MediaPicker allowDelete={true} />
+        </>
+      )
+    );
+
+    expect(await screen.findAllByTitle('old.jpg')).toHaveLength(2);
+
+    await cms.media.rename('old.jpg', 'new.jpg');
+
+    await waitFor(() =>
+      expect(screen.getAllByTitle('new.jpg')).toHaveLength(2)
+    );
+  });
+});

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -20,6 +20,7 @@ import {
   List,
   RefreshCw,
   Search,
+  TextCursorInput,
   X,
 } from 'lucide-react';
 import React, { useEffect, useState, forwardRef, useRef } from 'react';
@@ -39,7 +40,7 @@ import {
   ListMediaItem,
   checkerboardStyle,
 } from './media-item';
-import { DeleteModal, NewFolderModal } from './modal';
+import { DeleteModal, NewFolderModal, RenameModal } from './modal';
 import {
   DEFAULT_MEDIA_UPLOAD_TYPES,
   absoluteImgURL,
@@ -71,6 +72,16 @@ const join = function (...parts) {
   });
 
   return parts.join(slash);
+};
+
+/**
+ * Media-root-relative `directory/filename`, the path shape the store's rename
+ * and delete calls expect — no origin, public folder or media root prefix.
+ */
+const mediaItemPath = (item: Media, filename: string) => {
+  const directory = item.directory === '.' ? '' : item.directory || '';
+  const trimmed = directory.replace(/^\/+|\/+$/g, '');
+  return trimmed ? `${trimmed}/${filename}` : filename;
 };
 
 export interface MediaRequest {
@@ -138,6 +149,7 @@ export function MediaPicker({
   });
 
   const [deleteModalOpen, setDeleteModalOpen] = React.useState(false);
+  const [renameModalOpen, setRenameModalOpen] = React.useState(false);
   const [newFolderModalOpen, setNewFolderModalOpen] = React.useState(false);
   const [listError, setListError] = useState<MediaListError>(defaultListError);
   const [directory, setDirectory] = useState<string | undefined>(
@@ -257,8 +269,17 @@ export function MediaPicker({
     if (loadFolders) setLoadFolders(false);
 
     return cms.events.subscribe(
-      ['media:delete:success', 'media:pageSize'],
-      () => {
+      ['media:delete:success', 'media:rename:success', 'media:pageSize'],
+      (event) => {
+        if (event.type === 'media:rename:success') {
+          // Every mounted picker sees this, so only the ones actually
+          // previewing the renamed file swap their selection.
+          setActiveItem((current) =>
+            current && mediaItemPath(current, current.filename) === event.from
+              ? event.media
+              : current
+          );
+        }
         setRefreshing(true);
         resetOffset();
         resetList();
@@ -289,6 +310,21 @@ export function MediaPicker({
       captureEvent(MediaManagerContentDeletedEvent, { fileType: ext });
     };
   }
+
+  // Only stores that implement rename can offer the action; a store without it
+  // would fail on click. Static stores are read-only, and folders never become
+  // the active item, so neither needs a separate check here.
+  const canRename =
+    allowDelete &&
+    !cms.media.store.isStatic &&
+    typeof cms.media.store.rename === 'function';
+
+  const renameMediaItem = async (item: Media, newFilename: string) => {
+    await cms.media.rename(
+      mediaItemPath(item, item.filename),
+      mediaItemPath(item, newFilename)
+    );
+  };
 
   let selectMediaItem: (_item: Media) => void;
 
@@ -499,6 +535,15 @@ export function MediaPicker({
           close={() => setDeleteModalOpen(false)}
         />
       )}
+      {renameModalOpen && activeItem && (
+        <RenameModal
+          filename={activeItem.filename}
+          renameFunc={async (newFilename) => {
+            await renameMediaItem(activeItem, newFilename);
+          }}
+          close={() => setRenameModalOpen(false)}
+        />
+      )}
       {newFolderModalOpen && (
         <NewFolderModal
           onSubmit={(name) => {
@@ -644,6 +689,10 @@ export function MediaPicker({
               deleteMediaItem={() => {
                 setDeleteModalOpen(true);
               }}
+              allowRename={canRename}
+              renameMediaItem={() => {
+                setRenameModalOpen(true);
+              }}
             />
           </div>
         </SyncStatusContainer>
@@ -658,6 +707,8 @@ const ActiveItemPreview = ({
   selectMediaItem,
   deleteMediaItem,
   allowDelete,
+  renameMediaItem,
+  allowRename,
 }) => {
   const thumbnail = activeItem
     ? (activeItem.thumbnails || {})['1000x1000']
@@ -713,6 +764,12 @@ const ActiveItemPreview = ({
                 >
                   <ArrowDownToLine className='mr-1 -ml-0.5 w-6 h-auto opacity-70' />
                   Insert
+                </Button>
+              )}
+              {allowRename && (
+                <Button size='medium' onClick={renameMediaItem}>
+                  <TextCursorInput className='mr-1 -ml-0.5 w-6 h-auto opacity-70' />
+                  Rename
                 </Button>
               )}
               {allowDelete && (

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -314,7 +314,7 @@ export function MediaPicker({
   // Only stores that implement rename can offer the action; a store without it
   // would fail on click. Static stores are read-only, and folders never become
   // the active item, so neither needs a separate check here.
-  const canRename =
+  const allowRename =
     allowDelete &&
     !cms.media.store.isStatic &&
     typeof cms.media.store.rename === 'function';
@@ -689,7 +689,7 @@ export function MediaPicker({
               deleteMediaItem={() => {
                 setDeleteModalOpen(true);
               }}
-              allowRename={canRename}
+              allowRename={allowRename}
               renameMediaItem={() => {
                 setRenameModalOpen(true);
               }}

--- a/packages/tinacms/src/toolkit/components/media/media-manager.tsx
+++ b/packages/tinacms/src/toolkit/components/media/media-manager.tsx
@@ -78,11 +78,16 @@ const join = function (...parts) {
  * Media-root-relative `directory/filename`, the path shape the store's rename
  * and delete calls expect — no origin, public folder or media root prefix.
  */
-const mediaItemPath = (item: Media, filename: string) => {
+const mediaItemPath = (item: Media) => {
   const directory = item.directory === '.' ? '' : item.directory || '';
   const trimmed = directory.replace(/^\/+|\/+$/g, '');
-  return trimmed ? `${trimmed}/${filename}` : filename;
+  return trimmed ? `${trimmed}/${item.filename}` : item.filename;
 };
+
+const basename = (path: string) => path.slice(path.lastIndexOf('/') + 1);
+
+const siblingPath = (path: string, name: string) =>
+  `${path.slice(0, path.lastIndexOf('/') + 1)}${name}`;
 
 export interface MediaRequest {
   directory?: string;
@@ -275,7 +280,7 @@ export function MediaPicker({
           // Every mounted picker sees this, so only the ones actually
           // previewing the renamed file swap their selection.
           setActiveItem((current) =>
-            current && mediaItemPath(current, current.filename) === event.from
+            current && mediaItemPath(current) === event.from
               ? event.media
               : current
           );
@@ -320,10 +325,8 @@ export function MediaPicker({
     typeof cms.media.store.rename === 'function';
 
   const renameMediaItem = async (item: Media, newFilename: string) => {
-    await cms.media.rename(
-      mediaItemPath(item, item.filename),
-      mediaItemPath(item, newFilename)
-    );
+    const from = mediaItemPath(item);
+    await cms.media.rename(from, siblingPath(from, newFilename));
   };
 
   let selectMediaItem: (_item: Media) => void;
@@ -537,7 +540,7 @@ export function MediaPicker({
       )}
       {renameModalOpen && activeItem && (
         <RenameModal
-          filename={activeItem.filename}
+          filename={basename(activeItem.filename)}
           renameFunc={async (newFilename) => {
             await renameMediaItem(activeItem, newFilename);
           }}

--- a/packages/tinacms/src/toolkit/components/media/modal.test.tsx
+++ b/packages/tinacms/src/toolkit/components/media/modal.test.tsx
@@ -1,0 +1,164 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MediaRenameError } from '@toolkit/core/media';
+import { ModalProvider } from '@toolkit/react-modals';
+import React from 'react';
+import { RenameModal } from './modal';
+
+const renderModal = (
+  props: Partial<React.ComponentProps<typeof RenameModal>> = {}
+) => {
+  const renameFunc = props.renameFunc ?? vi.fn().mockResolvedValue(undefined);
+  const close = props.close ?? vi.fn();
+  render(
+    <ModalProvider>
+      <RenameModal
+        filename={props.filename ?? 'photo.jpg'}
+        renameFunc={renameFunc}
+        close={close}
+      />
+    </ModalProvider>
+  );
+  return {
+    renameFunc,
+    close,
+    input: () => screen.getByPlaceholderText('File name') as HTMLInputElement,
+    // `Button` renders `disabled` as pointer-events-none styling rather than
+    // the DOM attribute, so "is it disabled" is asserted through the class and
+    // through the handler refusing to run.
+    submit: () => screen.getByText('Rename').closest('button'),
+    submitBlocked: () =>
+      screen
+        .getByText('Rename')
+        .closest('button')
+        .className.includes('pointer-events-none'),
+  };
+};
+
+describe('RenameModal', () => {
+  it('edits only the basename and keeps the extension visible', () => {
+    const { input } = renderModal({ filename: 'photo.jpg' });
+    expect(input().value).toBe('photo');
+    expect(screen.getByText('.jpg')).toBeDefined();
+  });
+
+  it('warns that content references are not updated', () => {
+    renderModal();
+    expect(screen.getByText(/will not update existing content/i)).toBeDefined();
+  });
+
+  it('blocks submit while the name is unchanged', () => {
+    const { submit, submitBlocked, renameFunc } = renderModal({
+      filename: 'photo.jpg',
+    });
+    expect(submitBlocked()).toBe(true);
+    fireEvent.click(submit());
+    expect(renameFunc).not.toHaveBeenCalled();
+  });
+
+  it('blocks submit when the name is emptied', () => {
+    const { input, submit, submitBlocked, renameFunc } = renderModal();
+    fireEvent.change(input(), { target: { value: '   ' } });
+    expect(submitBlocked()).toBe(true);
+    fireEvent.click(submit());
+    expect(renameFunc).not.toHaveBeenCalled();
+  });
+
+  it('previews the sanitised name and submits it', async () => {
+    const { input, submit, renameFunc } = renderModal({
+      filename: 'photo.jpg',
+    });
+
+    fireEvent.change(input(), { target: { value: 'my new photo' } });
+    expect(screen.getByText('my-new-photo.jpg')).toBeDefined();
+
+    fireEvent.click(submit());
+    await waitFor(() =>
+      expect(renameFunc).toHaveBeenCalledWith('my-new-photo.jpg')
+    );
+  });
+
+  it('preserves the extension even when the base contains dots', async () => {
+    const { input, submit, renameFunc } = renderModal({
+      filename: 'photo.jpg',
+    });
+
+    fireEvent.change(input(), { target: { value: 'v1.2.final' } });
+    fireEvent.click(submit());
+
+    await waitFor(() =>
+      expect(renameFunc).toHaveBeenCalledWith('v1.2.final.jpg')
+    );
+  });
+
+  it('blocks a name that sanitises away entirely', () => {
+    const { input, submit, submitBlocked, renameFunc } = renderModal();
+    fireEvent.change(input(), { target: { value: '///' } });
+    expect(submitBlocked()).toBe(true);
+    expect(screen.getByText(/isn't valid/i)).toBeDefined();
+    fireEvent.click(submit());
+    expect(renameFunc).not.toHaveBeenCalled();
+  });
+
+  it('closes after a successful rename', async () => {
+    const { input, submit, close } = renderModal();
+    fireEvent.change(input(), { target: { value: 'renamed' } });
+    fireEvent.click(submit());
+    await waitFor(() => expect(close).toHaveBeenCalled());
+  });
+
+  it('stays open and shows a specific message on collision', async () => {
+    const renameFunc = vi
+      .fn()
+      .mockRejectedValue(
+        new MediaRenameError({ code: 'NAME_COLLISION', message: 'taken' })
+      );
+    const { input, submit, close } = renderModal({ renameFunc });
+
+    fireEvent.change(input(), { target: { value: 'taken' } });
+    fireEvent.click(submit());
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert').textContent).toContain(
+      'A file named "taken.jpg" already exists'
+    );
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing source without closing', async () => {
+    const renameFunc = vi
+      .fn()
+      .mockRejectedValue(
+        new MediaRenameError({ code: 'NOT_FOUND', message: 'gone' })
+      );
+    const { input, submit, close } = renderModal({ renameFunc });
+
+    fireEvent.change(input(), { target: { value: 'renamed' } });
+    fireEvent.click(submit());
+
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert').textContent).toContain('no longer exists');
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('disables the inputs while the rename is in flight', async () => {
+    let release: () => void;
+    const renameFunc = vi.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        release = resolve;
+      })
+    );
+    const { input, submit, submitBlocked } = renderModal({ renameFunc });
+
+    fireEvent.change(input(), { target: { value: 'renamed' } });
+    fireEvent.click(submit());
+
+    await waitFor(() => expect(submitBlocked()).toBe(true));
+    expect(input().disabled).toBe(true);
+
+    // a second click must not fire another request
+    fireEvent.click(submit());
+    expect(renameFunc).toHaveBeenCalledTimes(1);
+
+    release();
+  });
+});

--- a/packages/tinacms/src/toolkit/components/media/modal.tsx
+++ b/packages/tinacms/src/toolkit/components/media/modal.tsx
@@ -1,14 +1,17 @@
-import React from 'react';
 import { Input } from '@toolkit/fields';
+// Direct path rather than the '@tinacms/toolkit' barrel: the barrel re-exports
+// this module, so going through it resolves to undefined at runtime.
+import { LoadingDots } from '@toolkit/form-builder';
 import {
   Modal,
-  ModalHeader,
-  ModalBody,
-  PopupModal,
   ModalActions,
+  ModalBody,
+  ModalHeader,
+  PopupModal,
 } from '@toolkit/react-modals';
 import { Button } from '@toolkit/styles';
-import { LoadingDots } from '@tinacms/toolkit';
+import React from 'react';
+import { sanitizeFilename, splitFilename } from './utils';
 
 interface DeleteModalProps {
   close(): void;
@@ -19,6 +22,129 @@ interface NewFolderModalProps {
   onSubmit(filename: string): void;
   close(): void;
 }
+
+interface RenameModalProps {
+  close(): void;
+  renameFunc(newFilename: string): Promise<void>;
+  filename: string;
+}
+
+const renameErrorMessage = (error: any, attemptedName: string): string => {
+  switch (error?.code) {
+    case 'NAME_COLLISION':
+      return `A file named "${attemptedName}" already exists in this folder. Choose a different name.`;
+    case 'NOT_FOUND':
+      return 'This file no longer exists. Refresh the media library and try again.';
+    case 'INVALID_FILENAME':
+    case 'INVALID_PATH':
+      return "That name isn't valid. Avoid slashes and special characters.";
+    case 'UNAUTHORIZED':
+      return "You don't have permission to rename this file.";
+    case 'UNSUPPORTED':
+      return error?.message || 'This media store does not support renaming.';
+    default:
+      return error?.message || 'Failed to rename the file. Please try again.';
+  }
+};
+
+export const RenameModal = ({
+  close,
+  renameFunc,
+  filename,
+}: RenameModalProps) => {
+  const { base, ext } = splitFilename(filename);
+  const [nextBase, setNextBase] = React.useState(base);
+  const [processing, setProcessing] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  const trimmedBase = nextBase.trim();
+  // Sanitize the base on its own and re-attach the original extension, so a
+  // base containing slashes or dots can never rewrite or drop it.
+  const sanitizedBase = sanitizeFilename(trimmedBase);
+  const sanitized = `${sanitizedBase}${ext}`;
+  const isEmpty = trimmedBase.length === 0;
+  // Nothing usable survived, so sanitizeFilename fell back to its placeholder
+  // instead of producing something derived from the input.
+  const isStripped =
+    !isEmpty && sanitizedBase === 'file' && trimmedBase !== 'file';
+  const isUnchanged = sanitized === filename;
+  const canSubmit = !processing && !isEmpty && !isStripped && !isUnchanged;
+  const showPreview = !isEmpty && !isStripped && sanitizedBase !== trimmedBase;
+
+  let hint: string | null = null;
+  if (isEmpty) {
+    hint = 'Enter a file name.';
+  } else if (isStripped) {
+    hint = "That name isn't valid. Try using letters, numbers or hyphens.";
+  }
+
+  return (
+    <Modal>
+      <PopupModal>
+        <ModalHeader close={close}>Rename {filename}</ModalHeader>
+        <ModalBody padded={true}>
+          <p className='text-sm text-gray-500 mb-4 italic'>
+            <span className='font-bold'>Note</span> &ndash; Renaming this file
+            will not update existing content that references the old path.
+          </p>
+          <div className='flex items-center gap-2'>
+            <Input
+              value={nextBase}
+              placeholder='File name'
+              required
+              disabled={processing}
+              onChange={(e) => {
+                setNextBase(e.target.value);
+                setError(null);
+              }}
+            />
+            {ext && (
+              <span className='text-base text-gray-500 shrink-0'>{ext}</span>
+            )}
+          </div>
+          {showPreview && (
+            <p className='text-sm text-gray-500 mt-2'>
+              Will be saved as <strong>{sanitized}</strong>
+            </p>
+          )}
+          {hint && <p className='text-sm text-gray-500 mt-2'>{hint}</p>}
+          {error && (
+            <p role='alert' className='text-sm text-red-500 mt-2'>
+              {error}
+            </p>
+          )}
+        </ModalBody>
+        <ModalActions>
+          <Button style={{ flexGrow: 2 }} disabled={processing} onClick={close}>
+            Cancel
+          </Button>
+          <Button
+            style={{ flexGrow: 3 }}
+            variant='primary'
+            disabled={!canSubmit}
+            onClick={async () => {
+              // Button only renders `disabled` as pointer-events-none styling,
+              // so the guard has to live here to stop a double submit.
+              if (!canSubmit) return;
+              setProcessing(true);
+              setError(null);
+              try {
+                await renameFunc(sanitized);
+                close();
+              } catch (e) {
+                setError(renameErrorMessage(e, sanitized));
+                setProcessing(false);
+              }
+            }}
+          >
+            <span className='mr-1'>Rename</span>
+            {processing && <LoadingDots />}
+          </Button>
+        </ModalActions>
+      </PopupModal>
+    </Modal>
+  );
+};
 
 export const DeleteModal = ({
   close,

--- a/packages/tinacms/src/toolkit/components/media/modal.tsx
+++ b/packages/tinacms/src/toolkit/components/media/modal.tsx
@@ -1,6 +1,4 @@
 import { Input } from '@toolkit/fields';
-// Direct path rather than the '@tinacms/toolkit' barrel: the barrel re-exports
-// this module, so going through it resolves to undefined at runtime.
 import { LoadingDots } from '@toolkit/form-builder';
 import {
   Modal,
@@ -11,7 +9,7 @@ import {
 } from '@toolkit/react-modals';
 import { Button } from '@toolkit/styles';
 import React from 'react';
-import { sanitizeFilename, splitFilename } from './utils';
+import { previewRename, splitFilename } from './utils';
 
 interface DeleteModalProps {
   close(): void;
@@ -52,31 +50,17 @@ export const RenameModal = ({
   renameFunc,
   filename,
 }: RenameModalProps) => {
-  const { base, ext } = splitFilename(filename);
-  const [nextBase, setNextBase] = React.useState(base);
+  const [nextBase, setNextBase] = React.useState(
+    () => splitFilename(filename).base
+  );
   const [processing, setProcessing] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
-  const trimmedBase = nextBase.trim();
-  // Sanitize the base on its own and re-attach the original extension, so a
-  // base containing slashes or dots can never rewrite or drop it.
-  const sanitizedBase = sanitizeFilename(trimmedBase);
-  const sanitized = `${sanitizedBase}${ext}`;
-  const isEmpty = trimmedBase.length === 0;
-  // Nothing usable survived, so sanitizeFilename fell back to its placeholder
-  // instead of producing something derived from the input.
-  const isStripped =
-    !isEmpty && sanitizedBase === 'file' && trimmedBase !== 'file';
-  const isUnchanged = sanitized === filename;
-  const canSubmit = !processing && !isEmpty && !isStripped && !isUnchanged;
-  const showPreview = !isEmpty && !isStripped && sanitizedBase !== trimmedBase;
-
-  let hint: string | null = null;
-  if (isEmpty) {
-    hint = 'Enter a file name.';
-  } else if (isStripped) {
-    hint = "That name isn't valid. Try using letters, numbers or hyphens.";
-  }
+  const { sanitized, extension, valid, preview, hint } = previewRename(
+    nextBase,
+    filename
+  );
+  const canSubmit = !processing && valid;
 
   return (
     <Modal>
@@ -98,13 +82,15 @@ export const RenameModal = ({
                 setError(null);
               }}
             />
-            {ext && (
-              <span className='text-base text-gray-500 shrink-0'>{ext}</span>
+            {extension && (
+              <span className='text-base text-gray-500 shrink-0'>
+                {extension}
+              </span>
             )}
           </div>
-          {showPreview && (
+          {preview && (
             <p className='text-sm text-gray-500 mt-2'>
-              Will be saved as <strong>{sanitized}</strong>
+              Will be saved as <strong>{preview}</strong>
             </p>
           )}
           {hint && <p className='text-sm text-gray-500 mt-2'>{hint}</p>}

--- a/packages/tinacms/src/toolkit/components/media/utils.test.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { sanitizeFilename } from './utils';
+import { previewRename, sanitizeFilename, splitFilename } from './utils';
 
 describe('sanitizeFilename', () => {
   it('returns simple ASCII names unchanged', () => {
@@ -72,5 +72,88 @@ describe('sanitizeFilename', () => {
     const result = sanitizeFilename(`${'a'.repeat(500)}.jpg`);
     expect(result.endsWith('.jpg')).toBe(true);
     expect(result.length).toBeLessThanOrEqual(204);
+  });
+});
+
+describe('splitFilename', () => {
+  it('splits on the final dot', () => {
+    expect(splitFilename('a.b.jpg')).toEqual({ base: 'a.b', ext: '.jpg' });
+  });
+
+  it('treats a leading dot as part of the base, not an extension', () => {
+    expect(splitFilename('.gitignore')).toEqual({
+      base: '.gitignore',
+      ext: '',
+    });
+  });
+
+  it('returns an empty extension for a trailing dot', () => {
+    expect(splitFilename('photo.')).toEqual({ base: 'photo.', ext: '' });
+  });
+
+  it('agrees with sanitizeFilename about what the extension is', () => {
+    for (const name of ['a.b.jpg', '.gitignore', 'photo.', 'plain']) {
+      const { ext } = splitFilename(name);
+      expect(sanitizeFilename(name).endsWith(ext)).toBe(true);
+    }
+  });
+});
+
+describe('previewRename', () => {
+  it('keeps the extension when the base contains dots', () => {
+    const { sanitized } = previewRename('report.v2', 'report.pdf');
+    expect(sanitized).toBe('report.v2.pdf');
+  });
+
+  it('never lets the base rewrite or drop the extension', () => {
+    expect(previewRename('a/b/c.png', 'photo.jpg').sanitized).toBe('c.png.jpg');
+    expect(previewRename('///', 'photo.jpg').sanitized).toBe('file.jpg');
+  });
+
+  it('produces a name that sanitizeFilename leaves alone', () => {
+    for (const [input, current] of [
+      ['my photo', 'a.jpg'],
+      ['réport', 'a.PDF'],
+      ['a#b&c', 'a.jpg'],
+    ]) {
+      const { sanitized } = previewRename(input, current);
+      expect(sanitizeFilename(sanitized)).toBe(sanitized);
+    }
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    const { sanitized, valid } = previewRename('  renamed  ', 'photo.jpg');
+    expect(sanitized).toBe('renamed.jpg');
+    expect(valid).toBe(true);
+  });
+
+  it('is invalid and hints when the input is empty', () => {
+    const { valid, hint, preview } = previewRename('   ', 'photo.jpg');
+    expect(valid).toBe(false);
+    expect(hint).toBe('Enter a file name.');
+    expect(preview).toBeNull();
+  });
+
+  it('is invalid and hints when the input sanitizes away entirely', () => {
+    const { valid, hint } = previewRename('///', 'photo.jpg');
+    expect(valid).toBe(false);
+    expect(hint).toMatch(/isn't valid/);
+  });
+
+  it('still allows the literal fallback name to be typed', () => {
+    const { valid, hint } = previewRename('file', 'photo.jpg');
+    expect(valid).toBe(true);
+    expect(hint).toBeNull();
+  });
+
+  it('is invalid when the result matches the current name', () => {
+    const { valid, hint } = previewRename('photo', 'photo.jpg');
+    expect(valid).toBe(false);
+    expect(hint).toBeNull();
+  });
+
+  it('only previews when the result differs from what was typed', () => {
+    expect(previewRename('renamed', 'photo.jpg').preview).toBeNull();
+    expect(previewRename('my photo', 'photo.jpg').preview).toBe('my-photo.jpg');
   });
 });

--- a/packages/tinacms/src/toolkit/components/media/utils.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.ts
@@ -57,6 +57,21 @@ const MAX_BASENAME_LENGTH = 200;
  * Example: `image-a\u0308.jpg` becomes `image-ä.jpg`,
  * so URLs use `%C3%A4` instead of the decomposed `%CC%88` sequence.
  */
+/**
+ * Splits a filename into its base and extension using the same final-dot rule
+ * as {@link sanitizeFilename}, so both agree on what the extension is.
+ */
+export const splitFilename = (
+  filename: string
+): { base: string; ext: string } => {
+  const lastDot = filename.lastIndexOf('.');
+  const hasExt = lastDot > 0 && lastDot < filename.length - 1;
+  return {
+    base: hasExt ? filename.slice(0, lastDot) : filename,
+    ext: hasExt ? filename.slice(lastDot) : '',
+  };
+};
+
 export const sanitizeFilename = (filename: string): string => {
   if (!filename) return 'file';
 

--- a/packages/tinacms/src/toolkit/components/media/utils.ts
+++ b/packages/tinacms/src/toolkit/components/media/utils.ts
@@ -50,13 +50,9 @@ export const absoluteImgURL = (str: string) => {
 // a directory prefix is prepended.
 const MAX_BASENAME_LENGTH = 200;
 
-/**
- * Normalizes filenames to NFC and replaces characters that are unsafe for
- * URLs or common filesystems with a hyphen, while preserving the extension.
- *
- * Example: `image-a\u0308.jpg` becomes `image-ä.jpg`,
- * so URLs use `%C3%A4` instead of the decomposed `%CC%88` sequence.
- */
+// Stands in for a base name that sanitizes away to nothing.
+const FALLBACK_NAME = 'file';
+
 /**
  * Splits a filename into its base and extension using the same final-dot rule
  * as {@link sanitizeFilename}, so both agree on what the extension is.
@@ -72,16 +68,19 @@ export const splitFilename = (
   };
 };
 
+/**
+ * Normalizes filenames to NFC and replaces characters that are unsafe for
+ * URLs or common filesystems with a hyphen, while preserving the extension.
+ *
+ * Example: `image-a\u0308.jpg` becomes `image-ä.jpg`,
+ * so URLs use `%C3%A4` instead of the decomposed `%CC%88` sequence.
+ */
 export const sanitizeFilename = (filename: string): string => {
-  if (!filename) return 'file';
+  if (!filename) return FALLBACK_NAME;
 
   const normalized = filename.normalize('NFC');
   const justName = normalized.split(/[\\/]/).pop() || '';
-
-  const lastDot = justName.lastIndexOf('.');
-  const hasExt = lastDot > 0 && lastDot < justName.length - 1;
-  const rawBase = hasExt ? justName.slice(0, lastDot) : justName;
-  const rawExt = hasExt ? justName.slice(lastDot) : '';
+  const { base: rawBase, ext: rawExt } = splitFilename(justName);
 
   const clean = (input: string) =>
     input
@@ -97,11 +96,46 @@ export const sanitizeFilename = (filename: string): string => {
   let base = clean(rawBase).replace(/^[.\-]+|[.\-]+$/g, '');
   const ext = clean(rawExt);
 
-  if (!base) base = 'file';
+  if (!base) base = FALLBACK_NAME;
 
   if (base.length > MAX_BASENAME_LENGTH) {
-    base = base.slice(0, MAX_BASENAME_LENGTH).replace(/[.\-]+$/, '') || 'file';
+    base =
+      base.slice(0, MAX_BASENAME_LENGTH).replace(/[.\-]+$/, '') ||
+      FALLBACK_NAME;
   }
 
   return `${base}${ext}`;
+};
+
+/**
+ * Validation and preview for the rename modal, given what the editor has typed
+ * and the file's current name.
+ *
+ * The base is sanitized on its own and the extension re-attached afterwards, so
+ * a base containing slashes or dots can never rewrite or drop the extension.
+ */
+export const previewRename = (input: string, currentFilename: string) => {
+  const base = input.trim();
+  const extension = splitFilename(currentFilename).ext;
+  const sanitizedBase = sanitizeFilename(base);
+  const sanitized = `${sanitizedBase}${extension}`;
+
+  const isEmpty = base.length === 0;
+  // Nothing usable survived, so sanitizeFilename fell back to its placeholder
+  // rather than producing something derived from the input.
+  const isStripped =
+    !isEmpty && sanitizedBase === FALLBACK_NAME && base !== FALLBACK_NAME;
+  const usable = !isEmpty && !isStripped;
+
+  return {
+    sanitized,
+    extension,
+    valid: usable && sanitized !== currentFilename,
+    preview: usable && sanitized !== `${base}${extension}` ? sanitized : null,
+    hint: isEmpty
+      ? 'Enter a file name.'
+      : isStripped
+        ? "That name isn't valid. Try using letters, numbers or hyphens."
+        : null,
+  };
 };

--- a/packages/tinacms/src/toolkit/core/media-store.default.test.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.test.ts
@@ -2,6 +2,7 @@ import type { MediaWorkflowConfirmBranchEvent } from '@toolkit/form-builder/edit
 import type { TinaCMS } from '@toolkit/tina-cms';
 import { EventBus } from './event';
 import type { Media, MediaUploadOptions } from './media';
+import { MediaRenameError } from './media';
 import { TinaMediaStore } from './media-store.default';
 
 /** Runs `fn`, returning the value it throws/rejects with (or fails the test). */
@@ -1574,5 +1575,192 @@ describe('TinaMediaStore — self-hosted repo media', () => {
     ).resolves.toBeDefined();
 
     vi.unstubAllGlobals();
+  });
+});
+
+describe('TinaMediaStore — rename capability', () => {
+  it('is exposed on a local instance', () => {
+    const { store } = buildStore({
+      isLocalMode: true,
+      contentApiUrl: 'http://localhost:4001/graphql',
+    });
+    expect(typeof store.rename).toBe('function');
+  });
+
+  it('is absent on a TinaCloud instance so the UI hides the action', () => {
+    const { store } = buildStore();
+    expect(store.rename).toBeUndefined();
+    // guards against re-adding it as a prototype method, which would
+    // advertise support on every instance
+    expect('rename' in Object.getPrototypeOf(store)).toBe(false);
+  });
+
+  it('is absent on a self-hosted repo-media instance', () => {
+    const { store } = buildStore({
+      isCustomContentApi: true,
+      contentApiUrl: '/api/tina/gql',
+    });
+    expect(store.rename).toBeUndefined();
+  });
+
+  it('is absent on a static instance', () => {
+    const events = new EventBus();
+    const cms = {
+      api: { tina: { isLocalMode: true } },
+      events,
+    } as unknown as TinaCMS;
+    const store = new TinaMediaStore(cms, {
+      '0': [
+        {
+          id: 'a.png',
+          filename: 'a.png',
+          src: '/uploads/a.png',
+          directory: '',
+          thumbnails: {
+            '75x75': '/uploads/a.png',
+            '400x400': '/uploads/a.png',
+            '1000x1000': '/uploads/a.png',
+          },
+          type: 'file',
+        },
+      ],
+    });
+
+    expect(store.isStatic).toBe(true);
+    expect(store.rename).toBeUndefined();
+  });
+});
+
+describe('TinaMediaStore — local rename', () => {
+  const buildLocalStore = () => {
+    const built = buildStore({
+      isLocalMode: true,
+      contentApiUrl: 'http://localhost:4001/graphql',
+    });
+    built.api.schema.schema.config.media.tina = {
+      mediaRoot: 'uploads',
+      publicFolder: 'public',
+    };
+    const fetchFunction = vi.fn();
+    built.store.fetchFunction = fetchFunction;
+    return { ...built, fetchFunction };
+  };
+
+  it('POSTs from/to as JSON to the local rename route', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue(makeJsonResponse(200, { success: true }));
+
+    await store.rename('products/old.png', 'products/new.png');
+
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchFunction.mock.calls[0];
+    expect(url).toBe('http://localhost:4001/media/rename');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({ 'Content-Type': 'application/json' });
+    expect(JSON.parse(init.body)).toEqual({
+      from: 'products/old.png',
+      to: 'products/new.png',
+    });
+  });
+
+  it('resolves with a Media built from the media root', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue(makeJsonResponse(200, { success: true }));
+
+    const result = await store.rename('products/old.png', 'products/new.png');
+
+    expect(result).toEqual({
+      type: 'file',
+      id: 'new.png',
+      filename: 'new.png',
+      directory: 'products',
+      src: '/uploads/products/new.png',
+      thumbnails: {
+        '75x75': '/uploads/products/new.png',
+        '400x400': '/uploads/products/new.png',
+        '1000x1000': '/uploads/products/new.png',
+      },
+    });
+  });
+
+  it('handles a file at the media root', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue(makeJsonResponse(200, { success: true }));
+
+    const result = await store.rename('old.png', 'new.png');
+
+    expect(result).toMatchObject({
+      directory: '',
+      filename: 'new.png',
+      src: '/uploads/new.png',
+    });
+  });
+
+  it('surfaces the backend error code so the UI can be specific', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue(
+      makeJsonResponse(409, {
+        code: 'NAME_COLLISION',
+        message: '"new.png" already exists.',
+      })
+    );
+
+    const error = await store.rename('old.png', 'new.png').catch((e) => e);
+
+    expect(error).toBeInstanceOf(MediaRenameError);
+    expect(error.code).toBe('NAME_COLLISION');
+    expect(error.message).toContain('already exists');
+  });
+
+  it('maps a NOT_FOUND response', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue(
+      makeJsonResponse(404, { code: 'NOT_FOUND', message: 'gone' })
+    );
+
+    const error = await store.rename('old.png', 'new.png').catch((e) => e);
+
+    expect(error.code).toBe('NOT_FOUND');
+  });
+
+  it('reports UNSUPPORTED when a CLI without the route answers 404', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: vi.fn().mockRejectedValue(new Error('not json')),
+    } as unknown as Response);
+
+    const error = await store.rename('old.png', 'new.png').catch((e) => e);
+
+    expect(error).toBeInstanceOf(MediaRenameError);
+    expect(error.code).toBe('UNSUPPORTED');
+    expect(error.message).toContain('@tinacms/cli');
+  });
+
+  it('reports UNSUPPORTED when a CLI without the route serves the SPA with a 200', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: vi.fn().mockRejectedValue(new Error('not json')),
+    } as unknown as Response);
+
+    const error = await store.rename('old.png', 'new.png').catch((e) => e);
+
+    expect(error.code).toBe('UNSUPPORTED');
+  });
+
+  it('falls back to BACKEND_FAILURE for an unstructured server error', async () => {
+    const { store, fetchFunction } = buildLocalStore();
+    fetchFunction.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: vi.fn().mockRejectedValue(new Error('not json')),
+    } as unknown as Response);
+
+    const error = await store.rename('old.png', 'new.png').catch((e) => e);
+
+    expect(error.code).toBe('BACKEND_FAILURE');
   });
 });

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -20,6 +20,7 @@ import {
   Media,
   MediaList,
   MediaListOptions,
+  MediaRenameError,
   MediaStore,
   MediaUploadOptions,
 } from './media';
@@ -114,11 +115,24 @@ export class TinaMediaStore implements MediaStore {
   private workflowBranchOverride: string | undefined;
   private mediaWorkflowInProgress = false;
 
+  /**
+   * Renaming is only implemented against the local dev server. This is an
+   * instance property rather than a prototype method on purpose: the media
+   * manager decides whether to offer the action by checking whether the store
+   * defines `rename`, so a cloud-backed instance must not carry one — a
+   * prototype method would advertise support everywhere and surface an action
+   * that always fails.
+   */
+  rename?: (from: string, to: string) => Promise<Media>;
+
   constructor(cms: TinaCMS, staticMedia?: StaticMedia) {
     this.cms = cms;
     if (staticMedia && Object.keys(staticMedia).length > 0) {
       this.isStatic = true;
       this.staticMedia = staticMedia;
+    }
+    if (!this.isStatic && cms?.api?.tina?.isLocalMode) {
+      this.rename = (from, to) => this.rename_local(from, to);
     }
   }
 
@@ -652,20 +666,15 @@ export class TinaMediaStore implements MediaStore {
     return results;
   }
 
-  private async persist_local(media: MediaUploadOptions[]): Promise<Media[]> {
-    const newFiles: Media[] = [];
+  /** Media root as a `/uploads/`-style prefix for local `src` values. */
+  private localMediaFolder(): string {
+    const tinaMedia = this.cms.api.tina.schema.schema?.config?.media?.tina;
     const hasTinaMedia =
-      Object.keys(
-        this.cms.api.tina.schema.schema?.config?.media?.tina || {}
-      ).includes('mediaRoot') &&
-      Object.keys(
-        this.cms.api.tina.schema.schema?.config?.media?.tina || {}
-      ).includes('publicFolder');
+      Object.keys(tinaMedia || {}).includes('mediaRoot') &&
+      Object.keys(tinaMedia || {}).includes('publicFolder');
 
     // Folder always has leading and trailing slashes
-    let folder: string = hasTinaMedia
-      ? this.cms.api.tina.schema.schema?.config?.media?.tina.mediaRoot
-      : '/';
+    let folder: string = hasTinaMedia ? tinaMedia.mediaRoot : '/';
 
     if (!folder.startsWith('/')) {
       // ensure folder always has a /
@@ -674,6 +683,45 @@ export class TinaMediaStore implements MediaStore {
     if (!folder.endsWith('/')) {
       folder = folder + '/';
     }
+    return folder;
+  }
+
+  /** Stripped directory does not have leading or trailing slashes */
+  private stripDirectorySlashes(directory: string): string {
+    let stripped = directory || '';
+    if (stripped.startsWith('/')) {
+      stripped = stripped.substr(1) || '';
+    }
+    if (stripped.endsWith('/')) {
+      stripped = stripped.substr(0, stripped.length - 1) || '';
+    }
+    return stripped;
+  }
+
+  /** Shared by local upload and local rename so both describe a file identically. */
+  private buildLocalMedia(directory: string, filename: string): Media {
+    const folder = this.localMediaFolder();
+    const strippedDirectory = this.stripDirectorySlashes(directory);
+    const src = strippedDirectory
+      ? `${folder}${strippedDirectory}/${filename}`
+      : `${folder}${filename}`;
+
+    return {
+      type: 'file',
+      id: filename,
+      filename,
+      directory,
+      src,
+      thumbnails: {
+        '75x75': src,
+        '400x400': src,
+        '1000x1000': src,
+      },
+    };
+  }
+
+  private async persist_local(media: MediaUploadOptions[]): Promise<Media[]> {
+    const newFiles: Media[] = [];
 
     for (const item of media) {
       const { file, directory } = item;
@@ -681,15 +729,7 @@ export class TinaMediaStore implements MediaStore {
       // upload URL, the on-disk path, and the value persisted into content,
       // so every layer agrees on the same bytes.
       const safeName = sanitizeFilename(file.name);
-      // Stripped directory does not have leading or trailing slashes
-      let strippedDirectory = directory;
-      if (strippedDirectory.startsWith('/')) {
-        strippedDirectory = strippedDirectory.substr(1) || '';
-      }
-      if (strippedDirectory.endsWith('/')) {
-        strippedDirectory =
-          strippedDirectory.substr(0, strippedDirectory.length - 1) || '';
-      }
+      const strippedDirectory = this.stripDirectorySlashes(directory);
 
       const formData = new FormData();
       // The third arg of FormData#append overrides the part filename — pass
@@ -704,11 +744,6 @@ export class TinaMediaStore implements MediaStore {
       if (uploadPath.startsWith('/')) {
         uploadPath = uploadPath.substr(1);
       }
-      const filePath = `${
-        strippedDirectory
-          ? `${folder}${strippedDirectory}/${safeName}`
-          : folder + safeName
-      }`;
       const res = await this.fetchFunction(`${this.url}/upload/${uploadPath}`, {
         method: 'POST',
         body: formData,
@@ -721,25 +756,56 @@ export class TinaMediaStore implements MediaStore {
 
       const fileRes = await res.json();
       if (fileRes?.success) {
-        const parsedRes: Media = {
-          type: 'file',
-          id: safeName,
-          filename: safeName,
-          directory,
-          src: filePath,
-          thumbnails: {
-            '75x75': filePath,
-            '400x400': filePath,
-            '1000x1000': filePath,
-          },
-        };
-
-        newFiles.push(parsedRes);
+        newFiles.push(this.buildLocalMedia(directory, safeName));
       } else {
         throw new Error('Unexpected error uploading media');
       }
     }
     return newFiles;
+  }
+
+  /**
+   * `from`/`to` are media-root-relative `directory/filename` paths, matching
+   * what the delete route receives.
+   */
+  private async rename_local(from: string, to: string): Promise<Media> {
+    this.setup();
+
+    const res = await this.fetchFunction(`${this.url}/rename`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ from, to }),
+    });
+
+    const body = await res.json().catch(() => null);
+
+    if (res.status !== 200 || !body?.success) {
+      throw this.toRenameError(res.status, body);
+    }
+
+    const lastSlash = to.lastIndexOf('/');
+    return this.buildLocalMedia(
+      lastSlash === -1 ? '' : to.slice(0, lastSlash),
+      lastSlash === -1 ? to : to.slice(lastSlash + 1)
+    );
+  }
+
+  private toRenameError(status: number, body: any): MediaRenameError {
+    if (body?.code) {
+      return new MediaRenameError({
+        code: body.code,
+        message: body.message || 'Failed to rename the file.',
+      });
+    }
+    // No structured body: a CLI predating the /media/rename route lets the
+    // request fall through to the dev server's own handling.
+    return new MediaRenameError({
+      code: status === 404 || status === 200 ? 'UNSUPPORTED' : 'BACKEND_FAILURE',
+      message:
+        status === 404 || status === 200
+          ? 'This version of the TinaCMS CLI does not support renaming media. Update @tinacms/cli to rename files.'
+          : 'Failed to rename the file.',
+    });
   }
 
   async persist(media: MediaUploadOptions[]): Promise<Media[]> {

--- a/packages/tinacms/src/toolkit/core/media-store.default.ts
+++ b/packages/tinacms/src/toolkit/core/media-store.default.ts
@@ -800,7 +800,8 @@ export class TinaMediaStore implements MediaStore {
     // No structured body: a CLI predating the /media/rename route lets the
     // request fall through to the dev server's own handling.
     return new MediaRenameError({
-      code: status === 404 || status === 200 ? 'UNSUPPORTED' : 'BACKEND_FAILURE',
+      code:
+        status === 404 || status === 200 ? 'UNSUPPORTED' : 'BACKEND_FAILURE',
       message:
         status === 404 || status === 200
           ? 'This version of the TinaCMS CLI does not support renaming media. Update @tinacms/cli to rename files.'

--- a/packages/tinacms/src/toolkit/core/media.test.ts
+++ b/packages/tinacms/src/toolkit/core/media.test.ts
@@ -40,10 +40,7 @@ describe('MediaManager.rename', () => {
     const rename = vi.fn().mockResolvedValue(renamed);
     const { manager } = buildManager(buildStore({ rename }));
 
-    const result = await manager.rename(
-      'products/old.jpg',
-      'products/new.jpg'
-    );
+    const result = await manager.rename('products/old.jpg', 'products/new.jpg');
 
     expect(rename).toHaveBeenCalledWith('products/old.jpg', 'products/new.jpg');
     expect(result).toBe(renamed);

--- a/packages/tinacms/src/toolkit/core/media.test.ts
+++ b/packages/tinacms/src/toolkit/core/media.test.ts
@@ -1,0 +1,110 @@
+import { EventBus } from './event';
+import {
+  Media,
+  MediaManager,
+  MediaRenameError,
+  MediaStore,
+  MediaUploadOptions,
+} from './media';
+
+const media = (filename: string, directory = 'products'): Media => ({
+  type: 'file',
+  id: filename,
+  filename,
+  directory,
+  src: `/uploads/${directory}/${filename}`,
+});
+
+const buildStore = (overrides: Partial<MediaStore> = {}): MediaStore => ({
+  accept: '*',
+  async persist(_files: MediaUploadOptions[]) {
+    return [];
+  },
+  async delete() {},
+  async list() {
+    return { items: [] };
+  },
+  ...overrides,
+});
+
+const buildManager = (store: MediaStore) => {
+  const events = new EventBus();
+  const seen: { type: string; [key: string]: any }[] = [];
+  events.subscribe('*', (event) => seen.push(event));
+  return { manager: new MediaManager(store, events), events, seen };
+};
+
+describe('MediaManager.rename', () => {
+  it('delegates to the store and returns the new media', async () => {
+    const renamed = media('new.jpg');
+    const rename = vi.fn().mockResolvedValue(renamed);
+    const { manager } = buildManager(buildStore({ rename }));
+
+    const result = await manager.rename(
+      'products/old.jpg',
+      'products/new.jpg'
+    );
+
+    expect(rename).toHaveBeenCalledWith('products/old.jpg', 'products/new.jpg');
+    expect(result).toBe(renamed);
+  });
+
+  it('dispatches start then success with the resolved media', async () => {
+    const renamed = media('new.jpg');
+    const { manager, seen } = buildManager(
+      buildStore({ rename: vi.fn().mockResolvedValue(renamed) })
+    );
+
+    await manager.rename('products/old.jpg', 'products/new.jpg');
+
+    expect(seen.map((e) => e.type)).toEqual([
+      'media:rename:start',
+      'media:rename:success',
+    ]);
+    expect(seen[0]).toMatchObject({
+      from: 'products/old.jpg',
+      to: 'products/new.jpg',
+    });
+    expect(seen[1]).toMatchObject({
+      from: 'products/old.jpg',
+      to: 'products/new.jpg',
+      media: renamed,
+    });
+  });
+
+  it('dispatches failure and rethrows when the store rejects', async () => {
+    const error = new MediaRenameError({
+      code: 'NAME_COLLISION',
+      message: 'already exists',
+    });
+    const { manager, seen } = buildManager(
+      buildStore({ rename: vi.fn().mockRejectedValue(error) })
+    );
+
+    await expect(
+      manager.rename('products/old.jpg', 'products/new.jpg')
+    ).rejects.toBe(error);
+
+    expect(seen.map((e) => e.type)).toEqual([
+      'media:rename:start',
+      'media:rename:failure',
+    ]);
+    expect(seen[1]).toMatchObject({
+      from: 'products/old.jpg',
+      to: 'products/new.jpg',
+      error,
+    });
+  });
+
+  it('throws UNSUPPORTED without dispatching when the store cannot rename', async () => {
+    const { manager, seen } = buildManager(buildStore());
+
+    const error = await manager
+      .rename('products/old.jpg', 'products/new.jpg')
+      .catch((e) => e);
+
+    expect(error).toBeInstanceOf(MediaRenameError);
+    expect(error.code).toBe('UNSUPPORTED');
+    expect(seen).toHaveLength(0);
+  });
+});

--- a/packages/tinacms/src/toolkit/core/media.ts
+++ b/packages/tinacms/src/toolkit/core/media.ts
@@ -92,11 +92,14 @@ export interface MediaStore {
   list(options?: MediaListOptions): Promise<MediaList>;
 
   /**
-   * Reserved hook for renaming a media object in the store.
+   * Renames a media object in the store. `from` and `to` are media-root-relative
+   * `directory/filename` paths, matching what `delete` receives.
    *
-   * Not yet implemented in `TinaMediaStore` or surfaced in `MediaManager` —
-   * declared here as an extension point so stores can begin to opt in once
-   * the corresponding assets-api endpoint is built.
+   * Optional by design: the media manager only offers a Rename action when the
+   * store instance actually defines it, so stores opt in individually. Defining
+   * it on the prototype but leaving it unsupported at runtime would surface an
+   * action that always fails — see `TinaMediaStore`, which assigns it per
+   * instance.
    */
   rename?(from: string, to: string): Promise<Media>;
 
@@ -238,6 +241,29 @@ export class MediaManager implements MediaStore {
     }
   }
 
+  /**
+   * `from` and `to` are media-root-relative `directory/filename` paths — the
+   * same shape `delete` sends. They must not carry an origin, a CDN host, the
+   * public folder, or the media root prefix.
+   */
+  async rename(from: string, to: string): Promise<Media> {
+    if (typeof this.store.rename !== 'function') {
+      throw new MediaRenameError({
+        code: 'UNSUPPORTED',
+        message: 'This media store does not support renaming.',
+      });
+    }
+    try {
+      this.events.dispatch({ type: 'media:rename:start', from, to });
+      const media = await this.store.rename(from, to);
+      this.events.dispatch({ type: 'media:rename:success', from, to, media });
+      return media;
+    } catch (error) {
+      this.events.dispatch({ type: 'media:rename:failure', from, to, error });
+      throw error;
+    }
+  }
+
   async list(options: MediaListOptions): Promise<MediaList> {
     try {
       this.events.dispatch({ type: 'media:list:start', ...options });
@@ -307,6 +333,25 @@ export const E_DEFAULT = new MediaListError({
   message: 'Something went wrong accessing your media from TinaCloud.',
   docsLink: 'https://tina.io/docs/r/repo-based-media',
 });
+
+export type MediaRenameErrorCode =
+  | 'NOT_FOUND'
+  | 'NAME_COLLISION'
+  | 'INVALID_FILENAME'
+  | 'INVALID_PATH'
+  | 'UNAUTHORIZED'
+  | 'UNSUPPORTED'
+  | 'BACKEND_FAILURE';
+
+export class MediaRenameError extends Error {
+  public ERR_TYPE = 'MediaRenameError';
+  public code: MediaRenameErrorCode;
+
+  constructor(config: { code: MediaRenameErrorCode; message: string }) {
+    super(config.message);
+    this.code = config.code;
+  }
+}
 
 export const E_SELF_HOSTED_MEDIA = new MediaListError({
   title: "Repo-based media isn't available when self-hosting",

--- a/packages/tinacms/src/toolkit/tina-cms.ts
+++ b/packages/tinacms/src/toolkit/tina-cms.ts
@@ -110,13 +110,6 @@ export class TinaCMS extends CMS {
         level: 'error',
         message: 'Failed to delete file.',
       }),
-      'media:rename:failure': (event: CMSEvent & { error?: Error }) => ({
-        error: event.error,
-        level: 'error',
-        message: `Failed to rename file.${
-          event.error?.message ? ` ${event.error.message}` : ''
-        }`,
-      }),
       ...alerts,
     });
 

--- a/packages/tinacms/src/toolkit/tina-cms.ts
+++ b/packages/tinacms/src/toolkit/tina-cms.ts
@@ -110,6 +110,13 @@ export class TinaCMS extends CMS {
         level: 'error',
         message: 'Failed to delete file.',
       }),
+      'media:rename:failure': (event: CMSEvent & { error?: Error }) => ({
+        error: event.error,
+        level: 'error',
+        message: `Failed to rename file.${
+          event.error?.message ? ` ${event.error.message}` : ''
+        }`,
+      }),
       ...alerts,
     });
 

--- a/playwright/tina-playwright/tests/api/media.spec.ts
+++ b/playwright/tina-playwright/tests/api/media.spec.ts
@@ -4,7 +4,16 @@
  */
 
 import { test, expect } from "../../fixtures/test-content";
-import { uploadMedia, listMedia, deleteMedia } from "../../utils/media";
+import {
+  uploadMedia,
+  listMedia,
+  deleteMedia,
+  renameMedia,
+} from "../../utils/media";
+
+// The framework dev server that serves public/; the Tina API server that
+// apiContext targets does not.
+const SITE_URL = process.env.SITE_URL ?? "http://localhost:3000";
 
 test("media — upload → list → delete round-trip", async ({
   apiContext,
@@ -31,4 +40,89 @@ test("media — upload → list → delete round-trip", async ({
 
   const afterDelete = await listMedia(apiContext);
   expect(afterDelete.files.map((f) => f.filename)).not.toContain(filename);
+});
+
+test("media — upload → rename → list → fetch new URL → delete", async ({
+  apiContext,
+  mediaCleanup,
+}) => {
+  const stamp = Date.now();
+  const original = `playwright-rename-${stamp}.txt`;
+  const renamed = `playwright-renamed-${stamp}.txt`;
+
+  mediaCleanup.track(original);
+  mediaCleanup.track(renamed);
+
+  const uploadResp = await uploadMedia(
+    apiContext,
+    original,
+    Buffer.from("rename payload")
+  );
+  expect(uploadResp.status()).toBe(200);
+
+  const renameResp = await renameMedia(apiContext, original, renamed);
+  expect(renameResp.status()).toBe(200);
+  expect(await renameResp.json()).toEqual({
+    success: true,
+    from: original,
+    to: renamed,
+  });
+
+  // The old path is gone from the listing and the new one has taken its place.
+  const afterRename = await listMedia(apiContext);
+  const names = afterRename.files.map((f) => f.filename);
+  expect(names).not.toContain(original);
+  expect(names).toContain(renamed);
+
+  // The served URL follows the new name. Media is served by the framework dev
+  // server from public/, not by the Tina API server apiContext points at.
+  const src = afterRename.files.find((f) => f.filename === renamed)!.src;
+  const served = await apiContext.get(`${SITE_URL}${src}`);
+  expect(served.status()).toBe(200);
+  expect(await served.text()).toBe("rename payload");
+
+  // ...and the old one stops resolving.
+  const oldUrl = await apiContext.get(`${SITE_URL}/uploads/${original}`);
+  expect(oldUrl.status()).toBe(404);
+
+  expect((await deleteMedia(apiContext, renamed)).ok()).toBeTruthy();
+  const afterDelete = await listMedia(apiContext);
+  expect(afterDelete.files.map((f) => f.filename)).not.toContain(renamed);
+});
+
+test("media — rename onto an existing name is rejected as a collision", async ({
+  apiContext,
+  mediaCleanup,
+}) => {
+  const stamp = Date.now();
+  const source = `playwright-collide-src-${stamp}.txt`;
+  const taken = `playwright-collide-dest-${stamp}.txt`;
+
+  mediaCleanup.track(source);
+  mediaCleanup.track(taken);
+
+  await uploadMedia(apiContext, source, Buffer.from("source"));
+  await uploadMedia(apiContext, taken, Buffer.from("destination"));
+
+  const resp = await renameMedia(apiContext, source, taken);
+  expect(resp.status()).toBe(409);
+  expect((await resp.json()).code).toBe("NAME_COLLISION");
+
+  // Neither file was touched.
+  const names = (await listMedia(apiContext)).files.map((f) => f.filename);
+  expect(names).toContain(source);
+  expect(names).toContain(taken);
+});
+
+test("media — rename of a missing file reports NOT_FOUND", async ({
+  apiContext,
+}) => {
+  const stamp = Date.now();
+  const resp = await renameMedia(
+    apiContext,
+    `playwright-missing-${stamp}.txt`,
+    `playwright-missing-renamed-${stamp}.txt`
+  );
+  expect(resp.status()).toBe(404);
+  expect((await resp.json()).code).toBe("NOT_FOUND");
 });

--- a/playwright/tina-playwright/tests/api/security.spec.ts
+++ b/playwright/tina-playwright/tests/api/security.spec.ts
@@ -275,7 +275,7 @@ const RENAME_VECTORS: { label: string; from: string; to: string }[] = [
   {
     label: "media root as destination",
     from: "rename-security-probe.txt",
-    to: "",
+    to: ".",
   },
 ];
 
@@ -284,8 +284,7 @@ for (const vector of RENAME_VECTORS) {
     const resp = await renameMedia(apiContext, vector.from, vector.to);
     const responseText = await resp.text();
 
-    // An empty destination is refused as a bad request before path resolution.
-    expect(vector.to === "" ? [400] : [403]).toContain(resp.status());
+    expect(resp.status()).toBe(403);
 
     const residual = responseText
       .replace(vector.from, "")

--- a/playwright/tina-playwright/tests/api/security.spec.ts
+++ b/playwright/tina-playwright/tests/api/security.spec.ts
@@ -34,7 +34,12 @@ import {
   updateDocument,
   deleteDocument,
 } from "../../utils/graphql";
-import { uploadMedia, deleteMedia, encodeMediaPath } from "../../utils/media";
+import {
+  uploadMedia,
+  deleteMedia,
+  encodeMediaPath,
+  renameMedia,
+} from "../../utils/media";
 
 // ---------------------------------------------------------------------------
 // Traversal vectors — plausible attack payloads that must be rejected.
@@ -248,4 +253,45 @@ for (const route of MEDIA_ROUTES) {
       assertNoLeak(responseText, vector);
     });
   }
+}
+
+// ---------------------------------------------------------------------------
+// Media rename — paths travel in a JSON body rather than the URL, so the
+// encoding vectors above don't apply; both ends still have to be validated.
+// ---------------------------------------------------------------------------
+
+const RENAME_VECTORS: { label: string; from: string; to: string }[] = [
+  { label: "traversal in from", from: "../../etc/passwd", to: "stolen.txt" },
+  {
+    label: "traversal in to",
+    from: "rename-security-probe.txt",
+    to: "../../etc/passwd",
+  },
+  {
+    label: "still-encoded traversal",
+    from: "..%2f..%2fetc%2fpasswd",
+    to: "stolen.txt",
+  },
+  {
+    label: "media root as destination",
+    from: "rename-security-probe.txt",
+    to: "",
+  },
+];
+
+for (const vector of RENAME_VECTORS) {
+  test(`media rename rejects ${vector.label}`, async ({ apiContext }) => {
+    const resp = await renameMedia(apiContext, vector.from, vector.to);
+    const responseText = await resp.text();
+
+    // An empty destination is refused as a bad request before path resolution.
+    expect(vector.to === "" ? [400] : [403]).toContain(resp.status());
+
+    const residual = responseText
+      .replace(vector.from, "")
+      .replace(vector.to, "");
+    expect(residual).not.toMatch(FILESYSTEM_LEAK);
+    assertNoEscapeWrite();
+    expect(fs.existsSync(path.join(PROJECT_ROOT, "etc", "passwd"))).toBe(false);
+  });
 }

--- a/playwright/tina-playwright/utils/media.ts
+++ b/playwright/tina-playwright/utils/media.ts
@@ -1,9 +1,10 @@
 import { APIRequestContext, APIResponse } from "@playwright/test";
 
-// Helpers for the three media routes served by the Vite dev server:
+// Helpers for the media routes served by the Vite dev server:
 //   POST   /media/upload/<path>   (multipart)
 //   GET    /media/list/<folder>
 //   DELETE /media/<path>
+//   POST   /media/rename          (JSON { from, to })
 //
 // Paths are URL-encoded so exotic inputs (../, null bytes) survive client-side
 // normalisation — the server decodes and validates. Pass `rawPath: true` for
@@ -45,6 +46,16 @@ export async function listMedia(
 }> {
   const resp = await apiContext.get(`/media/list/${folder}`);
   return resp.json();
+}
+
+// `from`/`to` are media-root-relative paths and travel in a JSON body, so no
+// path encoding is involved.
+export function renameMedia(
+  apiContext: APIRequestContext,
+  from: string,
+  to: string
+): Promise<APIResponse> {
+  return apiContext.post(`/media/rename`, { data: { from, to } });
 }
 
 export function deleteMedia(


### PR DESCRIPTION
Refs #6722 — implements the local file-system half. Tina Cloud rename stays blocked on tinacloud#3442 and is intentionally **not** part of this PR.

## What

Editors can now rename a media file from the Media Manager instead of deleting and re-uploading it, or going to GitHub.

Selecting a file in the preview panel offers **Rename** alongside Insert and Delete. The modal edits the basename, keeps the extension, previews the sanitised result using the same rules uploads apply, and reports collisions and missing files specifically rather than with a generic failure.

## How it works

`RenameModal` → `MediaManager.rename(from, to)` → `TinaMediaStore.rename` → `POST /media/rename` on the CLI dev server → `MediaModel.renameMedia`.

- `from` / `to` are media-root-relative `directory/filename` paths, the same shape `delete` already sends. The route also accepts (and ignores) `branch` for parity with the cloud contract.
- Both paths are resolved with `resolveStrictlyWithinBase`, so a rename can never land outside the configured media root.
- The move is `overwrite: false`; an existing destination comes back as a `NAME_COLLISION` instead of clobbering a file. Case-only renames (`photo.jpg` → `Photo.jpg`) hop through a staging name so they work on case-insensitive filesystems.
- `media:rename:success` refreshes every open media picker, and pickers previewing the renamed file follow it to its new path.

<img width="1383" height="1019" alt="Screenshot 2026-08-03 at 11 44 40 am" src="https://github.com/user-attachments/assets/962c8efc-1899-4143-b810-2f173d779d0c" />

**Figure: UI with Rename button**

<img width="1057" height="489" alt="Screenshot 2026-08-03 at 11 45 19 am" src="https://github.com/user-attachments/assets/87341a61-71bb-4894-acb6-0a295ed06156" />

**Figure: UI of rename modal**

## Testing

- `packages/@tinacms/cli` — `MediaModel.renameMedia` (happy path, subdirectories, NOT_FOUND, NAME_COLLISION, folder source,
case-only rename, staging rollback, traversal ane route handler's status-code mapping, and thecross-origin gate on `/media/rename`.
- `packages/tinacms` — `MediaManager.rename` eveity detection and error mapping, `RenameModal`behaviour, and `MediaPicker` gating / list refresh / multi-picker sync.
- `playwright` — upload → rename → list → fetch l HTTP, plus collision, NOT_FOUND and traversalvectors.