### PR TITLE
feat(v4): rich-text renderer, Plate editor and field plugin

### DIFF
--- a/packages/v4/@tinacms/rich-text/package.json
+++ b/packages/v4/@tinacms/rich-text/package.json
@@ -1,0 +1,85 @@
+{
+  "name": "@tinacms/rich-text",
+  "version": "4.0.0-alpha.0",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "The Plate rich-text editor for TinaCMS v4. A value contract keeps the editor separate from the storage format. You can replace one of them, and the other stays the same.",
+  "type": "module",
+  "repository": {
+    "url": "https://github.com/tinacms/tinacms.git",
+    "directory": "packages/v4/@tinacms/rich-text"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tinacms-scripts build",
+    "types": "tsc && tsc -p tsconfig.test.json",
+    "test": "vitest run --passWithNoTests"
+  },
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./editor": {
+      "types": "./src/editor.ts",
+      "default": "./src/editor.ts"
+    }
+  },
+  "dependencies": {
+    "@ariakit/react": "catalog:",
+    "@headlessui/react": "catalog:",
+    "@radix-ui/react-dialog": "catalog:",
+    "@radix-ui/react-dropdown-menu": "catalog:",
+    "@radix-ui/react-popover": "catalog:",
+    "@radix-ui/react-separator": "catalog:",
+    "@radix-ui/react-slot": "catalog:",
+    "@radix-ui/react-toolbar": "catalog:",
+    "@radix-ui/react-tooltip": "catalog:",
+    "@tinacms/mdx": "workspace:*",
+    "@tinacms/schema-tools": "workspace:*",
+    "@tinacms/ui": "workspace:*",
+    "@udecode/cn": "catalog:",
+    "@udecode/plate": "catalog:",
+    "@udecode/plate-autoformat": "catalog:",
+    "@udecode/plate-basic-marks": "catalog:",
+    "@udecode/plate-block-quote": "catalog:",
+    "@udecode/plate-break": "catalog:",
+    "@udecode/plate-code-block": "catalog:",
+    "@udecode/plate-combobox": "catalog:",
+    "@udecode/plate-dnd": "catalog:",
+    "@udecode/plate-floating": "catalog:",
+    "@udecode/plate-heading": "catalog:",
+    "@udecode/plate-highlight": "catalog:",
+    "@udecode/plate-horizontal-rule": "catalog:",
+    "@udecode/plate-indent-list": "catalog:",
+    "@udecode/plate-link": "catalog:",
+    "@udecode/plate-list": "catalog:",
+    "@udecode/plate-node-id": "catalog:",
+    "@udecode/plate-reset-node": "catalog:",
+    "@udecode/plate-resizable": "catalog:",
+    "@udecode/plate-selection": "catalog:",
+    "@udecode/plate-slash-command": "catalog:",
+    "@udecode/plate-table": "catalog:",
+    "@udecode/plate-trailing-block": "catalog:",
+    "class-variance-authority": "catalog:",
+    "cmdk": "catalog:",
+    "color-string": "catalog:",
+    "is-hotkey": "catalog:",
+    "lowlight": "catalog:",
+    "lucide-react": "catalog:",
+    "mermaid": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0"
+  },
+  "devDependencies": {
+    "@tinacms/scripts": "workspace:*",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "typescript": "^5.7.3",
+    "vitest": "^2.1.9"
+  }
+}

--- a/packages/v4/@tinacms/rich-text/src/boundary.test.ts
+++ b/packages/v4/@tinacms/rich-text/src/boundary.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const SRC = path.dirname(fileURLToPath(import.meta.url));
+
+const sourceFiles = (dir: string): string[] =>
+  readdirSync(dir).flatMap((entry) => {
+    const full = path.join(dir, entry);
+    if (statSync(full).isDirectory()) return sourceFiles(full);
+    return /\.tsx?$/.test(entry) && !/\.test\.tsx?$/.test(entry) ? [full] : [];
+  });
+
+const IMPORT = /(?:from|import)\s*\(?\s*['"]([^'"]+)['"]/g;
+
+const importsOf = (file: string): string[] => {
+  const contents = readFileSync(file, 'utf8');
+  return [...contents.matchAll(IMPORT)].map((match) => match[1]);
+};
+
+describe('package boundary', () => {
+  const files = sourceFiles(SRC);
+
+  it('has sources to check', () => {
+    expect(files.length).toBeGreaterThan(50);
+  });
+
+  it('never imports the host package', () => {
+    const offenders = files.filter((file) =>
+      importsOf(file).some((specifier) =>
+        specifier.startsWith('@tinacms/tinacms')
+      )
+    );
+    expect(offenders.map((file) => path.relative(SRC, file))).toEqual([]);
+  });
+
+  it('never reaches outside its own src directory', () => {
+    const offenders = files.filter((file) =>
+      importsOf(file)
+        .filter((specifier) => specifier.startsWith('.'))
+        .some((specifier) => {
+          const resolved = path.resolve(path.dirname(file), specifier);
+          return !resolved.startsWith(SRC);
+        })
+    );
+    expect(offenders.map((file) => path.relative(SRC, file))).toEqual([]);
+  });
+});

--- a/packages/v4/@tinacms/rich-text/src/editor.ts
+++ b/packages/v4/@tinacms/rich-text/src/editor.ts
@@ -1,0 +1,12 @@
+export { RichEditor, type RichEditorProps } from './plate';
+export {
+  EditorContext,
+  type EditorContextValue,
+  useEditorContext,
+} from './plate/editor-context';
+export type { RichEditorField } from './plate/editor-field';
+export type { MdxTemplate, TemplateField } from './plate/types';
+export type {
+  ToolbarOverrides,
+  ToolbarOverrideType,
+} from './plate/toolbar/toolbar-overrides';

--- a/packages/v4/@tinacms/rich-text/src/error-message.tsx
+++ b/packages/v4/@tinacms/rich-text/src/error-message.tsx
@@ -1,0 +1,56 @@
+export const INVALID_MARKDOWN_TYPE = 'invalid_markdown';
+
+export type EmptyTextElement = { type: 'text'; text: '' };
+export type PositionItem = {
+  line?: number | null;
+  column?: number | null;
+  offset?: number | null;
+  _index?: number | null;
+  _bufferIndex?: number | null;
+};
+export type Position = {
+  start: PositionItem;
+  end: PositionItem;
+};
+export type InvalidMarkdownElement = {
+  type: typeof INVALID_MARKDOWN_TYPE;
+  value: string;
+  message: string;
+  position?: Position;
+  children: [EmptyTextElement];
+};
+
+type ErrorType = {
+  message: string;
+  position?: {
+    startColumn: number;
+    endColumn: number;
+    startLineNumber: number;
+    endLineNumber: number;
+  };
+};
+const buildError = (element: InvalidMarkdownElement): ErrorType => {
+  return {
+    message: element.message,
+    position: element.position && {
+      endColumn: element.position.end.column,
+      startColumn: element.position.start.column,
+      startLineNumber: element.position.start.line,
+      endLineNumber: element.position.end.line,
+    },
+  };
+};
+export const buildErrorMessage = (element: InvalidMarkdownElement): string => {
+  if (!element) {
+    return '';
+  }
+  const errorMessage = buildError(element);
+  const message = errorMessage
+    ? `${errorMessage.message}${
+        errorMessage.position
+          ? ` at line: ${errorMessage.position.startLineNumber}, column: ${errorMessage.position.startColumn}`
+          : ''
+      }`
+    : null;
+  return message;
+};

--- a/packages/v4/@tinacms/rich-text/src/index.ts
+++ b/packages/v4/@tinacms/rich-text/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  EMPTY_RICH_TEXT,
+  type RichTextNode,
+  type RichTextValue,
+} from './value';
+export {
+  buildErrorMessage,
+  INVALID_MARKDOWN_TYPE,
+  type InvalidMarkdownElement,
+} from './error-message';

--- a/packages/v4/@tinacms/rich-text/src/plate/components/editor.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/editor.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import * as React from 'react';
+
+import type { PlateContentProps } from '@udecode/plate/react';
+import type { VariantProps } from 'class-variance-authority';
+
+import { cn } from '@tinacms/ui/lib/utils';
+import { PlateContainer, PlateContent } from '@udecode/plate/react';
+import { cva } from 'class-variance-authority';
+
+const editorContainerVariants = cva(
+  'relative w-full cursor-text caret-primary select-text selection:bg-brand/25 focus-visible:outline-none [&_.slate-selection-area]:z-50 [&_.slate-selection-area]:border [&_.slate-selection-area]:border-brand/25 [&_.slate-selection-area]:bg-brand/15',
+  {
+    defaultVariants: {
+      variant: 'default',
+    },
+    variants: {
+      variant: {
+        comment: cn(
+          'flex flex-wrap justify-between gap-1 px-1 py-0.5 text-sm',
+          'rounded-md border-[1.5px] border-transparent bg-transparent',
+          'has-[[data-slate-editor]:focus]:border-brand/50 has-[[data-slate-editor]:focus]:ring-2 has-[[data-slate-editor]:focus]:ring-brand/30',
+          'has-aria-disabled:border-input has-aria-disabled:bg-muted'
+        ),
+        default: 'h-full',
+        demo: 'h-[650px]',
+        select: cn(
+          'group rounded-md border border-input ring-offset-background focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2',
+          'has-data-readonly:w-fit has-data-readonly:cursor-default has-data-readonly:border-transparent has-data-readonly:focus-within:[box-shadow:none]'
+        ),
+      },
+    },
+  }
+);
+
+export const EditorContainer = ({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> &
+  VariantProps<typeof editorContainerVariants>) => {
+  return (
+    <PlateContainer
+      className={cn(
+        'ignore-click-outside/toolbar',
+        editorContainerVariants({ variant }),
+        className
+      )}
+      {...props}
+    />
+  );
+};
+
+EditorContainer.displayName = 'EditorContainer';
+
+const editorVariants = cva(
+  cn(
+    'group/editor',
+    'relative w-full cursor-text overflow-x-hidden overflow-y-auto break-words whitespace-pre-wrap select-text',
+    'rounded-md ring-offset-background focus-visible:outline-none',
+    'placeholder:text-muted-foreground/80 **:data-slate-placeholder:top-[auto_!important] **:data-slate-placeholder:text-muted-foreground/80 **:data-slate-placeholder:opacity-100!',
+    '[&_strong]:font-bold'
+  ),
+  {
+    defaultVariants: {
+      variant: 'default',
+    },
+    variants: {
+      disabled: {
+        true: 'cursor-not-allowed opacity-50',
+      },
+      focused: {
+        true: 'ring-2 ring-ring ring-offset-2',
+      },
+      variant: {
+        ai: 'w-full px-0 text-base md:text-sm',
+        aiChat:
+          'max-h-[min(70vh,320px)] w-full max-w-[700px] overflow-y-auto px-3 py-2 text-base md:text-sm',
+        comment: cn('rounded-none border-none bg-transparent text-sm'),
+        default: 'size-full px-2 sm:px-4 pt-2 text-base min-h-[100px]',
+        demo: 'size-full px-2 sm:px-4 pt-2 text-base h-[650px]',
+        fullWidth: 'size-full px-2 sm:px-4 pt-4 pb-72 text-base',
+        none: '',
+        select: 'px-3 py-2 text-base data-readonly:w-fit',
+      },
+    },
+  }
+);
+
+export type EditorProps = PlateContentProps &
+  VariantProps<typeof editorVariants>;
+
+export const Editor = React.forwardRef<HTMLDivElement, EditorProps>(
+  ({ className, disabled, focused, variant, ...props }, ref) => {
+    return (
+      <PlateContent
+        ref={ref}
+        className={cn(
+          editorVariants({
+            disabled,
+            focused,
+            variant,
+          }),
+          className
+        )}
+        disabled={disabled}
+        disableDefaultStyles
+        {...props}
+      />
+    );
+  }
+);
+
+Editor.displayName = 'Editor';

--- a/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/fixed-toolbar-buttons.tsx
@@ -1,0 +1,249 @@
+import { cn } from '@tinacms/ui/lib/utils';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import {
+  BulletedListPlugin,
+  NumberedListPlugin,
+} from '@udecode/plate-list/react';
+import { TablePlugin } from '@udecode/plate-table/react';
+import { useEditorState } from '@udecode/plate/react';
+import React from 'react';
+import { useResize } from '../hooks/use-resize';
+import { helpers, unsupportedItemsInTable } from '../plugins/core/common';
+import {
+  CONTAINER_MD_BREAKPOINT,
+  EMBED_ICON_WIDTH,
+  HEADING_ICON_ONLY,
+  HEADING_ICON_WITH_TEXT,
+  HEADING_LABEL,
+  HIGHLIGHT_ICON_WIDTH,
+  OVERFLOW_MENU_WIDTH,
+  STANDARD_ICON_WIDTH,
+  type ToolbarOverrideType,
+} from '../toolbar/toolbar-overrides';
+import { useToolbarContext } from '../toolbar/toolbar-provider';
+import { HeadingsMenu } from './headings-dropdown';
+import { CodeBlockToolbarButton } from './plate-ui/code-block-toolbar-button';
+import { HorizontalRuleToolbarButton } from './plate-ui/hr-toolbar-button';
+import { ImageToolbarButton } from './plate-ui/image-toolbar-button';
+import { ListToolbarButton } from './plate-ui/indent-list-toolbar-button';
+import { LinkToolbarButton } from './plate-ui/link-toolbar-button';
+import {
+  BoldToolbarButton,
+  CodeToolbarButton,
+  HighlightToolbarButton,
+  ItalicToolbarButton,
+  StrikethroughToolbarButton,
+} from './plate-ui/mark-toolbar-button';
+import { MermaidToolbarButton } from './plate-ui/mermaid-toolbar-button';
+import OverflowMenu from './plate-ui/overflow-menu';
+import { QuoteToolbarButton } from './plate-ui/quote-toolbar-button';
+import { RawMarkdownToolbarButton } from './plate-ui/raw-markdown-toolbar-button';
+import { TableDropdownMenu } from './plate-ui/table/table-dropdown-menu';
+import TemplatesToolbarButton from './plate-ui/templates-toolbar-button';
+import { ToolbarGroup } from './plate-ui/toolbar';
+
+type ToolbarItem = {
+  label: string;
+  width: (paragraphIconExists?: boolean) => number;
+  Component: React.ReactNode;
+};
+
+const toolbarItems: { [key in ToolbarOverrideType]: ToolbarItem } = {
+  heading: {
+    label: HEADING_LABEL,
+    width: (paragraphIconExists) =>
+      paragraphIconExists ? HEADING_ICON_WITH_TEXT : HEADING_ICON_ONLY, // Dynamically handle width based on paragraph icon
+    Component: (
+      <ToolbarGroup noSeparator>
+        <HeadingsMenu />
+      </ToolbarGroup>
+    ),
+  },
+  link: {
+    label: 'Link',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <LinkToolbarButton />,
+  },
+  image: {
+    label: 'Image',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <ImageToolbarButton />,
+  },
+  hr: {
+    label: 'Horizontal Rule',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <HorizontalRuleToolbarButton />,
+  },
+  quote: {
+    label: 'Quote',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <QuoteToolbarButton />,
+  },
+  ul: {
+    label: 'Unordered List',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <ListToolbarButton nodeType={BulletedListPlugin.key} />,
+  },
+  ol: {
+    label: 'Ordered List',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <ListToolbarButton nodeType={NumberedListPlugin.key} />,
+  },
+  bold: {
+    label: 'Bold',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <BoldToolbarButton />,
+  },
+  strikethrough: {
+    label: 'Strikethrough',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <StrikethroughToolbarButton />,
+  },
+  highlight: {
+    label: 'Highlight',
+    width: () => HIGHLIGHT_ICON_WIDTH,
+    Component: <HighlightToolbarButton />,
+  },
+  italic: {
+    label: 'Italic',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <ItalicToolbarButton />,
+  },
+  code: {
+    label: 'Code',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <CodeToolbarButton />,
+  },
+  codeBlock: {
+    label: 'Code Block',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <CodeBlockToolbarButton />,
+  },
+  mermaid: {
+    label: 'Mermaid',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <MermaidToolbarButton />,
+  },
+  table: {
+    label: 'Table',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <TableDropdownMenu />,
+  },
+  raw: {
+    label: 'Raw Markdown',
+    width: () => STANDARD_ICON_WIDTH,
+    Component: <RawMarkdownToolbarButton />,
+  },
+  embed: {
+    label: 'Templates',
+    width: () => EMBED_ICON_WIDTH,
+    Component: <TemplatesToolbarButton />,
+  },
+};
+
+export default function FixedToolbarButtons() {
+  const toolbarRef = React.useRef(null);
+  const [itemsShown, setItemsShown] = React.useState(11);
+  const { overrides, templates } = useToolbarContext();
+  const showEmbedButton = templates.length > 0;
+
+  let items: ToolbarItem[] =
+    overrides?.toolbar === undefined
+      ? Object.values(toolbarItems)
+      : overrides.toolbar
+          .map((item) => toolbarItems[item])
+          .filter((item) => item !== undefined);
+
+  if (!showEmbedButton) {
+    items = items.filter((item) => item.label !== toolbarItems.embed.label);
+  }
+
+  items = items.filter((item) => item.label !== toolbarItems.raw.label);
+
+  const editorState = useEditorState();
+  const userInTable = helpers.isNodeActive(editorState, TablePlugin);
+
+  const userInCodeBlock = helpers.isNodeActive(editorState, CodeBlockPlugin);
+
+  useResize(toolbarRef, (entry) => {
+    const width = entry.target.getBoundingClientRect().width;
+    const headingButton = items.find((item) => item.label === HEADING_LABEL);
+    const headingWidth = headingButton
+      ? headingButton.width(width >= CONTAINER_MD_BREAKPOINT)
+      : 0;
+
+    const availableWidth = width - headingWidth;
+
+    const countItemsFitting = (budget: number) => {
+      let count = headingButton ? 1 : 0;
+      let used = 0;
+      for (const item of items) {
+        if (item.label === HEADING_LABEL) continue;
+        if (used + item.width() > budget) break;
+        used += item.width();
+        count += 1;
+      }
+      return count;
+    };
+
+    const fitCount = countItemsFitting(availableWidth);
+
+    setItemsShown(
+      fitCount >= items.length
+        ? items.length
+        : countItemsFitting(availableWidth - OVERFLOW_MENU_WIDTH)
+    );
+  });
+
+  const getOpacity = (item: ToolbarItem) => {
+    if (userInTable && unsupportedItemsInTable.has(item.label)) {
+      return 'opacity-25 pointer-events-none';
+    }
+    if (userInCodeBlock) {
+      return 'opacity-25 pointer-events-none';
+    }
+    return 'opacity-100';
+  };
+
+  return (
+    <div className='w-full overflow-hidden @container/toolbar' ref={toolbarRef}>
+      <div
+        className='flex'
+        style={{
+          transform: 'translateX(calc(-1px))',
+        }}
+      >
+        <>
+          {items.slice(0, itemsShown).map((item) => (
+            <div
+              className={cn(
+                'transition duration-500 ease-in-out',
+                getOpacity(item)
+              )}
+              key={item.label}
+            >
+              {item.Component}
+            </div>
+          ))}
+          {items.length > itemsShown && (
+            <div className='w-fit'>
+              <OverflowMenu>
+                {items.slice(itemsShown).flatMap((c) => (
+                  <div
+                    className={cn(
+                      'transition duration-500 ease-in-out',
+                      getOpacity(c)
+                    )}
+                    key={c.label}
+                  >
+                    {c.Component}
+                  </div>
+                ))}
+              </OverflowMenu>
+            </div>
+          )}
+        </>
+      </div>
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/floating-toolbar-buttons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/floating-toolbar-buttons.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { TurnIntoDropdownMenu } from './plate-ui/turn-into-dropdown-menu';
+
+export default function FloatingToolbarButtons() {
+  return (
+    <div className='rounded-md'>
+      <TurnIntoDropdownMenu />
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/headings-dropdown.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/headings-dropdown.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+
+import type { DropdownMenuProps } from '@radix-ui/react-dropdown-menu';
+import { helpers, unsupportedItemsInTable } from '../plugins/core/common';
+import { ToolbarButton } from './plate-ui/toolbar';
+
+import { TablePlugin } from '@udecode/plate-table/react';
+import {
+  ParagraphPlugin,
+  useEditorRef,
+  useEditorSelector,
+  useEditorState,
+} from '@udecode/plate/react';
+import { useToolbarContext } from '../toolbar/toolbar-provider';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  useOpenState,
+} from './plate-ui/dropdown-menu';
+import {
+  getHeadingItem,
+  headingItemsByLevel,
+  paragraphItem,
+} from './plate-ui/heading-items';
+
+export function HeadingsMenu(props: DropdownMenuProps) {
+  const { headingLevels } = useToolbarContext();
+  const items = [
+    paragraphItem,
+    ...headingLevels.map((level) => headingItemsByLevel[level]),
+  ];
+  const value: string = useEditorSelector((editor) => {
+    let initialNodeType: string = ParagraphPlugin.key;
+    let allNodesMatchInitialNodeType = false;
+    const codeBlockEntries = editor.api.nodes({
+      match: (n) => editor.api.isBlock(n),
+      mode: 'highest',
+    });
+    const nodes = Array.from(codeBlockEntries);
+
+    if (nodes.length > 0) {
+      initialNodeType = nodes[0][0].type as string;
+      allNodesMatchInitialNodeType = nodes.every(([node]) => {
+        const type: string = (node?.type as string) || ParagraphPlugin.key;
+
+        return type === initialNodeType;
+      });
+    }
+
+    return allNodesMatchInitialNodeType ? initialNodeType : ParagraphPlugin.key;
+  }, []);
+
+  const editor = useEditorRef();
+  const editorState = useEditorState();
+  const openState = useOpenState();
+
+  const userInTable = helpers.isNodeActive(editorState, TablePlugin.key);
+
+  const selectedItem = getHeadingItem(value) ?? paragraphItem;
+  const { icon: SelectedItemIcon, label: selectedItemLabel } = selectedItem;
+
+  return (
+    <div className='rounded-md'>
+      <DropdownMenu modal={false} {...openState} {...props}>
+        <DropdownMenuTrigger asChild>
+          <ToolbarButton
+            showArrow
+            isDropdown
+            pressed={openState.open}
+            tooltip='Headings'
+          >
+            <SelectedItemIcon className='size-5' />
+            <span className='@md/toolbar:flex hidden'>{selectedItemLabel}</span>
+          </ToolbarButton>
+        </DropdownMenuTrigger>
+
+        <DropdownMenuContent
+          align='start'
+          className='min-w-0 rounded-none rounded-bl rounded-br border-border'
+        >
+          <DropdownMenuRadioGroup
+            className='flex flex-col gap-0.5'
+            onValueChange={(type) => {
+              editor.tf.toggleBlock(type);
+              editor.tf.collapse();
+              editor.tf.focus();
+            }}
+            value={value}
+          >
+            {items
+              .filter((item) => {
+                if (userInTable) {
+                  return !unsupportedItemsInTable.has(item.label);
+                }
+                return true;
+              })
+              .map(({ icon: Icon, label, value: itemValue }) => (
+                <DropdownMenuRadioItem
+                  className='min-w-[180px]'
+                  key={itemValue}
+                  value={itemValue}
+                >
+                  <Icon className='mr-2 size-5' />
+                  {label}
+                </DropdownMenuRadioItem>
+              ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/blockquote-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/blockquote-element.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import React from 'react';
+
+import { cn, withRef } from '@udecode/cn';
+import { PlateElement } from '@udecode/plate/react';
+
+export const BlockquoteElement = withRef<typeof PlateElement>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <PlateElement
+        ref={ref}
+        as='blockquote'
+        className={cn(
+          className,
+          'my-1 border-l-2 border-gray-200 pl-6 not-tina-prose text-gray-500'
+        )}
+        {...props}
+      >
+        {children}
+      </PlateElement>
+    );
+  }
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/button.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+
+import { Slot } from '@radix-ui/react-slot';
+import { cn, withRef } from '@udecode/cn';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+export const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  {
+    defaultVariants: {
+      size: 'default',
+      variant: 'default',
+    },
+    variants: {
+      isMenu: {
+        true: 'h-auto w-full cursor-pointer justify-start',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        icon: 'size-10',
+        lg: 'h-11 rounded px-8',
+        none: '',
+        sm: 'h-9 rounded px-3',
+        sms: 'size-9 rounded px-0',
+        xs: 'h-8 rounded px-3',
+      },
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        inlineLink: 'text-base text-primary underline underline-offset-4',
+        link: 'text-primary underline-offset-4 hover:underline',
+        outline:
+          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        tinaPrimary:
+          'bg-tina-orange-dark text-white hover:bg-tina-orange-dark/90 disabled:bg-tina-orange-dark/50',
+      },
+    },
+  }
+);
+
+export const Button = withRef<
+  'button',
+  {
+    asChild?: boolean;
+  } & VariantProps<typeof buttonVariants>
+>(({ asChild = false, className, isMenu, size, variant, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      className={cn(buttonVariants({ className, isMenu, size, variant }))}
+      ref={ref}
+      contentEditable={false}
+      type='button'
+      {...props}
+    />
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-combobox.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-combobox.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import type { TCodeBlockElement } from '@udecode/plate-code-block';
+
+import { cn } from '@tinacms/ui/lib/utils';
+import { useElement, useReadOnly } from '@udecode/plate/react';
+import { Check, ChevronDown } from 'lucide-react';
+
+import { Button } from './button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from './command';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+const languages: { label: string; value: string }[] = [
+  { label: 'Plain Text', value: 'plaintext' },
+  { label: 'Arduino', value: 'arduino' },
+  { label: 'Bash', value: 'bash' },
+  { label: 'C', value: 'c' },
+  { label: 'C++', value: 'cpp' },
+  { label: 'C#', value: 'csharp' },
+  { label: 'CSS', value: 'css' },
+  { label: 'Diff', value: 'diff' },
+  { label: 'Go', value: 'go' },
+  { label: 'GraphQL', value: 'graphql' },
+  { label: 'INI', value: 'ini' },
+  { label: 'Java', value: 'java' },
+  { label: 'JavaScript', value: 'javascript' },
+  { label: 'JSON', value: 'json' },
+  { label: 'Kotlin', value: 'kotlin' },
+  { label: 'Less', value: 'less' },
+  { label: 'Lua', value: 'lua' },
+  { label: 'Makefile', value: 'makefile' },
+  { label: 'Mermaid', value: 'mermaid' },
+  { label: 'Markdown', value: 'markdown' },
+  { label: 'Objective-C', value: 'objectivec' },
+  { label: 'Perl', value: 'perl' },
+  { label: 'PHP', value: 'php' },
+  { label: 'PHP Template', value: 'php-template' },
+  { label: 'Python', value: 'python' },
+  { label: 'Python REPL', value: 'python-repl' },
+  { label: 'R', value: 'r' },
+  { label: 'Ruby', value: 'ruby' },
+  { label: 'Rust', value: 'rust' },
+  { label: 'SCSS', value: 'scss' },
+  { label: 'Shell', value: 'shell' },
+  { label: 'SQL', value: 'sql' },
+  { label: 'Swift', value: 'swift' },
+  { label: 'TypeScript', value: 'ts' },
+  { label: 'VB.Net', value: 'vbnet' },
+  { label: 'WebAssembly', value: 'wasm' },
+  { label: 'XML', value: 'xml' },
+  { label: 'YAML', value: 'yaml' },
+
+  { label: 'ASCIIDoc', value: 'asciidoc' },
+  { label: 'Clojure', value: 'clojure' },
+  { label: 'CMake', value: 'cmake' },
+  { label: 'Dart', value: 'dart' },
+  { label: 'Django', value: 'django' },
+  { label: 'Dockerfile', value: 'dockerfile' },
+  { label: 'Elixir', value: 'elixir' },
+  { label: 'Elm', value: 'elm' },
+  { label: 'Erlang', value: 'erlang' },
+  { label: 'Gradle', value: 'gradle' },
+  { label: 'Groovy', value: 'groovy' },
+  { label: 'Handlebars', value: 'handlebars' },
+  { label: 'Haskell', value: 'haskell' },
+  { label: 'HTML', value: 'html' },
+  { label: 'HTMLBars', value: 'htmlbars' },
+  { label: 'Julia', value: 'julia' },
+  { label: 'LaTeX', value: 'latex' },
+  { label: 'MATLAB', value: 'matlab' },
+  { label: 'NGINX', value: 'nginx' },
+  { label: 'Nix', value: 'nix' },
+  { label: 'OCaml', value: 'ocaml' },
+  { label: 'PowerShell', value: 'powershell' },
+  { label: 'Protocol Buffers', value: 'protobuf' },
+  { label: 'Scala', value: 'scala' },
+  { label: 'Verilog', value: 'verilog' },
+  { label: 'VHDL', value: 'vhdl' },
+];
+
+interface CodeBlockComboboxProps {
+  onLanguageChange: (lang: string) => void;
+}
+
+export function CodeBlockCombobox({
+  onLanguageChange,
+}: CodeBlockComboboxProps) {
+  const [open, setOpen] = useState(false);
+  const readOnly = useReadOnly();
+  const element = useElement<TCodeBlockElement>();
+  const value = element.lang || 'plaintext';
+  const [searchValue, setSearchValue] = React.useState('');
+
+  const items = React.useMemo(
+    () =>
+      languages.filter(
+        (language) =>
+          !searchValue ||
+          language.label.toLowerCase().includes(searchValue.toLowerCase())
+      ),
+    [searchValue]
+  );
+
+  if (readOnly) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild tabIndex={-1}>
+        <Button
+          tabIndex={-1}
+          size='xs'
+          className={cn(
+            'h-6 justify-between gap-1 px-2 text-xs text-muted-foreground select-none',
+            'hover:bg-[#E2E8F0] bg-[#F1F5F9] text-[#64748B] hover:text-[#0F172A]',
+            open && 'bg-[#E2E8F0] text-[#0F172A]'
+          )}
+          aria-expanded={open}
+          role='combobox'
+        >
+          {languages.find((language) => language.value === value)?.label ??
+            'Plain Text'}
+          <ChevronDown className='size-4' />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        className='w-[200px] p-0 z-[10000]'
+        onCloseAutoFocus={() => setSearchValue('')}
+      >
+        <Command shouldFilter={false}>
+          <CommandInput
+            tabIndex={-1}
+            className='h-9'
+            value={searchValue}
+            onValueChange={(value) => setSearchValue(value)}
+            placeholder='Search language...'
+          />
+          <CommandEmpty>No language found.</CommandEmpty>
+
+          <CommandList className='h-48 overflow-y-auto'>
+            <CommandGroup>
+              {items.map((language) => (
+                <CommandItem
+                  key={language.label}
+                  className='cursor-pointer rounded-md'
+                  value={language.value}
+                  onSelect={(value) => {
+                    onLanguageChange(value);
+                    setSearchValue(value);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      value === language.value ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                  {language.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block-toolbar-button.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { withRef } from '@udecode/cn';
+import { useEditorState } from '@udecode/plate/react';
+
+import { insertEmptyCodeBlock } from '@udecode/plate-code-block';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { helpers } from '../../plugins/core/common';
+import { Icons } from './icons';
+import { ToolbarButton } from './toolbar';
+
+const useCodeBlockToolbarButtonState = () => {
+  const editor = useEditorState();
+
+  const isBlockActive = () => helpers.isNodeActive(editor, CodeBlockPlugin.key);
+
+  return {
+    pressed: isBlockActive(),
+  };
+};
+
+const useCodeBlockToolbarButton = (state) => {
+  const editor = useEditorState();
+
+  const onClick = () => {
+    insertEmptyCodeBlock(editor);
+  };
+
+  const onMouseDown = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return {
+    props: {
+      onClick,
+      onMouseDown,
+      pressed: state.pressed,
+    },
+  };
+};
+
+export const CodeBlockToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+  }
+>(({ clear, ...rest }, ref) => {
+  const state = useCodeBlockToolbarButtonState();
+
+  const { props } = useCodeBlockToolbarButton(state);
+
+  return (
+    <ToolbarButton ref={ref} tooltip='Code Block' {...rest} {...props}>
+      <Icons.codeBlock />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/code-block-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/code-block-element.tsx
@@ -1,0 +1,177 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { cn, withRef } from '@udecode/cn';
+import {
+  TCodeBlockElement,
+  formatCodeBlock,
+  isLangSupported,
+} from '@udecode/plate-code-block';
+import { PlateElement } from '@udecode/plate/react';
+import { BracesIcon } from 'lucide-react';
+import mermaid from 'mermaid';
+
+import {
+  CodeLineElement,
+  CodeBlockElement as PlateCodeBlockElement,
+} from '@tinacms/mdx';
+import { Button } from '../button';
+import { CodeBlockCombobox } from '../code-block-combobox';
+import { MermaidElementWithRef } from '../mermaid-element';
+import { ErrorMessage } from './error-message';
+
+export function codeLineToString(content: PlateCodeBlockElement): string {
+  return (content.children || [])
+    .map((line: CodeLineElement) =>
+      (line.children || [])
+        .map((textNode: { text: string }) => textNode.text)
+        .join('')
+    )
+    .join('\n');
+}
+
+export const CodeBlockElement = withRef<typeof PlateElement>(
+  ({ children, className, ...props }, ref) => {
+    const { editor, element } = props;
+
+    const [isEditing, setIsEditing] = useState(true);
+    const [codeBlockError, setCodeBlockError] = useState<string | null>(null);
+
+    useEffect(() => {
+      if ((element.lang as string) !== 'mermaid') {
+        return;
+      }
+
+      let isCancelled = false;
+
+      const validateMermaid = async () => {
+        try {
+          await mermaid.parse(
+            codeLineToString(element as PlateCodeBlockElement)
+          );
+
+          if (!isCancelled) {
+            setCodeBlockError(null);
+          }
+        } catch (err) {
+          if (!isCancelled) {
+            if (err instanceof Error && err.message) {
+              setCodeBlockError(err.message);
+            } else {
+              setCodeBlockError('An error occurred while parsing the diagram.');
+            }
+          }
+        }
+      };
+
+      validateMermaid();
+
+      return () => {
+        isCancelled = true;
+      };
+    }, [element.children, element.lang]);
+
+    return (
+      <PlateElement
+        ref={ref}
+        className={cn(className, 'py-1 not-tina-prose')}
+        {...props}
+      >
+        <style>{`
+          .tina-code-block .hljs-comment,
+          .tina-code-block .hljs-code,
+          .tina-code-block .hljs-formula { color: #6a737d; }
+          .tina-code-block .hljs-keyword,
+          .tina-code-block .hljs-doctag,
+          .tina-code-block .hljs-template-tag,
+          .tina-code-block .hljs-template-variable,
+          .tina-code-block .hljs-type,
+          .tina-code-block .hljs-variable.language_ { color: #d73a49; }
+          .tina-code-block .hljs-title,
+          .tina-code-block .hljs-title.class_,
+          .tina-code-block .hljs-title.class_.inherited__,
+          .tina-code-block .hljs-title.function_ { color: #6f42c1; }
+          .tina-code-block .hljs-attr,
+          .tina-code-block .hljs-attribute,
+          .tina-code-block .hljs-literal,
+          .tina-code-block .hljs-meta,
+          .tina-code-block .hljs-number,
+          .tina-code-block .hljs-operator,
+          .tina-code-block .hljs-selector-attr,
+          .tina-code-block .hljs-selector-class,
+          .tina-code-block .hljs-selector-id,
+          .tina-code-block .hljs-variable { color: #005cc5; }
+          .tina-code-block .hljs-regexp,
+          .tina-code-block .hljs-string,
+          .tina-code-block .hljs-meta_.hljs-string { color: #0366d6; }
+          .tina-code-block .hljs-built_in,
+          .tina-code-block .hljs-symbol { color: #e36209; }
+          .tina-code-block .hljs-name,
+          .tina-code-block .hljs-quote,
+          .tina-code-block .hljs-selector-tag,
+          .tina-code-block .hljs-selector-pseudo { color: #22863a; }
+          .tina-code-block .hljs-emphasis { font-style: italic; }
+          .tina-code-block .hljs-strong { font-weight: bold; }
+          .tina-code-block .hljs-section { font-weight: bold; color: #005cc5; }
+          .tina-code-block .hljs-bullet { color: #735c0f; }
+          .tina-code-block .hljs-addition { background: #f0fff4; color: #22863a; }
+          .tina-code-block .hljs-deletion { background: #ffeef0; color: #b31d28; }
+          .slate-code_line > span:last-child {margin-right: 1rem;}
+        `}</style>
+        <div className='relative rounded-md bg-[#F1F5F9] shadow-sm'>
+          {isEditing ? (
+            <pre
+              spellCheck={false}
+              className='overflow-x-auto p-4 pt-12 font-mono text-sm leading-[normal] [tab-size:2] print:break-inside-avoid my-2 tina-code-block'
+            >
+              <code>{children}</code>
+              <ErrorMessage error={codeBlockError} />
+            </pre>
+          ) : (
+            <MermaidElementWithRef
+              config={codeLineToString(element as PlateCodeBlockElement)}
+            />
+          )}
+
+          <div className='absolute top-0 py-1 pr-1 rounded-t-md z-10 flex w-full justify-end gap-0.5 select-none border-b border-[#CBD5E1] bg-[#F1F5F9]'>
+            {isLangSupported(element.lang as string) && (
+              <Button
+                tabIndex={-1}
+                size='icon'
+                variant='ghost'
+                className='size-6 text-xs'
+                onClick={() => formatCodeBlock(editor, { element })}
+                title='Format code'
+              >
+                <BracesIcon className='!size-3.5 text-muted-foreground' />
+              </Button>
+            )}
+            {(element.lang as string) === 'mermaid' && (
+              <Button
+                tabIndex={-1}
+                size='xs'
+                className={cn(
+                  'h-6 justify-between gap-1 px-2 text-xs text-muted-foreground select-none',
+                  'hover:bg-[#E2E8F0] bg-[#F1F5F9] text-[#64748B] hover:text-[#0F172A]'
+                )}
+                onClick={() => setIsEditing(!isEditing)}
+              >
+                {isEditing ? 'Preview' : 'Edit'}
+              </Button>
+            )}
+            <CodeBlockCombobox
+              onLanguageChange={(lang) => {
+                setCodeBlockError(null);
+                editor.tf.setNodes<TCodeBlockElement>(
+                  { lang },
+                  { at: element }
+                );
+              }}
+            />
+          </div>
+        </div>
+      </PlateElement>
+    );
+  }
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/error-message.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-block/error-message.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { AlertTriangle } from 'lucide-react';
+import React from 'react';
+
+interface ErrorMessageProps {
+  error: string | null;
+}
+
+export function ErrorMessage({ error }: ErrorMessageProps) {
+  if (!error) return null;
+
+  return (
+    <div
+      contentEditable={false}
+      className='mt-2 flex items-start rounded-md border border-red-300 bg-red-50 p-3 shadow-sm'
+      role='alert'
+    >
+      <div className='flex-shrink-0'>
+        <AlertTriangle className='h-5 w-5 text-red-400' aria-hidden='true' />
+      </div>
+      <div className='ml-3 flex-1'>
+        <pre className='m-0 font-mono text-sm text-red-700 whitespace-pre-wrap break-words'>
+          {error}
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-leaf.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-leaf.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { PlateLeaf, PlateLeafProps } from '@udecode/plate/react';
+import React from 'react';
+
+export function CodeLeaf(props: PlateLeafProps) {
+  return (
+    <PlateLeaf
+      {...props}
+      as='code'
+      className='rounded-md bg-muted px-[0.3em] py-[0.2em] font-mono text-sm whitespace-pre-wrap'
+    >
+      {props.children}
+    </PlateLeaf>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-line-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-line-element.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import React from 'react';
+
+import { withRef } from '@udecode/cn';
+import { PlateElement } from '@udecode/plate/react';
+
+export const CodeLineElement = withRef<typeof PlateElement>((props, ref) => (
+  <PlateElement ref={ref} {...props} />
+));

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-syntax-leaf.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/code-syntax-leaf.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import React from 'react';
+
+import { PlateLeaf, type PlateLeafProps } from '@udecode/plate/react';
+
+export function CodeSyntaxLeaf(props: PlateLeafProps) {
+  const tokenClassName = props.leaf.className as string;
+
+  return <PlateLeaf className={tokenClassName} {...props} />;
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/command.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/command.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import type { DialogProps } from '@radix-ui/react-dialog';
+import { Command as CommandPrimitive } from 'cmdk';
+import * as React from 'react';
+
+import {
+  cn,
+  createPrimitiveElement,
+  withCn,
+  withRef,
+  withVariants,
+} from '@udecode/cn';
+import { cva } from 'class-variance-authority';
+import { Search } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from './dialog';
+import { inputVariants } from './input';
+
+const commandVariants = cva(
+  'flex size-full flex-col rounded-md bg-popover text-popover-foreground focus-visible:outline-hidden',
+  {
+    defaultVariants: {
+      variant: 'default',
+    },
+    variants: {
+      variant: {
+        combobox: 'overflow-visible bg-transparent has-data-readonly:w-fit',
+        default: 'overflow-hidden',
+      },
+    },
+  }
+);
+
+export const Command = withVariants(CommandPrimitive, commandVariants, [
+  'variant',
+]);
+
+export function CommandDialog({ children, ...props }: DialogProps) {
+  return (
+    <Dialog {...props}>
+      <DialogContent className='overflow-hidden p-0 shadow-lg'>
+        <DialogTitle className='sr-only'>Command Dialog</DialogTitle>
+        <DialogDescription className='sr-only'>
+          Search through commands and documentation using the command menu
+        </DialogDescription>
+        <Command className='[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]]:px-2 [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-input-wrapper]_svg]:size-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:size-5'>
+          {children}
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export const CommandInput = withRef<typeof CommandPrimitive.Input>(
+  ({ className, ...props }, ref) => (
+    <div
+      className='flex items-center border-b border-gray-200 px-3'
+      cmdk-input-wrapper=''
+    >
+      <Search className='mr-2 size-4 shrink-0 opacity-50' />
+      <CommandPrimitive.Input
+        ref={ref}
+        className={cn(
+          'flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-hidden placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 focus:outline-none',
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+);
+
+export const InputCommand = withVariants(
+  CommandPrimitive.Input,
+  inputVariants,
+  ['variant']
+);
+
+export const CommandList = withCn(
+  CommandPrimitive.List,
+  'max-h-[500px] overflow-x-hidden overflow-y-auto'
+);
+
+export const CommandEmpty = withCn(
+  CommandPrimitive.Empty,
+  'py-6 text-center text-sm'
+);
+
+export const CommandGroup = withCn(
+  CommandPrimitive.Group,
+  'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground'
+);
+
+export const CommandSeparator = withCn(
+  CommandPrimitive.Separator,
+  '-mx-1 h-px bg-border'
+);
+
+export const CommandItem = withCn(
+  CommandPrimitive.Item,
+  'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0'
+);
+
+export const CommandShortcut = withCn(
+  createPrimitiveElement('span'),
+  'ml-auto text-xs tracking-widest text-muted-foreground'
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/dialog.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/dialog.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import * as React from 'react';
+
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import { cn, createPrimitiveElement, withCn, withRef } from '@udecode/cn';
+import { X } from 'lucide-react';
+
+export const Dialog = DialogPrimitive.Root;
+
+export const DialogTrigger = DialogPrimitive.Trigger;
+
+export const DialogPortal = DialogPrimitive.Portal;
+
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = withCn(
+  DialogPrimitive.Overlay,
+  'fixed inset-0 z-50 bg-black/80 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0'
+);
+
+export const DialogContent = withRef<typeof DialogPrimitive.Content>(
+  ({ children, className, ...props }, ref) => (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          'data-[state=closed]:slide-out-to-left-1/2 data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-48% data-[state=closed]:slide-out-to-top-48% fixed top-1/2 left-1/2 z-50 grid w-full max-w-lg -translate-x-1/2 -translate-y-1/2 gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:rounded-lg',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <DialogPrimitive.Close className='absolute top-4 right-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground'>
+          <X className='size-4' />
+          <span className='sr-only'>Close</span>
+        </DialogPrimitive.Close>
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+);
+
+export const DialogHeader = withCn(
+  createPrimitiveElement('div'),
+  'flex flex-col space-y-1.5 text-center sm:text-left'
+);
+
+export const DialogFooter = withCn(
+  createPrimitiveElement('div'),
+  'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2'
+);
+
+export const DialogTitle = withCn(
+  DialogPrimitive.Title,
+  'text-lg leading-none font-semibold tracking-tight'
+);
+
+export const DialogDescription = withCn(
+  DialogPrimitive.Description,
+  'text-sm text-muted-foreground'
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/dropdown-menu.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/dropdown-menu.tsx
@@ -1,0 +1,178 @@
+'use client';
+import React, { useCallback, useState } from 'react';
+
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import {
+  cn,
+  createPrimitiveElement,
+  withCn,
+  withProps,
+  withRef,
+  withVariants,
+} from '@udecode/cn';
+import { cva } from 'class-variance-authority';
+
+import { Icons } from './icons';
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+export const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+export const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+export const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+export const DropdownMenuSubTrigger = withRef<
+  typeof DropdownMenuPrimitive.SubTrigger,
+  {
+    inset?: boolean;
+  }
+>(({ children, className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    className={cn(
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent',
+      'data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      inset && 'pl-8',
+      className
+    )}
+    ref={ref}
+    {...props}
+  >
+    {children}
+    <Icons.chevronRight className='ml-auto size-4' />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+
+export const DropdownMenuSubContent = withCn(
+  DropdownMenuPrimitive.SubContent,
+  'z-[99999] min-w-32 overflow-hidden rounded border bg-white p-1 text-black shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2'
+);
+
+const DropdownMenuContentVariants = withProps(DropdownMenuPrimitive.Content, {
+  className: cn(
+    'z-[99999] min-w-32 overflow-hidden rounded border bg-white p-1 text-black shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2'
+  ),
+  sideOffset: 4,
+});
+
+export const DropdownMenuContent = withRef<
+  typeof DropdownMenuPrimitive.Content
+>(({ ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuContentVariants ref={ref} {...props} />
+  </DropdownMenuPrimitive.Portal>
+));
+
+const menuItemVariants = cva(
+  cn(
+    'relative flex h-9 cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors',
+    'focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50'
+  ),
+  {
+    variants: {
+      inset: {
+        true: 'pl-8',
+      },
+    },
+  }
+);
+
+export const DropdownMenuItem = withVariants(
+  DropdownMenuPrimitive.Item,
+  menuItemVariants,
+  ['inset']
+);
+
+export const DropdownMenuCheckboxItem = withRef<
+  typeof DropdownMenuPrimitive.CheckboxItem
+>(({ children, className, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    className={cn(
+      'relative flex select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'cursor-pointer',
+      className
+    )}
+    ref={ref}
+    {...props}
+  >
+    <span className='absolute left-2 flex size-3.5 items-center justify-center'>
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Icons.check className='size-4' />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+
+export const DropdownMenuRadioItem = withRef<
+  typeof DropdownMenuPrimitive.RadioItem,
+  {
+    hideIcon?: boolean;
+  }
+>(({ children, className, hideIcon, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    className={cn(
+      'relative flex select-none items-center rounded-sm pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'h-9 cursor-pointer px-2 data-[state=checked]:bg-accent data-[state=checked]:text-accent-foreground',
+      className
+    )}
+    ref={ref}
+    {...props}
+  >
+    {!hideIcon && (
+      <span className='absolute right-2 flex size-3.5 items-center justify-center'>
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Icons.check className='size-4' />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+    )}
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+
+const dropdownMenuLabelVariants = cva(
+  cn('select-none px-2 py-1.5 text-sm font-semibold'),
+  {
+    variants: {
+      inset: {
+        true: 'pl-8',
+      },
+    },
+  }
+);
+
+export const DropdownMenuLabel = withVariants(
+  DropdownMenuPrimitive.Label,
+  dropdownMenuLabelVariants,
+  ['inset']
+);
+
+export const DropdownMenuSeparator = withCn(
+  DropdownMenuPrimitive.Separator,
+  '-mx-1 my-1 h-px bg-muted'
+);
+
+export const DropdownMenuShortcut = withCn(
+  createPrimitiveElement('span'),
+  'ml-auto text-xs tracking-widest opacity-60'
+);
+
+export const useOpenState = () => {
+  const [open, setOpen] = useState(false);
+
+  const onOpenChange = useCallback(
+    (_value = !open) => {
+      setOpen(_value);
+    },
+    [open]
+  );
+
+  return {
+    onOpenChange,
+    open,
+  };
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/fixed-toolbar.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/fixed-toolbar.tsx
@@ -1,0 +1,7 @@
+import { withCn } from '@udecode/cn';
+import { Toolbar } from './toolbar';
+
+export const FixedToolbar = withCn(
+  Toolbar,
+  'p-1 sticky left-0 top-0 z-50 w-full justify-between overflow-x-auto border-b border-border bg-background rounded-t-md'
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/floating-toolbar.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/floating-toolbar.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React from 'react';
+
+import { PortalBody, cn, useComposedRef, withRef } from '@udecode/cn';
+
+import {
+  type FloatingToolbarState,
+  flip,
+  offset,
+} from '@udecode/plate-floating';
+
+import { useEditorRef, useEventEditorValue } from '@udecode/plate/react';
+import { Toolbar } from './toolbar';
+import { useCustomFloatingToolbar } from './use-floating-toolbar-hook';
+import { useCustomFloatingToolbarState } from './use-floating-toolbar-state';
+
+export const FloatingToolbar = withRef<
+  typeof Toolbar,
+  {
+    state?: FloatingToolbarState;
+  }
+>(({ children, state, ...props }, propRef) => {
+  const editorId = useEditorRef();
+  const focusedEditorId = useEventEditorValue('focus');
+  const test = useCustomFloatingToolbarState({
+    editorId: editorId.id,
+    focusedEditorId,
+    ...state,
+    floatingOptions: {
+      middleware: [
+        offset(12),
+        flip({
+          fallbackPlacements: [
+            'top-start',
+            'top-end',
+            'bottom-start',
+            'bottom-end',
+          ],
+          padding: 12,
+        }),
+      ],
+      placement: 'top',
+      ...state?.floatingOptions,
+    },
+  });
+
+  const {
+    hidden,
+    props: rootProps,
+    ref: floatingRef,
+  } = useCustomFloatingToolbar(test);
+
+  const ref = useComposedRef<HTMLDivElement>(propRef, floatingRef);
+
+  if (hidden) return null;
+
+  return (
+    <PortalBody>
+      <Toolbar
+        className={cn(
+          'absolute z-[10799] whitespace-nowrap border bg-popover px-1 opacity-100 shadow-md print:hidden rounded-md'
+        )}
+        {...props}
+        {...rootProps}
+        ref={ref}
+      >
+        {children}
+      </Toolbar>
+    </PortalBody>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/heading-items.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/heading-items.ts
@@ -1,0 +1,45 @@
+import { type HeadingLevel, isHeadingLevel } from '@tinacms/schema-tools';
+import { ParagraphPlugin } from '@udecode/plate/react';
+import type { ComponentType, SVGProps } from 'react';
+import { Icons } from './icons';
+
+export type HeadingItemIcon = ComponentType<SVGProps<SVGSVGElement>>;
+
+export interface HeadingMenuItem {
+  description: string;
+  icon: HeadingItemIcon;
+  label: string;
+  value: string;
+}
+
+const buildByLevel = <T>(
+  make: (level: HeadingLevel) => T
+): Record<HeadingLevel, T> => ({
+  h1: make('h1'),
+  h2: make('h2'),
+  h3: make('h3'),
+  h4: make('h4'),
+  h5: make('h5'),
+  h6: make('h6'),
+});
+
+export const headingItemsByLevel: Record<HeadingLevel, HeadingMenuItem> =
+  buildByLevel((level) => {
+    const depth = level.slice(1);
+    return {
+      description: `Heading ${depth}`,
+      icon: Icons[level],
+      label: `Heading ${depth}`,
+      value: level,
+    };
+  });
+
+export const paragraphItem: HeadingMenuItem = {
+  description: 'Paragraph',
+  icon: Icons.paragraph,
+  label: 'Paragraph',
+  value: ParagraphPlugin.key,
+};
+
+export const getHeadingItem = (value: string): HeadingMenuItem | undefined =>
+  isHeadingLevel(value) ? headingItemsByLevel[value] : undefined;

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/hr-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/hr-element.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+import * as React from 'react';
+
+import type { PlateElementProps } from '@udecode/plate/react';
+
+import { cn } from '@tinacms/ui/lib/utils';
+import {
+  PlateElement,
+  useFocused,
+  useReadOnly,
+  useSelected,
+} from '@udecode/plate/react';
+
+export function HrElement(props: PlateElementProps) {
+  const readOnly = useReadOnly();
+  const selected = useSelected();
+  const focused = useFocused();
+
+  return (
+    <PlateElement {...props}>
+      <div contentEditable={false}>
+        <hr
+          className={cn(
+            'mt-1 mb-2 h-0.5 rounded-sm border-none bg-gray-600 bg-clip-content mx-[10%] caret-transparent',
+            selected && focused && 'ring-2 ring-ring ring-offset-2',
+            !readOnly && 'cursor-pointer'
+          )}
+        />
+      </div>
+      {props.children}
+    </PlateElement>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/hr-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/hr-toolbar-button.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+
+import { withRef } from '@udecode/cn';
+import { useEditorState } from '@udecode/plate/react';
+
+import { HorizontalRulePlugin } from '@udecode/plate-horizontal-rule/react';
+import { ParagraphPlugin } from '@udecode/plate/react';
+import { helpers } from '../../plugins/core/common';
+import { Icons } from './icons';
+import { ToolbarButton } from './toolbar';
+
+const useHorizontalRuleToolbarButtonState = () => {
+  const editor = useEditorState();
+
+  const isBlockActive = () =>
+    helpers.isNodeActive(editor, HorizontalRulePlugin.key);
+
+  return {
+    pressed: isBlockActive(),
+  };
+};
+
+const useHorizontalRuleToolbarButton = (state) => {
+  const editor = useEditorState();
+
+  const onClick = () => {
+    editor.tf.insertNodes({
+      type: ParagraphPlugin.key,
+      children: [{ text: '' }],
+    });
+    editor.tf.setNodes({ type: HorizontalRulePlugin.key });
+    editor.tf.insertNodes({
+      type: ParagraphPlugin.key,
+      children: [{ text: '' }],
+    });
+  };
+
+  const onMouseDown = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return {
+    props: {
+      onClick,
+      onMouseDown,
+      pressed: state.pressed,
+    },
+  };
+};
+
+export const HorizontalRuleToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+  }
+>(({ clear, ...rest }, ref) => {
+  const state = useHorizontalRuleToolbarButtonState();
+
+  const { props } = useHorizontalRuleToolbarButton(state);
+
+  return (
+    <ToolbarButton ref={ref} tooltip='Horizontal Rule' {...rest} {...props}>
+      <Icons.horizontalRule />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/icons.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/icons.tsx
@@ -1,0 +1,774 @@
+import { cva } from 'class-variance-authority';
+import {
+  AlignCenter,
+  AlignJustify,
+  AlignLeft,
+  AlignRight,
+  Baseline,
+  Check,
+  ChevronDown,
+  ChevronRight,
+  ChevronsUpDown,
+  Combine,
+  Edit2,
+  ExternalLink,
+  Eye,
+  FileCode,
+  GripVertical,
+  Heading1,
+  Heading2,
+  Heading3,
+  Heading4,
+  Heading5,
+  Heading6,
+  Highlighter,
+  Indent,
+  Keyboard,
+  Link2Off,
+  type LucideProps,
+  MessageSquare,
+  MessageSquarePlus,
+  Minus,
+  Moon,
+  MoreHorizontal,
+  Outdent,
+  PaintBucket,
+  Pilcrow,
+  Plus,
+  Quote,
+  RectangleHorizontal,
+  RectangleVertical,
+  RotateCcw,
+  Search,
+  SeparatorHorizontal,
+  Settings,
+  Smile,
+  Strikethrough,
+  Subscript,
+  SunMedium,
+  Superscript,
+  Table,
+  Text,
+  Trash,
+  Twitter,
+  Underline,
+  Ungroup,
+  WrapText,
+  X,
+} from 'lucide-react';
+import React from 'react';
+
+import type { LucideIcon } from 'lucide-react';
+
+export type Icon = LucideIcon;
+
+const RawMarkdown = () => {
+  return (
+    <svg
+      stroke='currentColor'
+      fill='currentColor'
+      strokeWidth={0}
+      role='img'
+      className='h-5 w-5'
+      viewBox='0 0 24 24'
+      height='1em'
+      width='1em'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title />
+      <path d='M22.27 19.385H1.73A1.73 1.73 0 010 17.655V6.345a1.73 1.73 0 011.73-1.73h20.54A1.73 1.73 0 0124 6.345v11.308a1.73 1.73 0 01-1.73 1.731zM5.769 15.923v-4.5l2.308 2.885 2.307-2.885v4.5h2.308V8.078h-2.308l-2.307 2.885-2.308-2.885H3.46v7.847zM21.232 12h-2.309V8.077h-2.307V12h-2.308l3.461 4.039z' />
+    </svg>
+  );
+};
+const MermaidIcon = () => (
+  <svg
+    width='100%'
+    height='100%'
+    viewBox='0 0 491 491'
+    version='1.1'
+    xmlns='http://www.w3.org/2000/svg'
+    fillRule='evenodd'
+    clipRule='evenodd'
+    strokeLinejoin='round'
+    strokeMiterlimit={2}
+  >
+    <path d='M490.16,84.61C490.16,37.912 452.248,0 405.55,0L84.61,0C37.912,0 0,37.912 0,84.61L0,405.55C0,452.248 37.912,490.16 84.61,490.16L405.55,490.16C452.248,490.16 490.16,452.248 490.16,405.55L490.16,84.61Z' />
+    <path
+      d='M407.48,111.18C335.587,108.103 269.573,152.338 245.08,220C220.587,152.338 154.573,108.103 82.68,111.18C80.285,168.229 107.577,222.632 154.74,254.82C178.908,271.419 193.35,298.951 193.27,328.27L193.27,379.13L296.9,379.13L296.9,328.27C296.816,298.953 311.255,271.42 335.42,254.82C382.596,222.644 409.892,168.233 407.48,111.18Z'
+      fill='white'
+      fillRule='nonzero'
+    />
+  </svg>
+);
+
+const borderAll = (props: LucideProps) => (
+  <svg
+    viewBox='0 0 24 24'
+    height='48'
+    width='48'
+    focusable='false'
+    role='img'
+    fill='currentColor'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path d='M3 6a3 3 0 0 1 3-3h12a3 3 0 0 1 3 3v12a3 3 0 0 1-3 3H6a3 3 0 0 1-3-3V6zm10 13h5a1 1 0 0 0 1-1v-5h-6v6zm-2-6H5v5a1 1 0 0 0 1 1h5v-6zm2-2h6V6a1 1 0 0 0-1-1h-5v6zm-2-6H6a1 1 0 0 0-1 1v5h6V5z' />
+  </svg>
+);
+
+const borderBottom = (props: LucideProps) => (
+  <svg
+    viewBox='0 0 24 24'
+    height='48'
+    width='48'
+    focusable='false'
+    role='img'
+    fill='currentColor'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path d='M13 5a1 1 0 1 0 0-2h-2a1 1 0 1 0 0 2h2zm-8 6a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0v-2zm-2 7a1 1 0 1 1 2 0 1 1 0 0 0 1 1h12a1 1 0 0 0 1-1 1 1 0 1 1 2 0 3 3 0 0 1-3 3H6a3 3 0 0 1-3-3zm17-8a1 1 0 0 0-1 1v2a1 1 0 1 0 2 0v-2a1 1 0 0 0-1-1zM7 4a1 1 0 0 0-1-1 3 3 0 0 0-3 3 1 1 0 0 0 2 0 1 1 0 0 1 1-1 1 1 0 0 0 1-1zm11-1a1 1 0 1 0 0 2 1 1 0 0 1 1 1 1 1 0 1 0 2 0 3 3 0 0 0-3-3z' />
+  </svg>
+);
+
+const borderLeft = (props: LucideProps) => (
+  <svg
+    viewBox='0 0 24 24'
+    height='48'
+    width='48'
+    focusable='false'
+    role='img'
+    fill='currentColor'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path d='M6 21a1 1 0 1 0 0-2 1 1 0 0 1-1-1V6a1 1 0 0 1 1-1 1 1 0 0 0 0-2 3 3 0 0 0-3 3v12a3 3 0 0 0 3 3zm7-16a1 1 0 1 0 0-2h-2a1 1 0 1 0 0 2h2zm6 6a1 1 0 1 1 2 0v2a1 1 0 1 1-2 0v-2zm-5 9a1 1 0 0 1-1 1h-2a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zm4-17a1 1 0 1 0 0 2 1 1 0 0 1 1 1 1 1 0 1 0 2 0 3 3 0 0 0-3-3zm-1 17a1 1 0 0 0 1 1 3 3 0 0 0 3-3 1 1 0 1 0-2 0 1 1 0 0 1-1 1 1 1 0 0 0-1 1z' />
+  </svg>
+);
+
+const borderNone = (props: LucideProps) => (
+  <svg
+    viewBox='0 0 24 24'
+    height='48'
+    width='48'
+    focusable='false'
+    role='img'
+    fill='currentColor'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path d='M14 4a1 1 0 0 1-1 1h-2a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zm-9 7a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0v-2zm14 0a1 1 0 1 1 2 0v2a1 1 0 1 1-2 0v-2zm-6 10a1 1 0 1 0 0-2h-2a1 1 0 1 0 0 2h2zM7 4a1 1 0 0 0-1-1 3 3 0 0 0-3 3 1 1 0 0 0 2 0 1 1 0 0 1 1-1 1 1 0 0 0 1-1zm11-1a1 1 0 1 0 0 2 1 1 0 0 1 1 1 1 1 0 1 0 2 0 3 3 0 0 0-3-3zM7 20a1 1 0 0 1-1 1 3 3 0 0 1-3-3 1 1 0 1 1 2 0 1 1 0 0 0 1 1 1 1 0 0 1 1 1zm11 1a1 1 0 1 1 0-2 1 1 0 0 0 1-1 1 1 0 1 1 2 0 3 3 0 0 1-3 3z' />
+  </svg>
+);
+
+const borderRight = (props: LucideProps) => (
+  <svg
+    viewBox='0 0 24 24'
+    height='48'
+    width='48'
+    focusable='false'
+    role='img'
+    fill='currentColor'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path d='M13 5a1 1 0 1 0 0-2h-2a1 1 0 1 0 0 2h2zm-8 6a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0v-2zm9 9a1 1 0 0 1-1 1h-2a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zM6 3a1 1 0 0 1 0 2 1 1 0 0 0-1 1 1 1 0 0 1-2 0 3 3 0 0 1 3-3zm1 17a1 1 0 0 1-1 1 3 3 0 0 1-3-3 1 1 0 1 1 2 0 1 1 0 0 0 1 1 1 1 0 0 1 1 1zm11 1a1 1 0 1 1 0-2 1 1 0 0 0 1-1V6a1 1 0 0 0-1-1 1 1 0 1 1 0-2 3 3 0 0 1 3 3v12a3 3 0 0 1-3 3z' />
+  </svg>
+);
+
+const borderTop = (props: LucideProps) => (
+  <svg
+    viewBox='0 0 24 24'
+    height='48'
+    width='48'
+    focusable='false'
+    role='img'
+    fill='currentColor'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path d='M3 6a1 1 0 0 0 2 0 1 1 0 0 1 1-1h12a1 1 0 0 1 1 1 1 1 0 1 0 2 0 3 3 0 0 0-3-3H6a3 3 0 0 0-3 3zm2 5a1 1 0 1 0-2 0v2a1 1 0 1 0 2 0v-2zm14 0a1 1 0 1 1 2 0v2a1 1 0 1 1-2 0v-2zm-5 9a1 1 0 0 1-1 1h-2a1 1 0 1 1 0-2h2a1 1 0 0 1 1 1zm-8 1a1 1 0 1 0 0-2 1 1 0 0 1-1-1 1 1 0 1 0-2 0 3 3 0 0 0 3 3zm11-1a1 1 0 0 0 1 1 3 3 0 0 0 3-3 1 1 0 1 0-2 0 1 1 0 0 1-1 1 1 1 0 0 0-1 1z' />
+  </svg>
+);
+
+export const iconVariants = cva('', {
+  variants: {
+    variant: {
+      toolbar: 'size-5',
+      menuItem: 'mr-2 size-5',
+    },
+    size: {
+      sm: 'mr-2 size-4',
+      md: 'mr-2 size-6',
+    },
+  },
+  defaultVariants: {},
+});
+
+export const DoubleColumnOutlined = (props: LucideProps) => (
+  <svg
+    fill='none'
+    height='16'
+    viewBox='0 0 16 16'
+    width='16'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path
+      clipRule='evenodd'
+      d='M8.5 3H13V13H8.5V3ZM7.5 2H8.5H13C13.5523 2 14 2.44772 14 3V13C14 13.5523 13.5523 14 13 14H8.5H7.5H3C2.44772 14 2 13.5523 2 13V3C2 2.44772 2.44772 2 3 2H7.5ZM7.5 13H3L3 3H7.5V13Z'
+      fill='#595E6F'
+      fillRule='evenodd'
+    />
+  </svg>
+);
+
+export const ThreeColumnOutlined = (props: LucideProps) => (
+  <svg
+    fill='none'
+    height='16'
+    viewBox='0 0 16 16'
+    width='16'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path
+      clipRule='evenodd'
+      d='M9.25 3H6.75V13H9.25V3ZM9.25 2H6.75H5.75H3C2.44772 2 2 2.44772 2 3V13C2 13.5523 2.44772 14 3 14H5.75H6.75H9.25H10.25H13C13.5523 14 14 13.5523 14 13V3C14 2.44772 13.5523 2 13 2H10.25H9.25ZM10.25 3V13H13V3H10.25ZM3 13H5.75V3H3L3 13Z'
+      fill='#4C5161'
+      fillRule='evenodd'
+    />
+  </svg>
+);
+
+export const RightSideDoubleColumnOutlined = (props: LucideProps) => (
+  <svg
+    fill='none'
+    height='16'
+    viewBox='0 0 16 16'
+    width='16'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path
+      clipRule='evenodd'
+      d='M11.25 3H13V13H11.25V3ZM10.25 2H11.25H13C13.5523 2 14 2.44772 14 3V13C14 13.5523 13.5523 14 13 14H11.25H10.25H3C2.44772 14 2 13.5523 2 13V3C2 2.44772 2.44772 2 3 2H10.25ZM10.25 13H3L3 3H10.25V13Z'
+      fill='#595E6F'
+      fillRule='evenodd'
+    />
+  </svg>
+);
+
+export const LeftSideDoubleColumnOutlined = (props: LucideProps) => (
+  <svg
+    fill='none'
+    height='16'
+    viewBox='0 0 16 16'
+    width='16'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path
+      clipRule='evenodd'
+      d='M5.75 3H13V13H5.75V3ZM4.75 2H5.75H13C13.5523 2 14 2.44772 14 3V13C14 13.5523 13.5523 14 13 14H5.75H4.75H3C2.44772 14 2 13.5523 2 13V3C2 2.44772 2.44772 2 3 2H4.75ZM4.75 13H3L3 3H4.75V13Z'
+      fill='#595E6F'
+      fillRule='evenodd'
+    />
+  </svg>
+);
+
+export const DoubleSideDoubleColumnOutlined = (props: LucideProps) => (
+  <svg
+    fill='none'
+    height='16'
+    viewBox='0 0 16 16'
+    width='16'
+    xmlns='http://www.w3.org/2000/svg'
+    {...props}
+  >
+    <path
+      clipRule='evenodd'
+      d='M10.25 3H5.75V13H10.25V3ZM10.25 2H5.75H4.75H3C2.44772 2 2 2.44772 2 3V13C2 13.5523 2.44772 14 3 14H4.75H5.75H10.25H11.25H13C13.5523 14 14 13.5523 14 13V3C14 2.44772 13.5523 2 13 2H11.25H10.25ZM11.25 3V13H13V3H11.25ZM3 13H4.75V3H3L3 13Z'
+      fill='#595E6F'
+      fillRule='evenodd'
+    />
+  </svg>
+);
+
+export const Overflow = (props) => (
+  <svg
+    xmlns='http://www.w3.org/2000/svg'
+    className='h-5 w-5'
+    fill='none'
+    viewBox='0 0 24 24'
+    stroke='currentColor'
+    {...props}
+  >
+    <path
+      strokeLinecap='round'
+      strokeLinejoin='round'
+      strokeWidth={2}
+      d='M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z'
+    />
+  </svg>
+);
+
+export const Icons = {
+  add: Plus,
+  alignCenter: AlignCenter,
+  alignJustify: AlignJustify,
+  alignLeft: AlignLeft,
+  alignRight: AlignRight,
+  arrowDown: ChevronDown,
+  bg: PaintBucket,
+  blockquote: Quote,
+  overflow: Overflow,
+  borderAll,
+  borderBottom,
+  borderLeft,
+  borderNone,
+  borderRight,
+  borderTop,
+  check: Check,
+  chevronRight: ChevronRight,
+  chevronsUpDown: ChevronsUpDown,
+  clear: X,
+  close: X,
+  paint: PaintBucket,
+  codeblock: FileCode,
+  color: Baseline,
+  column: RectangleVertical,
+  combine: Combine,
+  ungroup: Ungroup,
+  comment: MessageSquare,
+  commentAdd: MessageSquarePlus,
+  delete: Trash,
+  dragHandle: GripVertical,
+  editing: Edit2,
+  emoji: Smile,
+  externalLink: ExternalLink,
+  h1: Heading1,
+  h2: Heading2,
+  h3: Heading3,
+  h4: Heading4,
+  h5: Heading5,
+  h6: Heading6,
+  indent: Indent,
+  kbd: Keyboard,
+  lineHeight: WrapText,
+  minus: Minus,
+  mermaid: MermaidIcon,
+  more: MoreHorizontal,
+  outdent: Outdent,
+  paragraph: Pilcrow,
+  refresh: RotateCcw,
+  row: RectangleHorizontal,
+  search: Search,
+  settings: Settings,
+  highlight: Highlighter,
+  strikethrough: Strikethrough,
+  subscript: Subscript,
+  superscript: Superscript,
+  table: Table,
+  text: Text,
+  trash: Trash,
+  underline: Underline,
+  unlink: Link2Off,
+  viewing: Eye,
+  doubleColumn: DoubleColumnOutlined,
+  doubleSideDoubleColumn: DoubleSideDoubleColumnOutlined,
+  threeColumn: ThreeColumnOutlined,
+  leftSideDoubleColumn: LeftSideDoubleColumnOutlined,
+  rightSideDoubleColumn: RightSideDoubleColumnOutlined,
+  horizontalRule: SeparatorHorizontal,
+  heading: HeadingIcon,
+  link: LinkIcon,
+  quote: QuoteIcon,
+  image: ImageIcon,
+  ul: UnorderedListIcon,
+  ol: OrderedListIcon,
+  code: CodeIcon,
+  codeBlock: CodeBlockIcon,
+  bold: BoldIcon,
+  italic: ItalicIcon,
+  raw: RawMarkdown,
+  gitHub: (props: LucideProps) => (
+    <svg viewBox='0 0 438.549 438.549' {...props}>
+      <path
+        fill='currentColor'
+        d='M409.132 114.573c-19.608-33.596-46.205-60.194-79.798-79.8-33.598-19.607-70.277-29.408-110.063-29.408-39.781 0-76.472 9.804-110.063 29.408-33.596 19.605-60.192 46.204-79.8 79.8C9.803 148.168 0 184.854 0 224.63c0 47.78 13.94 90.745 41.827 128.906 27.884 38.164 63.906 64.572 108.063 79.227 5.14.954 8.945.283 11.419-1.996 2.475-2.282 3.711-5.14 3.711-8.562 0-.571-.049-5.708-.144-15.417a2549.81 2549.81 0 01-.144-25.406l-6.567 1.136c-4.187.767-9.469 1.092-15.846 1-6.374-.089-12.991-.757-19.842-1.999-6.854-1.231-13.229-4.086-19.13-8.559-5.898-4.473-10.085-10.328-12.56-17.556l-2.855-6.57c-1.903-4.374-4.899-9.233-8.992-14.559-4.093-5.331-8.232-8.945-12.419-10.848l-1.999-1.431c-1.332-.951-2.568-2.098-3.711-3.429-1.142-1.331-1.997-2.663-2.568-3.997-.572-1.335-.098-2.43 1.427-3.289 1.525-.859 4.281-1.276 8.28-1.276l5.708.853c3.807.763 8.516 3.042 14.133 6.851 5.614 3.806 10.229 8.754 13.846 14.842 4.38 7.806 9.657 13.754 15.846 17.847 6.184 4.093 12.419 6.136 18.699 6.136 6.28 0 11.704-.476 16.274-1.423 4.565-.952 8.848-2.383 12.847-4.285 1.713-12.758 6.377-22.559 13.988-29.41-10.848-1.14-20.601-2.857-29.264-5.14-8.658-2.286-17.605-5.996-26.835-11.14-9.235-5.137-16.896-11.516-22.985-19.126-6.09-7.614-11.088-17.61-14.987-29.979-3.901-12.374-5.852-26.648-5.852-42.826 0-23.035 7.52-42.637 22.557-58.817-7.044-17.318-6.379-36.732 1.997-58.24 5.52-1.715 13.706-.428 24.554 3.853 10.85 4.283 18.794 7.952 23.84 10.994 5.046 3.041 9.089 5.618 12.135 7.708 17.705-4.947 35.976-7.421 54.818-7.421s37.117 2.474 54.823 7.421l10.849-6.849c7.419-4.57 16.18-8.758 26.262-12.565 10.088-3.805 17.802-4.853 23.134-3.138 8.562 21.509 9.325 40.922 2.279 58.24 15.036 16.18 22.559 35.787 22.559 58.817 0 16.178-1.958 30.497-5.853 42.966-3.9 12.471-8.941 22.457-15.125 29.979-6.191 7.521-13.901 13.85-23.131 18.986-9.232 5.14-18.182 8.85-26.84 11.136-8.662 2.286-18.415 4.004-29.263 5.146 9.894 8.562 14.842 22.077 14.842 40.539v60.237c0 3.422 1.19 6.279 3.572 8.562 2.379 2.279 6.136 2.95 11.276 1.995 44.163-14.653 80.185-41.062 108.068-79.226 27.88-38.161 41.825-81.126 41.825-128.906-.01-39.771-9.818-76.454-29.414-110.049z'
+      ></path>
+    </svg>
+  ),
+  logo: (props: LucideProps) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' {...props}>
+      <path
+        fill='currentColor'
+        d='M11.572 0c-.176 0-.31.001-.358.007a19.76 19.76 0 0 1-.364.033C7.443.346 4.25 2.185 2.228 5.012a11.875 11.875 0 0 0-2.119 5.243c-.096.659-.108.854-.108 1.747s.012 1.089.108 1.748c.652 4.506 3.86 8.292 8.209 9.695.779.25 1.6.422 2.534.525.363.04 1.935.04 2.299 0 1.611-.178 2.977-.577 4.323-1.264.207-.106.247-.134.219-.158-.02-.013-.9-1.193-1.955-2.62l-1.919-2.592-2.404-3.558a338.739 338.739 0 0 0-2.422-3.556c-.009-.002-.018 1.579-.023 3.51-.007 3.38-.01 3.515-.052 3.595a.426.426 0 0 1-.206.214c-.075.037-.14.044-.495.044H7.81l-.108-.068a.438.438 0 0 1-.157-.171l-.05-.106.006-4.703.007-4.705.072-.092a.645.645 0 0 1 .174-.143c.096-.047.134-.051.54-.051.478 0 .558.018.682.154.035.038 1.337 1.999 2.895 4.361a10760.433 10760.433 0 0 0 4.735 7.17l1.9 2.879.096-.063a12.317 12.317 0 0 0 2.466-2.163 11.944 11.944 0 0 0 2.824-6.134c.096-.66.108-.854.108-1.748 0-.893-.012-1.088-.108-1.747-.652-4.506-3.859-8.292-8.208-9.695a12.597 12.597 0 0 0-2.499-.523A33.119 33.119 0 0 0 11.573 0zm4.069 7.217c.347 0 .408.005.486.047a.473.473 0 0 1 .237.277c.018.06.023 1.365.018 4.304l-.006 4.218-.744-1.14-.746-1.14v-3.066c0-1.982.01-3.097.023-3.15a.478.478 0 0 1 .233-.296c.096-.05.13-.054.5-.054z'
+      />
+    </svg>
+  ),
+  moon: Moon,
+  sun: SunMedium,
+  twitter: Twitter,
+};
+
+export const EllipsisIcon = ({ title }) => {
+  return (
+    <>
+      {title && <span className='sr-only'>{title}</span>}
+      <svg
+        xmlns='http://www.w3.org/2000/svg'
+        className='h-5 w-5'
+        fill='none'
+        viewBox='0 0 24 24'
+        stroke='currentColor'
+      >
+        <path
+          strokeLinecap='round'
+          strokeLinejoin='round'
+          strokeWidth={2}
+          d='M12 5v.01M12 12v.01M12 19v.01M12 6a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2zm0 7a1 1 0 110-2 1 1 0 010 2z'
+        />
+      </svg>
+    </>
+  );
+};
+
+export function UnorderedListIcon(props) {
+  const title = props.title || 'format list bulleted';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path d='M7 5h14v2H7V5z' fill='currentColor' />
+        <path
+          d='M4 7.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z'
+          fill='currentColor'
+        />
+        <path
+          d='M7 11h14v2H7v-2zm0 6h14v2H7v-2zm-3 2.5c.82 0 1.5-.68 1.5-1.5s-.67-1.5-1.5-1.5-1.5.68-1.5 1.5.68 1.5 1.5 1.5z'
+          fill='currentColor'
+        />
+        <path
+          d='M4 13.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function HeadingIcon(props) {
+  const title = props.title || 'format size';
+
+  return (
+    <svg
+      height='24'
+      width='24'
+      className='h-5 w-5'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M9 4v3h5v12h3V7h5V4H9zm-6 8h3v7h3v-7h3V9H3v3z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function OrderedListIcon(props) {
+  const title = props.title || 'format list numbered';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M2 17h2v.5H3v1h1v.5H2v1h3v-4H2v1zm1-9h1V4H2v1h1v3zm-1 3h1.8L2 13.1v.9h3v-1H3.2L5 10.9V10H2v1zm5-6v2h14V5H7zm0 14h14v-2H7v2zm0-6h14v-2H7v2z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function QuoteIcon(props) {
+  const title = props.title || 'format quote';
+
+  return (
+    <svg
+      height='24'
+      className='h-5 w-5'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M6 17h3l2-4V7H5v6h3l-2 4zm8 0h3l2-4V7h-6v6h3l-2 4z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function LinkIcon(props) {
+  const title = props.title || 'insert link';
+
+  return (
+    <svg
+      height='24'
+      className='h-5 w-5'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1 0 1.71-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function CodeIcon(props) {
+  const title = props.title || 'code';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function CodeBlockIcon(props) {
+  const title = props.title || 'code-block';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      stroke='currentColor'
+      fill='currentColor'
+      strokeWidth={0}
+      viewBox='0 0 16 16'
+      height='1em'
+      width='1em'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <path d='M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h12zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2H2z' />
+      <path d='M6.854 4.646a.5.5 0 0 1 0 .708L4.207 8l2.647 2.646a.5.5 0 0 1-.708.708l-3-3a.5.5 0 0 1 0-.708l3-3a.5.5 0 0 1 .708 0zm2.292 0a.5.5 0 0 0 0 .708L11.793 8l-2.647 2.646a.5.5 0 0 0 .708.708l3-3a.5.5 0 0 0 0-.708l-3-3a.5.5 0 0 0-.708 0z' />
+    </svg>
+  );
+}
+
+export function ImageIcon(props) {
+  const title = props.title || 'image';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M19 5v14H5V5h14zm0-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm-4.86 8.86l-3 3.87L9 13.14 6 17h12l-3.86-5.14z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function BoldIcon(props) {
+  const title = props.title || 'format bold';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M15.6 10.79c.97-.67 1.65-1.77 1.65-2.79 0-2.26-1.75-4-4-4H7v14h7.04c2.09 0 3.71-1.7 3.71-3.79 0-1.52-.86-2.82-2.15-3.42zM10 6.5h3c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5h-3v-3zm3.5 9H10v-3h3.5c.83 0 1.5.67 1.5 1.5s-.67 1.5-1.5 1.5z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function ItalicIcon(props) {
+  const title = props.title || 'format italic';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M10 4v3h2.21l-3.42 8H6v3h8v-3h-2.21l3.42-8H18V4h-8z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function UnderlineIcon(props) {
+  const title = props.title || 'format underlined';
+
+  return (
+    <svg
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M12 17c3.31 0 6-2.69 6-6V3h-2.5v8c0 1.93-1.57 3.5-3.5 3.5S8.5 12.93 8.5 11V3H6v8c0 3.31 2.69 6 6 6zm-7 2v2h14v-2H5z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function StrikethroughIcon(props) {
+  const title = props.title || 'strikethrough s';
+
+  return (
+    <svg
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M6.85 7.08C6.85 4.37 9.45 3 12.24 3c1.64 0 3 .49 3.9 1.28.77.65 1.46 1.73 1.46 3.24h-3.01c0-.31-.05-.59-.15-.85-.29-.86-1.2-1.28-2.25-1.28-1.86 0-2.34 1.02-2.34 1.7 0 .48.25.88.74 1.21.38.25.77.48 1.41.7H7.39c-.21-.34-.54-.89-.54-1.92zM21 12v-2H3v2h9.62c1.15.45 1.96.75 1.96 1.97 0 1-.81 1.67-2.28 1.67-1.54 0-2.93-.54-2.93-2.51H6.4c0 .55.08 1.13.24 1.58.81 2.29 3.29 3.3 5.67 3.3 2.27 0 5.3-.89 5.3-4.05 0-.3-.01-1.16-.48-1.94H21V12z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function LightningIcon(props) {
+  const title = props.title || 'lightning';
+
+  return (
+    <svg
+      className='h-5 w-5'
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g
+        fill='currentColor'
+        stroke='currentColor'
+        strokeLinecap='square'
+        strokeLinejoin='miter'
+        strokeMiterlimit='10'
+        strokeWidth='2'
+      >
+        <polygon
+          fill='none'
+          points='13,3 3,14 12,14 11,21 21,10 12,10 '
+          stroke='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function ArrowDownIcon(props) {
+  const title = props.title || 'keyboard arrow down';
+
+  return (
+    <svg
+      height='24'
+      width='24'
+      viewBox='0 0 24 24'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <title>{title}</title>
+      <g fill='none'>
+        <path
+          d='M7.41 8.59L12 13.17l4.59-4.58L18 10l-6 6-6-6 1.41-1.41z'
+          fill='currentColor'
+        />
+      </g>
+    </svg>
+  );
+}
+
+export function PlusIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      xmlns='http://www.w3.org/2000/svg'
+      className={`h-4 w-4 ${className}`}
+      viewBox='0 0 20 20'
+      fill='currentColor'
+    >
+      <path
+        fillRule='evenodd'
+        d='M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z'
+        clipRule='evenodd'
+      />
+    </svg>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/image-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/image-toolbar-button.tsx
@@ -1,0 +1,49 @@
+import { withRef } from '@udecode/cn';
+import React from 'react';
+
+import { Icons } from './icons';
+
+import { useEditorState } from '@udecode/plate/react';
+import { helpers } from '../../plugins/core/common';
+import { ELEMENT_IMG } from '../../plugins/create-img-plugin';
+import { ToolbarButton } from './toolbar';
+
+const useImageToolbarButtonState = () => {
+  const editor = useEditorState();
+
+  const isBlockActive = () => helpers.isNodeActive(editor, ELEMENT_IMG);
+
+  return {
+    pressed: isBlockActive(),
+  };
+};
+
+// ponytail: inert until the media capability exists — picking an image needs a
+const useImageToolbarButton = (state) => {
+  useEditorState();
+
+  return {
+    props: {
+      disabled: true,
+      onMouseDown: (e) => e.preventDefault(),
+      pressed: state.pressed,
+    },
+  };
+};
+
+export const ImageToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+  }
+>(({ clear, ...rest }, ref) => {
+  const state = useImageToolbarButtonState();
+
+  const { props } = useImageToolbarButton(state);
+
+  return (
+    <ToolbarButton ref={ref} tooltip='Image' {...rest} {...props}>
+      <Icons.image />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/indent-list-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/indent-list-toolbar-button.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import React from 'react';
+
+import { withRef } from '@udecode/cn';
+import {
+  BulletedListPlugin,
+  useListToolbarButton,
+  useListToolbarButtonState,
+} from '@udecode/plate-list/react';
+import { List, ListOrdered } from 'lucide-react';
+
+import { ToolbarButton } from './toolbar';
+
+export const ListToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    nodeType?: string;
+  }
+>(({ nodeType = BulletedListPlugin.key, ...rest }, ref) => {
+  const state = useListToolbarButtonState({ nodeType });
+  const { props } = useListToolbarButton(state);
+
+  return (
+    <ToolbarButton
+      ref={ref}
+      tooltip={
+        nodeType === BulletedListPlugin.key ? 'Bulleted List' : 'Numbered List'
+      }
+      {...props}
+      {...rest}
+    >
+      {nodeType === BulletedListPlugin.key ? <List /> : <ListOrdered />}
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/inline-combobox.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/inline-combobox.tsx
@@ -1,0 +1,333 @@
+import React, {
+  type HTMLAttributes,
+  type ReactNode,
+  type RefObject,
+  createContext,
+  forwardRef,
+  startTransition,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+
+import {
+  UseComboboxInputResult,
+  useComboboxInput,
+  useHTMLInputCursorState,
+} from '@udecode/plate-combobox/react';
+
+import {
+  Combobox,
+  ComboboxItem,
+  type ComboboxItemProps,
+  ComboboxPopover,
+  ComboboxProvider,
+  Portal,
+  useComboboxContext,
+  useComboboxStore,
+} from '@ariakit/react';
+import { cn } from '@tinacms/ui/lib/utils';
+import { Point, TElement } from '@udecode/plate';
+import { filterWords } from '@udecode/plate-combobox';
+import { useComposedRef, useEditorRef } from '@udecode/plate/react';
+import { cva } from 'class-variance-authority';
+
+type FilterFn = (
+  item: { keywords?: string[]; value: string },
+  search: string
+) => boolean;
+
+interface InlineComboboxContextValue {
+  filter: FilterFn | false;
+  inputProps: UseComboboxInputResult['props'];
+  inputRef: RefObject<HTMLInputElement>;
+  removeInput: UseComboboxInputResult['removeInput'];
+  setHasEmpty: (hasEmpty: boolean) => void;
+  showTrigger: boolean;
+  trigger: string;
+}
+
+const InlineComboboxContext = createContext<InlineComboboxContextValue>(
+  null as any
+);
+
+export const defaultFilter: FilterFn = ({ keywords = [], value }, search) =>
+  [value, ...keywords].some((keyword) => filterWords(keyword, search));
+
+interface InlineComboboxProps {
+  children: ReactNode;
+  element: TElement;
+  trigger: string;
+  filter?: FilterFn | false;
+  hideWhenNoValue?: boolean;
+  setValue?: (value: string) => void;
+  showTrigger?: boolean;
+  value?: string;
+}
+
+const InlineCombobox = ({
+  children,
+  element,
+  filter = defaultFilter,
+  hideWhenNoValue = false,
+  setValue: setValueProp,
+  showTrigger = true,
+  trigger,
+  value: valueProp,
+}: InlineComboboxProps) => {
+  const editor = useEditorRef();
+  const inputRef = React.useRef<HTMLInputElement>(null);
+  const cursorState = useHTMLInputCursorState(inputRef);
+
+  const [valueState, setValueState] = useState('');
+  const hasValueProp = valueProp !== undefined;
+  const value = hasValueProp ? valueProp : valueState;
+
+  const setValue = useCallback(
+    (newValue: string) => {
+      setValueProp?.(newValue);
+
+      if (!hasValueProp) {
+        setValueState(newValue);
+      }
+    },
+    [setValueProp, hasValueProp]
+  );
+
+  const insertPoint = React.useRef<Point | null>(null);
+
+  useEffect(() => {
+    const path = editor.api.findPath(element);
+
+    if (!path) return;
+
+    const point = editor.api.before(path);
+
+    if (!point) return;
+
+    const pointRef = editor.api.pointRef(point);
+    insertPoint.current = pointRef.current;
+
+    return () => {
+      pointRef.unref();
+    };
+  }, [editor, element]);
+
+  const { props: inputProps, removeInput } = useComboboxInput({
+    cancelInputOnBlur: true,
+    cursorState,
+    onCancelInput: (cause) => {
+      if (cause !== 'backspace') {
+        editor.tf.insertText(trigger + value, {
+          at: insertPoint?.current ?? undefined,
+        });
+      }
+    },
+    ref: inputRef,
+  });
+
+  const [hasEmpty, setHasEmpty] = useState(false);
+
+  const contextValue: InlineComboboxContextValue = useMemo(
+    () => ({
+      filter,
+      inputProps,
+      inputRef,
+      removeInput,
+      setHasEmpty,
+      showTrigger,
+      trigger,
+    }),
+    [
+      trigger,
+      showTrigger,
+      filter,
+      inputRef,
+      inputProps,
+      removeInput,
+      setHasEmpty,
+    ]
+  );
+
+  const store = useComboboxStore({
+    setValue: (newValue) => startTransition(() => setValue(newValue)),
+  });
+
+  const items = store.useState('items');
+
+  useEffect(() => {
+    if (!store.getState().activeId) {
+      store.setActiveId(store.first());
+    }
+  }, [items, store]);
+
+  return (
+    <span contentEditable={false}>
+      <ComboboxProvider
+        open={
+          (items.length > 0 || hasEmpty) &&
+          (!hideWhenNoValue || value.length > 0)
+        }
+        store={store}
+      >
+        <InlineComboboxContext.Provider value={contextValue}>
+          {children}
+        </InlineComboboxContext.Provider>
+      </ComboboxProvider>
+    </span>
+  );
+};
+
+const InlineComboboxInput = forwardRef<
+  HTMLInputElement,
+  HTMLAttributes<HTMLInputElement>
+>(({ className, ...props }, propRef) => {
+  const {
+    inputProps,
+    inputRef: contextRef,
+    showTrigger,
+    trigger,
+  } = useContext(InlineComboboxContext);
+
+  const store = useComboboxContext();
+  const value = store.useState('value');
+
+  const ref = useComposedRef(propRef, contextRef);
+
+  return (
+    <>
+      {showTrigger && trigger}
+
+      <span className='relative min-h-[1lh]'>
+        <span
+          aria-hidden='true'
+          className='invisible overflow-hidden text-nowrap'
+        >
+          {value || '\u200B'}
+        </span>
+
+        <Combobox
+          autoSelect
+          className={cn(
+            'absolute left-0 top-0 size-full bg-transparent outline-none',
+            className
+          )}
+          ref={ref}
+          value={value}
+          {...inputProps}
+          {...props}
+        />
+      </span>
+    </>
+  );
+});
+
+InlineComboboxInput.displayName = 'InlineComboboxInput';
+
+const InlineComboboxContent: typeof ComboboxPopover = ({
+  className,
+  ...props
+}) => {
+  return (
+    <Portal>
+      <ComboboxPopover
+        className={cn(
+          'z-[9999999] max-h-[288px] w-[300px] overflow-y-auto rounded bg-white shadow-md',
+          className
+        )}
+        {...props}
+      />
+    </Portal>
+  );
+};
+
+const comboboxItemVariants = cva(
+  'relative flex h-9 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none',
+  {
+    defaultVariants: {
+      interactive: true,
+    },
+    variants: {
+      interactive: {
+        false: '',
+        true: 'cursor-pointer transition-colors hover:bg-blue-500 hover:text-black data-[active-item=true]:bg-orange-400 data-[active-item=true]:text-black',
+      },
+    },
+  }
+);
+
+export type InlineComboboxItemProps = {
+  keywords?: string[];
+} & ComboboxItemProps &
+  Required<Pick<ComboboxItemProps, 'value'>>;
+
+const InlineComboboxItem = ({
+  className,
+  keywords,
+  onClick,
+  ...props
+}: InlineComboboxItemProps) => {
+  const { value } = props;
+
+  const { filter, removeInput } = useContext(InlineComboboxContext);
+
+  const store = useComboboxContext();
+
+  // biome-ignore lint/correctness/useHookAtTopLevel: not ready to fix these yet
+  const search = filter && store.useState('value');
+
+  const visible = useMemo(
+    () => !filter || filter({ keywords, value }, search as string),
+    [filter, value, keywords, search]
+  );
+
+  if (!visible) return null;
+
+  return (
+    <ComboboxItem
+      className={cn(comboboxItemVariants(), className)}
+      onClick={(event) => {
+        removeInput(true);
+        onClick?.(event);
+      }}
+      {...props}
+    />
+  );
+};
+
+const InlineComboboxEmpty = ({
+  children,
+  className,
+}: HTMLAttributes<HTMLDivElement>) => {
+  const { setHasEmpty } = useContext(InlineComboboxContext);
+  const store = useComboboxContext();
+  const items = store.useState('items');
+
+  useEffect(() => {
+    setHasEmpty(true);
+
+    return () => {
+      setHasEmpty(false);
+    };
+  }, [setHasEmpty]);
+
+  if (items.length > 0) return null;
+
+  return (
+    <div
+      className={cn(comboboxItemVariants({ interactive: false }), className)}
+    >
+      {children}
+    </div>
+  );
+};
+
+export {
+  InlineCombobox,
+  InlineComboboxContent,
+  InlineComboboxEmpty,
+  InlineComboboxInput,
+  InlineComboboxItem,
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/input.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/input.tsx
@@ -1,0 +1,25 @@
+import { withVariants } from '@udecode/cn';
+import { cva } from 'class-variance-authority';
+
+export const inputVariants = cva(
+  'flex w-full rounded bg-transparent text-sm file:border-0 file:bg-background file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50',
+  {
+    defaultVariants: {
+      h: 'md',
+      variant: 'default',
+    },
+    variants: {
+      h: {
+        md: 'h-10 px-3 py-2',
+        sm: 'h-9 px-3 py-2',
+      },
+      variant: {
+        default:
+          'border border-input ring-offset-background focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        ghost: 'border-none focus-visible:ring-transparent',
+      },
+    },
+  }
+);
+
+export const Input = withVariants('input', inputVariants, ['variant', 'h']);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-element.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import * as React from 'react';
+
+import type { TLinkElement } from '@udecode/plate-link';
+import type { PlateElementProps } from '@udecode/plate/react';
+
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { useLink } from '@udecode/plate-link/react';
+import { PlateElement, useEditorRef } from '@udecode/plate/react';
+
+export function LinkElement(props: PlateElementProps<TLinkElement>) {
+  const { props: linkProps } = useLink({ element: props.element });
+  const editor = useEditorRef();
+
+  const isInCodeBlock = editor?.api.above({
+    match: { type: editor.getType(CodeBlockPlugin) },
+  });
+
+  if (isInCodeBlock) {
+    return (
+      <code
+        {...props.attributes}
+        className='rounded-md bg-muted px-[0.3em] py-[0.2em] font-mono text-sm whitespace-pre-wrap'
+      >
+        {props.children}
+      </code>
+    );
+  }
+
+  return (
+    <PlateElement
+      {...props}
+      as='a'
+      className='font-small underline underline-offset-2 text-blue-500 hover:text-blue-600 transition-color ease-out duration-150'
+      attributes={{
+        ...props.attributes,
+        ...(linkProps as any),
+      }}
+    >
+      {props.children}
+    </PlateElement>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-floating-toolbar.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-floating-toolbar.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import * as React from 'react';
+
+import { PortalBody } from '@udecode/cn';
+import {
+  type UseVirtualFloatingOptions,
+  flip,
+  limitShift,
+  offset,
+  shift,
+} from '@udecode/plate-floating';
+import { type TLinkElement, getLinkAttributes } from '@udecode/plate-link';
+import {
+  FloatingLinkUrlInput,
+  type LinkFloatingToolbarState,
+  LinkPlugin,
+  submitFloatingLink,
+  useFloatingLinkEdit,
+  useFloatingLinkEditState,
+  useFloatingLinkInsert,
+  useFloatingLinkInsertState,
+} from '@udecode/plate-link/react';
+import {
+  useEditorPlugin,
+  useEditorRef,
+  useEditorSelection,
+  useFormInputProps,
+  usePluginOption,
+} from '@udecode/plate/react';
+import { cva } from 'class-variance-authority';
+import { CircleX, ExternalLink, Link, Text, Unlink } from 'lucide-react';
+import { buttonVariants } from './button';
+import { Separator } from './separator';
+
+const popoverVariants = cva(
+  'z-[999999] w-auto rounded-md border bg-popover p-1 text-popover-foreground shadow-md outline-hidden'
+);
+
+const inputVariants = cva(
+  'flex h-[28px] w-full rounded-md border-none bg-transparent px-1.5 py-1 text-base placeholder:text-muted-foreground focus-visible:ring-transparent focus-visible:outline-none md:text-sm'
+);
+
+export function LinkFloatingToolbar({
+  state,
+}: {
+  state?: LinkFloatingToolbarState;
+}) {
+  const activeCommentId = usePluginOption({ key: 'comment' }, 'activeId');
+  const activeSuggestionId = usePluginOption({ key: 'suggestion' }, 'activeId');
+  const { api, editor } = useEditorPlugin(LinkPlugin);
+
+  const isUrlValidator = usePluginOption(LinkPlugin, 'isUrl');
+
+  const [currentUrl, setCurrentUrl] = React.useState('');
+  const [isValidUrl, setIsValidUrl] = React.useState(true);
+
+  const handleUrlInput = React.useCallback(
+    (e: React.FormEvent<HTMLInputElement>) => {
+      const value = e.currentTarget.value;
+      setCurrentUrl(value);
+      if (value && isUrlValidator) {
+        const valid = isUrlValidator(value);
+        setIsValidUrl(valid);
+      } else {
+        setIsValidUrl(true);
+      }
+    },
+    [isUrlValidator]
+  );
+
+  const floatingOptions: UseVirtualFloatingOptions = React.useMemo(() => {
+    return {
+      middleware: [
+        offset(8),
+        flip({
+          fallbackPlacements: ['bottom-end', 'top-start', 'top-end'],
+          padding: 12,
+        }),
+        shift({ padding: 8, limiter: limitShift() }),
+      ],
+      placement:
+        activeSuggestionId || activeCommentId ? 'top-start' : 'bottom-start',
+    };
+  }, [activeCommentId, activeSuggestionId]);
+
+  const insertState = useFloatingLinkInsertState({
+    ...state,
+    floatingOptions: {
+      ...floatingOptions,
+      ...state?.floatingOptions,
+    },
+  });
+  const {
+    hidden,
+    props: insertProps,
+    ref: insertRef,
+    textInputProps,
+  } = useFloatingLinkInsert(insertState);
+
+  const editState = useFloatingLinkEditState({
+    ...state,
+    floatingOptions: {
+      ...floatingOptions,
+      ...state?.floatingOptions,
+    },
+  });
+  const {
+    editButtonProps,
+    props: editProps,
+    ref: editRef,
+    unlinkButtonProps,
+  } = useFloatingLinkEdit(editState);
+  const inputProps = useFormInputProps({
+    preventDefaultOnEnterKeydown: true,
+  });
+
+  if (hidden) return null;
+
+  const input = (
+    <div
+      className='z-[999999] flex w-[330px] flex-col relative'
+      {...inputProps}
+    >
+      {!isValidUrl && currentUrl && (
+        <div className='absolute -top-16 left-0 right-0 z-[1000000] mb-2'>
+          <div
+            className='bg-red-50 border border-red-200 rounded-md p-2 shadow-lg'
+            role='alert'
+            aria-live='polite'
+          >
+            <div className='flex items-center'>
+              <CircleX className='size-4 text-red-500 mr-2 flex-shrink-0' />
+              <span className='text-sm text-red-700 text-wrap'>
+                Invalid URL. Please prefix link with https:// or use a relative
+                path like /about
+              </span>
+            </div>
+            <div className='absolute -bottom-1 left-4 w-2 h-2 bg-red-50 border-r border-b border-red-200 transform rotate-45'></div>
+          </div>
+        </div>
+      )}
+
+      <div className='flex items-center'>
+        <div className='flex items-center pr-1 pl-2 text-muted-foreground'>
+          <Link className='size-4' />
+        </div>
+
+        <FloatingLinkUrlInput
+          className={inputVariants()}
+          placeholder='Paste link'
+          data-plate-focus
+          onInput={handleUrlInput}
+        />
+      </div>
+      <Separator className='my-1' />
+      <div className='flex items-center'>
+        <div className='flex items-center pr-1 pl-2 text-muted-foreground'>
+          <Text className='size-4' />
+        </div>
+        <input
+          className={inputVariants()}
+          placeholder='Text to display'
+          data-plate-focus
+          {...textInputProps}
+        />
+      </div>
+      <Separator className='my-1' />
+      <div className='flex items-center justify-end gap-2 px-2 py-1'>
+        <button
+          type='button'
+          className={buttonVariants({ size: 'sm', variant: 'ghost' })}
+          onClick={() => {
+            api.floatingLink.hide();
+          }}
+        >
+          Cancel
+        </button>
+        <button
+          type='button'
+          className={buttonVariants({
+            size: 'sm',
+            variant: 'tinaPrimary',
+          })}
+          onClick={() => {
+            if (isValidUrl && currentUrl) {
+              submitFloatingLink(editor);
+            }
+          }}
+          disabled={!isValidUrl && !!currentUrl}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  );
+
+  const editContent = editState.isEditing ? (
+    input
+  ) : (
+    <div className='box-content flex items-center'>
+      <button
+        className={buttonVariants({ size: 'sm', variant: 'ghost' })}
+        type='button'
+        {...editButtonProps}
+      >
+        Edit link
+      </button>
+
+      <Separator orientation='vertical' />
+
+      <LinkOpenButton />
+
+      <Separator orientation='vertical' />
+
+      <button
+        className={buttonVariants({
+          size: 'icon',
+          variant: 'ghost',
+        })}
+        type='button'
+        {...unlinkButtonProps}
+      >
+        <Unlink width={18} />
+      </button>
+    </div>
+  );
+
+  return (
+    <PortalBody>
+      <div
+        ref={insertRef}
+        className={popoverVariants()}
+        {...insertProps}
+        style={{
+          ...(insertProps.style as React.CSSProperties),
+          zIndex: 999999,
+        }}
+      >
+        {input}
+      </div>
+
+      <div
+        ref={editRef}
+        className={popoverVariants()}
+        {...editProps}
+        style={{ ...(editProps.style as React.CSSProperties), zIndex: 999999 }}
+      >
+        {editContent}
+      </div>
+    </PortalBody>
+  );
+}
+
+function LinkOpenButton() {
+  const editor = useEditorRef();
+  const selection = useEditorSelection();
+
+  const attributes = React.useMemo(() => {
+    const entry = editor.api.node<TLinkElement>({
+      match: { type: editor.getType(LinkPlugin) },
+    });
+    if (!entry) {
+      return {};
+    }
+    const [element] = entry;
+    return getLinkAttributes(editor, element);
+  }, [editor, selection]);
+
+  return (
+    <a
+      {...attributes}
+      className={buttonVariants({
+        size: 'icon',
+        variant: 'ghost',
+      })}
+      onMouseOver={(e) => {
+        e.stopPropagation();
+      }}
+      aria-label='Open link in a new tab'
+      target='_blank'
+    >
+      <ExternalLink width={18} />
+    </a>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/link-toolbar-button.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { withRef } from '@udecode/cn';
+
+import { Icons } from './icons';
+
+import {
+  useLinkToolbarButton,
+  useLinkToolbarButtonState,
+} from '@udecode/plate-link/react';
+import { ToolbarButton } from './toolbar';
+
+export const LinkToolbarButton = withRef<typeof ToolbarButton>((rest, ref) => {
+  const state = useLinkToolbarButtonState();
+  const { props } = useLinkToolbarButton(state);
+
+  return (
+    <ToolbarButton ref={ref} {...props} {...rest} tooltip='Link'>
+      <Icons.link />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/list-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/list-element.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import React from 'react';
+
+import { withRef, withVariants } from '@udecode/cn';
+import { PlateElement } from '@udecode/plate/react';
+import { cva } from 'class-variance-authority';
+
+const listVariants = cva('m-0 ps-6', {
+  variants: {
+    variant: {
+      ol: 'list-decimal',
+      ul: 'list-disc [&_ul]:list-[circle] [&_ul_ul]:list-[square]',
+    },
+  },
+});
+
+const ListElementVariants = withVariants(PlateElement, listVariants, [
+  'variant',
+]);
+
+export const ListElement = withRef<typeof ListElementVariants>(
+  ({ children, variant = 'ul', ...props }, ref) => {
+    return (
+      <ListElementVariants ref={ref} as={variant!} variant={variant} {...props}>
+        {children}
+      </ListElementVariants>
+    );
+  }
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mark-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mark-toolbar-button.tsx
@@ -1,0 +1,183 @@
+'use client';
+
+import { withRef } from '@udecode/cn';
+import {
+  BoldPlugin,
+  CodePlugin,
+  ItalicPlugin,
+  StrikethroughPlugin,
+} from '@udecode/plate-basic-marks/react';
+import {
+  useEditorRef,
+  useMarkToolbarButton,
+  useMarkToolbarButtonState,
+} from '@udecode/plate/react';
+import React from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  useOpenState,
+} from './dropdown-menu';
+import { Icons } from './icons';
+import { ToolbarButton } from './toolbar';
+
+const MarkToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+    nodeType: string;
+  }
+>(({ clear, nodeType, ...rest }, ref) => {
+  const state = useMarkToolbarButtonState({ clear, nodeType });
+  const { props } = useMarkToolbarButton(state);
+
+  return <ToolbarButton ref={ref} {...props} {...rest} />;
+});
+
+const highlightColors = [
+  { label: 'Yellow', value: '#FEF08A' },
+  { label: 'Green', value: '#BBF7D0' },
+  { label: 'Blue', value: '#BFDBFE' },
+  { label: 'Red', value: '#CC4141' },
+] as const;
+
+export const BoldToolbarButton = () => (
+  <MarkToolbarButton tooltip='Bold (⌘+B)' nodeType={BoldPlugin.key}>
+    <Icons.bold />
+  </MarkToolbarButton>
+);
+
+export const StrikethroughToolbarButton = () => (
+  <MarkToolbarButton tooltip='Strikethrough' nodeType={StrikethroughPlugin.key}>
+    <Icons.strikethrough />
+  </MarkToolbarButton>
+);
+
+export const ItalicToolbarButton = () => (
+  <MarkToolbarButton tooltip='Italic (⌘+I)' nodeType={ItalicPlugin.key}>
+    <Icons.italic />
+  </MarkToolbarButton>
+);
+
+export const CodeToolbarButton = () => (
+  <MarkToolbarButton tooltip='Code (⌘+E)' nodeType={CodePlugin.key}>
+    <Icons.code />
+  </MarkToolbarButton>
+);
+
+export const HighlightToolbarButton = () => <HighlightColorToolbarButton />;
+
+const useHighlightToolbar = () => {
+  const editor = useEditorRef();
+  const openState = useOpenState();
+  const savedSelection = React.useRef(editor.selection);
+  const inlineCodeActive = useMarkToolbarButtonState({
+    nodeType: CodePlugin.key,
+  }).pressed;
+
+  const rememberSelection = React.useCallback(() => {
+    if (editor.selection) {
+      savedSelection.current = structuredClone(editor.selection);
+    }
+  }, [editor]);
+
+  React.useEffect(() => {
+    if (openState.open) {
+      rememberSelection();
+    }
+  }, [openState.open, rememberSelection]);
+
+  const applyHighlight = React.useCallback(
+    (highlightColor?: string) => {
+      if (inlineCodeActive) {
+        openState.onOpenChange(false);
+        return;
+      }
+
+      if (savedSelection.current) {
+        editor.tf.select(structuredClone(savedSelection.current));
+      }
+
+      if (highlightColor) {
+        editor.tf.addMark('highlight', true);
+        editor.tf.addMark('highlightColor', highlightColor);
+      } else {
+        editor.tf.removeMark('highlight');
+        editor.tf.removeMark('highlightColor');
+      }
+
+      editor.tf.setNodes(
+        highlightColor
+          ? {
+              highlight: true,
+              highlightColor,
+            }
+          : {
+              highlight: undefined,
+              highlightColor: undefined,
+            },
+        {
+          at: editor.selection ?? undefined,
+          match: (node) => editor.api.isText(node),
+          split: true,
+        }
+      );
+
+      editor.tf.focus();
+      openState.onOpenChange(false);
+    },
+    [editor, inlineCodeActive, openState]
+  );
+
+  return {
+    applyHighlight,
+    inlineCodeActive,
+    openState,
+    rememberSelection,
+  };
+};
+
+const HighlightColorToolbarButton = () => {
+  const { applyHighlight, inlineCodeActive, openState, rememberSelection } =
+    useHighlightToolbar();
+
+  return (
+    <DropdownMenu modal={false} {...openState}>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton
+          isDropdown
+          showArrow
+          pressed={openState.open}
+          tooltip='Highlight color'
+          disabled={inlineCodeActive}
+          onMouseDown={rememberSelection}
+        >
+          <div className='flex items-center gap-1.5'>
+            <Icons.highlight />
+            <span className='sr-only'>Highlight color</span>
+          </div>
+        </ToolbarButton>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align='start' className='min-w-[180px]'>
+        <DropdownMenuItem onSelect={() => applyHighlight()}>
+          Clear highlight
+        </DropdownMenuItem>
+        {highlightColors.map((color) => (
+          <DropdownMenuItem
+            key={color.value}
+            onSelect={() => applyHighlight(color.value)}
+          >
+            <span
+              className='mr-2 inline-block size-4 rounded border border-gray-300'
+              style={{ backgroundColor: color.value }}
+            />
+            {color.label}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-element.tsx
@@ -1,0 +1,21 @@
+import mermaid from 'mermaid';
+import React, { useEffect, useRef } from 'react';
+
+export const MermaidElementWithRef = ({ config }) => {
+  const mermaidRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const node = mermaidRef.current?.querySelector<HTMLElement>('.mermaid');
+    if (!node) return;
+
+    mermaid.run({ nodes: [node] }).catch(() => {});
+  }, [config]);
+
+  return (
+    <div contentEditable={false} className='border-border border-b pt-10'>
+      <div ref={mermaidRef}>
+        <pre className='mermaid not-tina-prose'>{config}</pre>
+      </div>
+    </div>
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/mermaid-toolbar-button.tsx
@@ -1,0 +1,82 @@
+import { CodeLineElement } from '@tinacms/mdx';
+import { withRef } from '@udecode/cn';
+import { TElement } from '@udecode/plate';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { useEditorState } from '@udecode/plate/react';
+import React from 'react';
+import { helpers } from '../../plugins/core/common';
+import { Icons } from './icons';
+import { ToolbarButton } from './toolbar';
+
+const DEFAULT_MERMAID_CONFIG = `%% This won't render without implementing a rendering engine (e.g. mermaid on npm)
+flowchart TD
+    id1(this is an example flow diagram)
+    --> id2(modify me to see changes!)
+    id2
+    --> id3(Click the top button to preview the changes)
+    --> id4(Learn about mermaid diagrams - mermaid.js.org)`;
+
+const useMermaidToolbarButtonState = () => {
+  const editor = useEditorState();
+
+  const isBlockActive = () => helpers.isNodeActive(editor, CodeBlockPlugin.key);
+
+  return {
+    pressed: isBlockActive(),
+  };
+};
+
+function makeCodeLine(text: string): CodeLineElement {
+  return {
+    type: 'code_line',
+    children: [{ text }],
+  };
+}
+
+const useMermaidToolbarButton = (state) => {
+  const editor = useEditorState();
+
+  const onClick = () => {
+    const newMermaidCodeBlockNode: TElement = {
+      type: CodeBlockPlugin.key,
+      lang: 'mermaid',
+      children: DEFAULT_MERMAID_CONFIG.split('\n').map(makeCodeLine),
+      value: DEFAULT_MERMAID_CONFIG,
+    };
+
+    editor.tf.insertNodes(newMermaidCodeBlockNode, {
+      nextBlock: true,
+      select: true,
+    });
+  };
+
+  const onMouseDown = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return {
+    props: {
+      onClick,
+      onMouseDown,
+      pressed: state.pressed,
+    },
+  };
+};
+
+export const MermaidToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+  }
+>(({ clear, ...rest }, ref) => {
+  const state = useMermaidToolbarButtonState();
+
+  const { props } = useMermaidToolbarButton(state);
+
+  return (
+    <ToolbarButton ref={ref} tooltip='Mermaid' {...rest} {...props}>
+      <Icons.mermaid />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/overflow-menu.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/overflow-menu.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+  useOpenState,
+} from '../plate-ui/dropdown-menu';
+import { Icons } from './icons';
+import { ToolbarButton } from './toolbar';
+
+type OverflowMenuProps = {
+  [key: string]: any;
+  children: React.ReactNode[];
+};
+export default function OverflowMenu({
+  children,
+  ...props
+}: OverflowMenuProps) {
+  const openState = useOpenState();
+
+  return (
+    <DropdownMenu modal={false} {...openState} {...props}>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton
+          showArrow={false}
+          data-testid='rich-text-editor-overflow-menu-button'
+          isDropdown
+          pressed={openState.open}
+          tooltip='More tools...'
+        >
+          <Icons.overflow className='size-5' />
+        </ToolbarButton>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align='start' className='min-w-0 flex flex-grow'>
+        {children}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/paragraph-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/paragraph-element.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import React from 'react';
+
+import { cn } from '@tinacms/ui/lib/utils';
+import { PlateElement, withRef } from '@udecode/plate/react';
+
+export const ParagraphElement = withRef<typeof PlateElement>(
+  ({ children, className, ...props }, ref) => {
+    return (
+      <PlateElement
+        ref={ref}
+        className={cn(className, 'm-0 px-0 py-1')}
+        {...props}
+      >
+        {children}
+      </PlateElement>
+    );
+  }
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/popover.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/popover.tsx
@@ -1,0 +1,41 @@
+'use client';
+import * as React from 'react';
+
+import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { cn, withRef } from '@udecode/cn';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+export const Popover = PopoverPrimitive.Root;
+
+export const PopoverTrigger = PopoverPrimitive.Trigger;
+
+export const PopoverAnchor = PopoverPrimitive.Anchor;
+
+export const popoverVariants = cva(
+  'z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden print:hidden',
+  {
+    defaultVariants: {
+      animate: true,
+    },
+    variants: {
+      animate: {
+        true: 'data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95',
+      },
+    },
+  }
+);
+
+export const PopoverContent = withRef<
+  typeof PopoverPrimitive.Content,
+  VariantProps<typeof popoverVariants>
+>(({ align = 'center', animate, className, sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      className={cn(popoverVariants({ animate }), className)}
+      align={align}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+));

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/quote-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/quote-toolbar-button.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { withRef } from '@udecode/cn';
+
+import { Icons } from './icons';
+
+import { BaseBlockquotePlugin } from '@udecode/plate-block-quote';
+import { useEditorState } from '@udecode/plate/react';
+import { helpers } from '../../plugins/core/common';
+import { ToolbarButton } from './toolbar';
+
+const useBlockQuoteToolbarButtonState = () => {
+  const editor = useEditorState();
+
+  const isBlockActive = () =>
+    helpers.isNodeActive(editor, BaseBlockquotePlugin.key);
+
+  return {
+    pressed: isBlockActive(),
+  };
+};
+
+const useBlockQuoteToolbarButton = (state) => {
+  const editor = useEditorState();
+
+  const onClick = () => {
+    editor.tf.toggleBlock(BaseBlockquotePlugin.key);
+  };
+
+  const onMouseDown = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
+  return {
+    props: {
+      onClick,
+      onMouseDown,
+      pressed: state.pressed,
+    },
+  };
+};
+
+export const QuoteToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+  }
+>(({ clear, ...rest }, ref) => {
+  const state = useBlockQuoteToolbarButtonState();
+  const { props } = useBlockQuoteToolbarButton(state);
+
+  return (
+    <ToolbarButton ref={ref} tooltip='Quote (⌘+⇧+.)' {...rest} {...props}>
+      <Icons.quote />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/raw-markdown-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/raw-markdown-toolbar-button.tsx
@@ -1,0 +1,40 @@
+import { withRef } from '@udecode/cn';
+import React from 'react';
+import { useEditorContext } from '../../editor-context';
+import { Icons } from './icons';
+import { ToolbarButton } from './toolbar';
+
+const useRawMarkdownToolbarButton = () => {
+  const { setRawMode } = useEditorContext();
+
+  const onMouseDown = (e) => {
+    setRawMode(true);
+  };
+
+  return {
+    props: {
+      onMouseDown,
+      pressed: false,
+    },
+  };
+};
+
+export const RawMarkdownToolbarButton = withRef<
+  typeof ToolbarButton,
+  {
+    clear?: string | string[];
+  }
+>(({ clear, ...rest }, ref) => {
+  const { props } = useRawMarkdownToolbarButton();
+  return (
+    <ToolbarButton
+      ref={ref}
+      tooltip='Raw Markdown'
+      {...rest}
+      {...props}
+      data-testid='markdown-button'
+    >
+      <Icons.raw />
+    </ToolbarButton>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/resizable.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/resizable.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React from 'react';
+
+import { cn, withRef, withVariants } from '@udecode/cn';
+import {
+  Resizable as ResizablePrimitive,
+  ResizeHandle as ResizeHandlePrimitive,
+} from '@udecode/plate-resizable';
+import { cva } from 'class-variance-authority';
+
+export const mediaResizeHandleVariants = cva(
+  cn(
+    'top-0 flex w-6 select-none flex-col justify-center',
+    "after:flex after:h-16 after:w-[3px] after:rounded-[6px] after:bg-ring after:opacity-0 after:content-['_'] group-hover:after:opacity-100"
+  ),
+  {
+    variants: {
+      direction: {
+        left: '-left-3 -ml-3 pl-3',
+        right: '-right-3 -mr-3 items-end pr-3',
+      },
+    },
+  }
+);
+
+const resizeHandleVariants = cva(cn('absolute z-40'), {
+  variants: {
+    direction: {
+      bottom: 'w-full cursor-row-resize',
+      left: 'h-full cursor-col-resize',
+      right: 'h-full cursor-col-resize',
+      top: 'w-full cursor-row-resize',
+    },
+  },
+});
+
+const ResizeHandleVariants = withVariants(
+  ResizeHandlePrimitive,
+  resizeHandleVariants,
+  ['direction']
+);
+
+export const ResizeHandle = withRef<typeof ResizeHandlePrimitive>(
+  (props, ref) => (
+    <ResizeHandleVariants
+      direction={props.options?.direction}
+      ref={ref}
+      {...props}
+    />
+  )
+);
+
+const resizableVariants = cva('', {
+  variants: {
+    align: {
+      center: 'mx-auto',
+      left: 'mr-auto',
+      right: 'ml-auto',
+    },
+  },
+});
+
+export const Resizable = withVariants(ResizablePrimitive, resizableVariants, [
+  'align',
+]);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/separator.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/separator.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import { withProps, withVariants } from '@udecode/cn';
+import { cva } from 'class-variance-authority';
+
+const separatorVariants = cva('shrink-0 bg-border', {
+  defaultVariants: {
+    orientation: 'horizontal',
+  },
+  variants: {
+    orientation: {
+      horizontal: 'h-px w-full',
+      vertical: 'h-full w-px',
+    },
+  },
+});
+
+export const Separator = withVariants(
+  withProps(SeparatorPrimitive.Root, {
+    decorative: true,
+    orientation: 'horizontal',
+  }),
+  separatorVariants
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/slash-input-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/slash-input-element.tsx
@@ -1,0 +1,133 @@
+import React, { type ComponentType, type SVGProps } from 'react';
+
+import { withRef } from '@udecode/cn';
+import { HEADING_KEYS } from '@udecode/plate-heading';
+import { type PlateEditor, PlateElement } from '@udecode/plate/react';
+import { Icons } from './icons';
+
+import { toggleList } from '@udecode/plate-list';
+import {
+  BulletedListPlugin,
+  NumberedListPlugin,
+} from '@udecode/plate-list/react';
+import type { HeadingLevel } from '../../toolbar/toolbar-overrides';
+import { useToolbarContext } from '../../toolbar/toolbar-provider';
+import {
+  InlineCombobox,
+  InlineComboboxContent,
+  InlineComboboxEmpty,
+  InlineComboboxInput,
+  InlineComboboxItem,
+} from './inline-combobox';
+
+interface SlashCommandRule {
+  icon: ComponentType<SVGProps<SVGSVGElement>>;
+  onSelect: (editor: PlateEditor) => void;
+  value: string;
+  keywords?: string[];
+}
+
+const headingRulesByLevel: Record<HeadingLevel, SlashCommandRule> = {
+  h1: {
+    icon: Icons.h1,
+    onSelect: (editor) => editor.tf.toggleBlock(HEADING_KEYS.h1),
+    value: 'Heading 1',
+  },
+  h2: {
+    icon: Icons.h2,
+    onSelect: (editor) => editor.tf.toggleBlock(HEADING_KEYS.h2),
+    value: 'Heading 2',
+  },
+  h3: {
+    icon: Icons.h3,
+    onSelect: (editor) => editor.tf.toggleBlock(HEADING_KEYS.h3),
+    value: 'Heading 3',
+  },
+  h4: {
+    icon: Icons.h4,
+    onSelect: (editor) => editor.tf.toggleBlock(HEADING_KEYS.h4),
+    value: 'Heading 4',
+  },
+  h5: {
+    icon: Icons.h5,
+    onSelect: (editor) => editor.tf.toggleBlock(HEADING_KEYS.h5),
+    value: 'Heading 5',
+  },
+  h6: {
+    icon: Icons.h6,
+    onSelect: (editor) => editor.tf.toggleBlock(HEADING_KEYS.h6),
+    value: 'Heading 6',
+  },
+};
+
+const DEFAULT_SLASH_HEADING_LEVELS: readonly HeadingLevel[] = [
+  'h1',
+  'h2',
+  'h3',
+];
+
+const listRules: SlashCommandRule[] = [
+  {
+    icon: Icons.ul,
+    keywords: ['ul', 'unordered list'],
+    onSelect: (editor) => {
+      toggleList(editor, { type: BulletedListPlugin.key });
+    },
+    value: 'Bulleted list',
+  },
+  {
+    icon: Icons.ol,
+    keywords: ['ol', 'ordered list'],
+    onSelect: (editor) => {
+      toggleList(editor, { type: NumberedListPlugin.key });
+    },
+    value: 'Numbered list',
+  },
+];
+
+export const SlashInputElement = withRef<typeof PlateElement>(
+  ({ className, ...props }, ref) => {
+    const { children, editor, element } = props;
+    const { headingLevels, headingLevelsConfigured } = useToolbarContext();
+    const slashHeadingLevels = headingLevelsConfigured
+      ? headingLevels
+      : DEFAULT_SLASH_HEADING_LEVELS;
+    const rules: SlashCommandRule[] = [
+      ...slashHeadingLevels.map((level) => headingRulesByLevel[level]),
+      ...listRules,
+    ];
+
+    return (
+      <PlateElement
+        as='span'
+        data-slate-value={element.value}
+        ref={ref}
+        {...props}
+      >
+        <InlineCombobox element={element} trigger='/'>
+          <InlineComboboxInput />
+
+          <InlineComboboxContent>
+            <InlineComboboxEmpty>
+              No matching commands found
+            </InlineComboboxEmpty>
+
+            {rules.map(({ icon: Icon, keywords, onSelect, value }) => (
+              <InlineComboboxItem
+                key={value}
+                keywords={keywords}
+                onClick={() => onSelect(editor)}
+                value={value}
+              >
+                <Icon aria-hidden className='mr-2 size-4' />
+                {value}
+              </InlineComboboxItem>
+            ))}
+          </InlineComboboxContent>
+        </InlineCombobox>
+
+        {children}
+      </PlateElement>
+    );
+  }
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/block-selection.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/block-selection.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import React from 'react';
+
+import { cn } from '@tinacms/ui/lib/utils';
+import { DndPlugin } from '@udecode/plate-dnd';
+import { useBlockSelected } from '@udecode/plate-selection/react';
+import { usePluginOption } from '@udecode/plate/react';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+export const blockSelectionVariants = cva(
+  'pointer-events-none absolute inset-0 z-1 bg-brand/[.13] transition-opacity',
+  {
+    defaultVariants: {
+      active: true,
+    },
+    variants: {
+      active: {
+        false: 'opacity-0',
+        true: 'opacity-100',
+      },
+    },
+  }
+);
+
+export function BlockSelection({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement> &
+  VariantProps<typeof blockSelectionVariants>) {
+  const isBlockSelected = useBlockSelected();
+  const isDragging = usePluginOption(DndPlugin, 'isDragging');
+
+  if (!isBlockSelected) return null;
+
+  return (
+    <div
+      className={cn(
+        blockSelectionVariants({
+          active: isBlockSelected && !isDragging,
+        }),
+        className
+      )}
+      data-slot='block-selection'
+      {...props}
+    />
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-cell-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-cell-element.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import React from 'react';
+
+import type { TTableCellElement } from '@udecode/plate-table';
+
+import { cn, withProps, withRef } from '@udecode/cn';
+import { useBlockSelected } from '@udecode/plate-selection/react';
+import {
+  TablePlugin,
+  TableRowPlugin,
+  useTableCellElement,
+} from '@udecode/plate-table/react';
+import {
+  PlateElement,
+  useEditorPlugin,
+  useElementSelector,
+} from '@udecode/plate/react';
+
+import { blockSelectionVariants } from './block-selection';
+
+export const TableCellElement = withRef<
+  typeof PlateElement,
+  {
+    isHeader?: boolean;
+  }
+>(({ children, className, isHeader, style, ...props }, ref) => {
+  const { api } = useEditorPlugin(TablePlugin);
+  const element = props.element as TTableCellElement;
+
+  const rowId = useElementSelector(([node]) => node.id as string, [], {
+    key: TableRowPlugin.key,
+  });
+  const isSelectingRow = useBlockSelected(rowId);
+  const { borders, minHeight, selected, width } = useTableCellElement();
+
+  return (
+    <PlateElement
+      ref={ref}
+      as={isHeader ? 'th' : 'td'}
+      attributes={() => ({
+        ...props.attributes,
+        colSpan: api.table.getColSpan(element),
+        rowSpan: api.table.getRowSpan(element),
+      })}
+      className={cn(
+        'relative h-full overflow-visible border border-gray-200 bg-background p-0',
+        element.background ? 'bg-[--cellBackground]' : 'bg-background',
+        cn(
+          isHeader && 'text-left [&_>_*]:m-0',
+          'before:size-full',
+          selected && 'before:z-10 before:bg-muted',
+          "before:absolute before:box-border before:select-none before:content-['']"
+        ),
+        className
+      )}
+      style={
+        {
+          '--cellBackground': element.background,
+          maxWidth: width || 240,
+          minWidth: width || 120,
+          ...style,
+        } as React.CSSProperties
+      }
+      {...props}
+    >
+      <div
+        className='relative z-20 box-border h-full px-3 py-2'
+        style={{ minHeight }}
+      >
+        {children}
+      </div>
+
+      {isSelectingRow && (
+        <div className={blockSelectionVariants()} contentEditable={false} />
+      )}
+    </PlateElement>
+  );
+});
+
+export const TableCellHeaderElement = withProps(TableCellElement, {
+  isHeader: true,
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-dropdown-menu.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-dropdown-menu.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import type { DropdownMenuProps } from '@radix-ui/react-dropdown-menu';
+
+import { cn } from '@tinacms/ui/lib/utils';
+import { TablePlugin, useTableMergeState } from '@udecode/plate-table/react';
+import { useEditorPlugin, useEditorSelector } from '@udecode/plate/react';
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  Combine,
+  Grid3x3Icon,
+  Table,
+  Trash2Icon,
+  Ungroup,
+  XIcon,
+} from 'lucide-react';
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+  useOpenState,
+} from '../dropdown-menu';
+import { ToolbarButton } from '../toolbar';
+
+export function TableDropdownMenu(props: DropdownMenuProps) {
+  const tableSelected = useEditorSelector(
+    (editor) => editor.api.some({ match: { type: TablePlugin.key } }),
+    []
+  );
+
+  const { editor, tf } = useEditorPlugin(TablePlugin);
+  const openState = useOpenState();
+  const mergeState = useTableMergeState();
+
+  return (
+    <DropdownMenu modal={false} {...openState} {...props}>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton pressed={openState.open} tooltip='Table' isDropdown>
+          <Table />
+        </ToolbarButton>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent
+        className='flex w-[180px] min-w-0 flex-col'
+        align='start'
+      >
+        <DropdownMenuGroup>
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger>
+              <Grid3x3Icon />
+              <span>Table</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className='m-0 p-0'>
+              <TablePicker />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger disabled={!tableSelected}>
+              <div className='size-4' />
+              <span>Cell</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!mergeState.canMerge}
+                onSelect={() => {
+                  tf.table.merge();
+                  editor.tf.focus();
+                }}
+              >
+                <Combine />
+                Merge cells
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!mergeState.canSplit}
+                onSelect={() => {
+                  tf.table.split();
+                  editor.tf.focus();
+                }}
+              >
+                <Ungroup />
+                Split cell
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger disabled={!tableSelected}>
+              <div className='size-4' />
+              <span>Row</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!tableSelected}
+                onSelect={() => {
+                  tf.insert.tableRow({ before: true });
+                  editor.tf.focus();
+                }}
+              >
+                <ArrowUp />
+                Insert row before
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!tableSelected}
+                onSelect={() => {
+                  tf.insert.tableRow();
+                  editor.tf.focus();
+                }}
+              >
+                <ArrowDown />
+                Insert row after
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!tableSelected}
+                onSelect={() => {
+                  tf.remove.tableRow();
+                  editor.tf.focus();
+                }}
+              >
+                <XIcon />
+                Delete row
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuSub>
+            <DropdownMenuSubTrigger disabled={!tableSelected}>
+              <div className='size-4' />
+              <span>Column</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!tableSelected}
+                onSelect={() => {
+                  tf.insert.tableColumn({ before: true });
+                  editor.tf.focus();
+                }}
+              >
+                <ArrowLeft />
+                Insert column before
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!tableSelected}
+                onSelect={() => {
+                  tf.insert.tableColumn();
+                  editor.tf.focus();
+                }}
+              >
+                <ArrowRight />
+                Insert column after
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                className='min-w-[180px]'
+                disabled={!tableSelected}
+                onSelect={() => {
+                  tf.remove.tableColumn();
+                  editor.tf.focus();
+                }}
+              >
+                <XIcon />
+                Delete column
+              </DropdownMenuItem>
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+
+          <DropdownMenuItem
+            className='min-w-[180px]'
+            disabled={!tableSelected}
+            onSelect={() => {
+              tf.remove.table();
+              editor.tf.focus();
+            }}
+          >
+            <Trash2Icon />
+            Delete table
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+export function TablePicker() {
+  const { editor, tf } = useEditorPlugin(TablePlugin);
+
+  const [tablePicker, setTablePicker] = useState({
+    grid: Array.from({ length: 8 }, () => Array.from({ length: 8 }).fill(0)),
+    size: { colCount: 0, rowCount: 0 },
+  });
+
+  const onCellMove = (rowIndex: number, colIndex: number) => {
+    const newGrid = [...tablePicker.grid];
+
+    for (let i = 0; i < newGrid.length; i++) {
+      for (let j = 0; j < newGrid[i].length; j++) {
+        newGrid[i][j] =
+          i >= 0 && i <= rowIndex && j >= 0 && j <= colIndex ? 1 : 0;
+      }
+    }
+
+    setTablePicker({
+      grid: newGrid,
+      size: { colCount: colIndex + 1, rowCount: rowIndex + 1 },
+    });
+  };
+
+  return (
+    <div
+      className='m-0 flex! flex-col p-0'
+      onClick={() => {
+        tf.insert.table(tablePicker.size, { select: true });
+        editor.tf.focus();
+      }}
+    >
+      <div className='grid size-[130px] grid-cols-8 gap-0.5 p-1'>
+        {tablePicker.grid.map((rows, rowIndex) =>
+          rows.map((value, columIndex) => {
+            return (
+              <div
+                key={`(${rowIndex},${columIndex})`}
+                className={cn(
+                  'col-span-1 size-3 border border-solid bg-secondary',
+                  !!value && 'border-current'
+                )}
+                onMouseMove={() => {
+                  onCellMove(rowIndex, columIndex);
+                }}
+              />
+            );
+          })
+        )}
+      </div>
+
+      <div className='text-center text-xs text-current'>
+        {tablePicker.size.rowCount} x {tablePicker.size.colCount}
+      </div>
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-element.tsx
@@ -1,0 +1,360 @@
+'use client';
+
+import React, { useCallback, useState } from 'react';
+
+import type * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+
+import { PopoverAnchor } from '@radix-ui/react-popover';
+import { cn, withRef } from '@udecode/cn';
+import { BlockSelectionPlugin } from '@udecode/plate-selection/react';
+import { type TTableElement, setCellBackground } from '@udecode/plate-table';
+import {
+  TablePlugin,
+  TableProvider,
+  useTableBordersDropdownMenuContentState,
+  useTableElement,
+  useTableMergeState,
+} from '@udecode/plate-table/react';
+import {
+  PlateElement,
+  useEditorPlugin,
+  useEditorRef,
+  useEditorSelector,
+  useElement,
+  usePluginOption,
+  useReadOnly,
+  useRemoveNodeButton,
+  useSelected,
+  withHOC,
+} from '@udecode/plate/react';
+import {
+  ArrowDown,
+  ArrowLeft,
+  ArrowRight,
+  ArrowUp,
+  CombineIcon,
+  EraserIcon,
+  Grid2X2Icon,
+  PaintBucketIcon,
+  SquareSplitHorizontalIcon,
+  Trash2Icon,
+  XIcon,
+} from 'lucide-react';
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+} from '../dropdown-menu';
+import { Popover, PopoverContent } from '../popover';
+import { Toolbar, ToolbarButton, ToolbarGroup } from '../toolbar';
+
+export const TableElement = withHOC(
+  TableProvider,
+  withRef<typeof PlateElement>(({ children, className, ...props }, ref) => {
+    const readOnly = useReadOnly();
+    const isSelectionAreaVisible = usePluginOption(
+      BlockSelectionPlugin,
+      'isSelectionAreaVisible'
+    );
+    const hasControls = !readOnly && !isSelectionAreaVisible;
+    const selected = useSelected();
+    const {
+      isSelectingCell,
+      marginLeft,
+      props: tableProps,
+    } = useTableElement();
+
+    const content = (
+      <PlateElement
+        ref={ref}
+        className={cn(
+          className,
+          'overflow-x-auto py-2',
+          hasControls && '*:data-[slot=block-selection]:left-2'
+        )}
+        style={{ paddingLeft: marginLeft }}
+        {...props}
+      >
+        <div className='group/table relative w-fit'>
+          <table
+            className={cn(
+              'mr-0 table h-px border-collapse border border-gray-200 not-tina-prose my-2',
+              isSelectingCell && 'selection:bg-transparent'
+            )}
+            {...tableProps}
+          >
+            <tbody className='min-w-full'>{children}</tbody>
+          </table>
+        </div>
+      </PlateElement>
+    );
+
+    if (readOnly || !selected) {
+      return content;
+    }
+
+    return <TableFloatingToolbar>{content}</TableFloatingToolbar>;
+  })
+);
+
+export const TableFloatingToolbar = withRef<typeof PopoverContent>(
+  ({ children, ...props }, ref) => {
+    const { tf } = useEditorPlugin(TablePlugin);
+    const element = useElement<TTableElement>();
+    const { props: buttonProps } = useRemoveNodeButton({ element });
+    const collapsed = useEditorSelector(
+      (editor) => !editor.api.isExpanded(),
+      []
+    );
+
+    const { canMerge, canSplit } = useTableMergeState();
+
+    return (
+      <Popover open={canMerge || canSplit || collapsed} modal={false}>
+        <PopoverAnchor asChild>{children}</PopoverAnchor>
+        <PopoverContent
+          ref={ref}
+          asChild
+          onOpenAutoFocus={(e) => e.preventDefault()}
+          contentEditable={false}
+          {...props}
+        >
+          <Toolbar
+            className='scrollbar-hide flex w-auto max-w-[80vw] flex-row overflow-x-auto rounded-md border bg-popover p-1 shadow-md print:hidden'
+            contentEditable={false}
+          >
+            <ToolbarGroup>
+              <ColorDropdownMenu tooltip='Background color'>
+                <PaintBucketIcon />
+              </ColorDropdownMenu>
+              {canMerge && (
+                <ToolbarButton
+                  onClick={() => tf.table.merge()}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Merge cells'
+                >
+                  <CombineIcon />
+                </ToolbarButton>
+              )}
+              {canSplit && (
+                <ToolbarButton
+                  onClick={() => tf.table.split()}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Split cell'
+                >
+                  <SquareSplitHorizontalIcon />
+                </ToolbarButton>
+              )}
+
+              <DropdownMenu modal={false}>
+                <DropdownMenuTrigger asChild>
+                  <ToolbarButton tooltip='Cell borders'>
+                    <Grid2X2Icon />
+                  </ToolbarButton>
+                </DropdownMenuTrigger>
+
+                <DropdownMenuPortal>
+                  <TableBordersDropdownMenuContent />
+                </DropdownMenuPortal>
+              </DropdownMenu>
+
+              {collapsed && (
+                <ToolbarGroup>
+                  <ToolbarButton tooltip='Delete table' {...buttonProps}>
+                    <Trash2Icon />
+                  </ToolbarButton>
+                </ToolbarGroup>
+              )}
+            </ToolbarGroup>
+
+            {collapsed && (
+              <ToolbarGroup>
+                <ToolbarButton
+                  onClick={() => {
+                    tf.insert.tableRow({ before: true });
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Insert row before'
+                >
+                  <ArrowUp />
+                </ToolbarButton>
+                <ToolbarButton
+                  onClick={() => {
+                    tf.insert.tableRow();
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Insert row after'
+                >
+                  <ArrowDown />
+                </ToolbarButton>
+                <ToolbarButton
+                  onClick={() => {
+                    tf.remove.tableRow();
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Delete row'
+                >
+                  <XIcon />
+                </ToolbarButton>
+              </ToolbarGroup>
+            )}
+
+            {collapsed && (
+              <ToolbarGroup>
+                <ToolbarButton
+                  onClick={() => {
+                    tf.insert.tableColumn({ before: true });
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Insert column before'
+                >
+                  <ArrowLeft />
+                </ToolbarButton>
+                <ToolbarButton
+                  onClick={() => {
+                    tf.insert.tableColumn();
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Insert column after'
+                >
+                  <ArrowRight />
+                </ToolbarButton>
+                <ToolbarButton
+                  onClick={() => {
+                    tf.remove.tableColumn();
+                  }}
+                  onMouseDown={(e) => e.preventDefault()}
+                  tooltip='Delete column'
+                >
+                  <XIcon />
+                </ToolbarButton>
+              </ToolbarGroup>
+            )}
+          </Toolbar>
+        </PopoverContent>
+      </Popover>
+    );
+  }
+);
+
+export const TableBordersDropdownMenuContent = withRef<
+  typeof DropdownMenuPrimitive.Content
+>((props, ref) => {
+  const editor = useEditorRef();
+  const {
+    getOnSelectTableBorder,
+    hasBottomBorder,
+    hasLeftBorder,
+    hasNoBorders,
+    hasOuterBorders,
+    hasRightBorder,
+    hasTopBorder,
+  } = useTableBordersDropdownMenuContentState();
+
+  return (
+    <DropdownMenuContent
+      ref={ref}
+      className={cn('min-w-[220px]')}
+      onCloseAutoFocus={(e) => {
+        e.preventDefault();
+        editor.tf.focus();
+      }}
+      align='start'
+      side='right'
+      sideOffset={0}
+      {...props}
+    >
+      <DropdownMenuGroup>
+        <DropdownMenuCheckboxItem
+          checked={hasTopBorder}
+          onCheckedChange={getOnSelectTableBorder('top')}
+        >
+          <div>Top Border</div>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={hasRightBorder}
+          onCheckedChange={getOnSelectTableBorder('right')}
+        >
+          <div>Right Border</div>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={hasBottomBorder}
+          onCheckedChange={getOnSelectTableBorder('bottom')}
+        >
+          <div>Bottom Border</div>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={hasLeftBorder}
+          onCheckedChange={getOnSelectTableBorder('left')}
+        >
+          <div>Left Border</div>
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuGroup>
+
+      <DropdownMenuGroup>
+        <DropdownMenuCheckboxItem
+          checked={hasNoBorders}
+          onCheckedChange={getOnSelectTableBorder('none')}
+        >
+          <div>No Border</div>
+        </DropdownMenuCheckboxItem>
+        <DropdownMenuCheckboxItem
+          checked={hasOuterBorders}
+          onCheckedChange={getOnSelectTableBorder('outer')}
+        >
+          <div>Outside Borders</div>
+        </DropdownMenuCheckboxItem>
+      </DropdownMenuGroup>
+    </DropdownMenuContent>
+  );
+});
+
+type ColorDropdownMenuProps = {
+  children: React.ReactNode;
+  tooltip: string;
+};
+
+function ColorDropdownMenu({ children, tooltip }: ColorDropdownMenuProps) {
+  const [open, setOpen] = useState(false);
+
+  const editor = useEditorRef();
+  const selectedCells = usePluginOption(TablePlugin, 'selectedCells');
+
+  const onUpdateColor = useCallback(
+    (color: string) => {
+      setOpen(false);
+      setCellBackground(editor, { color, selectedCells: selectedCells ?? [] });
+    },
+    [selectedCells, editor]
+  );
+
+  const onClearColor = useCallback(() => {
+    setOpen(false);
+    setCellBackground(editor, {
+      color: null,
+      selectedCells: selectedCells ?? [],
+    });
+  }, [selectedCells, editor]);
+
+  return (
+    <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton tooltip={tooltip}>{children}</ToolbarButton>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align='start'>
+        <DropdownMenuGroup>
+          <DropdownMenuItem className='p-2' onClick={onClearColor}>
+            <EraserIcon />
+            <span>Clear</span>
+          </DropdownMenuItem>
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-row-element.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/table/table-row-element.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+
+import { cn, withRef } from '@udecode/cn';
+import { useDropLine } from '@udecode/plate-dnd';
+import {
+  PlateElement,
+  useEditorRef,
+  useElement,
+  useSelected,
+} from '@udecode/plate/react';
+import { GripVertical } from 'lucide-react';
+import { Button } from '../button';
+
+export const TableRowElement = withRef<typeof PlateElement>(
+  ({ children, className, ...props }, ref) => {
+    const selected = useSelected();
+
+    return (
+      <PlateElement
+        as='tr'
+        className={cn(className, 'group/row')}
+        data-selected={selected ? 'true' : undefined}
+        {...props}
+      >
+        {children}
+      </PlateElement>
+    );
+  }
+);
+
+function RowDragHandle({ dragRef }: { dragRef: React.Ref<any> }) {
+  const editor = useEditorRef();
+  const element = useElement();
+
+  return (
+    <Button
+      ref={dragRef}
+      variant='outline'
+      className={cn(
+        'absolute top-1/2 left-0 z-51 h-6 w-4 -translate-y-1/2 p-0 focus-visible:ring-0 focus-visible:ring-offset-0',
+        'cursor-grab active:cursor-grabbing',
+        'opacity-0 transition-opacity duration-100 group-hover/row:opacity-100 group-has-data-[resizing="true"]/row:opacity-0'
+      )}
+      onClick={() => {
+        editor.tf.select(element);
+      }}
+    >
+      <GripVertical className='text-muted-foreground' />
+    </Button>
+  );
+}
+
+function DropLine() {
+  const { dropLine } = useDropLine();
+
+  if (!dropLine) return null;
+
+  return (
+    <div
+      className={cn(
+        'absolute inset-x-0 left-2 z-50 h-0.5 bg-brand/50',
+        dropLine === 'top' ? '-top-px' : '-bottom-px'
+      )}
+    />
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/templates-toolbar-button.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/templates-toolbar-button.tsx
@@ -1,0 +1,72 @@
+import { type PlateEditor, useEditorState } from '@udecode/plate/react';
+import React, { useState } from 'react';
+import { insertMDX } from '../../plugins/create-mdx-plugins';
+import { useToolbarContext } from '../../toolbar/toolbar-provider';
+import type { MdxTemplate } from '../../types';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  useOpenState,
+} from './dropdown-menu';
+import { ToolbarButton } from './toolbar';
+
+export default function TemplatesToolbarButton() {
+  const { templates } = useToolbarContext();
+  const editor = useEditorState();
+
+  return <EmbedButton templates={templates} editor={editor} />;
+}
+
+interface EmbedButtonProps {
+  editor: PlateEditor;
+  templates: MdxTemplate[];
+}
+
+const TEMPLATE_COUNT_NEEDING_FILTER = 10;
+
+const EmbedButton: React.FC<EmbedButtonProps> = ({ editor, templates }) => {
+  const { open, onOpenChange } = useOpenState();
+  const [filterText, setFilterText] = useState('');
+
+  const filteredTemplates = templates.filter((template) =>
+    template.name.toLowerCase().includes(filterText.toLowerCase())
+  );
+
+  return (
+    <DropdownMenu modal={false} open={open} onOpenChange={onOpenChange}>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton showArrow isDropdown pressed={open} tooltip='Embed'>
+          Embed
+        </ToolbarButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align='start'
+        className='max-h-72 overflow-y-auto border-border rounded-none rounded-bl rounded-br'
+      >
+        {templates.length > TEMPLATE_COUNT_NEEDING_FILTER && (
+          <input
+            type='text'
+            placeholder='Filter templates...'
+            className='w-full p-2 border border-gray-300 rounded'
+            value={filterText}
+            onChange={(event) => setFilterText(event.target.value)}
+          />
+        )}
+        {filteredTemplates.map((template) => (
+          <DropdownMenuItem
+            key={template.name}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onOpenChange(false);
+              insertMDX(editor, template);
+            }}
+          >
+            {template.label || template.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/text-area.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/text-area.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@tinacms/ui/lib/utils';
+import * as React from 'react';
+
+export interface TextareaProps
+  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          'flex min-h-[80px] w-full rounded border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/toolbar.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/toolbar.tsx
@@ -1,0 +1,167 @@
+'use client';
+
+import * as React from 'react';
+
+import * as ToolbarPrimitive from '@radix-ui/react-toolbar';
+import { cn, withCn, withRef, withVariants } from '@udecode/cn';
+import { type VariantProps, cva } from 'class-variance-authority';
+
+import { Icons } from './icons';
+
+import { Separator } from './separator';
+import { withTooltip } from './tooltip';
+
+export const Toolbar = withCn(
+  ToolbarPrimitive.Root,
+  'relative flex select-none items-center gap-1 bg-background'
+);
+
+export const ToolbarToggleGroup = withCn(
+  ToolbarPrimitive.ToolbarToggleGroup,
+  'flex items-center'
+);
+
+export const ToolbarLink = withCn(
+  ToolbarPrimitive.Link,
+  'font-medium underline underline-offset-4'
+);
+
+export const ToolbarSeparator = withCn(
+  ToolbarPrimitive.Separator,
+  'my-1 w-px shrink-0 bg-border'
+);
+
+const toolbarButtonVariants = cva(
+  cn(
+    'inline-flex items-center justify-center rounded text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+    '[&_svg:not([data-icon])]:size-5'
+  ),
+  {
+    defaultVariants: {
+      size: 'sm',
+      variant: 'default',
+    },
+    variants: {
+      size: {
+        default: 'h-10 px-3',
+        lg: 'h-11 px-5',
+        sm: 'h-9 px-2',
+      },
+      variant: {
+        default:
+          'bg-transparent hover:bg-muted hover:text-muted-foreground aria-checked:bg-accent aria-checked:text-accent-foreground',
+        outline:
+          'border border-input bg-transparent hover:bg-accent hover:text-accent-foreground',
+      },
+    },
+  }
+);
+
+const ToolbarButton = withTooltip(
+  React.forwardRef<
+    React.ElementRef<typeof ToolbarToggleItem>,
+    {
+      isDropdown?: boolean;
+      pressed?: boolean;
+      showArrow?: boolean;
+    } & Omit<
+      React.ComponentPropsWithoutRef<typeof ToolbarToggleItem>,
+      'asChild' | 'value'
+    > &
+      VariantProps<typeof toolbarButtonVariants>
+  >(
+    (
+      {
+        children,
+        className,
+        isDropdown = true,
+        showArrow,
+        pressed,
+        size,
+        variant,
+        ...props
+      },
+      ref
+    ) => {
+      return typeof pressed === 'boolean' ? (
+        <ToolbarToggleGroup
+          disabled={props.disabled}
+          type='single'
+          value='single'
+        >
+          <ToolbarToggleItem
+            className={cn(
+              toolbarButtonVariants({
+                size,
+                variant,
+              }),
+              isDropdown && 'my-1 justify-between',
+              className
+            )}
+            ref={ref}
+            value={pressed ? 'single' : ''}
+            {...props}
+          >
+            {isDropdown && showArrow ? (
+              <>
+                <div className='flex flex-1'>{children}</div>
+                <div>
+                  <Icons.arrowDown className='ml-0.5 size-4' data-icon />
+                </div>
+              </>
+            ) : (
+              children
+            )}
+          </ToolbarToggleItem>
+        </ToolbarToggleGroup>
+      ) : (
+        <ToolbarPrimitive.Button
+          className={cn(
+            toolbarButtonVariants({
+              size,
+              variant,
+            }),
+            isDropdown && 'pr-1',
+            className
+          )}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </ToolbarPrimitive.Button>
+      );
+    }
+  )
+);
+ToolbarButton.displayName = 'ToolbarButton';
+
+export { ToolbarButton };
+
+export const ToolbarToggleItem = withVariants(
+  ToolbarPrimitive.ToggleItem,
+  toolbarButtonVariants,
+  ['variant', 'size']
+);
+
+export const ToolbarGroup = withRef<
+  'div',
+  {
+    noSeparator?: boolean;
+  }
+>(({ children, className, noSeparator }, ref) => {
+  const childArr = React.Children.map(children, (c) => c);
+
+  if (!childArr || childArr.length === 0) return null;
+
+  return (
+    <div className={cn('flex', className)} ref={ref}>
+      {!noSeparator && (
+        <div className='h-full py-1'>
+          <Separator orientation='vertical' />
+        </div>
+      )}
+
+      <div className='mx-1 flex items-center gap-1'>{children}</div>
+    </div>
+  );
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/tooltip.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/tooltip.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React from 'react';
+
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+import { withCn, withProps } from '@udecode/cn';
+
+export const TooltipProvider = TooltipPrimitive.Provider;
+
+export const Tooltip = TooltipPrimitive.Root;
+
+export const TooltipTrigger = TooltipPrimitive.Trigger;
+
+export const TooltipPortal = TooltipPrimitive.Portal;
+
+export const TooltipContent = withCn(
+  withProps(TooltipPrimitive.Content, {
+    sideOffset: 4,
+  }),
+  'z-[9999] overflow-hidden rounded border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md'
+);
+
+export function withTooltip<T extends React.ElementType>(Component: T) {
+  return React.forwardRef<
+    React.ComponentRef<T>,
+    {
+      tooltip?: React.ReactNode;
+      tooltipContentProps?: Omit<
+        React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>,
+        'children'
+      >;
+      tooltipProps?: Omit<
+        React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Root>,
+        'children'
+      >;
+    } & React.ComponentPropsWithoutRef<T>
+  >(function ExtendComponent(
+    { tooltip, tooltipContentProps, tooltipProps, ...props },
+    ref
+  ) {
+    const [mounted, setMounted] = React.useState(false);
+
+    React.useEffect(() => {
+      setMounted(true);
+    }, []);
+
+    const component = <Component ref={ref} {...(props as any)} />;
+
+    if (tooltip && mounted) {
+      return (
+        <Tooltip {...tooltipProps}>
+          <TooltipTrigger asChild>{component}</TooltipTrigger>
+
+          <TooltipPortal>
+            <TooltipContent {...tooltipContentProps}>{tooltip}</TooltipContent>
+          </TooltipPortal>
+        </Tooltip>
+      );
+    }
+
+    return component;
+  });
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/turn-into-dropdown-menu.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/turn-into-dropdown-menu.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+
+import type { DropdownMenuProps } from '@radix-ui/react-dropdown-menu';
+
+import {
+  ParagraphPlugin,
+  useEditorRef,
+  useEditorSelector,
+  useEditorState,
+} from '@udecode/plate/react';
+
+import {
+  getHeadingItem,
+  headingItemsByLevel,
+  paragraphItem,
+} from './heading-items';
+
+import { toggleList, unwrapList } from '@udecode/plate-list';
+import { TablePlugin } from '@udecode/plate-table/react';
+import { helpers } from '../../plugins/core/common';
+import { useToolbarContext } from '../../toolbar/toolbar-provider';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+  useOpenState,
+} from './dropdown-menu';
+import { ToolbarButton } from './toolbar';
+
+export function TurnIntoDropdownMenu(props: DropdownMenuProps) {
+  const { headingLevels } = useToolbarContext();
+  const items = [
+    paragraphItem,
+    ...headingLevels.map((level) => headingItemsByLevel[level]),
+  ];
+  const value: string = useEditorSelector((editor) => {
+    let initialNodeType: string = ParagraphPlugin.key;
+    let allNodesMatchInitialNodeType = false;
+    const codeBlockEntries = editor.api.nodes({
+      match: (n) => editor.api.isBlock(n),
+      mode: 'highest',
+    });
+    const nodes = Array.from(codeBlockEntries);
+
+    if (nodes.length > 0) {
+      initialNodeType = nodes[0][0].type as string;
+      allNodesMatchInitialNodeType = nodes.every(([node]) => {
+        const type: string = (node?.type as string) || ParagraphPlugin.key;
+
+        return type === initialNodeType;
+      });
+    }
+
+    return allNodesMatchInitialNodeType ? initialNodeType : ParagraphPlugin.key;
+  }, []);
+
+  const editor = useEditorRef();
+  const openState = useOpenState();
+
+  const selectedItem = getHeadingItem(value) ?? paragraphItem;
+  const { icon: SelectedItemIcon, label: selectedItemLabel } = selectedItem;
+
+  const editorState = useEditorState();
+  const userInTable = helpers.isNodeActive(editorState, TablePlugin.key);
+  if (userInTable) return null;
+
+  return (
+    <DropdownMenu modal={false} {...openState} {...props}>
+      <DropdownMenuTrigger asChild>
+        <ToolbarButton
+          className='lg:min-w-[130px]'
+          isDropdown
+          showArrow
+          pressed={openState.open}
+          tooltip='Turn into'
+        >
+          <span className=''>{selectedItemLabel}</span>
+        </ToolbarButton>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align='start' className='min-w-0'>
+        <DropdownMenuLabel>Turn into</DropdownMenuLabel>
+
+        <DropdownMenuRadioGroup
+          className='flex flex-col gap-0.5'
+          onValueChange={(type) => {
+            if (type === 'ul' || type === 'ol') {
+              toggleList(editor, { type });
+            } else {
+              unwrapList(editor);
+              editor.tf.toggleBlock(type);
+            }
+
+            editor.tf.collapse();
+            editor.tf.focus();
+          }}
+          value={value}
+        >
+          {items.map(({ icon: Icon, label, value: itemValue }) => (
+            <DropdownMenuRadioItem
+              className='min-w-[180px]'
+              key={itemValue}
+              value={itemValue}
+            >
+              <Icon className='mr-2 size-5' />
+              {label}
+            </DropdownMenuRadioItem>
+          ))}
+        </DropdownMenuRadioGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/use-floating-toolbar-hook.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/use-floating-toolbar-hook.tsx
@@ -1,0 +1,101 @@
+import { useFloatingToolbarState } from '@udecode/plate-floating';
+import { useEditorSelector, useOnClickOutside } from '@udecode/plate/react';
+import React from 'react';
+
+export const useCustomFloatingToolbar = ({
+  editorId,
+  floating,
+  focusedEditorId,
+  hideToolbar,
+  mousedown,
+  open,
+  readOnly,
+  selectionExpanded,
+  selectionText,
+  setMousedown,
+  setOpen,
+  setWaitForCollapsedSelection,
+  showWhenReadOnly,
+  waitForCollapsedSelection,
+}: ReturnType<typeof useFloatingToolbarState>) => {
+  React.useEffect(() => {
+    if (!(editorId === focusedEditorId)) {
+      setWaitForCollapsedSelection(true);
+    }
+    if (!selectionExpanded) {
+      setWaitForCollapsedSelection(false);
+    }
+  }, [
+    editorId,
+    focusedEditorId,
+    selectionExpanded,
+    setWaitForCollapsedSelection,
+  ]);
+
+  React.useEffect(() => {
+    const mouseup = () => setMousedown(false);
+    const mousedown = () => setMousedown(true);
+
+    document.addEventListener('mouseup', mouseup);
+    document.addEventListener('mousedown', mousedown);
+
+    return () => {
+      document.removeEventListener('mouseup', mouseup);
+      document.removeEventListener('mousedown', mousedown);
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (
+      !selectionExpanded ||
+      !selectionText ||
+      (mousedown && !open) ||
+      hideToolbar ||
+      (readOnly && !showWhenReadOnly)
+    ) {
+      setOpen(false);
+    } else if (
+      selectionText &&
+      selectionExpanded &&
+      (!waitForCollapsedSelection || readOnly)
+    ) {
+      setOpen(true);
+    }
+  }, [
+    setOpen,
+    editorId,
+    focusedEditorId,
+    hideToolbar,
+    showWhenReadOnly,
+    selectionExpanded,
+    selectionText,
+    mousedown,
+    waitForCollapsedSelection,
+    open,
+    readOnly,
+  ]);
+
+  const { update } = floating;
+
+  useEditorSelector(() => {
+    update?.();
+  }, [update]);
+
+  const clickOutsideRef = useOnClickOutside(
+    () => {
+      setOpen(false);
+    },
+    {
+      ignoreClass: 'ignore-click-outside/toolbar',
+    }
+  );
+
+  return {
+    clickOutsideRef,
+    hidden: !open,
+    props: {
+      style: floating.style,
+    },
+    ref: floating.refs.setFloating,
+  };
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/use-floating-toolbar-state.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/components/plate-ui/use-floating-toolbar-state.tsx
@@ -1,0 +1,69 @@
+import { mergeProps } from '@udecode/plate';
+import {
+  FloatingToolbarState,
+  getSelectionBoundingClientRect,
+  useVirtualFloating,
+} from '@udecode/plate-floating';
+import {
+  useEditorReadOnly,
+  useEditorRef,
+  useEditorSelector,
+  useFocused,
+} from '@udecode/plate/react';
+import React from 'react';
+
+export const useCustomFloatingToolbarState = ({
+  editorId,
+  floatingOptions,
+  focusedEditorId,
+  hideToolbar,
+  showWhenReadOnly,
+}: {
+  editorId: string;
+  focusedEditorId: string | null;
+} & FloatingToolbarState) => {
+  const editor = useEditorRef();
+  const selectionExpanded = useEditorSelector(
+    () => editor.api.isExpanded(),
+    []
+  );
+
+  const selectionText = useEditorSelector(() => editor.api.string(), []);
+  const readOnly = useEditorReadOnly();
+
+  const focused = useFocused();
+
+  const [open, setOpen] = React.useState(false);
+  const [waitForCollapsedSelection, setWaitForCollapsedSelection] =
+    React.useState(false);
+  const [mousedown, setMousedown] = React.useState(false);
+
+  const floating = useVirtualFloating(
+    mergeProps(
+      {
+        open,
+        getBoundingClientRect: () => getSelectionBoundingClientRect(editor),
+        onOpenChange: setOpen,
+      },
+      floatingOptions
+    )
+  );
+
+  return {
+    editorId,
+    floating,
+    focused,
+    focusedEditorId,
+    hideToolbar,
+    mousedown,
+    open,
+    readOnly,
+    selectionExpanded,
+    selectionText,
+    setMousedown,
+    setOpen,
+    setWaitForCollapsedSelection,
+    showWhenReadOnly,
+    waitForCollapsedSelection,
+  };
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/editor-context.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/editor-context.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { MdxTemplate } from './types';
+
+export interface EditorContextValue {
+  fieldName: string;
+  templates: MdxTemplate[];
+  rawMode: boolean;
+  setRawMode: (mode: boolean) => void;
+  onActivateField: (address: string) => void;
+}
+
+export const EditorContext = React.createContext<EditorContextValue>({
+  fieldName: '',
+  rawMode: false,
+  setRawMode: () => {},
+  templates: [],
+  onActivateField: () => {},
+});
+
+export const useEditorContext = () => {
+  return React.useContext(EditorContext);
+};
+
+export const useTemplates = () => {
+  return React.useContext(EditorContext);
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/editor-field.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/editor-field.ts
@@ -1,0 +1,7 @@
+import type { ToolbarOverrides } from './toolbar/toolbar-overrides';
+import type { MdxTemplate } from './types';
+
+export interface RichEditorField {
+  templates?: MdxTemplate[];
+  overrides?: ToolbarOverrides;
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/embed-hooks.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/embed-hooks.ts
@@ -1,0 +1,58 @@
+import { useSelected } from '@udecode/plate/react';
+import { isHotkey } from 'is-hotkey';
+import React from 'react';
+import { useEditorContext } from '../editor-context';
+
+const handleCloseBase = (editor, element) => {
+  const path = editor.findPath(element);
+  const editorEl = editor.toDOMNode(editor, editor);
+  if (editorEl) {
+    // FIXME: jumping back from a nested form needs both editor focus and node
+    editorEl.focus();
+    setTimeout(() => {
+      editor.tf.select(path);
+    }, 1);
+  }
+};
+
+const handleRemoveBase = (editor, element) => {
+  const path = editor.findPath(element);
+  editor.tf.removeNodes({
+    at: path,
+  });
+};
+
+export const useHotkey = (key, callback) => {
+  const selected = useSelected();
+
+  const onKeyDown = React.useEffectEvent((e) => {
+    if (!selected || !isHotkey(key, e)) return;
+    e.preventDefault();
+    callback();
+  });
+
+  React.useEffect(() => {
+    document.addEventListener('keydown', onKeyDown);
+
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, []);
+};
+
+export const useEmbedHandles = (editor, element, baseFieldName: string) => {
+  const { onActivateField } = useEditorContext();
+  const [isExpanded, setIsExpanded] = React.useState(false);
+
+  const handleClose = () => {
+    setIsExpanded(false);
+    handleCloseBase(editor, element);
+  };
+  const path = editor.findPath(element);
+  const fieldName = `${baseFieldName}.children.${path.join('.children.')}.props`;
+  const handleSelect = () => onActivateField(fieldName);
+
+  const handleRemove = () => {
+    handleRemoveBase(editor, element);
+  };
+
+  return { isExpanded, handleClose, handleRemove, handleSelect };
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/use-create-editor.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/use-create-editor.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import type { Value } from '@udecode/plate';
+
+import { usePlateEditor } from '@udecode/plate/react';
+
+export const useCreateEditor = ({
+  plugins,
+  value,
+  components = {},
+}: {
+  plugins: any[];
+  value: Value;
+  components?: Record<string, any>;
+}) => {
+  return usePlateEditor<Value, (typeof plugins)[number]>({
+    plugins,
+    value,
+    components,
+  });
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/hooks/use-resize.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/hooks/use-resize.ts
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export const useResize = (
+  ref: React.RefObject<HTMLElement | null>,
+  callback: (entry: ResizeObserverEntry) => void
+) => {
+  const onResize = React.useEffectEvent(callback);
+
+  React.useEffect(() => {
+    if (!ref.current) return;
+
+    const resizeObserver = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        onResize(entry);
+      }
+    });
+    resizeObserver.observe(ref.current);
+
+    return () => resizeObserver.disconnect();
+  }, [ref]);
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/index.tsx
@@ -1,0 +1,82 @@
+import { Plate } from '@udecode/plate/react';
+import React from 'react';
+import type { RichTextValue } from '../value';
+import { Editor, EditorContainer } from './components/editor';
+import FixedToolbarButtons from './components/fixed-toolbar-buttons';
+import { FixedToolbar } from './components/plate-ui/fixed-toolbar';
+import { TooltipProvider } from './components/plate-ui/tooltip';
+import type { RichEditorField } from './editor-field';
+import { useCreateEditor } from './hooks/use-create-editor';
+import { helpers, normalizeLinksInCodeBlocks } from './plugins/core/common';
+import { createEditorPlugins } from './plugins/editor-plugins';
+import { Components } from './plugins/ui/components';
+import { ToolbarProvider } from './toolbar/toolbar-provider';
+
+export interface RichEditorProps {
+  input: {
+    value: RichTextValue;
+    onChange: (value: RichTextValue) => void;
+  };
+  field: RichEditorField;
+  ariaLabel?: string;
+}
+
+export const RichEditor = ({ input, field, ariaLabel }: RichEditorProps) => {
+  const [initialValue] = React.useState(() => {
+    if (input.value?.children?.length) {
+      return helpers.withRootNodeIds(
+        input.value.children.map(helpers.normalize)
+      );
+    }
+    return [{ type: 'p', children: [{ type: 'text', text: '' }] }];
+  });
+  const showFloatingToolbar = field?.overrides?.showFloatingToolbar !== false;
+  const builtPlugins = React.useMemo(
+    () =>
+      createEditorPlugins({
+        headingLevels: field?.overrides?.headingLevels,
+      }),
+    [field?.overrides?.headingLevels]
+  );
+  const plugins = showFloatingToolbar
+    ? builtPlugins
+    : builtPlugins.filter((plugin) => plugin.key !== 'floating-toolbar');
+
+  const editor = useCreateEditor({
+    plugins: [...plugins],
+    value: initialValue,
+    components: Components(),
+  });
+
+  return (
+    <div>
+      <Plate
+        editor={editor}
+        onChange={(value) => {
+          const normalized = (value.value as any[]).map(
+            normalizeLinksInCodeBlocks
+          );
+
+          input.onChange({
+            type: 'root',
+            children: normalized,
+          });
+        }}
+      >
+        <EditorContainer>
+          <TooltipProvider>
+            <ToolbarProvider
+              templates={field.templates ?? []}
+              overrides={field?.overrides}
+            >
+              <FixedToolbar>
+                <FixedToolbarButtons />
+              </FixedToolbar>
+              <Editor aria-label={ariaLabel} />
+            </ToolbarProvider>
+          </TooltipProvider>
+        </EditorContainer>
+      </Plate>
+    </div>
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/media.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/media.tsx
@@ -1,0 +1,46 @@
+import { FileIcon, Trash2Icon } from 'lucide-react';
+import type React from 'react';
+
+export interface Media {
+  id: string;
+  filename: string;
+  src?: string;
+}
+
+export const isImage = (filename: string): boolean =>
+  /\.(gif|jpg|jpeg|tiff|png|svg|webp|avif)(\?.*)?$/i.test(filename);
+
+export const StyledImage = ({ src }: { src: string }) => (
+  <img
+    src={src}
+    alt=''
+    className={`m-0 block h-auto max-h-48 max-w-full overflow-hidden rounded bg-gray-200 object-contain shadow lg:max-h-64 ${
+      /\.svg$/.test(src) ? 'min-w-[12rem]' : ''
+    }`}
+  />
+);
+
+export const StyledFile = ({ src }: { src: string }) => (
+  <div className='flex w-full max-w-full flex-1 items-center justify-start gap-3'>
+    <div className='flex h-12 w-12 flex-none justify-center rounded border border-gray-100 bg-white shadow'>
+      <FileIcon className='h-full w-3/5 text-gray-300' />
+    </div>
+    <span className='w-full flex-1 truncate break-words text-left text-base text-gray-500'>
+      {src}
+    </span>
+  </div>
+);
+
+export const DeleteImageButton = ({
+  onClick,
+}: {
+  onClick: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+}) => (
+  <button
+    type='button'
+    onClick={onClick}
+    className='flex-none rounded border border-gray-100 bg-white p-1.5 shadow'
+  >
+    <Trash2Icon className='h-auto w-5 caret-transparent' />
+  </button>
+);

--- a/packages/v4/@tinacms/rich-text/src/plate/nested-form.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/nested-form.tsx
@@ -1,0 +1,11 @@
+import type { TemplateField } from './types';
+
+// ponytail: stub — editing an embed's props needs a nested form panel, and that
+export const NestedForm = (_props: {
+  onClose: () => void;
+  id: string;
+  label: string;
+  fields: TemplateField[];
+  initialValues: object;
+  onChange: (values: object) => void;
+}) => null;

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-block.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-block.ts
@@ -1,0 +1,66 @@
+import {
+  ALL_HEADING_LEVELS,
+  type HeadingLevel,
+  normalizeHeadingLevels,
+} from '@tinacms/schema-tools';
+import { AutoformatRule } from '@udecode/plate-autoformat';
+import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import { insertEmptyCodeBlock } from '@udecode/plate-code-block';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { HEADING_KEYS } from '@udecode/plate-heading';
+import { HorizontalRulePlugin } from '@udecode/plate-horizontal-rule/react';
+import { ParagraphPlugin } from '@udecode/plate/react';
+import { preFormat } from './autoformat-utils';
+
+const headingAutoformatByLevel: Record<HeadingLevel, AutoformatRule> = {
+  h1: { mode: 'block', type: HEADING_KEYS.h1, match: '# ', preFormat },
+  h2: { mode: 'block', type: HEADING_KEYS.h2, match: '## ', preFormat },
+  h3: { mode: 'block', type: HEADING_KEYS.h3, match: '### ', preFormat },
+  h4: { mode: 'block', type: HEADING_KEYS.h4, match: '#### ', preFormat },
+  h5: { mode: 'block', type: HEADING_KEYS.h5, match: '##### ', preFormat },
+  h6: { mode: 'block', type: HEADING_KEYS.h6, match: '###### ', preFormat },
+};
+
+const nonHeadingAutoformatBlocks: AutoformatRule[] = [
+  {
+    mode: 'block',
+    type: BlockquotePlugin.key,
+    match: '> ',
+    preFormat,
+  },
+  {
+    mode: 'block',
+    type: CodeBlockPlugin.key,
+    match: '```',
+    preFormat,
+    format: (editor) => {
+      insertEmptyCodeBlock(editor, {
+        defaultType: ParagraphPlugin.key,
+        insertNodesOptions: { select: true },
+      });
+    },
+  },
+  {
+    mode: 'block',
+    type: HorizontalRulePlugin.key,
+    match: ['---', '—-', '___ '],
+    format: (editor) => {
+      editor.tf.setNodes({ type: HorizontalRulePlugin.key });
+      editor.tf.insertNodes({
+        type: ParagraphPlugin.key,
+        children: [{ text: '' }],
+      });
+    },
+  },
+];
+
+export const getAutoformatBlocks = (
+  headingLevels: readonly HeadingLevel[] = ALL_HEADING_LEVELS
+): AutoformatRule[] => [
+  ...normalizeHeadingLevels(headingLevels).map(
+    (level) => headingAutoformatByLevel[level]
+  ),
+  ...nonHeadingAutoformatBlocks,
+];
+
+export const autoformatBlocks: AutoformatRule[] = getAutoformatBlocks();

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-lists.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-lists.ts
@@ -1,0 +1,42 @@
+import { AutoformatRule } from '@udecode/plate-autoformat';
+import {
+  BulletedListPlugin,
+  ListItemPlugin,
+  NumberedListPlugin,
+  TodoListPlugin,
+} from '@udecode/plate-list/react';
+import { formatList, preFormat } from './autoformat-utils';
+
+export const autoformatLists: AutoformatRule[] = [
+  {
+    mode: 'block',
+    type: ListItemPlugin.key,
+    match: ['* ', '- '],
+    preFormat,
+    format: (editor) => formatList(editor, BulletedListPlugin.key),
+  },
+  {
+    mode: 'block',
+    type: ListItemPlugin.key,
+    match: ['1. ', '1) '],
+    preFormat,
+    format: (editor) => formatList(editor, NumberedListPlugin.key),
+  },
+  {
+    mode: 'block',
+    type: TodoListPlugin.key,
+    match: '[] ',
+  },
+  {
+    mode: 'block',
+    type: TodoListPlugin.key,
+    match: '[x] ',
+    format: (editor) =>
+      editor.tf.setNodes(
+        { type: TodoListPlugin.key, checked: true },
+        {
+          match: (n) => editor.api.isBlock(n),
+        }
+      ),
+  },
+];

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-marks.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-marks.ts
@@ -1,0 +1,40 @@
+import { AutoformatRule } from '@udecode/plate-autoformat';
+import {
+  BoldPlugin,
+  CodePlugin,
+  ItalicPlugin,
+  StrikethroughPlugin,
+} from '@udecode/plate-basic-marks/react';
+
+export const autoformatMarks: AutoformatRule[] = [
+  {
+    mode: 'mark',
+    type: [BoldPlugin.key, ItalicPlugin.key],
+    match: '***',
+  },
+  {
+    mode: 'mark',
+    type: BoldPlugin.key,
+    match: '**',
+  },
+  {
+    mode: 'mark',
+    type: ItalicPlugin.key,
+    match: '*',
+  },
+  {
+    mode: 'mark',
+    type: ItalicPlugin.key,
+    match: '_',
+  },
+  {
+    mode: 'mark',
+    type: CodePlugin.key,
+    match: '`',
+  },
+  {
+    mode: 'mark',
+    type: StrikethroughPlugin.key,
+    match: ['~~', '~'],
+  },
+];

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-rules.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-rules.ts
@@ -1,0 +1,9 @@
+import { autoformatBlocks } from './autoformat-block';
+import { autoformatLists } from './autoformat-lists';
+import { autoformatMarks } from './autoformat-marks';
+
+export const autoformatRules = [
+  ...autoformatBlocks,
+  ...autoformatLists,
+  ...autoformatMarks,
+];

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-utils.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/autoformat/autoformat-utils.ts
@@ -1,0 +1,34 @@
+import { ElementApi, SlateEditor } from '@udecode/plate';
+import { isType } from '@udecode/plate';
+import { AutoformatBlockRule } from '@udecode/plate-autoformat';
+import {
+  CodeBlockPlugin,
+  CodeLinePlugin,
+} from '@udecode/plate-code-block/react';
+import { toggleList, unwrapList } from '@udecode/plate-list';
+
+export const preFormat: AutoformatBlockRule['preFormat'] = (editor) =>
+  unwrapList(editor);
+
+const format = (editor: SlateEditor, customFormatting: any) => {
+  if (editor.selection) {
+    const parentEntry = editor.api.parent(editor.selection);
+    if (!parentEntry) return;
+    const [node] = parentEntry;
+    if (
+      ElementApi.isElement(node) &&
+      !isType(editor, node, CodeBlockPlugin.key) &&
+      !isType(editor, node, CodeLinePlugin.key)
+    ) {
+      customFormatting();
+    }
+  }
+};
+
+export const formatList = (editor: SlateEditor, elementType: string) => {
+  format(editor, () =>
+    toggleList(editor, {
+      type: elementType,
+    })
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/common.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/common.tsx
@@ -1,0 +1,129 @@
+import { NodeApi } from '@udecode/plate';
+import { getListItemEntry } from '@udecode/plate-list';
+import { type PlateEditor } from '@udecode/plate/react';
+import { ELEMENT_IMG } from '../create-img-plugin';
+import { ELEMENT_MDX_BLOCK, ELEMENT_MDX_INLINE } from '../create-mdx-plugins';
+import { HANDLES_MDX } from './formatting';
+
+export const unsupportedItemsInTable = new Set([
+  'Code Block',
+  'Unordered List',
+  'Ordered List',
+  'Horizontal Rule',
+  'Quote',
+  'Mermaid',
+  'Heading 1',
+  'Heading 2',
+  'Heading 3',
+  'Heading 4',
+  'Heading 5',
+  'Heading 6',
+]);
+
+const isNodeActive = (editor, type) => {
+  const pluginType = editor.getType(type);
+  return (
+    !!editor?.selection && editor.api.some({ match: { type: pluginType } })
+  );
+};
+
+const isListActive = (editor, type) => {
+  const res = !!editor?.selection && getListItemEntry(editor);
+  return !!res && res.list[0].type === type;
+};
+
+let seededNodeIds = 0;
+const withRootNodeIds = (nodes: any[]) =>
+  nodes.map((node) =>
+    node.id ? node : { ...node, id: `seed-${++seededNodeIds}` }
+  );
+
+const normalize = (node: any) => {
+  if (
+    [ELEMENT_MDX_BLOCK, ELEMENT_MDX_INLINE, ELEMENT_IMG].includes(node.type)
+  ) {
+    return {
+      ...node,
+      children: [{ type: 'text', text: '' }],
+    };
+  }
+  if (node.children) {
+    if (node.children.length) {
+      return {
+        ...node,
+        children: node.children.map(normalize),
+      };
+    }
+    return {
+      ...node,
+      children: [{ text: '' }],
+    };
+  }
+  return node;
+};
+
+export const insertInlineElement = (editor: PlateEditor, inlineElement) => {
+  editor.tf.insertNodes([inlineElement]);
+};
+
+export const insertBlockElement = (editor: PlateEditor, blockElement) => {
+  editor.tf.withoutNormalizing(() => {
+    const block = editor.api.block();
+    if (!block) return;
+    if (isCurrentBlockEmpty(editor)) {
+      editor.tf.setNodes(blockElement);
+    } else {
+      editor.tf.insertNodes([blockElement]);
+    }
+  });
+};
+
+const isCurrentBlockEmpty = (editor) => {
+  if (!editor.selection) {
+    return false;
+  }
+  const [node] = editor.api.node(editor.selection);
+  const cursor = editor.selection.focus;
+  const blockAbove = editor.api.block();
+  const isEmpty =
+    !NodeApi.string(node) &&
+    !node.children?.some((child) => editor.api.isInline(child)) &&
+    editor.api.isStart(cursor, blockAbove[1]);
+
+  return isEmpty;
+};
+
+const currentNodeSupportsMDX = (editor: PlateEditor) =>
+  editor.api.node({
+    match: { type: HANDLES_MDX },
+  });
+
+export function normalizeLinksInCodeBlocks(node) {
+  if (node.type === 'code_line' && node.children) {
+    return {
+      ...node,
+      children: node.children.flatMap((child) => {
+        if (child.type === 'a') {
+          return child.children || [];
+        }
+        return [normalizeLinksInCodeBlocks(child)];
+      }),
+    };
+  }
+  if (node.children) {
+    return {
+      ...node,
+      children: node.children.map(normalizeLinksInCodeBlocks),
+    };
+  }
+  return node;
+}
+
+export const helpers = {
+  isNodeActive,
+  isListActive,
+  currentNodeSupportsMDX,
+  normalize,
+  normalizeLinksInCodeBlocks,
+  withRootNodeIds,
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/formatting.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/formatting.tsx
@@ -1,0 +1,63 @@
+import { AutoformatPlugin } from '@udecode/plate-autoformat/react';
+import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import { ExitBreakPlugin, SoftBreakPlugin } from '@udecode/plate-break/react';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { HEADING_KEYS, HEADING_LEVELS } from '@udecode/plate-heading';
+import { ResetNodePlugin } from '@udecode/plate-reset-node/react';
+import { TrailingBlockPlugin } from '@udecode/plate-trailing-block';
+import { ParagraphPlugin } from '@udecode/plate/react';
+import { autoformatRules } from './autoformat/autoformat-rules';
+
+export const HANDLES_MDX = [
+  HEADING_KEYS.h1,
+  HEADING_KEYS.h2,
+  HEADING_KEYS.h3,
+  HEADING_KEYS.h4,
+  HEADING_KEYS.h5,
+  HEADING_KEYS.h6,
+  ParagraphPlugin.key,
+];
+
+export const plugins: any[] = [
+  TrailingBlockPlugin,
+  AutoformatPlugin.configure({
+    options: {
+      rules: autoformatRules,
+    },
+  }),
+  ExitBreakPlugin.configure({
+    options: {
+      rules: [
+        {
+          hotkey: 'mod+enter',
+        },
+        {
+          hotkey: 'mod+shift+enter',
+          before: true,
+        },
+        {
+          hotkey: 'enter',
+          query: {
+            start: true,
+            end: true,
+            allow: HEADING_LEVELS,
+          },
+        },
+      ],
+    },
+  }),
+  ResetNodePlugin.configure({}),
+  SoftBreakPlugin.configure({
+    options: {
+      rules: [
+        { hotkey: 'shift+enter' },
+        {
+          hotkey: 'enter',
+          query: {
+            allow: [CodeBlockPlugin.key],
+          },
+        },
+      ],
+    },
+  }),
+];

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/core/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/core/index.tsx
@@ -1,0 +1,3 @@
+export { plugins as formattingPlugins } from './formatting';
+
+//TODO (Ask Jeff): Check with Jeff if we still need this export (we already rewrite the plugin in a different file)

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-html-block/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-html-block/index.tsx
@@ -1,0 +1,67 @@
+import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import { createPlatePlugin } from '@udecode/plate/react';
+import React from 'react';
+
+export const createHTMLBlockPlugin = createPlatePlugin({
+  key: 'html',
+  node: {
+    isElement: true,
+    isVoid: true,
+    isInline: false,
+  },
+});
+
+export const createHTMLInlinePlugin = createPlatePlugin({
+  key: 'html_inline',
+  node: {
+    isElement: true,
+    isVoid: true,
+    isInline: true,
+  },
+});
+
+export const KEY_BLOCKQUOTE_ENTER_BREAK = 'blockquote-enter-break';
+
+export const createBlockquoteEnterBreakPlugin = createPlatePlugin({
+  key: KEY_BLOCKQUOTE_ENTER_BREAK,
+
+  handlers: {
+    onKeyDown: ({ editor, event }) => {
+      if (event.key !== 'Enter') return;
+      const blockquoteEntry = editor.api.above({
+        match: { type: BlockquotePlugin.key },
+      });
+
+      if (!blockquoteEntry) return;
+
+      event.preventDefault();
+      const cursorPosition = editor.selection?.focus;
+      if (!cursorPosition) return;
+
+      editor.tf.insertNodes(
+        [
+          { type: ELEMENT_BREAK, children: [{ text: '' }] },
+          { type: 'text', text: '' },
+        ],
+        {
+          at: { path: cursorPosition.path, offset: cursorPosition.offset },
+          select: true,
+        }
+      );
+    },
+  },
+});
+
+export const ELEMENT_BREAK = 'break';
+
+export const createBreakPlugin = createPlatePlugin({
+  key: ELEMENT_BREAK,
+  node: {
+    isElement: true,
+    isVoid: true,
+    isInline: true,
+    component: () => {
+      return <br />;
+    },
+  },
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/component.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/component.tsx
@@ -1,0 +1,98 @@
+import { ParagraphPlugin, useSelected } from '@udecode/plate/react';
+import React from 'react';
+import { useTemplates } from '../../editor-context';
+import { useEmbedHandles, useHotkey } from '../../hooks/embed-hooks';
+import {
+  DeleteImageButton,
+  StyledFile,
+  StyledImage,
+  isImage,
+} from '../../media';
+import { NestedForm } from '../../nested-form';
+
+export const ImgEmbed = ({
+  attributes,
+  children,
+  element,
+  editor,
+  onChange,
+}) => {
+  const selected = useSelected();
+  const { fieldName } = useTemplates();
+  const { handleClose, handleRemove, handleSelect, isExpanded } =
+    useEmbedHandles(editor, element, fieldName);
+
+  useHotkey('enter', () => {
+    editor.tf.insertNodes([
+      { type: ParagraphPlugin.key, children: [{ text: '' }] },
+    ]);
+  });
+
+  return (
+    <span {...attributes} className=''>
+      {children}
+      {element.url ? (
+        <div
+          className={`relative w-full max-w-full flex justify-start ${
+            isImage(element.url) ? 'items-start gap-3' : 'items-center gap-2'
+          }`}
+        >
+          <button
+            type='button'
+            className={`flex-shrink min-w-0 focus-within:shadow-outline focus-within:border-blue-500 rounded outline-none overflow-visible cursor-pointer border-none hover:opacity-60 transition ease-out duration-100 ${
+              selected ? 'shadow-outline border-blue-500' : ''
+            }`}
+            onClick={handleSelect}
+          >
+            {isImage(element.url) ? (
+              <StyledImage src={element.url} />
+            ) : (
+              <StyledFile src={element.url} />
+            )}
+          </button>
+          <DeleteImageButton
+            onClick={(e) => {
+              e.stopPropagation();
+              handleRemove();
+            }}
+          />
+        </div>
+      ) : (
+        <button
+          type='button'
+          className='outline-none relative hover:opacity-60 w-full'
+          onClick={handleSelect}
+        >
+          <div className='text-center rounded-[5px] bg-gray-100 text-gray-300 leading-[1.35] py-3 text-[15px] font-normal transition-all ease-out duration-100 hover:opacity-60'>
+            Click to select an image
+          </div>
+        </button>
+      )}
+      {isExpanded && (
+        <ImageForm
+          onChange={onChange}
+          initialValues={element}
+          onClose={handleClose}
+          element={element}
+        />
+      )}
+    </span>
+  );
+};
+
+export const ImageForm = (props) => {
+  return (
+    <NestedForm
+      id='image-form'
+      label='Image'
+      fields={[
+        { label: 'URL', name: 'url', type: 'string' },
+        { label: 'Caption', name: 'caption', type: 'string' },
+        { label: 'Alt', name: 'alt', type: 'string' },
+      ]}
+      initialValues={props.initialValues}
+      onChange={props.onChange}
+      onClose={props.onClose}
+    />
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-img-plugin/index.tsx
@@ -1,0 +1,47 @@
+import { PlateEditor, createPlatePlugin } from '@udecode/plate/react';
+import React from 'react';
+import { type Media, isImage } from '../../media';
+import { insertInlineElement } from '../core/common';
+import { ImgEmbed } from './component';
+
+export const ELEMENT_IMG = 'img';
+
+const ImgEmbedComponent = (props) => {
+  const handleChange = (values) => {
+    const path = props.path;
+    props.editor.tf.setNodes(values, { at: path });
+  };
+  return <ImgEmbed {...props} onChange={handleChange} />;
+};
+
+const createImgPlugin = createPlatePlugin({
+  key: ELEMENT_IMG,
+  node: {
+    isVoid: true,
+    isInline: true,
+    isElement: true,
+  },
+}).withComponent(ImgEmbedComponent);
+
+export const insertImg = (editor: PlateEditor, media: Media) => {
+  if (isImage(media.src)) {
+    insertInlineElement(editor, {
+      type: ELEMENT_IMG,
+      children: [{ text: '' }],
+      url: media.src,
+      caption: '',
+      alt: '',
+    });
+  } else {
+    insertInlineElement(editor, {
+      type: 'a',
+      url: media.src,
+      title: media.filename,
+      children: [{ text: media.filename }],
+    });
+  }
+
+  editor.tf.normalize({ force: true });
+};
+
+export default createImgPlugin;

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-invalid-markdown-plugin/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-invalid-markdown-plugin/index.tsx
@@ -1,0 +1,53 @@
+import { PlateElementProps, createPlatePlugin } from '@udecode/plate/react';
+import React from 'react';
+import {
+  INVALID_MARKDOWN_TYPE,
+  buildErrorMessage,
+} from '../../../error-message';
+
+export const ELEMENT_INVALID_MARKDOWN = INVALID_MARKDOWN_TYPE;
+
+export const createInvalidMarkdownPlugin = createPlatePlugin({
+  key: ELEMENT_INVALID_MARKDOWN,
+  options: {
+    isElement: true,
+    isVoid: true,
+    isInline: false,
+  },
+  node: {
+    component: InvalidMarkdownElement,
+  },
+});
+
+function InvalidMarkdownElement({
+  attributes,
+  element,
+  children,
+}: PlateElementProps) {
+  return (
+    <div {...attributes}>
+      <ErrorMessage error={element} />
+      {children}
+    </div>
+  );
+}
+
+function ErrorMessage({ error }) {
+  const message = buildErrorMessage(error);
+  return (
+    <div contentEditable={false} className='bg-red-50 sm:rounded-lg'>
+      <div className='px-4 py-5 sm:p-6'>
+        <h3 className='text-lg leading-6 font-medium text-red-800'>
+          ❌ Error parsing markdown
+        </h3>
+        <div className='mt-2 max-w-xl text-sm text-red-800 space-y-4'>
+          <p>{message}</p>
+          <p>
+            To fix this, edit the file directly. Your original markdown is kept
+            as-is until it parses.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-mdx-plugins/component.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-mdx-plugins/component.tsx
@@ -1,0 +1,249 @@
+import {
+  Popover,
+  PopoverButton,
+  PopoverPanel,
+  Transition,
+} from '@headlessui/react';
+import { ElementApi } from '@udecode/plate';
+import {
+  ParagraphPlugin,
+  PlateEditor,
+  useSelected,
+} from '@udecode/plate/react';
+import React from 'react';
+import { ELEMENT_MDX_INLINE } from '.';
+import { EllipsisIcon } from '../../components/plate-ui/icons';
+import { useTemplates } from '../../editor-context';
+import { useEmbedHandles, useHotkey } from '../../hooks/embed-hooks';
+import { NestedForm } from '../../nested-form';
+import { classNames } from '../ui/helpers';
+
+const Wrapper = ({ inline, children }) => {
+  const Component = inline ? 'span' : 'div';
+  return (
+    <Component
+      contentEditable={false}
+      style={{ userSelect: 'none' }}
+      className='relative'
+    >
+      {children}
+    </Component>
+  );
+};
+
+interface InlineEmbedProps {
+  attributes: any;
+  children: any;
+  element: any;
+  onChange?: (value: any) => void;
+  editor: PlateEditor;
+}
+
+export const InlineEmbed = ({
+  attributes,
+  children,
+  element,
+  onChange,
+  editor,
+}: InlineEmbedProps) => {
+  const selected = useSelected();
+  const { templates, fieldName } = useTemplates();
+  const { handleClose, handleRemove, handleSelect, isExpanded } =
+    useEmbedHandles(editor, element, fieldName);
+  useHotkey('enter', () => {
+    editor.tf.insertNodes([
+      { type: ParagraphPlugin.key, children: [{ text: '' }] },
+    ]);
+  });
+  useHotkey('space', () => {
+    editor.tf.insertNodes([{ text: ' ' }], {
+      match: (n) => {
+        if (ElementApi.isElement(n) && n.type === ELEMENT_MDX_INLINE) {
+          return true;
+        }
+      },
+      select: true,
+    });
+  });
+
+  const activeTemplate = templates.find(
+    (template) => template.name === element.name
+  );
+
+  const formProps = {
+    activeTemplate,
+    element,
+    editor,
+    onChange,
+    onClose: handleClose,
+  };
+
+  if (!activeTemplate) {
+    return null;
+  }
+
+  const label = getLabel(activeTemplate, formProps);
+  return (
+    <span {...attributes}>
+      {children}
+      <Wrapper inline={true}>
+        <span
+          style={{ margin: '0 0.5px' }}
+          className='relative inline-flex shadow-sm rounded leading-none'
+        >
+          {selected && (
+            <span className='absolute inset-0 ring-2 ring-blue-100 ring-inset rounded z-10 pointer-events-none' />
+          )}
+          <span
+            style={{ fontWeight: 'inherit', maxWidth: '275px' }}
+            className='truncate cursor-pointer relative inline-flex items-center justify-start px-2 py-0.5 rounded-l border border-gray-200 bg-white  hover:bg-gray-50 focus:z-10 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500'
+            onMouseDown={handleSelect}
+          >
+            {label}
+          </span>
+          <DotMenu onOpen={handleSelect} onRemove={handleRemove} />
+        </span>
+        {isExpanded && <EmbedNestedForm {...formProps} />}
+      </Wrapper>
+    </span>
+  );
+};
+
+export const BlockEmbed = ({
+  attributes,
+  children,
+  element,
+  editor,
+  onChange,
+}) => {
+  const selected = useSelected();
+  const { templates, fieldName } = useTemplates();
+  const { handleClose, handleRemove, handleSelect, isExpanded } =
+    useEmbedHandles(editor, element, fieldName);
+
+  useHotkey('enter', () => {
+    editor.tf.insertNodes([
+      { type: ParagraphPlugin.key, children: [{ text: '' }] },
+    ]);
+  });
+
+  const activeTemplate = templates.find(
+    (template) => template.name === element.name
+  );
+
+  const formProps = {
+    activeTemplate,
+    element,
+    editor,
+    onChange,
+    onClose: handleClose,
+  };
+
+  if (!activeTemplate) {
+    return null;
+  }
+
+  const label = getLabel(activeTemplate, formProps);
+  return (
+    <div {...attributes} className='w-full my-2'>
+      {children}
+      <Wrapper inline={false}>
+        <span className='relative w-full inline-flex shadow-sm rounded'>
+          {selected && (
+            <span className='absolute inset-0 ring-2 ring-blue-100 ring-inset rounded z-10 pointer-events-none' />
+          )}
+          <span
+            onMouseDown={handleSelect}
+            className='truncate cursor-pointer w-full relative inline-flex items-center justify-start px-4 py-2 rounded-l border border-gray-200 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500'
+          >
+            {label}
+          </span>
+          <DotMenu onOpen={handleSelect} onRemove={handleRemove} />
+        </span>
+        {isExpanded && <EmbedNestedForm {...formProps} />}
+      </Wrapper>
+    </div>
+  );
+};
+
+const getLabel = (activeTemplate, formProps) => {
+  const titleField = activeTemplate.fields.find((field) => field.isTitle);
+  let label = activeTemplate.label || activeTemplate.name;
+  if (titleField) {
+    const titleValue = formProps.element.props[titleField.name];
+    if (titleValue) {
+      label = `${label}: ${titleValue}`;
+    }
+  }
+
+  return label;
+};
+
+const EmbedNestedForm = ({
+  editor,
+  element,
+  activeTemplate,
+  onClose,
+  onChange,
+}) => {
+  const path = editor.findPath(element);
+  const id = [...path, activeTemplate.name].join('.');
+  return (
+    <NestedForm
+      id={id}
+      label={activeTemplate.label}
+      fields={activeTemplate.fields}
+      initialValues={element.props}
+      onChange={onChange}
+      onClose={onClose}
+    />
+  );
+};
+
+const DotMenu = ({ onOpen, onRemove }) => {
+  return (
+    <Popover as='span' className='-ml-px relative block'>
+      <PopoverButton
+        as='span'
+        className='cursor-pointer h-full relative inline-flex items-center px-1 py-0.5 rounded-r border border-gray-200 bg-white text-gray-500 hover:bg-gray-50 focus:outline-none focus:ring-1 focus:ring-blue-500 focus:border-blue-500'
+      >
+        <EllipsisIcon title='Open options' />
+      </PopoverButton>
+      <Transition
+        enter='transition ease-out duration-100'
+        enterFrom='transform opacity-0 scale-95'
+        enterTo='transform opacity-100 scale-100'
+        leave='transition ease-in duration-75'
+        leaveFrom='transform opacity-100 scale-100'
+        leaveTo='transform opacity-0 scale-95'
+      >
+        <PopoverPanel className='z-30 fixed origin-top-right right-0'>
+          <div className='mt-2 -mr-1 rounded shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none'>
+            <div className='py-1'>
+              <span
+                onClick={onOpen}
+                className={classNames(
+                  'cursor-pointer text-left w-full block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900'
+                )}
+              >
+                Edit
+              </span>
+              <button
+                type='button'
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  onRemove();
+                }}
+                className={classNames(
+                  'cursor-pointer text-left w-full block px-4 py-2 text-sm hover:bg-gray-100 hover:text-gray-900'
+                )}
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        </PopoverPanel>
+      </Transition>
+    </Popover>
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/create-mdx-plugins/index.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/create-mdx-plugins/index.tsx
@@ -1,0 +1,65 @@
+import {
+  PlateEditor,
+  createPlatePlugin,
+  useEditorRef,
+} from '@udecode/plate/react';
+import React from 'react';
+import type { MdxTemplate } from '../../types';
+import { insertBlockElement, insertInlineElement } from '../core/common';
+import { BlockEmbed, InlineEmbed } from './component';
+
+export const ELEMENT_MDX_INLINE = 'mdxJsxTextElement';
+export const ELEMENT_MDX_BLOCK = 'mdxJsxFlowElement';
+
+const Embed = (props) => {
+  const editor = useEditorRef();
+  const handleChange = (values) => {
+    const path = editor.api.findPath(props.element);
+    props.editor.tf.setNodes({ props: values }, { at: path });
+  };
+
+  if (props.inline) {
+    return <InlineEmbed {...props} onChange={handleChange} />;
+  }
+  return <BlockEmbed {...props} onChange={handleChange} />;
+};
+
+export const createMdxInlinePlugin = createPlatePlugin({
+  key: ELEMENT_MDX_INLINE,
+  node: {
+    isElement: true,
+    isVoid: true,
+    isInline: true,
+    component: (props) => <Embed {...props} inline={true} />,
+  },
+});
+
+export const createMdxBlockPlugin = createPlatePlugin({
+  key: ELEMENT_MDX_BLOCK,
+  node: {
+    isElement: true,
+    isVoid: true,
+    component: (props) => <Embed {...props} inline={false} />,
+  },
+});
+
+export const insertMDX = (editor: PlateEditor, value: MdxTemplate) => {
+  const isInline = value.inline;
+  if (isInline) {
+    insertInlineElement(editor, {
+      type: ELEMENT_MDX_INLINE,
+      name: value.name,
+      children: [{ text: '' }],
+      props: value.defaultItem ? value.defaultItem : {},
+    });
+  } else {
+    insertBlockElement(editor, {
+      type: ELEMENT_MDX_BLOCK,
+      name: value.name,
+      children: [{ text: '' }],
+      props: value.defaultItem ? value.defaultItem : {},
+    });
+
+    editor.tf.normalize({ force: true });
+  }
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/editor-plugins.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/editor-plugins.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import type { HeadingLevel } from '@tinacms/schema-tools';
+import { createSlatePlugin } from '@udecode/plate';
+import {
+  AutoformatRule,
+  autoformatArrow,
+  autoformatLegal,
+  autoformatMath,
+  autoformatPunctuation,
+  autoformatSmartQuotes,
+} from '@udecode/plate-autoformat';
+import { AutoformatPlugin } from '@udecode/plate-autoformat/react';
+import {
+  BasicMarksPlugin,
+  UnderlinePlugin,
+} from '@udecode/plate-basic-marks/react';
+import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import { ExitBreakPlugin, SoftBreakPlugin } from '@udecode/plate-break/react';
+import {
+  isCodeBlockEmpty,
+  isSelectionAtCodeBlockStart,
+  unwrapCodeBlock,
+} from '@udecode/plate-code-block';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { HEADING_KEYS, HEADING_LEVELS } from '@udecode/plate-heading';
+import { HeadingPlugin } from '@udecode/plate-heading/react';
+import { HighlightPlugin } from '@udecode/plate-highlight/react';
+import { HorizontalRulePlugin } from '@udecode/plate-horizontal-rule/react';
+import { ListStyleType } from '@udecode/plate-indent-list';
+import { IndentListPlugin } from '@udecode/plate-indent-list/react';
+import { LinkPlugin } from '@udecode/plate-link/react';
+import { unwrapList } from '@udecode/plate-list';
+import {
+  BulletedListPlugin,
+  ListPlugin,
+  NumberedListPlugin,
+} from '@udecode/plate-list/react';
+import { NodeIdPlugin } from '@udecode/plate-node-id';
+import { ResetNodePlugin } from '@udecode/plate-reset-node/react';
+import { SlashPlugin } from '@udecode/plate-slash-command/react';
+import { TablePlugin } from '@udecode/plate-table/react';
+import { TrailingBlockPlugin } from '@udecode/plate-trailing-block';
+import { ParagraphPlugin } from '@udecode/plate/react';
+import { all, createLowlight } from 'lowlight';
+import React from 'react';
+import { LinkFloatingToolbar } from '../components/plate-ui/link-floating-toolbar';
+import { isUrl } from '../transforms/is-url';
+import { getAutoformatBlocks } from './core/autoformat/autoformat-block';
+import { autoformatLists } from './core/autoformat/autoformat-lists';
+import { autoformatMarks } from './core/autoformat/autoformat-marks';
+import {
+  createBlockquoteEnterBreakPlugin,
+  createBreakPlugin,
+  createHTMLInlinePlugin,
+} from './create-html-block';
+import { createHTMLBlockPlugin } from './create-html-block';
+import createImgPlugin from './create-img-plugin';
+import { createInvalidMarkdownPlugin } from './create-invalid-markdown-plugin';
+import {
+  createMdxBlockPlugin,
+  createMdxInlinePlugin,
+} from './create-mdx-plugins';
+import { FloatingToolbarPlugin } from './ui/floating-toolbar-plugin';
+
+export const HANDLES_MDX = [
+  HEADING_KEYS.h1,
+  HEADING_KEYS.h2,
+  HEADING_KEYS.h3,
+  HEADING_KEYS.h4,
+  HEADING_KEYS.h5,
+  HEADING_KEYS.h6,
+  ParagraphPlugin.key,
+];
+
+const resetBlockTypesCommonRule = {
+  defaultType: ParagraphPlugin.key,
+  types: [...HEADING_LEVELS, BlockquotePlugin.key],
+};
+
+const resetBlockTypesCodeBlockRule = {
+  types: [CodeBlockPlugin.key],
+  defaultType: ParagraphPlugin.key,
+  onReset: unwrapCodeBlock,
+};
+
+export const viewPlugins: any[] = [
+  BasicMarksPlugin,
+  UnderlinePlugin,
+  HighlightPlugin,
+  HeadingPlugin.configure({ options: { levels: 6 } }),
+  ParagraphPlugin,
+  CodeBlockPlugin.configure({
+    options: { lowlight: createLowlight(all) },
+  }),
+  BlockquotePlugin,
+] as const;
+
+const CorrectNodeBehaviorPlugin = createSlatePlugin({
+  key: 'WITH_CORRECT_NODE_BEHAVIOR',
+});
+
+const ClearHighlightOnEnterPlugin = createSlatePlugin({
+  key: 'CLEAR_HIGHLIGHT_ON_ENTER',
+}).overrideEditor(({ editor, tf: { insertBreak } }) => ({
+  transforms: {
+    insertBreak() {
+      const keyboardEvent = editor.currentKeyboardEvent;
+      const isPlainEnter =
+        keyboardEvent?.key === 'Enter' &&
+        !keyboardEvent.shiftKey &&
+        !keyboardEvent.metaKey &&
+        !keyboardEvent.ctrlKey &&
+        !keyboardEvent.altKey;
+      const activeMarks = editor.api.marks();
+      const hasHighlight = Boolean(
+        activeMarks?.highlight || activeMarks?.highlightColor
+      );
+
+      insertBreak();
+
+      if (!isPlainEnter || !hasHighlight) {
+        return;
+      }
+
+      editor.tf.removeMark('highlight');
+      editor.tf.removeMark('highlightColor');
+
+      editor.tf.unsetNodes(['highlight', 'highlightColor'], {
+        at: editor.selection ?? undefined,
+        match: (node) => editor.api.isText(node),
+      });
+    },
+  },
+}));
+
+export interface CreateEditorPluginsOptions {
+  headingLevels?: readonly HeadingLevel[];
+}
+
+export const createEditorPlugins = ({
+  headingLevels,
+}: CreateEditorPluginsOptions = {}): any[] => [
+  createMdxBlockPlugin,
+  createMdxInlinePlugin,
+  createImgPlugin,
+  createHTMLBlockPlugin,
+  createHTMLInlinePlugin,
+  createBlockquoteEnterBreakPlugin,
+  createInvalidMarkdownPlugin,
+  CorrectNodeBehaviorPlugin,
+  ClearHighlightOnEnterPlugin,
+  LinkPlugin.configure({
+    options: {
+      isUrl: (url) => isUrl(url),
+    },
+    render: { afterEditable: () => <LinkFloatingToolbar /> },
+  }),
+
+  ...viewPlugins,
+  ListPlugin,
+  IndentListPlugin,
+  HorizontalRulePlugin,
+  NodeIdPlugin,
+  TablePlugin,
+  SlashPlugin,
+  TrailingBlockPlugin,
+  createBreakPlugin,
+  FloatingToolbarPlugin,
+
+  AutoformatPlugin.configure({
+    options: {
+      enableUndoOnDelete: true,
+      rules: [
+        ...autoformatMarks,
+        ...getAutoformatBlocks(headingLevels),
+        ...autoformatLists,
+        ...autoformatSmartQuotes,
+        ...autoformatPunctuation,
+        ...autoformatLegal,
+        ...autoformatArrow,
+        ...autoformatMath,
+      ].map(
+        (rule): AutoformatRule => ({
+          ...rule,
+          query: (editor) =>
+            !editor.api.some({
+              match: { type: editor.getType(CodeBlockPlugin) },
+            }),
+        })
+      ),
+    },
+  }),
+
+  ExitBreakPlugin.configure({
+    options: {
+      rules: [
+        { hotkey: 'mod+enter' },
+        { hotkey: 'mod+shift+enter', before: true },
+        {
+          hotkey: 'enter',
+          query: { start: true, end: true, allow: HEADING_LEVELS },
+        },
+      ],
+    },
+  }),
+  ResetNodePlugin.configure({
+    options: {
+      rules: [
+        {
+          ...resetBlockTypesCommonRule,
+          hotkey: 'Enter',
+          predicate: (editor) =>
+            editor.api.isEmpty(editor.selection, { block: true }),
+        },
+        {
+          ...resetBlockTypesCommonRule,
+          hotkey: 'Backspace',
+          predicate: (editor) => editor.api.isAt({ start: true }),
+        },
+        {
+          ...resetBlockTypesCodeBlockRule,
+          hotkey: 'Enter',
+          predicate: isCodeBlockEmpty,
+        },
+        {
+          ...resetBlockTypesCodeBlockRule,
+          hotkey: 'Backspace',
+          predicate: isSelectionAtCodeBlockStart,
+        },
+        {
+          types: [BulletedListPlugin.key, NumberedListPlugin.key],
+          defaultType: ParagraphPlugin.key,
+          hotkey: 'Backspace',
+          predicate: (editor) => editor.api.isAt({ start: true }),
+          onReset: unwrapList,
+        },
+      ],
+    },
+  }),
+  SoftBreakPlugin.configure({
+    options: {
+      rules: [
+        { hotkey: 'shift+enter' },
+        {
+          hotkey: 'enter',
+          query: { allow: [CodeBlockPlugin.key, BlockquotePlugin.key] },
+        },
+      ],
+    },
+  }),
+];

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/autocomplete.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/autocomplete.tsx
@@ -1,0 +1,103 @@
+import {
+  Combobox,
+  ComboboxButton,
+  ComboboxInput,
+  ComboboxOption,
+  ComboboxOptions,
+  Transition,
+} from '@headlessui/react';
+import { ChevronDownIcon } from 'lucide-react';
+import React, { Fragment } from 'react';
+import { classNames } from './helpers';
+
+interface AutocompleteItem {
+  key: string;
+  label: string;
+  render: (
+    item: Omit<AutocompleteItem, 'render'>
+  ) => string | React.JSX.Element;
+}
+
+interface AutocompleteProps {
+  value: Omit<AutocompleteItem, 'render'>;
+  defaultQuery?: string;
+  onChange: (item: AutocompleteItem) => void;
+  items: AutocompleteItem[];
+}
+
+const filterItems = (
+  items: AutocompleteItem[],
+  query: string
+): AutocompleteItem[] => {
+  try {
+    const reFilter = new RegExp(query, 'i');
+    const matched = items.filter((item) => reFilter.test(item.label));
+    if (matched.length === 0) return items;
+    return matched;
+  } catch {
+    return items;
+  }
+};
+
+export const Autocomplete: React.FC<AutocompleteProps> = ({
+  value,
+  onChange,
+  defaultQuery,
+  items,
+}) => {
+  const [query, setQuery] = React.useState(defaultQuery ?? '');
+  const filteredItems = filterItems(items, query);
+
+  return (
+    <Combobox
+      value={value}
+      onChange={onChange}
+      as='div'
+      className='relative inline-block text-left z-20'
+    >
+      <div className='mt-1'>
+        <div className='relative w-full cursor-default overflow-hidden rounded-lg bg-white text-left shadow-md sm:text-sm'>
+          <ComboboxInput
+            className='w-full border-none py-2 pl-3 pr-10 text-sm leading-5 text-gray-900 focus:ring-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-300'
+            displayValue={(item: AutocompleteItem) =>
+              item?.label ?? 'Plain Text'
+            }
+            onChange={(event) => setQuery(event.target.value)}
+            onClick={(ev) => ev.stopPropagation()}
+          />
+          <ComboboxButton className='absolute inset-y-0 right-0 flex items-center pr-2'>
+            <ChevronDownIcon
+              className='h-5 w-5 text-gray-400'
+              aria-hidden='true'
+            />
+          </ComboboxButton>
+        </div>
+      </div>
+      <Transition
+        enter='transition ease-out duration-100'
+        enterFrom='transform opacity-0 scale-95'
+        enterTo='transform opacity-100 scale-100'
+        leave='transition ease-in duration-75'
+        leaveFrom='transform opacity-100 scale-100'
+        leaveTo='transform opacity-0 scale-95'
+      >
+        <ComboboxOptions className='origin-top-right absolute right-0 mt-1 w-full max-h-[300px] overflow-y-auto rounded shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none'>
+          {filteredItems.map((item) => (
+            <ComboboxOption key={item.key} value={item}>
+              {({ focus }) => (
+                <button
+                  className={classNames(
+                    focus ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                    'block px-4 py-2 text-xs w-full text-right'
+                  )}
+                >
+                  {item.render(item)}
+                </button>
+              )}
+            </ComboboxOption>
+          ))}
+        </ComboboxOptions>
+      </Transition>
+    </Combobox>
+  );
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/components.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/components.tsx
@@ -1,0 +1,258 @@
+import { withProps } from '@udecode/cn';
+import {
+  BoldPlugin,
+  CodePlugin,
+  ItalicPlugin,
+  StrikethroughPlugin,
+  UnderlinePlugin,
+} from '@udecode/plate-basic-marks/react';
+import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import {
+  CodeBlockPlugin,
+  CodeLinePlugin,
+  CodeSyntaxPlugin,
+} from '@udecode/plate-code-block/react';
+import { HEADING_KEYS } from '@udecode/plate-heading';
+import { HighlightPlugin } from '@udecode/plate-highlight/react';
+import { HorizontalRulePlugin } from '@udecode/plate-horizontal-rule/react';
+import { LinkPlugin } from '@udecode/plate-link/react';
+import {
+  BulletedListPlugin,
+  ListItemPlugin,
+  NumberedListPlugin,
+} from '@udecode/plate-list/react';
+import { SlashInputPlugin } from '@udecode/plate-slash-command/react';
+import {
+  TableCellHeaderPlugin,
+  TableCellPlugin,
+  TablePlugin,
+  TableRowPlugin,
+} from '@udecode/plate-table/react';
+import { ParagraphPlugin, PlateElement, PlateLeaf } from '@udecode/plate/react';
+import colorString from 'color-string';
+import React from 'react';
+import { BlockquoteElement } from '../../components/plate-ui/blockquote-element';
+import { CodeBlockElement } from '../../components/plate-ui/code-block/code-block-element';
+import { CodeLeaf } from '../../components/plate-ui/code-leaf';
+import { CodeLineElement } from '../../components/plate-ui/code-line-element';
+import { CodeSyntaxLeaf } from '../../components/plate-ui/code-syntax-leaf';
+import { HrElement } from '../../components/plate-ui/hr-element';
+import { LinkElement } from '../../components/plate-ui/link-element';
+import { ListElement } from '../../components/plate-ui/list-element';
+import { ParagraphElement } from '../../components/plate-ui/paragraph-element';
+import { SlashInputElement } from '../../components/plate-ui/slash-input-element';
+import {
+  TableCellElement,
+  TableCellHeaderElement,
+} from '../../components/plate-ui/table/table-cell-element';
+import { TableElement } from '../../components/plate-ui/table/table-element';
+import { TableRowElement } from '../../components/plate-ui/table/table-row-element';
+import { classNames } from './helpers';
+
+const blockClasses = 'mt-0.5';
+const headerClasses = 'font-normal';
+
+function getContrastColor(color: string): string {
+  const parsed = colorString.get.rgb(color);
+  if (!parsed) return '#000000';
+  const [r, g, b] = parsed;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#000000' : '#ffffff';
+}
+
+const HighlightLeaf = ({
+  leaf,
+  ...props
+}: React.ComponentProps<typeof PlateLeaf>) => {
+  const backgroundColor = (leaf.highlightColor as string) || '#FEF08A';
+  return (
+    <PlateLeaf
+      as='mark'
+      className='rounded-sm'
+      style={{ backgroundColor, color: getContrastColor(backgroundColor) }}
+      leaf={leaf}
+      {...props}
+    />
+  );
+};
+
+type HeadingComponentProps = {
+  attributes: React.HTMLAttributes<HTMLHeadingElement>;
+  children: React.ReactNode;
+  className?: string;
+};
+
+const Heading1 = ({
+  attributes,
+  children,
+  className,
+}: HeadingComponentProps) => (
+  <h1
+    {...attributes}
+    className={classNames(
+      headerClasses,
+      blockClasses,
+      className,
+      'text-4xl mb-4 last:mb-0 mt-6 first:mt-0 font-inter'
+    )}
+  >
+    {children}
+  </h1>
+);
+
+const Heading2 = ({
+  attributes,
+  children,
+  className,
+}: HeadingComponentProps) => (
+  <h2
+    {...attributes}
+    className={classNames(
+      headerClasses,
+      blockClasses,
+      className,
+      'text-3xl mb-4 last:mb-0 mt-6 first:mt-0 font-inter'
+    )}
+  >
+    {children}
+  </h2>
+);
+
+const Heading3 = ({
+  attributes,
+  children,
+  className,
+}: HeadingComponentProps) => (
+  <h3
+    {...attributes}
+    className={classNames(
+      headerClasses,
+      blockClasses,
+      className,
+      'text-2xl mb-4 last:mb-0 mt-6 first:mt-0 font-inter'
+    )}
+  >
+    {children}
+  </h3>
+);
+
+const Heading4 = ({
+  attributes,
+  children,
+  className,
+}: HeadingComponentProps) => (
+  <h4
+    {...attributes}
+    className={classNames(
+      headerClasses,
+      blockClasses,
+      className,
+      'text-xl mb-4 last:mb-0 mt-6 first:mt-0 font-inter'
+    )}
+  >
+    {children}
+  </h4>
+);
+
+const headerFontStyle: React.CSSProperties = {
+  fontFamily: "'Inter', sans-serif",
+  fontWeight: '400',
+};
+
+const Heading5 = ({
+  attributes,
+  children,
+  className,
+}: HeadingComponentProps) => (
+  <h5
+    {...attributes}
+    className={classNames(
+      headerClasses,
+      blockClasses,
+      className,
+      'text-lg mb-4 last:mb-0 mt-6 first:mt-0'
+    )}
+    style={headerFontStyle}
+  >
+    {children}
+  </h5>
+);
+
+const Heading6 = ({
+  attributes,
+  children,
+  className,
+}: HeadingComponentProps) => (
+  <h6
+    {...attributes}
+    className={classNames(
+      headerClasses,
+      blockClasses,
+      className,
+      'text-base mb-4 last:mb-0 mt-6 first:mt-0'
+    )}
+    style={headerFontStyle}
+  >
+    {children}
+  </h6>
+);
+
+export const Components = () => {
+  return {
+    [SlashInputPlugin.key]: SlashInputElement,
+    [HEADING_KEYS.h1]: Heading1,
+    [HEADING_KEYS.h2]: Heading2,
+    [HEADING_KEYS.h3]: Heading3,
+    [HEADING_KEYS.h4]: Heading4,
+    [HEADING_KEYS.h5]: Heading5,
+    [HEADING_KEYS.h6]: Heading6,
+    [ParagraphPlugin.key]: ParagraphElement,
+    [BlockquotePlugin.key]: BlockquoteElement,
+    [CodeBlockPlugin.key]: CodeBlockElement,
+    [CodeLinePlugin.key]: CodeLineElement,
+    [CodeSyntaxPlugin.key]: CodeSyntaxLeaf,
+    html: ({ attributes, editor, element, children, className }) => {
+      return (
+        <div
+          {...attributes}
+          className={classNames(
+            'font-mono text-sm bg-green-100 cursor-not-allowed mb-4',
+            className
+          )}
+        >
+          {children}
+          {element.value}
+        </div>
+      );
+    },
+    html_inline: ({ attributes, editor, element, children, className }) => {
+      return (
+        <span
+          {...attributes}
+          className={classNames(
+            'font-mono bg-green-100 cursor-not-allowed',
+            className
+          )}
+        >
+          {children}
+          {element.value}
+        </span>
+      );
+    },
+    [BulletedListPlugin.key]: withProps(ListElement, { variant: 'ul' }),
+    [NumberedListPlugin.key]: withProps(ListElement, { variant: 'ol' }),
+    [ListItemPlugin.key]: withProps(PlateElement, { as: 'li' }),
+    [LinkPlugin.key]: LinkElement,
+    [CodePlugin.key]: CodeLeaf,
+    [HighlightPlugin.key]: HighlightLeaf,
+    [UnderlinePlugin.key]: withProps(PlateLeaf, { as: 'u' }),
+    [StrikethroughPlugin.key]: withProps(PlateLeaf, { as: 's' }),
+    [ItalicPlugin.key]: withProps(PlateLeaf, { as: 'em' }),
+    [BoldPlugin.key]: withProps(PlateLeaf, { as: 'strong' }),
+    [HorizontalRulePlugin.key]: HrElement,
+    [TableCellHeaderPlugin.key]: TableCellHeaderElement,
+    [TableCellPlugin.key]: TableCellElement,
+    [TablePlugin.key]: TableElement,
+    [TableRowPlugin.key]: TableRowElement,
+  };
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/dropdown.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/dropdown.tsx
@@ -1,0 +1,62 @@
+import {
+  Menu,
+  MenuButton,
+  MenuItem,
+  MenuItems,
+  Transition,
+} from '@headlessui/react';
+import { ChevronDownIcon } from 'lucide-react';
+import React from 'react';
+import { classNames } from './helpers';
+
+export function Dropdown({
+  label,
+  items,
+}: {
+  label: string | React.JSX.Element;
+  items: {
+    key: string;
+    onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+    render: string | React.JSX.Element;
+  }[];
+}) {
+  return (
+    <Menu as='div' className='relative inline-block text-left z-20'>
+      <div>
+        <MenuButton className='inline-flex justify-center w-full rounded border border-gray-300 shadow-sm px-2 py-1 bg-white text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-offset-gray-100 focus:ring-blue-500'>
+          {label}
+          <ChevronDownIcon className='-mr-1 ml-2 h-4 w-4' aria-hidden='true' />
+        </MenuButton>
+      </div>
+
+      <Transition
+        enter='transition ease-out duration-100'
+        enterFrom='transform opacity-0 scale-95'
+        enterTo='transform opacity-100 scale-100'
+        leave='transition ease-in duration-75'
+        leaveFrom='transform opacity-100 scale-100'
+        leaveTo='transform opacity-0 scale-95'
+      >
+        <MenuItems className='origin-top-right absolute right-0 mt-2 w-32 max-h-[200px] overflow-y-auto rounded shadow-lg bg-white ring-1 ring-black ring-opacity-5 focus:outline-none'>
+          <div className='py-1'>
+            {items.map((item) => (
+              <MenuItem key={item.key}>
+                {({ focus }) => (
+                  <button
+                    onClick={item.onClick}
+                    className={classNames(
+                      focus ? 'bg-gray-100 text-gray-900' : 'text-gray-700',
+                      'block px-4 py-2 text-xs w-full text-right'
+                    )}
+                  >
+                    {item.render}
+                  </button>
+                )}
+              </MenuItem>
+            ))}
+          </div>
+        </MenuItems>
+      </Transition>
+    </Menu>
+  );
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/floating-toolbar-plugin.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/floating-toolbar-plugin.tsx
@@ -1,0 +1,16 @@
+'use client';
+import { createPlatePlugin } from '@udecode/plate/react';
+import React from 'react';
+import FloatingToolbarButtons from '../../components/floating-toolbar-buttons';
+import { FloatingToolbar } from '../../components/plate-ui/floating-toolbar';
+
+export const FloatingToolbarPlugin = createPlatePlugin({
+  key: 'floating-toolbar',
+  render: {
+    afterEditable: () => (
+      <FloatingToolbar>
+        <FloatingToolbarButtons />
+      </FloatingToolbar>
+    ),
+  },
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/helpers.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/plugins/ui/helpers.tsx
@@ -1,0 +1,3 @@
+export function classNames(...classes: string[]) {
+  return classes.filter(Boolean).join(' ');
+}

--- a/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-overrides.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-overrides.tsx
@@ -1,0 +1,18 @@
+import type { HeadingLevel, ToolbarOverrideType } from '@tinacms/schema-tools';
+export type { HeadingLevel, ToolbarOverrideType };
+
+export const STANDARD_ICON_WIDTH = 36;
+export const HEADING_ICON_WITH_TEXT = 130;
+export const HEADING_ICON_ONLY = 62;
+export const EMBED_ICON_WIDTH = 54;
+export const HIGHLIGHT_ICON_WIDTH = 54;
+export const CONTAINER_MD_BREAKPOINT = 448;
+export const OVERFLOW_MENU_WIDTH = 36;
+
+export const HEADING_LABEL = 'Headings';
+
+export type ToolbarOverrides = {
+  toolbar?: ToolbarOverrideType[];
+  showFloatingToolbar?: boolean;
+  headingLevels?: HeadingLevel[];
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-provider.tsx
+++ b/packages/v4/@tinacms/rich-text/src/plate/toolbar/toolbar-provider.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { type ReactNode, createContext, useContext } from 'react';
+
+import {
+  ALL_HEADING_LEVELS,
+  type HeadingLevel,
+  normalizeHeadingLevels,
+} from '@tinacms/schema-tools';
+import type { MdxTemplate } from '../types';
+import type { ToolbarOverrides } from './toolbar-overrides';
+
+interface ToolbarContextProps {
+  templates: MdxTemplate[];
+  overrides: ToolbarOverrides | undefined;
+  headingLevels: readonly HeadingLevel[];
+  headingLevelsConfigured: boolean;
+}
+
+interface ToolbarProviderProps
+  extends Omit<
+    ToolbarContextProps,
+    'headingLevels' | 'headingLevelsConfigured'
+  > {
+  children: ReactNode;
+}
+
+const ToolbarContext = createContext<ToolbarContextProps | undefined>(
+  undefined
+);
+
+export const ToolbarProvider: React.FC<ToolbarProviderProps> = ({
+  templates,
+  overrides,
+  children,
+}) => {
+  const configured = overrides?.headingLevels;
+  const headingLevelsConfigured = Array.isArray(configured);
+
+  const headingLevels: readonly HeadingLevel[] = configured
+    ? normalizeHeadingLevels(configured)
+    : ALL_HEADING_LEVELS;
+
+  return (
+    <ToolbarContext.Provider
+      value={{
+        templates,
+        overrides,
+        headingLevels,
+        headingLevelsConfigured,
+      }}
+    >
+      {children}
+    </ToolbarContext.Provider>
+  );
+};
+
+export const useToolbarContext = (): ToolbarContextProps => {
+  const context = useContext(ToolbarContext);
+  if (!context) {
+    throw new Error('useToolbarContext must be used within a ToolbarProvider');
+  }
+  return context;
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.test.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.test.ts
@@ -1,0 +1,53 @@
+import { isUrl } from './is-url';
+
+describe('isUrl', () => {
+  test('validates full URLs with protocol', () => {
+    expect(isUrl('http://example.com')).toBe(true);
+    expect(isUrl('https://example.com')).toBe(true);
+    expect(isUrl('ftp://example.com')).toBe(true);
+  });
+
+  test('validates localhost URLs', () => {
+    expect(isUrl('http://localhost')).toBe(true);
+    expect(isUrl('http://localhost:3000')).toBe(true);
+  });
+
+  test('validates email links', () => {
+    expect(isUrl('mailto:someone@example.com')).toBe(true);
+    expect(isUrl('mailto:someone@example.com?subject=Hello')).toBe(true);
+  });
+
+  test('validates local URLs', () => {
+    expect(isUrl('/path/to/resource')).toBe(true);
+    expect(isUrl('/another/path')).toBe(true);
+  });
+
+  test('invalidates non-URLs and malformed URLs', () => {
+    expect(isUrl('not a url')).toBe(false);
+    expect(isUrl('http://')).toBe(false);
+    expect(isUrl('ftp://')).toBe(false);
+    expect(isUrl('http://.com')).toBe(false);
+  });
+
+  test('handles non-string inputs gracefully', () => {
+    expect(isUrl(123)).toBe(false);
+    expect(isUrl(null)).toBe(false);
+    expect(isUrl(undefined)).toBe(false);
+    expect(isUrl({})).toBe(false);
+  });
+
+  test('invalidates URLs without protocol if not a local URL', () => {
+    expect(isUrl('example.com')).toBe(false);
+    expect(isUrl('www.example.com')).toBe(false);
+  });
+
+  test('validates bare hash links', () => {
+    expect(isUrl('#foo')).toBe(true);
+    expect(isUrl('#section1')).toBe(true);
+  });
+
+  test('validates tel links', () => {
+    expect(isUrl('tel:123')).toBe(true);
+    expect(isUrl('tel:1234567')).toBe(true);
+  });
+});

--- a/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/transforms/is-url.ts
@@ -1,0 +1,45 @@
+const protocolAndDomainRE = /^(?:\w+:)?\/\/(\S+)$/;
+const emailLintRE = /mailto:([^?\\]+)/;
+const telLintRE = /tel:([\d-]+)/;
+const localhostDomainRE = /^localhost[\d:?]*(?:[^\d:?]\S*)?$/;
+const nonLocalhostDomainRE = /^[^\s.]+\.\S{2,}$/;
+const localUrlRE = /^\/\S+/;
+
+export const isUrl = (value: unknown) => {
+  if (typeof value !== 'string') {
+    return false;
+  }
+
+  if (value.startsWith('#')) {
+    return true;
+  }
+
+  const generalMatch = value.match(protocolAndDomainRE);
+  const emailLinkMatch = value.match(emailLintRE);
+  const telLinkMatch = value.match(telLintRE);
+  const localUrlMatch = value.match(localUrlRE);
+
+  if (emailLinkMatch || telLinkMatch || localUrlMatch) {
+    return true;
+  }
+
+  if (generalMatch) {
+    const everythingAfterProtocol = generalMatch[1];
+    if (!everythingAfterProtocol) {
+      return false;
+    }
+
+    try {
+      new URL(value);
+    } catch {
+      return false;
+    }
+
+    return (
+      localhostDomainRE.test(everythingAfterProtocol) ||
+      nonLocalhostDomainRE.test(everythingAfterProtocol)
+    );
+  }
+
+  return false;
+};

--- a/packages/v4/@tinacms/rich-text/src/plate/types.ts
+++ b/packages/v4/@tinacms/rich-text/src/plate/types.ts
@@ -1,0 +1,15 @@
+export interface TemplateField {
+  name: string;
+  label?: string;
+  type?: string;
+  isTitle?: boolean;
+}
+
+export type MdxTemplate = {
+  label: string;
+  key: string;
+  inline?: boolean;
+  name: string;
+  defaultItem?: {};
+  fields: TemplateField[];
+};

--- a/packages/v4/@tinacms/rich-text/src/value.test.ts
+++ b/packages/v4/@tinacms/rich-text/src/value.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { EMPTY_RICH_TEXT } from './value';
+
+describe('EMPTY_RICH_TEXT', () => {
+  it('cannot be mutated', () => {
+    expect(Object.isFrozen(EMPTY_RICH_TEXT)).toBe(true);
+    expect(Object.isFrozen(EMPTY_RICH_TEXT.children)).toBe(true);
+  });
+
+  it('throws rather than silently accepting a write in strict mode', () => {
+    expect(() => {
+      (EMPTY_RICH_TEXT.children as RichTextNodeArray).push({ type: 'p' });
+    }).toThrow();
+  });
+
+  it('is an empty document, not a document with an empty paragraph', () => {
+    expect(EMPTY_RICH_TEXT).toEqual({ type: 'root', children: [] });
+  });
+});
+
+type RichTextNodeArray = { type: string }[];

--- a/packages/v4/@tinacms/rich-text/src/value.ts
+++ b/packages/v4/@tinacms/rich-text/src/value.ts
@@ -1,0 +1,14 @@
+export interface RichTextNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface RichTextValue {
+  type: 'root';
+  children: RichTextNode[];
+}
+
+export const EMPTY_RICH_TEXT: RichTextValue = Object.freeze({
+  type: 'root',
+  children: Object.freeze([]) as RichTextNode[],
+});

--- a/packages/v4/@tinacms/rich-text/tsconfig.json
+++ b/packages/v4/@tinacms/rich-text/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../../../base.tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "jsx": "react-jsx",
+    "paths": {
+      // The repo root still resolves @types/react 18 (v3 is a React 18 package).
+      // Without these, a compilation that pulls in React 19-typed deps (Plate,
+      // Radix) sees two React type identities and every forwardRef component
+      // fails ElementType. Pin this package to its own React 19 types.
+      "react": ["./node_modules/@types/react"],
+      "react/*": ["./node_modules/@types/react/*"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-dom/*": ["./node_modules/@types/react-dom/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist", "src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"],
+  "include": ["src"]
+}

--- a/packages/v4/@tinacms/rich-text/tsconfig.test.json
+++ b/packages/v4/@tinacms/rich-text/tsconfig.test.json
@@ -1,0 +1,19 @@
+{
+  // The main tsconfig excludes tests because it emits declarations and tests are
+  // not part of the public surface. That left them unchecked by anything: vitest
+  // strips types without reading them, so a test could reference a type that no
+  // longer exists and both `pnpm types` and `pnpm test` would pass. That happened
+  // — a rename left `RichTextAst` behind in two test files and nothing noticed.
+  //
+  // This config checks them and emits nothing. `pnpm types` runs both.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "emitDeclarationOnly": false,
+    // Nothing is emitted, so rootDir has no job here — and keeping src's would
+    // reject the config files at the package root that this also checks.
+    "rootDir": "."
+  },
+  "exclude": ["node_modules", "**/dist"],
+  "include": ["src", "*.ts"]
+}

--- a/packages/v4/@tinacms/rich-text/vitest.config.ts
+++ b/packages/v4/@tinacms/rich-text/vitest.config.ts
@@ -1,0 +1,10 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});

--- a/packages/v4/@tinacms/tinacms/_docs/rich-text-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/rich-text-field.md
@@ -1,0 +1,237 @@
+# The `rich-text` field
+
+The `rich-text` field is one of the field plugins that v4 supplies. It is the
+Plate editor from v3, and an author sees the formatted text during the edit. The
+document stores markdown, and the editor holds the MDX abstract syntax tree
+(AST). `@tinacms/mdx` converts between the two formats. It is the same parser as
+v3, thus v3 content opens without a change. With `isBody: true`, the field
+controls the markdown body of the file, and not a frontmatter key. The source
+code is in `plugins/fields/rich-text/`.
+
+## Authoring
+
+`t.richText({...})` adds `type: 'rich-text'` (`RICH_TEXT_FIELD_TYPE`) to the
+config:
+
+```ts
+import { t } from '@tinacms/tinacms';
+
+const collection = {
+  name: 'post',
+  format: 'mdx',
+  fields: [
+    t.string({ name: 'title', required: true }),
+    t.richText({ name: 'body', label: 'Body', isBody: true }),
+  ],
+};
+```
+
+The config (`RichTextFieldSchema`, which extends `BaseFieldSchema`):
+
+| Key | Type | Effect |
+|---|---|---|
+| `name` | `string` (necessary) | The field key in the document. It is also the alternative label. |
+| `label` | `string` | The label on the screen. The validation messages use it. |
+| `required` | `boolean` | An empty body does not pass validation. |
+| `isBody` | `boolean` | This field is the markdown body of the file, and not a frontmatter key. |
+| `templates` | `MdxTemplate[]` | The MDX components that an author can embed in the text. |
+| `overrides` | `ToolbarOverrides` | The toolbar buttons and the heading levels that the editor shows. |
+
+v3 also took a bare list of buttons under `toolbarOverride`. v4 drops it:
+`overrides.toolbar` takes the same list, and it is the only shape the editor
+reads. A v3 schema with `toolbarOverride: ['bold', 'italic']` becomes
+`overrides: { toolbar: ['bold', 'italic'] }`.
+
+There is no `parser` option. Both of v3's values lose content through this
+field. `slatejson` makes `serializeMDX` return the AST, and this field writes
+that as an empty body. `markdown` uses a stringifier that has no
+`invalid_markdown` branch, so a body that did not parse saves as blank. The
+unset value — the only value — takes the path that both round-trips markdown
+and returns the original source for a body it could not parse. Add the option
+again, behind tests, if a real collection needs it.
+
+## The codec: what the file holds, and what the editor edits
+
+The editor and the storage format are separate. A **codec** owns the format
+entirely — how a body is read from the file and how it is written back — and the
+editor knows nothing about markdown. Replace the codec and you replace the
+format; nothing else in the field changes.
+
+The contract is `rich-text-codec.ts`, which has no dependencies at all so that
+implementing a codec does not drag the default one's parser in behind it:
+
+```ts
+export interface RichTextCodec {
+  name: string;
+  parse(source: string, node: FieldSchema): RichTextValue;
+  serialize(value: RichTextValue, node: FieldSchema): string;
+}
+```
+
+`RichTextValue` is the one thing both sides must agree on: it is the **editor's**
+document model, not any one format's AST. `serialize` always returns a string,
+because that string is what lands in the file.
+
+`node` is the field's own schema. The default codec reads `templates` off it to
+resolve embeds — without them `<Callout />` degrades to a raw `html` node instead
+of an element with props, which is the whole reason `descriptor.parse` and
+`descriptor.serialize` take a second argument at all. A field whose conversion
+uses only the value, like `number`, ignores it.
+
+### Choosing a codec
+
+The default is `mdxCodec` (`mdx-codec.ts`), markdown/MDX through `@tinacms/mdx` —
+the same parser v3 used, so a v3 content folder opens unchanged. A field can
+override it:
+
+```ts
+t.richText({ name: 'body', isBody: true, codec: myCodec })
+```
+
+`codecFor(node)` resolves it, and lives beside the default rather than beside the
+contract, so the contract stays implementation-free and the universal entry
+(`src/index.ts` reaches the schema) never pulls a parser into the main bundle.
+A project-wide default belongs on `defineConfig` (ADR-024) when that lands.
+
+One honest limit: because `codecFor` holds the default, overriding a field's codec
+does not currently drop `@tinacms/mdx` from the bundle. That is a bundling
+concern, not a correctness one, and the editor chunk dwarfs it either way.
+
+`rich-text-codec.test.ts` drives the whole field with a codec that stores
+upper-cased plain text — deliberately nothing like markdown, so it fails if any
+markdown assumption leaks out of the codec.
+
+### The separator line
+
+gray-matter adds the body to the closing `---\n` line directly. Thus the empty
+line between the frontmatter and the prose is a `\n` character at the start of
+the body string. The AST has no concept of leading space characters, thus
+`serializeMDX` removes that character. Without a correction, the CMS would
+change the format of each v3 document at the first save.
+
+`markdown.adapter.ts` writes the character again at serialization. Thus a save
+with no changes writes the same bytes to the file.
+`rich-text-field.test.tsx` tests this behavior.
+
+## `isBody` and the source of the value
+
+One field in a collection can set `isBody`, and no more than one. The local data
+layer makes this check (`content-multiple-body-fields`), because a file has one
+body.
+
+`markdownAdapter` gives the body to that field as its value at read, and it
+writes the body again at save. Thus `md` files and `mdx` files operate in the
+same way. A `json` file has no body, thus the adapter ignores the field name. If
+a save does not include the field, the body does not change.
+
+The form edits the body as the MDX AST. The local GraphQL pipeline
+(`graphql-pipeline.ts`) gives the same body to the website in the v3 MDX AST
+format. Thus one file has one shape and two consumers.
+
+## Render the value
+
+`<TinaMarkdown>` (`src/rich-text/`) renders the AST to React.
+`@tinacms/tinacms/adapters/react` exports it. It comes from v3 without a change,
+thus the `components` map of a site continues to operate:
+
+```tsx
+import { TinaMarkdown } from '@tinacms/tinacms/adapters/react';
+
+<TinaMarkdown content={post.body} components={{ MyEmbed: ({ ... }) => ... }} />
+```
+
+## Validation
+
+| Config | Rule | Message |
+|---|---|---|
+| — | The value must be an AST with the shape `{ type: 'root', children }` | `<label> must be rich text` |
+| — | The first child must not be `invalid_markdown` | `Unable to parse rich-text` |
+| `required` | The value must have children | `<label> is required` |
+
+If `@tinacms/mdx` cannot parse the markdown, it does not throw an error. It
+gives one `invalid_markdown` node, so the editor can still show the source text.
+
+This validation reports; it does not protect. A save does not run the resolver —
+`useFormSave` digests the values and calls `onSave` directly — so the value
+reaches the disk whether or not it passes. What keeps that safe is the
+serializer: for an `invalid_markdown` node it writes the original source back,
+not a blank body. `rich-text-field.test.tsx` covers that round trip.
+
+## Embeds
+
+An MDX component that an author can insert is a `templates` entry. The parser
+needs that list to build the element: with the template, `<Callout text="hi" />`
+becomes an `mdxJsxFlowElement` that carries `props`; without it, the same source
+becomes a raw `html` node. The list reaches the parser through the `node`
+argument of `parse`, and it reaches the embed components through
+`EditorContext`, which `rich-text-field.ui.tsx` provides.
+
+Editing the props of an embed needs the object field, which does not exist yet
+(see the next section). The embeds parse, render, and serialize now, so a
+document loses nothing when a user opens it.
+
+## The parts that the port does not include
+
+The editor is the editor of v3, file for file (86 files in `plate/`). Three
+parts are stubs, because v4 does not have the necessary capabilities now:
+
+| Stub | It waits for | Effect now |
+|---|---|---|
+| `nested-form.tsx` | The object field (`plugins/fields/object/`) | The CMS parses, renders, and serializes the embeds. Their side panel is not available, thus a document loses no data when a user opens it. |
+| `image-toolbar-button.tsx` | The media capability (`plugins/media/`) | The CMS renders and serializes the image nodes that exist. A user cannot insert a new image. |
+| The field definitions of `create-img-plugin` | The image field | An author edits the URL of an embed as a plain string. |
+| Raw mode | A raw markdown editor | v4 has no editor to switch to, so the toolbar button and the button on the parse-error card are hidden instead of dead. `EditorContext` keeps the `setRawMode` shape for when one exists. |
+
+v3 selected a widget for each field with `component`. v4 finds the widget from
+`type` in the field registry (ADR-009). For this reason, those field definitions
+have a different shape.
+
+The toolbar components use Radix, ariakit, and headlessui, and they do not use
+base-ui from v4. A change of approximately 53 `plate-ui` components to base-ui
+is a separate task. The team keeps it separate from the changes to the form
+layer.
+
+## Bundle
+
+The editor is approximately 3.6 MB after minification. The dynamic `client()`
+import of the plugin keeps the editor out of the main bundle. In the playground
+build, the editor is a separate chunk, and the entry chunk is 314 kB. The split
+of `.plugin.ts` and `.client.tsx` exists for this condition. `mermaid` is a
+large part of the weight of the editor. The team can remove `mermaid`, or load
+it only when a user needs it.
+
+## The connections
+
+- The manifest is `rich-text-field.plugin.ts`. Its name is
+  `tina:field:rich-text`, and it exports `richTextFieldPlugin`.
+- The registration is in `plugins/fields/index.ts`. That file adds the plugin to
+  `corePlugins`, and it supplies `t.richText`.
+- The body routing is in `markdown.adapter.ts` and `local-data-layer.ts`
+  (`bodyField`).
+- The renderer is in `src/rich-text/`. `adapters/react` exports it.
+
+## A note about `@types/react`
+
+The root of the repository supplies `@types/react` version 18, because v3 is a
+React 18 package. Some dependencies, for example Plate and Radix, have types for
+React 19. A compilation with those dependencies finds two React type identities.
+Then each `forwardRef` component fails the `ElementType` check, and the
+compilation gives approximately 94 errors. To prevent this, `tsconfig.json`
+points `react` and `react-dom` to the types in this package.
+
+## Tests
+
+`rich-text-field.test.tsx` does these tests:
+
+- It converts markdown to the AST with ingest, then converts the AST to markdown
+  with digest.
+- It makes sure that a save with no changes writes the same bytes through the
+  format adapter.
+- It makes sure that the separator line is correct after an edit to the body.
+- It makes sure that an empty body gets the default value.
+- It applies the `required` rule to an empty body.
+- It rejects an `invalid_markdown` node.
+- It rejects a value that is not an AST.
+- It examines the metadata of the descriptor in the registry.
+
+`format-adapters.test.ts` and `local-data-layer.test.ts` test the body routing.

--- a/packages/v4/@tinacms/tinacms/e2e/rich-text-field.spec.ts
+++ b/packages/v4/@tinacms/tinacms/e2e/rich-text-field.spec.ts
@@ -1,0 +1,141 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from '@playwright/test';
+import { setColumnWidth, toolbar } from './form-column';
+
+const body = (page: import('@playwright/test').Page) =>
+  page.getByRole('textbox', { name: 'body' });
+
+const saveButton = (page: import('@playwright/test').Page) =>
+  page.locator('aside').getByRole('button', { name: 'Save', exact: true });
+
+const status = (page: import('@playwright/test').Page) =>
+  page.locator('aside header').getByText(/^(No changes|Unsaved|Saved)$/);
+
+const openDocument = async (
+  page: import('@playwright/test').Page,
+  name: string
+) => {
+  await page.goto(
+    `/#/collections/post/${encodeURIComponent(`content/posts/${name}`)}`
+  );
+  await expect(body(page)).toBeVisible();
+};
+
+const CONTENT_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../playground/content/posts'
+);
+const snapshot = new Map<string, string>();
+
+test.beforeAll(async () => {
+  for (const name of await fs.readdir(CONTENT_DIR)) {
+    const file = path.join(CONTENT_DIR, name);
+    snapshot.set(file, await fs.readFile(file, 'utf8'));
+  }
+});
+
+test.afterAll(async () => {
+  await Promise.all(
+    [...snapshot].map(([file, contents]) => fs.writeFile(file, contents))
+  );
+});
+
+test.beforeEach(async ({ page }) => {
+  await openDocument(page, 'hello-world.mdx');
+});
+
+test.describe('rich-text layout', () => {
+  test('the editor stays inside the sidebar, even with nested lists', async ({
+    page,
+  }) => {
+    await openDocument(page, 'second-post.mdx');
+    await expect(body(page)).toContainText('bullet point');
+
+    const overflow = await page.locator('aside').evaluate((aside) => ({
+      client: aside.clientWidth,
+      scroll: aside.scrollWidth,
+    }));
+    expect(overflow.scroll).toBeLessThanOrEqual(overflow.client);
+
+    const fits = await body(page).evaluate((editor) => {
+      const track = editor.closest('aside') as HTMLElement;
+      return editor.clientWidth <= track.clientWidth;
+    });
+    expect(fits).toBe(true);
+  });
+
+  test('the toolbar fits its column at every width the column can take', async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1800, height: 900 });
+    await openDocument(page, 'second-post.mdx');
+
+    for (const columnWidth of [352, 420, 480, 560, 700, 900, 1200]) {
+      await setColumnWidth(page, columnWidth);
+
+      const row = await toolbar(page).evaluate((container) => {
+        const controls = Array.from(
+          (container.firstElementChild as HTMLElement).children
+        );
+        return {
+          container: container.getBoundingClientRect().width,
+          controls: controls.reduce(
+            (total, control) => total + control.getBoundingClientRect().width,
+            0
+          ),
+        };
+      });
+
+      expect(
+        row.controls,
+        `toolbar controls overflow a ${columnWidth}px column`
+      ).toBeLessThanOrEqual(row.container);
+    }
+  });
+});
+
+test.describe('rich-text save lifecycle', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('goes pristine -> dirty on a real edit -> clean once saved', async ({
+    page,
+  }) => {
+    await expect(status(page)).toHaveText('No changes');
+
+    await body(page).click();
+    await expect(status(page)).toHaveText('No changes');
+
+    await body(page).pressSequentially('Edited. ');
+    await expect(status(page)).toHaveText('Unsaved');
+
+    await saveButton(page).click();
+    await expect(status(page)).toHaveText('Saved');
+  });
+
+  test('typing and then deleting it returns the document to clean', async ({
+    page,
+  }) => {
+    await expect(status(page)).toHaveText('No changes');
+
+    await body(page).click();
+    await body(page).pressSequentially('Edited.');
+    await expect(status(page)).toHaveText('Unsaved');
+
+    for (const _ of 'Edited.') await page.keyboard.press('Backspace');
+    await expect(status(page)).toHaveText('Saved');
+  });
+
+  test('a second edit after saving can also reach clean', async ({ page }) => {
+    await body(page).click();
+    await body(page).pressSequentially('One. ');
+    await saveButton(page).click();
+    await expect(status(page)).toHaveText('Saved');
+
+    await body(page).pressSequentially('Two. ');
+    await expect(status(page)).toHaveText('Unsaved');
+    await saveButton(page).click();
+    await expect(status(page)).toHaveText('Saved');
+  });
+});

--- a/packages/v4/@tinacms/tinacms/package.json
+++ b/packages/v4/@tinacms/tinacms/package.json
@@ -79,6 +79,7 @@
     "@tanstack/react-query": "^5.101.4",
     "@tinacms/graphql": "workspace:*",
     "@tinacms/mdx": "workspace:*",
+    "@tinacms/rich-text": "workspace:*",
     "@tinacms/ui": "workspace:*",
     "gray-matter": "catalog:",
     "react-hook-form": "^7.80.0",

--- a/packages/v4/@tinacms/tinacms/playground/src/index.css
+++ b/packages/v4/@tinacms/tinacms/playground/src/index.css
@@ -6,3 +6,4 @@
    the editor renders unstyled and overflows its container. */
 @source "../../src";
 @source "../../../ui/src";
+@source "../../../rich-text/src";

--- a/packages/v4/@tinacms/tinacms/playground/src/preview/post-preview.tsx
+++ b/packages/v4/@tinacms/tinacms/playground/src/preview/post-preview.tsx
@@ -1,4 +1,8 @@
-import { tinaField, useTina } from '@tinacms/tinacms/adapters/react';
+import {
+  TinaMarkdown,
+  tinaField,
+  useTina,
+} from '@tinacms/tinacms/adapters/react';
 import { sampleDocument } from '../content';
 
 export function PostPreview() {
@@ -26,6 +30,9 @@ export function PostPreview() {
           ? 'This preview renders the document streamed from the editor. Click the title or the badge to focus its field in the sidebar.'
           : 'Standalone preview — rendering the static document.'}
       </p>
+      <div {...tinaField('body')}>
+        <TinaMarkdown content={post.body} />
+      </div>
     </article>
   );
 }

--- a/packages/v4/@tinacms/tinacms/playground/tina/config.ts
+++ b/packages/v4/@tinacms/tinacms/playground/tina/config.ts
@@ -14,6 +14,7 @@ export const postCollection = {
   fields: [
     t.string({ name: 'title', label: 'Title', required: true, min: 3 }),
     t.boolean({ name: 'featured', label: 'Featured' }),
+    t.richText({ name: 'body', label: 'Body', isBody: true }),
   ],
 } satisfies CollectionSchema;
 

--- a/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
+++ b/packages/v4/@tinacms/tinacms/playground/tina/tina-lock.json
@@ -19,6 +19,12 @@
             "name": "featured",
             "label": "Featured",
             "type": "boolean"
+          },
+          {
+            "name": "body",
+            "label": "Body",
+            "isBody": true,
+            "type": "rich-text"
           }
         ]
       }
@@ -32,6 +38,7 @@
   },
   "primitives": {
     "boolean": 1,
+    "rich-text": 1,
     "string": 1
   }
 }

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/index.ts
@@ -1,5 +1,11 @@
 export { TINA_FIELD_ATTR, tinaField } from '../../preview/protocol';
 export {
+  type Components,
+  StaticTinaMarkdown,
+  TinaMarkdown,
+  type TinaMarkdownContent,
+} from './tina-markdown';
+export {
   useTina,
   type UseTinaOptions,
   type UseTinaResult,

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.test.tsx
@@ -1,0 +1,271 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import type { TinaMarkdownContent } from '../../rich-text';
+import { StaticTinaMarkdown, TinaMarkdown } from './tina-markdown';
+
+const html = (
+  content: TinaMarkdownContent | TinaMarkdownContent[],
+  components?: any
+) =>
+  render(<TinaMarkdown content={content} components={components} />).container
+    .innerHTML;
+
+const staticHtml = (
+  content: TinaMarkdownContent | TinaMarkdownContent[],
+  components?: any
+) =>
+  render(<StaticTinaMarkdown content={content} components={components} />)
+    .container.innerHTML;
+
+const text = (value: string, marks: Record<string, unknown> = {}) =>
+  ({ type: 'text', text: value, ...marks }) as TinaMarkdownContent;
+
+describe('fallback markup', () => {
+  it('renders nothing for an empty value', () => {
+    expect(html(undefined as any)).toBe('');
+    expect(html({ type: 'root' })).toBe('');
+  });
+
+  it('renders a heading and a paragraph', () => {
+    expect(
+      html([
+        { type: 'h1', children: [text('Title')] },
+        { type: 'p', children: [text('Body')] },
+      ])
+    ).toBe('<h1>Title</h1><p>Body</p>');
+  });
+
+  it('nests marks outermost first', () => {
+    expect(
+      html([
+        {
+          type: 'p',
+          children: [text('hi', { bold: true, italic: true, code: true })],
+        },
+      ])
+    ).toBe('<p><strong><em><code>hi</code></em></strong></p>');
+  });
+
+  it('styles a highlight with its colour', () => {
+    expect(
+      html([
+        {
+          type: 'p',
+          children: [text('hi', { highlight: true, highlightColor: '#ff0' })],
+        },
+      ])
+    ).toBe('<p><mark style="background-color: #ff0;">hi</mark></p>');
+  });
+
+  it('renders a list', () => {
+    expect(
+      html([
+        {
+          type: 'ul',
+          children: [
+            {
+              type: 'li',
+              children: [{ type: 'lic', children: [text('one')] }],
+            },
+          ],
+        },
+      ])
+    ).toBe('<ul><li><div>one</div></li></ul>');
+  });
+
+  it('renders a code block as pre and code', () => {
+    expect(
+      html([
+        {
+          type: 'code_block',
+          children: [
+            { type: 'code_line', children: [text('one')] },
+            { type: 'code_line', children: [text('two')] },
+          ],
+        } as TinaMarkdownContent,
+      ])
+    ).toBe('<pre><code>one\ntwo</code></pre>');
+  });
+
+  it('escapes raw html instead of injecting it', () => {
+    expect(
+      html([{ type: 'html', value: '<script>alert(1)</script>' } as any])
+    ).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('drops an unsafe url', () => {
+    expect(
+      html([{ type: 'a', url: 'javascript:alert(1)', children: [] } as any])
+    ).not.toContain('javascript');
+  });
+
+  it('says which component was missing', () => {
+    expect(
+      html([{ type: 'mdxJsxFlowElement', name: 'Hero', props: {} } as any])
+    ).toBe('<span>No component provided for Hero</span>');
+  });
+});
+
+describe('supplied components', () => {
+  it('takes over a block and receives its rendered children', () => {
+    expect(
+      html([{ type: 'p', children: [text('hi')] }], {
+        p: (props: any) => <p className='lead'>{props.children}</p>,
+      })
+    ).toBe('<p class="lead">hi</p>');
+  });
+
+  it('receives the props of the node itself', () => {
+    expect(
+      html(
+        [{ type: 'a', url: 'https://tina.io', children: [text('go')] } as any],
+        {
+          a: (props: any) => <a href={props.url}>{props.children}</a>,
+        }
+      )
+    ).toBe('<a href="https://tina.io">go</a>');
+  });
+
+  it('renders an mdx element with the props from the tree', () => {
+    expect(
+      html(
+        [
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'Hero',
+            props: { title: 'Hi' },
+          } as any,
+        ] as any,
+        {
+          Hero: (props: any) => <h1>{props.title}</h1>,
+        }
+      )
+    ).toBe('<h1>Hi</h1>');
+  });
+
+  it('wraps a leaf in a supplied mark component', () => {
+    expect(
+      html([{ type: 'p', children: [text('hi', { bold: true })] }], {
+        bold: (props: any) => <b className='loud'>{props.children}</b>,
+      })
+    ).toBe('<p><b class="loud">hi</b></p>');
+  });
+
+  it('falls back to block_quote when only the deprecated name is given', () => {
+    expect(
+      html([{ type: 'blockquote', children: [text('hi')] }], {
+        block_quote: (props: any) => <blockquote>{props.children}</blockquote>,
+      })
+    ).toBe('<blockquote>hi</blockquote>');
+  });
+});
+
+describe('tables', () => {
+  const cell = (value: string) => ({
+    value: [{ type: 'p', children: [text(value)] }] as any,
+  });
+
+  it('renders an mdx table with a header row', () => {
+    expect(
+      html([
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'table',
+          props: {
+            firstRowHeader: true,
+            align: ['left', 'right'],
+            tableRows: [
+              { tableCells: [cell('A'), cell('B')] },
+              { tableCells: [cell('1'), cell('2')] },
+            ],
+          },
+        } as any,
+      ])
+    ).toBe(
+      '<table><thead><tr>' +
+        '<th align="left" style="text-align: left;">A</th>' +
+        '<th align="right" style="text-align: right;">B</th>' +
+        '</tr></thead><tbody><tr>' +
+        '<td align="left" style="text-align: left;">1</td>' +
+        '<td align="right" style="text-align: right;">2</td>' +
+        '</tr></tbody></table>'
+    );
+  });
+
+  it('leaves an unaligned cell without a text-align rule', () => {
+    expect(
+      html([
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'table',
+          props: { tableRows: [{ tableCells: [cell('A')] }] },
+        } as any,
+      ])
+    ).toBe('<table><tbody><tr><td>A</td></tr></tbody></table>');
+  });
+
+  it('hands a supplied table component the raw props', () => {
+    expect(
+      html(
+        [
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'table',
+            props: { tableRows: [{ tableCells: [cell('A')] }] },
+          } as any,
+        ],
+        { table: (props: any) => <div>{props.tableRows.length} row</div> }
+      )
+    ).toBe('<div>1 row</div>');
+  });
+
+  it('renders a pipe table with the border fallback', () => {
+    expect(
+      html([
+        {
+          type: 'table',
+          children: [
+            {
+              type: 'tr',
+              children: [
+                {
+                  type: 'td',
+                  children: [{ type: 'p', children: [text('A')] }],
+                },
+              ],
+            },
+          ],
+        } as any,
+      ])
+    ).toContain(
+      '<td style="border: 1px solid #EDECF3; padding: 0.25rem;">A</td>'
+    );
+  });
+});
+
+describe('the static renderer', () => {
+  const fixture: TinaMarkdownContent[] = [
+    { type: 'h1', children: [text('Title')] },
+    { type: 'p', children: [text('hi', { bold: true, italic: true })] },
+    {
+      type: 'ul',
+      children: [
+        { type: 'li', children: [{ type: 'lic', children: [text('one')] }] },
+      ],
+    },
+    { type: 'code_block', value: 'plain' } as TinaMarkdownContent,
+    { type: 'hr' },
+  ];
+
+  it('renders what the memoised one renders', () => {
+    expect(staticHtml(fixture)).toBe(html(fixture));
+  });
+
+  it('renders supplied components the same way', () => {
+    const components = {
+      p: (props: any) => <p className='lead'>{props.children}</p>,
+      bold: (props: any) => <b>{props.children}</b>,
+    };
+    expect(staticHtml(fixture, components)).toBe(html(fixture, components));
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.tsx
+++ b/packages/v4/@tinacms/tinacms/src/adapters/react/tina-markdown.tsx
@@ -1,0 +1,84 @@
+import React from 'react';
+import {
+  type RichTextComponents,
+  type RichTextHost,
+  type TinaMarkdownContent,
+  renderRichText,
+} from '../../rich-text';
+
+export type { TinaMarkdownContent };
+
+export type Components<ComponentAndProps extends object> = RichTextComponents<
+  ComponentAndProps,
+  React.JSX.Element
+>;
+
+type RichTextProps<CustomComponents extends { [key: string]: object }> = {
+  content: TinaMarkdownContent | TinaMarkdownContent[];
+  components?:
+    | Components<{}>
+    | Components<{
+        [BK in keyof CustomComponents]: (
+          props: CustomComponents[BK]
+        ) => React.JSX.Element;
+      }>;
+};
+
+const reactHost: RichTextHost<React.ReactNode> = {
+  element: (tag, props, children) =>
+    children === null
+      ? React.createElement(tag, props)
+      : React.createElement(tag, props, children),
+  component: (component, props, children) => {
+    const Component = component as React.ComponentType<any>;
+    return children === null ? (
+      <Component {...props} />
+    ) : (
+      <Component {...props}>{children}</Component>
+    );
+  },
+  text: (value) => value,
+  list: (items) => (
+    <>
+      {items.map((item, index) => (
+        <React.Fragment key={index}>{item}</React.Fragment>
+      ))}
+    </>
+  ),
+  memo: (render, cacheKey) => <MemoNode render={render} cacheKey={cacheKey} />,
+};
+
+const staticReactHost: RichTextHost<React.ReactNode> = {
+  ...reactHost,
+  memo: undefined,
+};
+
+export const TinaMarkdown = <
+  CustomComponents extends { [key: string]: object } = any,
+>({
+  content,
+  components = {},
+}: RichTextProps<CustomComponents>) => (
+  <>{renderRichText(content, components, reactHost)}</>
+);
+
+export const StaticTinaMarkdown = <
+  CustomComponents extends { [key: string]: object } = any,
+>({
+  content,
+  components = {},
+}: RichTextProps<CustomComponents>) => (
+  <>{renderRichText(content, components, staticReactHost)}</>
+);
+
+// FIXME: needs more testing with custom components. The memo stays by hand:
+const MemoNode = ({
+  render,
+  cacheKey,
+}: {
+  render: () => React.ReactNode;
+  cacheKey: unknown;
+}) => {
+  const node = React.useMemo(render, [JSON.stringify(cacheKey)]);
+  return <>{node}</>;
+};

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/codegen.ts
@@ -139,6 +139,7 @@ const ADMIN_CSS = `@import "@tinacms/ui/globals.css";
    so name the package sources here. These lines go when the dist build lands. */
 @source "../node_modules/@tinacms/tinacms/src";
 @source "../node_modules/@tinacms/ui/src";
+@source "../node_modules/@tinacms/rich-text/src";
 `;
 
 const scaffoldOnce = async (

--- a/packages/v4/@tinacms/tinacms/src/cli/commands/init.ts
+++ b/packages/v4/@tinacms/tinacms/src/cli/commands/init.ts
@@ -25,6 +25,7 @@ export const postCollection = {
   format: 'mdx',
   fields: [
     t.string({ name: 'title', label: 'Title', required: true }),
+    t.richText({ name: 'body', label: 'Body', isBody: true }),
   ],
 } satisfies CollectionSchema;
 

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
@@ -1,5 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+// Warm the Plate editor chain at module scope. Boot dynamically imports the
+// rich-text client, and paying its transform cost inside a test's async
+// timeout flakes on contended CI runners.
+import '../plugins/fields/rich-text/rich-text-field.client';
 import { asResolvedConfig } from '../config';
 import { defineConfig } from '../config';
 import { definePlugin } from '../core/plugin';
@@ -35,7 +39,7 @@ describe('TinaProvider boot', () => {
       </TinaProvider>
     );
     expect(await screen.findByTestId('field-types')).toHaveTextContent(
-      'boolean,datetime,number,string'
+      'boolean,datetime,number,rich-text,string'
     );
     expect(screen.getByTestId('namespaces')).toHaveTextContent(
       'branch,documents,ui'

--- a/packages/v4/@tinacms/tinacms/src/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/index.ts
@@ -36,5 +36,6 @@ export type {
   BooleanFieldSchema,
   DatetimeFieldSchema,
   NumberFieldSchema,
+  RichTextFieldSchema,
   StringFieldSchema,
 } from './plugins/fields';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -4,6 +4,8 @@ import datetimeFieldPlugin from './datetime/datetime-field.plugin';
 import { datetime } from './datetime/datetime-field.schema';
 import numberFieldPlugin from './number/number-field.plugin';
 import { number } from './number/number-field.schema';
+import richTextFieldPlugin from './rich-text/rich-text-field.plugin';
+import { richText } from './rich-text/rich-text-field.schema';
 import stringFieldPlugin from './string/string-field.plugin';
 import { string } from './string/string-field.schema';
 
@@ -12,12 +14,14 @@ export const corePlugins = [
   booleanFieldPlugin,
   numberFieldPlugin,
   datetimeFieldPlugin,
+  richTextFieldPlugin,
 ];
 
 // TODO: build `t` from the configured plugin set when defineConfig arrives
-export const t = { string, boolean, number, datetime };
+export const t = { string, boolean, number, datetime, richText };
 
 export type { BooleanFieldSchema } from './boolean/boolean-field.schema';
 export type { DatetimeFieldSchema } from './datetime/datetime-field.schema';
 export type { NumberFieldSchema } from './number/number-field.schema';
+export type { RichTextFieldSchema } from './rich-text/rich-text-field.schema';
 export type { StringFieldSchema } from './string/string-field.schema';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/markdown.codec.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/markdown.codec.ts
@@ -1,0 +1,18 @@
+import type { FieldSchema } from '../../../core/schema/types';
+import {
+  type MdxField,
+  asMdxField,
+  parseWithMdx,
+  serializeWithMdx,
+} from './mdx-parser';
+import type { RichTextCodec } from './rich-text-codec';
+
+const markdownField = (node: FieldSchema): MdxField => ({
+  ...asMdxField(node),
+  parser: { type: 'markdown' as const },
+});
+
+export const markdownCodec: RichTextCodec = {
+  parse: (source, node) => parseWithMdx(source, markdownField(node)),
+  serialize: (value, node) => serializeWithMdx(value, markdownField(node)),
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx-parser.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx-parser.ts
@@ -1,0 +1,36 @@
+import { parseMDX, serializeMDX } from '@tinacms/mdx';
+import { INVALID_MARKDOWN_TYPE } from '@tinacms/rich-text';
+import type { FieldSchema } from '../../../core/schema/types';
+import type { RichTextValue } from './rich-text-codec';
+
+const passthroughMedia = (url: string): string => url;
+
+export type MdxField = Parameters<typeof parseMDX>[1];
+
+export const asMdxField = (node: FieldSchema): MdxField => node as MdxField;
+
+const unparsedSource = (value: RichTextValue): string | undefined => {
+  const first = value.children[0] as
+    | { type?: string; value?: string }
+    | undefined;
+  if (first?.type !== INVALID_MARKDOWN_TYPE) return undefined;
+  return first.value ?? '';
+};
+
+export const parseWithMdx = (source: string, field: MdxField): RichTextValue =>
+  parseMDX(source, field, passthroughMedia) as RichTextValue;
+
+export const serializeWithMdx = (
+  value: RichTextValue,
+  field: MdxField
+): string => {
+  if (!value?.children) return '';
+  const unparsed = unparsedSource(value);
+  if (unparsed !== undefined) return unparsed;
+  const serialized = serializeMDX(
+    value as Parameters<typeof serializeMDX>[0],
+    field,
+    passthroughMedia
+  );
+  return typeof serialized === 'string' ? serialized : '';
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx.codec.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/mdx.codec.ts
@@ -1,0 +1,7 @@
+import { asMdxField, parseWithMdx, serializeWithMdx } from './mdx-parser';
+import type { RichTextCodec } from './rich-text-codec';
+
+export const mdxCodec: RichTextCodec = {
+  parse: (source, node) => parseWithMdx(source, asMdxField(node)),
+  serialize: (value, node) => serializeWithMdx(value, asMdxField(node)),
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.test.ts
@@ -1,0 +1,205 @@
+import { INVALID_MARKDOWN_TYPE } from '@tinacms/rich-text';
+import { describe, expect, it } from 'vitest';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import type { CollectionSchema } from '../../../core/schema/types';
+import { t } from '../../../index';
+import { markdownCodec } from './markdown.codec';
+import { mdxCodec } from './mdx.codec';
+import type { RichTextCodec } from './rich-text-codec';
+import { codecFor } from './rich-text-codecs';
+import richTextFieldPlugin from './rich-text-field.plugin';
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins([richTextFieldPlugin]);
+
+const shoutCodec: RichTextCodec = {
+  parse: (source) => ({
+    type: 'root',
+    children: [{ type: 'p', children: [{ type: 'text', text: source }] }],
+  }),
+  serialize: (value) => {
+    const paragraph = value.children[0] as
+      | { children?: { text?: string }[] }
+      | undefined;
+    return (paragraph?.children?.[0]?.text ?? '').toUpperCase();
+  },
+};
+
+describe('codec selection', () => {
+  it('defaults to markdown when a field declares none', () => {
+    expect(codecFor(t.richText({ name: 'body' }))).toBe(mdxCodec);
+  });
+
+  it("uses the field's own codec when it declares one", () => {
+    expect(codecFor(t.richText({ name: 'body', codec: shoutCodec }))).toBe(
+      shoutCodec
+    );
+  });
+});
+
+describe('codec selection follows the document', () => {
+  const body = t.richText({ name: 'body' });
+
+  it('reads a .mdx document as MDX and a .md document as markdown', () => {
+    expect(codecFor(body, { documentPath: 'content/posts/a.mdx' })).toBe(
+      mdxCodec
+    );
+    expect(codecFor(body, { documentPath: 'content/posts/a.md' })).toBe(
+      markdownCodec
+    );
+  });
+
+  it('falls back to MDX for a format with no markdown file of its own', () => {
+    expect(codecFor(body, { documentPath: 'content/posts/a.json' })).toBe(
+      mdxCodec
+    );
+    expect(codecFor(body, {})).toBe(mdxCodec);
+    expect(codecFor(body, { documentPath: 'no-extension' })).toBe(mdxCodec);
+  });
+
+  it("lets a field's declared codec win over the document's extension", () => {
+    expect(
+      codecFor(t.richText({ name: 'body', codec: shoutCodec }), {
+        documentPath: 'content/posts/a.md',
+      })
+    ).toBe(shoutCodec);
+  });
+});
+
+describe('the two parsers genuinely differ', () => {
+  const body = t.richText({ name: 'body' });
+  const PROSE_WITH_BRACES = 'Costs {100} dollars\n';
+
+  it('reads braces in .md prose as text where MDX fails the whole body', () => {
+    expect(markdownCodec.parse(PROSE_WITH_BRACES, body)).toEqual({
+      type: 'root',
+      children: [
+        {
+          type: 'p',
+          children: [{ type: 'text', text: 'Costs {100} dollars' }],
+        },
+      ],
+    });
+    expect(mdxCodec.parse(PROSE_WITH_BRACES, body).children[0]).toMatchObject({
+      type: INVALID_MARKDOWN_TYPE,
+    });
+  });
+
+  it('round-trips ordinary markdown unchanged', () => {
+    const source = '# Heading\n\nSome *prose* here.\n';
+    expect(
+      markdownCodec.serialize(markdownCodec.parse(source, body), body)
+    ).toBe(source);
+  });
+
+  it('writes an unparsed body back as its original source, never blank', () => {
+    const source = 'Body the parser could not read\n';
+    const unparsed = {
+      type: 'root' as const,
+      children: [
+        {
+          type: INVALID_MARKDOWN_TYPE,
+          value: source,
+          message: 'nope',
+          children: [{ type: 'text', text: '' }],
+        },
+      ],
+    };
+    expect(markdownCodec.serialize(unparsed, body)).toBe(source);
+  });
+});
+
+describe('a document carries its format through ingest and digest', () => {
+  const fields = [t.richText({ name: 'body', isBody: true })];
+  const PROSE_WITH_BRACES = 'Costs {100} dollars\n';
+
+  it('round-trips a .md body that MDX would have failed on', async () => {
+    const registry = await resolveRegistry();
+    const context = { documentPath: 'content/posts/prices.md' };
+    const values = ingestDocument(
+      { body: PROSE_WITH_BRACES },
+      fields,
+      registry,
+      context
+    );
+    expect(values.body).toMatchObject({
+      children: [{ type: 'p' }],
+    });
+    expect(digestDocument(values, fields, registry, context)).toEqual({
+      body: PROSE_WITH_BRACES,
+    });
+  });
+
+  it('still parses the same body as MDX when the document is .mdx', async () => {
+    const registry = await resolveRegistry();
+    const values = ingestDocument(
+      { body: PROSE_WITH_BRACES },
+      fields,
+      registry,
+      {
+        documentPath: 'content/posts/prices.mdx',
+      }
+    );
+    expect(values.body).toMatchObject({
+      children: [{ type: INVALID_MARKDOWN_TYPE }],
+    });
+  });
+});
+
+describe('a field carries its content through its codec', () => {
+  const collection: CollectionSchema = {
+    name: 'post',
+    format: 'mdx',
+    fields: [t.richText({ name: 'body', isBody: true, codec: shoutCodec })],
+  };
+
+  it('reads the stored body through the codec, not the markdown parser', async () => {
+    const registry = await resolveRegistry();
+    const values = ingestDocument(
+      { body: 'hello there' },
+      collection.fields,
+      registry
+    );
+    expect(values.body).toEqual({
+      type: 'root',
+      children: [
+        { type: 'p', children: [{ type: 'text', text: 'hello there' }] },
+      ],
+    });
+  });
+
+  it('writes what the codec serializes, not markdown', async () => {
+    const registry = await resolveRegistry();
+    const values = ingestDocument(
+      { body: 'hello there' },
+      collection.fields,
+      registry
+    );
+    expect(digestDocument(values, collection.fields, registry)).toEqual({
+      body: 'HELLO THERE',
+    });
+  });
+
+  it('leaves a field on the default codec untouched by the swap', async () => {
+    const registry = await resolveRegistry();
+    const markdownCollection: CollectionSchema = {
+      name: 'post',
+      format: 'mdx',
+      fields: [t.richText({ name: 'body', isBody: true })],
+    };
+    const values = ingestDocument(
+      { body: '# Heading\n' },
+      markdownCollection.fields,
+      registry
+    );
+    expect(digestDocument(values, markdownCollection.fields, registry)).toEqual(
+      {
+        body: '# Heading\n',
+      }
+    );
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codec.ts
@@ -1,0 +1,13 @@
+import type { FieldSchema } from '../../../core/schema/types';
+
+export {
+  EMPTY_RICH_TEXT,
+  type RichTextNode,
+  type RichTextValue,
+} from '@tinacms/rich-text';
+import type { RichTextValue } from '@tinacms/rich-text';
+
+export interface RichTextCodec {
+  parse(source: string, node: FieldSchema): RichTextValue;
+  serialize(value: RichTextValue, node: FieldSchema): string;
+}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codecs.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-codecs.ts
@@ -1,0 +1,65 @@
+import type { FieldTransformContext } from '../../../core/field/contract';
+import {
+  type CollectionFormat,
+  type FieldSchema,
+  formatForPath,
+} from '../../../core/schema/types';
+import { markdownCodec } from './markdown.codec';
+import { mdxCodec } from './mdx.codec';
+import type { RichTextCodec, RichTextValue } from './rich-text-codec';
+import {
+  isRichTextFieldSchema,
+  isRichTextValue,
+} from './rich-text-field.schema';
+
+const codecsByFormat: Partial<Record<CollectionFormat, RichTextCodec>> = {
+  mdx: mdxCodec,
+  md: markdownCodec,
+};
+
+export const codecFor = (
+  node: FieldSchema,
+  context: FieldTransformContext = {}
+): RichTextCodec => {
+  const declared = isRichTextFieldSchema(node) ? node.codec : undefined;
+  if (declared) return declared;
+  if (!context.documentPath) return mdxCodec;
+  const format = formatForPath(context.documentPath);
+  if (!format) return mdxCodec;
+  return codecsByFormat[format] ?? mdxCodec;
+};
+
+const sourceOfValue = new WeakMap<
+  RichTextValue,
+  { codec: RichTextCodec; node: FieldSchema; source: string }
+>();
+
+const sourceOf = (
+  value: RichTextValue,
+  codec: RichTextCodec,
+  node: FieldSchema
+): string => {
+  const cached = sourceOfValue.get(value);
+  if (cached && cached.codec === codec && cached.node === node) {
+    return cached.source;
+  }
+  const source = codec.serialize(value, node);
+  sourceOfValue.set(value, { codec, node, source });
+  return source;
+};
+
+export const writesSameSource = (
+  a: unknown,
+  b: unknown,
+  node: FieldSchema,
+  context: FieldTransformContext
+): boolean => {
+  if (a === b) return true;
+  if (!isRichTextValue(a) || !isRichTextValue(b)) return false;
+  const codec = codecFor(node, context);
+  try {
+    return sourceOf(a, codec, node) === sourceOf(b, codec, node);
+  } catch {
+    return false;
+  }
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.client.tsx
@@ -1,0 +1,25 @@
+import { defineClientPlugin } from '../../../client';
+import { EMPTY_RICH_TEXT, type RichTextValue } from './rich-text-codec';
+import { codecFor, writesSameSource } from './rich-text-codecs';
+import { richTextSchema } from './rich-text-field.schema';
+import { RichTextField } from './rich-text-field.ui';
+
+export default defineClientPlugin({
+  field: {
+    Component: RichTextField,
+    defaultValue: EMPTY_RICH_TEXT,
+    metadata: { layout: 'block', labelable: false },
+    schema: richTextSchema,
+    parse: (stored, node, context) =>
+      codecFor(node, context).parse(
+        typeof stored === 'string' ? stored : '',
+        node
+      ),
+    serialize: (value, node, context) =>
+      codecFor(node, context).serialize(
+        value == null ? EMPTY_RICH_TEXT : (value as RichTextValue),
+        node
+      ),
+    isEqual: writesSameSource,
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.plugin.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '../../../core/plugin';
+import { RICH_TEXT_FIELD_TYPE } from './rich-text-field.schema';
+
+export const richTextFieldPlugin = definePlugin({
+  name: 'tina:field:rich-text',
+  provides: ['field'],
+  field: { type: RICH_TEXT_FIELD_TYPE, contractVersion: 1 },
+  client: () => import('./rich-text-field.client'),
+});
+
+export default richTextFieldPlugin;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.render.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.render.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+// Warm the Plate editor chain at module scope. Boot dynamically imports the
+// rich-text client, and paying its transform cost inside a test's async
+// timeout flakes on contended CI runners.
+import './rich-text-field.client';
+import { asResolvedConfig } from '../../../config';
+import type { CollectionSchema } from '../../../core/schema/types';
+import { Field, FormProvider, TinaProvider } from '../../../editor';
+import { t } from '../../../index';
+import richTextFieldPlugin from './rich-text-field.plugin';
+
+const NO_COLLECTIONS = { collections: [] };
+
+const collection: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  format: 'mdx',
+  fields: [t.richText({ name: 'body', label: 'Body', isBody: true })],
+};
+
+const withCallout: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  format: 'mdx',
+  fields: [
+    t.richText({
+      name: 'body',
+      label: 'Body',
+      isBody: true,
+      templates: [
+        {
+          name: 'Callout',
+          label: 'Callout',
+          key: 'callout',
+          fields: [{ name: 'text', type: 'string' }],
+        },
+      ],
+    }),
+  ],
+};
+
+const renderBody = (markdown: string) =>
+  render(
+    <TinaProvider
+      config={asResolvedConfig({
+        plugins: [richTextFieldPlugin],
+        schema: NO_COLLECTIONS,
+      })}
+    >
+      <FormProvider
+        collection={collection}
+        path='content/posts/test.mdx'
+        document={{ body: markdown }}
+      >
+        <Field address='body' />
+      </FormProvider>
+    </TinaProvider>
+  );
+
+describe('RichTextField rendering', () => {
+  it('mounts the editor and shows the stored prose', async () => {
+    renderBody('# Heading\n\nSome prose.\n');
+    const editable = await screen.findByLabelText('body');
+    expect(editable).toHaveAttribute('role', 'textbox');
+    expect(editable).toHaveTextContent('Heading');
+    expect(editable).toHaveTextContent('Some prose.');
+  });
+
+  it('renders a configured embed, proving EditorContext is provided', async () => {
+    render(
+      <TinaProvider
+        config={asResolvedConfig({
+          plugins: [richTextFieldPlugin],
+          schema: NO_COLLECTIONS,
+        })}
+      >
+        <FormProvider
+          collection={withCallout}
+          path='content/posts/embed.mdx'
+          document={{ body: 'Before.\n\n<Callout text="hi" />\n\nAfter.\n' }}
+        >
+          <Field address='body' />
+        </FormProvider>
+      </TinaProvider>
+    );
+    const editable = await screen.findByLabelText('body');
+    expect(editable).toHaveTextContent('Callout');
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.schema.ts
@@ -1,0 +1,68 @@
+import { INVALID_MARKDOWN_TYPE } from '@tinacms/rich-text';
+import type { ToolbarOverrides } from '@tinacms/rich-text/editor';
+import type { MdxTemplate } from '@tinacms/rich-text/editor';
+import { type ZodType, z } from 'zod';
+import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
+
+export const RICH_TEXT_FIELD_TYPE = 'rich-text';
+
+import type { RichTextCodec, RichTextValue } from './rich-text-codec';
+
+export type {
+  RichTextCodec,
+  RichTextNode,
+  RichTextValue,
+} from './rich-text-codec';
+
+export interface RichTextFieldSchema extends BaseFieldSchema {
+  type: typeof RICH_TEXT_FIELD_TYPE;
+  isBody?: boolean;
+  templates?: MdxTemplate[];
+  overrides?: ToolbarOverrides;
+  codec?: RichTextCodec;
+}
+
+export const richText = (
+  config: Omit<RichTextFieldSchema, 'type'>
+): RichTextFieldSchema => ({ ...config, type: RICH_TEXT_FIELD_TYPE });
+
+export const isRichTextFieldSchema = (
+  node: FieldSchema
+): node is RichTextFieldSchema => node.type === RICH_TEXT_FIELD_TYPE;
+
+const labelOf = (node: BaseFieldSchema): string => node.label ?? node.name;
+
+export const isRichTextValue = (value: unknown): value is RichTextValue => {
+  const candidate = value as RichTextValue | null;
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    candidate.type === 'root' &&
+    Array.isArray(candidate.children)
+  );
+};
+
+const isUnparsedMarkdown = (value: RichTextValue): boolean =>
+  value.children[0]?.type === INVALID_MARKDOWN_TYPE;
+
+export const richTextSchema = (node: FieldSchema): ZodType => {
+  const ast = z
+    .custom<RichTextValue>(
+      isRichTextValue,
+      `${labelOf(node)} must be rich text`
+    )
+    .refine((value) => !isUnparsedMarkdown(value), 'Unable to parse rich-text');
+  if (node.required) {
+    return z.preprocess(
+      (value) => value ?? { type: 'root', children: [] },
+      ast.refine(
+        (value) => value.children.length > 0,
+        `${labelOf(node)} is required`
+      )
+    );
+  }
+  return z.preprocess(
+    (value) => (value == null ? undefined : value),
+    ast.optional()
+  );
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.test.tsx
@@ -1,0 +1,267 @@
+import { INVALID_MARKDOWN_TYPE } from '@tinacms/rich-text';
+import { describe, expect, it } from 'vitest';
+// Warm the Plate editor chain at module scope. resolveFieldPlugins dynamically
+// imports the rich-text client, and paying its transform cost inside a test's
+// timeout flakes on contended CI runners.
+import './rich-text-field.client';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import type { CollectionSchema } from '../../../core/schema/types';
+import { validateField } from '../../../core/validation';
+import { t } from '../../../index';
+import { formatAdapterFor } from '../../content/local/adapters/format-adapters';
+import type { RichTextValue } from './rich-text-codec';
+import richTextFieldPlugin from './rich-text-field.plugin';
+
+const collection: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  format: 'mdx',
+  fields: [
+    t.richText({ name: 'body', label: 'Body', isBody: true, required: true }),
+  ],
+};
+
+const bodyNode = collection.fields[0];
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins([richTextFieldPlugin]);
+
+const ast = (markdown: string, registry: FieldRegistry): RichTextValue =>
+  ingestDocument({ body: markdown }, collection.fields, registry)
+    .body as RichTextValue;
+
+describe('RichTextField ingest and digest', () => {
+  it('parses stored markdown into the mdx AST', async () => {
+    const registry = await resolveRegistry();
+    expect(ast('# Heading\n\nSome prose.\n', registry)).toEqual({
+      type: 'root',
+      children: [
+        { type: 'h1', children: [{ type: 'text', text: 'Heading' }] },
+        { type: 'p', children: [{ type: 'text', text: 'Some prose.' }] },
+      ],
+    });
+  });
+
+  it('serializes the AST back to markdown', async () => {
+    const registry = await resolveRegistry();
+    const values = { body: ast('# Heading\n\nSome prose.\n', registry) };
+    expect(digestDocument(values, collection.fields, registry)).toEqual({
+      body: '# Heading\n\nSome prose.\n',
+    });
+  });
+
+  it('seeds an empty root when the field is absent', async () => {
+    const registry = await resolveRegistry();
+    expect(ingestDocument({}, collection.fields, registry)).toEqual({
+      body: { type: 'root', children: [] },
+    });
+  });
+});
+
+describe('RichTextField round-trip through the format adapter', () => {
+  const adapter = formatAdapterFor('mdx');
+  const RAW = '---\ntitle: Hello World\n---\n\nBody prose.\n';
+
+  it('rewrites an untouched document byte-identically', async () => {
+    const registry = await resolveRegistry();
+    const stored = adapter.parse(RAW, 'body');
+    const values = ingestDocument(stored, collection.fields, registry);
+    const digested = digestDocument(values, collection.fields, registry);
+    expect(adapter.serialize({ ...stored, ...digested }, RAW, 'body')).toBe(
+      RAW
+    );
+  });
+
+  it('keeps the separator when the body is edited', async () => {
+    const registry = await resolveRegistry();
+    const values = { body: ast('Rewritten prose.\n', registry) };
+    const digested = digestDocument(values, collection.fields, registry);
+    expect(
+      adapter.serialize({ title: 'Hello World', ...digested }, RAW, 'body')
+    ).toBe('---\ntitle: Hello World\n---\n\nRewritten prose.\n');
+  });
+});
+
+describe('RichTextField templates through the node argument', () => {
+  const withTemplates: CollectionSchema = {
+    name: 'post',
+    format: 'mdx',
+    fields: [
+      t.richText({
+        name: 'body',
+        isBody: true,
+        templates: [
+          {
+            name: 'Callout',
+            label: 'Callout',
+            key: 'callout',
+            fields: [{ name: 'text', type: 'string' }],
+          },
+        ],
+      }),
+    ],
+  };
+  const SOURCE = 'Before.\n\n<Callout text="hi" />\n\nAfter.\n';
+
+  it('parses a configured embed into an element carrying its props', async () => {
+    const registry = await resolveRegistry();
+    const parsed = ingestDocument(
+      { body: SOURCE },
+      withTemplates.fields,
+      registry
+    ).body as RichTextValue;
+    expect(parsed.children[1]).toMatchObject({
+      type: 'mdxJsxFlowElement',
+      name: 'Callout',
+      props: { text: 'hi' },
+    });
+  });
+
+  it('round-trips the embed back to its original source', async () => {
+    const registry = await resolveRegistry();
+    const values = ingestDocument(
+      { body: SOURCE },
+      withTemplates.fields,
+      registry
+    );
+    expect(digestDocument(values, withTemplates.fields, registry)).toEqual({
+      body: SOURCE,
+    });
+  });
+
+  it('degrades the embed to raw html when templates are absent', async () => {
+    const registry = await resolveRegistry();
+    const parsed = ingestDocument({ body: SOURCE }, collection.fields, registry)
+      .body as RichTextValue;
+    expect(parsed.children[1]).toMatchObject({ type: 'html' });
+  });
+});
+
+describe('RichTextField unparseable markdown', () => {
+  const BROKEN = '<Unclosed\n';
+
+  it('keeps the original source through a full save round-trip', async () => {
+    const registry = await resolveRegistry();
+    const values = ingestDocument(
+      { body: BROKEN },
+      collection.fields,
+      registry
+    );
+    expect((values.body as RichTextValue).children[0]).toMatchObject({
+      type: INVALID_MARKDOWN_TYPE,
+    });
+    expect(digestDocument(values, collection.fields, registry)).toEqual({
+      body: BROKEN,
+    });
+  });
+});
+
+describe('RichTextField equality', () => {
+  const normalized = (value: RichTextValue): RichTextValue => {
+    const withIds = (node: Record<string, unknown>, index: number) => ({
+      ...node,
+      id: `node-${index}`,
+      ...(Array.isArray(node.children)
+        ? { children: node.children.map(withIds) }
+        : {}),
+    });
+    return {
+      ...value,
+      children: [
+        ...value.children.map((child, index) =>
+          withIds(child as Record<string, unknown>, index)
+        ),
+        { type: 'p', children: [{ type: 'text', text: '' }] },
+      ],
+    } as RichTextValue;
+  };
+
+  const isEqual = async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    if (!descriptor?.isEqual) throw new Error('no equality on the descriptor');
+    return (a: unknown, b: unknown) => descriptor.isEqual?.(a, b, bodyNode, {});
+  };
+
+  it('reads a normalized tree as the tree it was parsed from', async () => {
+    const registry = await resolveRegistry();
+    const parsed = ast('Some prose.\n', registry);
+    expect((await isEqual())(parsed, normalized(parsed))).toBe(true);
+  });
+
+  it('still reads a real edit as a change', async () => {
+    const registry = await resolveRegistry();
+    const parsed = ast('Some prose.\n', registry);
+    expect((await isEqual())(parsed, ast('Edited prose.\n', registry))).toBe(
+      false
+    );
+  });
+
+  it('reads an absent body and an empty one as two states', async () => {
+    const registry = await resolveRegistry();
+    expect((await isEqual())(undefined, ast('', registry))).toBe(false);
+    expect((await isEqual())(undefined, undefined)).toBe(true);
+  });
+});
+
+describe('RichTextField validation', () => {
+  it('rejects an empty required body', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    expect(
+      validateField(bodyNode, descriptor, { type: 'root', children: [] })
+    ).not.toEqual([]);
+  });
+
+  it('accepts a body with content', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    expect(validateField(bodyNode, descriptor, ast('# Hi', registry))).toEqual(
+      []
+    );
+  });
+
+  it('rejects markdown the parser could not read', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    const unparsed: RichTextValue = {
+      type: 'root',
+      children: [{ type: INVALID_MARKDOWN_TYPE }],
+    };
+    expect(validateField(bodyNode, descriptor, unparsed)).not.toEqual([]);
+  });
+
+  it('rejects a value that is not rich text at all', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    expect(validateField(bodyNode, descriptor, 'plain string')).not.toEqual([]);
+  });
+
+  it('accepts an absent value when the field is optional', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    const optional = t.richText({ name: 'body' });
+    expect(validateField(optional, descriptor, undefined)).toEqual([]);
+  });
+
+  it('reports an absent required body as required, not as malformed', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    expect(validateField(bodyNode, descriptor, undefined)).toEqual([
+      'Body is required',
+    ]);
+  });
+});
+
+describe('RichTextField metadata wrapping', () => {
+  it('registers the rich-text descriptor as a block field', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('rich-text');
+    expect(descriptor?.metadata).toEqual({ layout: 'block', labelable: false });
+    expect(descriptor?.defaultValue).toEqual({ type: 'root', children: [] });
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/rich-text/rich-text-field.ui.tsx
@@ -1,0 +1,84 @@
+import { EMPTY_RICH_TEXT, type RichTextValue } from '@tinacms/rich-text';
+import { EditorContext, RichEditor } from '@tinacms/rich-text/editor';
+import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
+import { useCallback, useRef } from 'react';
+import { toFieldAddress } from '../../../core/field/address';
+import {
+  useActiveField,
+  useDocumentPath,
+  useFieldActivation,
+  useFieldAddress,
+  useFieldErrors,
+  useFieldSchema,
+  useFieldValue,
+  useFormSeedKey,
+} from '../../../editor';
+import { writesSameSource } from './rich-text-codecs';
+import type { RichTextFieldSchema } from './rich-text-field.schema';
+
+const RAW_MODE_UNAVAILABLE = false;
+const setRawModeUnavailable = () => {};
+
+export function RichTextField() {
+  const address = useFieldAddress();
+  const seedKey = useFormSeedKey();
+  const field = useFieldSchema<RichTextFieldSchema>();
+  const [value, setValue] = useFieldValue<RichTextValue>(address);
+  const errors = useFieldErrors(address);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const { setActive } = useActiveField();
+  const activateEmbed = useCallback(
+    (embedAddress: string) => setActive(toFieldAddress(embedAddress)),
+    [setActive]
+  );
+
+  const documentPath = useDocumentPath();
+
+  const lastValue = useRef<RichTextValue>(EMPTY_RICH_TEXT);
+  const seededFor = useRef<string | null>(null);
+  if (seededFor.current !== seedKey) {
+    seededFor.current = seedKey;
+    lastValue.current = value ?? EMPTY_RICH_TEXT;
+  }
+  const setBody = useCallback(
+    (next: RichTextValue) => {
+      if (writesSameSource(next, lastValue.current, field, { documentPath })) {
+        return;
+      }
+      lastValue.current = next;
+      setValue(next);
+    },
+    [setValue, field, documentPath]
+  );
+
+  const editable = () =>
+    containerRef.current?.querySelector<HTMLElement>('[role="textbox"]');
+
+  useFieldActivation(() => {
+    setTimeout(() => editable()?.focus(), 0);
+  });
+
+  return (
+    <FieldWrapper errors={errors}>
+      <div ref={containerRef} className='min-w-0'>
+        <EditorContext.Provider
+          key={seedKey}
+          value={{
+            fieldName: address,
+            templates: field.templates ?? [],
+            rawMode: RAW_MODE_UNAVAILABLE,
+            setRawMode: setRawModeUnavailable,
+            onActivateField: activateEmbed,
+          }}
+        >
+          <RichEditor
+            input={{ value: value ?? EMPTY_RICH_TEXT, onChange: setBody }}
+            field={field}
+            ariaLabel={address}
+          />
+        </EditorContext.Provider>
+      </div>
+    </FieldWrapper>
+  );
+}

--- a/packages/v4/@tinacms/tinacms/src/rich-text/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/index.ts
@@ -1,0 +1,16 @@
+export { type RichTextHost, renderRichText } from './render';
+export { resolveRichTextNode } from './resolve';
+export type {
+  BaseComponents,
+  BaseComponentSignature,
+  RichTextChildren,
+  RichTextComponents,
+  RichTextInstruction,
+  RichTextMark,
+  RichTextMarkKey,
+  RichTextNodeFields,
+  RichTextTableAlign,
+  RichTextTableCell,
+  SuppliedComponents,
+  TinaMarkdownContent,
+} from './types';

--- a/packages/v4/@tinacms/tinacms/src/rich-text/render.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/render.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { type RichTextHost, renderRichText, styleToCss } from './render';
+import type { TinaMarkdownContent } from './types';
+
+const VOID_TAGS = new Set(['img', 'hr', 'br']);
+
+const escape = (value: string) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+
+const attributes = (props: Record<string, unknown>) =>
+  Object.entries(props)
+    .map(([name, value]) => [
+      name,
+      name === 'style' ? styleToCss(value as any) : value,
+    ])
+    .filter(([, value]) => value !== undefined && value !== null)
+    .map(([name, value]) => ` ${name}="${escape(String(value))}"`)
+    .join('');
+
+const stringHost: RichTextHost<string> = {
+  element: (tag, props, children) =>
+    VOID_TAGS.has(tag)
+      ? `<${tag}${attributes(props)}>`
+      : `<${tag}${attributes(props)}>${children ?? ''}</${tag}>`,
+  component: (component, props, children) =>
+    (component as (props: any) => string)({ ...props, children }),
+  text: (value) => escape(value),
+  list: (items) => items.join(''),
+};
+
+const toHtml = (
+  content: TinaMarkdownContent | TinaMarkdownContent[],
+  components: Record<string, unknown> = {}
+) => renderRichText(content, components, stringHost);
+
+const text = (value: string, marks: Record<string, unknown> = {}) =>
+  ({ type: 'text', text: value, ...marks }) as TinaMarkdownContent;
+
+describe('a host that is not a framework', () => {
+  it('renders a heading and a paragraph', () => {
+    expect(
+      toHtml([
+        { type: 'h1', children: [text('Title')] },
+        { type: 'p', children: [text('Body')] },
+      ])
+    ).toBe('<h1>Title</h1><p>Body</p>');
+  });
+
+  it('nests marks outermost first', () => {
+    expect(
+      toHtml([
+        {
+          type: 'p',
+          children: [text('hi', { bold: true, italic: true, code: true })],
+        },
+      ])
+    ).toBe('<p><strong><em><code>hi</code></em></strong></p>');
+  });
+
+  it('styles a highlight with its colour', () => {
+    expect(
+      toHtml([
+        {
+          type: 'p',
+          children: [text('hi', { highlight: true, highlightColor: '#ff0' })],
+        },
+      ])
+    ).toBe('<p><mark style="background-color: #ff0;">hi</mark></p>');
+  });
+
+  it('renders a list', () => {
+    expect(
+      toHtml([
+        {
+          type: 'ul',
+          children: [
+            {
+              type: 'li',
+              children: [{ type: 'lic', children: [text('one')] }],
+            },
+          ],
+        },
+      ])
+    ).toBe('<ul><li><div>one</div></li></ul>');
+  });
+
+  it('renders a code block as pre and code', () => {
+    expect(
+      toHtml([{ type: 'code_block', value: 'plain' } as TinaMarkdownContent])
+    ).toBe('<pre><code>plain</code></pre>');
+  });
+
+  it('escapes raw html instead of injecting it', () => {
+    expect(
+      toHtml([{ type: 'html', value: '<script>alert(1)</script>' } as any])
+    ).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+  });
+
+  it('drops an unsafe url', () => {
+    expect(
+      toHtml([{ type: 'a', url: 'javascript:alert(1)', children: [] } as any])
+    ).not.toContain('javascript');
+  });
+
+  it('says which component was missing', () => {
+    expect(
+      toHtml([{ type: 'mdxJsxFlowElement', name: 'Hero', props: {} } as any])
+    ).toBe('<span>No component provided for Hero</span>');
+  });
+
+  it('calls a component the site supplied', () => {
+    expect(
+      toHtml(
+        [
+          {
+            type: 'mdxJsxFlowElement',
+            name: 'Hero',
+            props: { title: 'Hi' },
+          } as any,
+        ],
+        { Hero: (props: any) => `<h1>${props.title}</h1>` }
+      )
+    ).toBe('<h1>Hi</h1>');
+  });
+
+  it('renders an mdx table with a header row', () => {
+    const cell = (value: string) => ({
+      value: [{ type: 'p', children: [text(value)] }],
+    });
+    expect(
+      toHtml([
+        {
+          type: 'mdxJsxFlowElement',
+          name: 'table',
+          props: {
+            firstRowHeader: true,
+            align: ['left', 'right'],
+            tableRows: [
+              { tableCells: [cell('A'), cell('B')] },
+              { tableCells: [cell('1'), cell('2')] },
+            ],
+          },
+        } as any,
+      ])
+    ).toBe(
+      '<table><thead><tr>' +
+        '<th align="left" style="text-align: left;">A</th>' +
+        '<th align="right" style="text-align: right;">B</th>' +
+        '</tr></thead><tbody><tr>' +
+        '<td align="left" style="text-align: left;">1</td>' +
+        '<td align="right" style="text-align: right;">2</td>' +
+        '</tr></tbody></table>'
+    );
+  });
+
+  it('renders a pipe table with the border fallback', () => {
+    expect(
+      toHtml([
+        {
+          type: 'table',
+          children: [
+            {
+              type: 'tr',
+              children: [
+                {
+                  type: 'td',
+                  children: [{ type: 'p', children: [text('A')] }],
+                },
+              ],
+            },
+          ],
+        } as any,
+      ])
+    ).toBe(
+      '<table style="border: 1px solid #EDECF3;"><tbody><tr>' +
+        '<td style="border: 1px solid #EDECF3; padding: 0.25rem;">A</td>' +
+        '</tr></tbody></table>'
+    );
+  });
+
+  it('renders nothing for an empty value', () => {
+    expect(toHtml(undefined as any)).toBe('');
+    expect(toHtml({ type: 'root' })).toBe('');
+  });
+});
+
+describe('styleToCss', () => {
+  it('kebab-cases the properties and drops the empty ones', () => {
+    expect(styleToCss({ backgroundColor: '#ff0', textAlign: undefined })).toBe(
+      'background-color: #ff0;'
+    );
+  });
+
+  it('has nothing to say about an empty style', () => {
+    expect(styleToCss({ textAlign: undefined })).toBeUndefined();
+    expect(styleToCss(undefined)).toBeUndefined();
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/rich-text/render.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/render.ts
@@ -1,0 +1,215 @@
+import { resolveRichTextNode } from './resolve';
+import type {
+  RichTextChildren,
+  RichTextInstruction,
+  RichTextProps,
+  RichTextTableAlign,
+  RichTextTableCell,
+  SuppliedComponents,
+  TinaMarkdownContent,
+} from './types';
+
+type Style = Record<string, string | undefined>;
+
+type CellTag = 'th' | 'td';
+
+export interface RichTextHost<Rendered> {
+  element(
+    tag: string,
+    props: Record<string, unknown>,
+    children: Rendered | null
+  ): Rendered;
+  component(
+    component: unknown,
+    props: Record<string, unknown>,
+    children: Rendered | null
+  ): Rendered;
+  text(value: string): Rendered;
+  list(items: Rendered[]): Rendered;
+  memo?(render: () => Rendered, cacheKey: unknown): Rendered;
+}
+
+type RenderContext<Rendered> = {
+  host: RichTextHost<Rendered>;
+  components: SuppliedComponents;
+  paragraphAs?: (children: Rendered | null) => Rendered;
+};
+
+export function renderRichText<Rendered>(
+  content: TinaMarkdownContent | TinaMarkdownContent[] | undefined,
+  components: SuppliedComponents,
+  host: RichTextHost<Rendered>
+): Rendered {
+  return renderNodes(nodesOf(content), { host, components });
+}
+
+const nodesOf = (
+  content: TinaMarkdownContent | TinaMarkdownContent[] | undefined
+): TinaMarkdownContent[] => {
+  if (!content) return [];
+  return Array.isArray(content) ? content : (content.children ?? []);
+};
+
+function renderNodes<Rendered>(
+  nodes: TinaMarkdownContent[],
+  context: RenderContext<Rendered>
+): Rendered {
+  const { host } = context;
+  return host.list(
+    nodes.map((node) => {
+      const render = () =>
+        renderInstruction(
+          resolveRichTextNode(node, context.components),
+          context
+        );
+      return host.memo
+        ? host.memo(render, [context.components, node])
+        : render();
+    })
+  );
+}
+
+function renderInstruction<Rendered>(
+  instruction: RichTextInstruction,
+  context: RenderContext<Rendered>
+): Rendered {
+  const { host, components } = context;
+  switch (instruction.kind) {
+    case 'nothing':
+      return host.list([]);
+    case 'text':
+      return host.text(instruction.text);
+    case 'leaf':
+      return renderLeaf(instruction, context);
+    case 'element': {
+      const children = renderChildren(instruction.children, context);
+      if (context.paragraphAs && instruction.tag === 'p') {
+        return context.paragraphAs(children);
+      }
+      return host.element(instruction.tag, instruction.props, children);
+    }
+    case 'component':
+      return host.component(
+        components[instruction.key],
+        instruction.props,
+        renderChildren(instruction.children, context)
+      );
+    case 'table':
+      return renderTable(instruction, context);
+  }
+}
+
+function renderChildren<Rendered>(
+  children: RichTextChildren,
+  context: RenderContext<Rendered>
+): Rendered | null {
+  switch (children.kind) {
+    case 'none':
+      return null;
+    case 'text':
+      return context.host.text(children.text);
+    case 'content':
+      return renderNodes(children.content ?? [], context);
+    case 'nodes':
+      return context.host.list(
+        children.nodes.map((node) => renderInstruction(node, context))
+      );
+  }
+}
+
+function renderLeaf<Rendered>(
+  instruction: Extract<RichTextInstruction, { kind: 'leaf' }>,
+  context: RenderContext<Rendered>
+): Rendered {
+  const { host, components } = context;
+  let rendered = host.text(instruction.text);
+  for (let index = instruction.marks.length - 1; index >= 0; index--) {
+    const mark = instruction.marks[index];
+    rendered =
+      mark.kind === 'component'
+        ? host.component(components[mark.key], mark.props, rendered)
+        : host.element(mark.tag, markStyle(mark.props), rendered);
+  }
+  return rendered;
+}
+
+const markStyle = (props: RichTextProps): RichTextProps =>
+  props.color ? { style: { backgroundColor: props.color } } : {};
+
+const TABLE_BORDER = '1px solid #EDECF3';
+const TABLE_CELL_PADDING = '0.25rem';
+
+const TABLE_FALLBACK = {
+  mdx: {
+    table: undefined as Style | undefined,
+    cell: (align?: RichTextTableAlign): Style => ({ textAlign: align }),
+  },
+  gfm: {
+    table: { border: TABLE_BORDER } as Style,
+    cell: (align?: RichTextTableAlign): Style => ({
+      textAlign: align,
+      border: TABLE_BORDER,
+      padding: TABLE_CELL_PADDING,
+    }),
+  },
+};
+
+function renderTable<Rendered>(
+  instruction: Extract<RichTextInstruction, { kind: 'table' }>,
+  context: RenderContext<Rendered>
+): Rendered {
+  const { host, components } = context;
+  const { align, header, rows, source } = instruction;
+  const fallback = TABLE_FALLBACK[source];
+
+  const cellRenderer =
+    (tag: CellTag, index: number) => (children: Rendered | null) => {
+      const props = { align: align[index] };
+      return components[tag]
+        ? host.component(components[tag], props, children)
+        : host.element(
+            tag,
+            { ...props, style: fallback.cell(align[index]) },
+            children
+          );
+    };
+
+  const row = (cells: RichTextTableCell[], tag: CellTag): Rendered => {
+    const rendered = host.list(
+      cells.map((tableCell, index) =>
+        renderNodes(nodesOf(tableCell.content), {
+          host,
+          components: {},
+          paragraphAs: cellRenderer(tag, index),
+        })
+      )
+    );
+    return components.tr
+      ? host.component(components.tr, {}, rendered)
+      : host.element('tr', {}, rendered);
+  };
+
+  const body = host.element(
+    'tbody',
+    {},
+    host.list(rows.map((cells) => row(cells, 'td')))
+  );
+  const inner = host.list(
+    header ? [host.element('thead', {}, row(header, 'th')), body] : [body]
+  );
+
+  return components.table
+    ? host.component(components.table, {}, inner)
+    : host.element('table', { style: fallback.table }, inner);
+}
+
+export function styleToCss(style: Style | undefined): string | undefined {
+  if (!style) return undefined;
+  const declarations = Object.entries(style)
+    .filter(([, value]) => value !== undefined)
+    .map(([property, value]) => `${toKebabCase(property)}: ${value}`);
+  return declarations.length ? `${declarations.join('; ')};` : undefined;
+}
+
+const toKebabCase = (property: string) =>
+  property.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);

--- a/packages/v4/@tinacms/tinacms/src/rich-text/resolve.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/resolve.test.ts
@@ -1,0 +1,330 @@
+import { describe, expect, it } from 'vitest';
+import { resolveRichTextNode } from './resolve';
+import type { SuppliedComponents, TinaMarkdownContent } from './types';
+
+const node = (value: Record<string, unknown>) => value as TinaMarkdownContent;
+const none: SuppliedComponents = {};
+const supplying = (...keys: string[]): SuppliedComponents =>
+  Object.fromEntries(keys.map((key) => [key, () => null]));
+
+describe('block nodes', () => {
+  it('falls back to the tag of the node', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'h2', children: [{ type: 'text', text: 'Title' }] }),
+      none
+    );
+    expect(instruction).toMatchObject({ kind: 'element', tag: 'h2' });
+  });
+
+  it('names the supplied component instead', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'h2', children: [] }),
+      supplying('h2')
+    );
+    expect(instruction).toMatchObject({ kind: 'component', key: 'h2' });
+  });
+
+  it('reads a component that is present but undefined as absent', () => {
+    const instruction = resolveRichTextNode(node({ type: 'p', children: [] }), {
+      p: undefined,
+    });
+    expect(instruction).toMatchObject({ kind: 'element', tag: 'p' });
+  });
+
+  it('prefers blockquote over the deprecated block_quote', () => {
+    expect(
+      resolveRichTextNode(
+        node({ type: 'blockquote', children: [] }),
+        supplying('blockquote', 'block_quote')
+      )
+    ).toMatchObject({ kind: 'component', key: 'blockquote' });
+    expect(
+      resolveRichTextNode(
+        node({ type: 'blockquote', children: [] }),
+        supplying('block_quote')
+      )
+    ).toMatchObject({ kind: 'component', key: 'block_quote' });
+  });
+
+  it('renders list item content as a div', () => {
+    expect(
+      resolveRichTextNode(node({ type: 'lic', children: [] }), none)
+    ).toMatchObject({ kind: 'element', tag: 'div' });
+  });
+
+  it('renders a break as br and a rule as hr', () => {
+    expect(resolveRichTextNode(node({ type: 'break' }), none)).toMatchObject({
+      kind: 'element',
+      tag: 'br',
+    });
+    expect(resolveRichTextNode(node({ type: 'hr' }), none)).toMatchObject({
+      kind: 'element',
+      tag: 'hr',
+    });
+  });
+});
+
+describe('urls', () => {
+  it('sanitizes a link href', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'a', url: 'javascript:alert(1)', children: [] }),
+      none
+    );
+    expect(instruction).toMatchObject({ kind: 'element', tag: 'a' });
+    expect((instruction as any).props.href).not.toContain('javascript');
+  });
+
+  it('sanitizes an image src', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'img', url: 'javascript:alert(1)', alt: 'x' }),
+      none
+    );
+    expect((instruction as any).props.src).not.toContain('javascript');
+  });
+
+  it('hands the raw node to a supplied component and lets it decide', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'a', url: 'https://tina.io', children: [] }),
+      supplying('a')
+    );
+    expect(instruction).toMatchObject({
+      kind: 'component',
+      key: 'a',
+      props: { url: 'https://tina.io' },
+    });
+  });
+});
+
+describe('leaves', () => {
+  it('orders marks outermost first, with the tag each falls back to', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'text', text: 'hi', bold: true, italic: true, code: true }),
+      none
+    );
+    expect(instruction).toEqual({
+      kind: 'leaf',
+      text: 'hi',
+      marks: [
+        { kind: 'element', tag: 'strong', props: {} },
+        { kind: 'element', tag: 'em', props: {} },
+        { kind: 'element', tag: 'code', props: {} },
+      ],
+    });
+  });
+
+  it('carries the highlight colour whether or not a component takes it', () => {
+    const highlighted = node({
+      type: 'text',
+      text: 'hi',
+      highlight: true,
+      highlightColor: '#ff0',
+    });
+    expect((resolveRichTextNode(highlighted, none) as any).marks).toEqual([
+      { kind: 'element', tag: 'mark', props: { color: '#ff0' } },
+    ]);
+    expect(
+      (resolveRichTextNode(highlighted, supplying('highlight')) as any).marks
+    ).toEqual([
+      { kind: 'component', key: 'highlight', props: { color: '#ff0' } },
+    ]);
+  });
+
+  it('puts a supplied text component innermost', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'text', text: 'hi', bold: true }),
+      supplying('text')
+    );
+    expect((instruction as any).marks).toEqual([
+      { kind: 'element', tag: 'strong', props: {} },
+      { kind: 'component', key: 'text', props: {} },
+    ]);
+  });
+
+  it('treats an untyped node carrying text as a leaf', () => {
+    expect(
+      resolveRichTextNode(node({ type: 'something-else', text: 'hi' }), none)
+    ).toMatchObject({ kind: 'leaf', text: 'hi' });
+  });
+
+  it('renders nothing for a node it does not know', () => {
+    expect(resolveRichTextNode(node({ type: 'something-else' }), none)).toEqual(
+      { kind: 'nothing' }
+    );
+  });
+});
+
+describe('code blocks', () => {
+  it('joins the lines of a code block into one string', () => {
+    const instruction = resolveRichTextNode(
+      node({
+        type: 'code_block',
+        children: [
+          { type: 'code_line', children: [{ type: 'text', text: 'one' }] },
+          { type: 'code_line', children: [{ type: 'text', text: 'two' }] },
+        ],
+      }),
+      supplying('code_block')
+    );
+    expect((instruction as any).props.value).toBe('one\ntwo');
+  });
+
+  it('falls back to the value of the node', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'code_block', value: 'plain' }),
+      supplying('code_block')
+    );
+    expect((instruction as any).props.value).toBe('plain');
+  });
+
+  it('wraps the fallback in pre and code', () => {
+    const instruction = resolveRichTextNode(
+      node({ type: 'code_block', value: 'plain' }),
+      none
+    );
+    expect(instruction).toMatchObject({
+      kind: 'element',
+      tag: 'pre',
+      children: {
+        kind: 'nodes',
+        nodes: [
+          {
+            kind: 'element',
+            tag: 'code',
+            children: { kind: 'text', text: 'plain' },
+          },
+        ],
+      },
+    });
+  });
+});
+
+describe('mdx elements', () => {
+  const hero = node({
+    type: 'mdxJsxFlowElement',
+    name: 'Hero',
+    props: { title: 'Hi' },
+  });
+
+  it('passes the props of the element straight through', () => {
+    expect(resolveRichTextNode(hero, supplying('Hero'))).toEqual({
+      kind: 'component',
+      key: 'Hero',
+      props: { title: 'Hi' },
+      children: { kind: 'none' },
+    });
+  });
+
+  it('uses component_missing when the site supplied one', () => {
+    expect(resolveRichTextNode(hero, supplying('component_missing'))).toEqual({
+      kind: 'component',
+      key: 'component_missing',
+      props: { name: 'Hero' },
+      children: { kind: 'none' },
+    });
+  });
+
+  it('states the name in a span when it did not', () => {
+    expect(resolveRichTextNode(hero, none)).toEqual({
+      kind: 'element',
+      tag: 'span',
+      props: {},
+      children: { kind: 'text', text: 'No component provided for Hero' },
+    });
+  });
+
+  it('escapes raw html rather than injecting it', () => {
+    expect(
+      resolveRichTextNode(
+        node({ type: 'html', value: '<script>alert(1)</script>' }),
+        none
+      )
+    ).toEqual({ kind: 'text', text: '<script>alert(1)</script>' });
+  });
+
+  it('renders nothing for a node still being edited', () => {
+    expect(
+      resolveRichTextNode(node({ type: 'maybe_mdx', children: [] }), none)
+    ).toEqual({ kind: 'nothing' });
+  });
+});
+
+describe('tables', () => {
+  const tableRows = [
+    { tableCells: [{ value: { type: 'p' } }, { value: { type: 'p' } }] },
+    { tableCells: [{ value: { type: 'p' } }, { value: { type: 'p' } }] },
+  ];
+
+  it('splits the header off an mdx table when the flag is set', () => {
+    const instruction = resolveRichTextNode(
+      node({
+        type: 'mdxJsxFlowElement',
+        name: 'table',
+        props: { firstRowHeader: true, align: ['left', 'right'], tableRows },
+      }),
+      none
+    ) as any;
+    expect(instruction.source).toBe('mdx');
+    expect(instruction.align).toEqual(['left', 'right']);
+    expect(instruction.header).toHaveLength(2);
+    expect(instruction.rows).toHaveLength(1);
+  });
+
+  it('keeps every row in the body without the flag', () => {
+    const instruction = resolveRichTextNode(
+      node({
+        type: 'mdxJsxFlowElement',
+        name: 'table',
+        props: { tableRows },
+      }),
+      none
+    ) as any;
+    expect(instruction.header).toBeNull();
+    expect(instruction.rows).toHaveLength(2);
+  });
+
+  it('survives a row with no cells', () => {
+    const instruction = resolveRichTextNode(
+      node({
+        type: 'mdxJsxFlowElement',
+        name: 'table',
+        props: { tableRows: [{}] },
+      }),
+      none
+    ) as any;
+    expect(instruction.rows).toEqual([[]]);
+  });
+
+  it('normalises a pipe table into the same shape', () => {
+    const instruction = resolveRichTextNode(
+      node({
+        type: 'table',
+        children: [{ type: 'tr', children: [{ type: 'td', children: [] }] }],
+      }),
+      none
+    ) as any;
+    expect(instruction.source).toBe('gfm');
+    expect(instruction.header).toBeNull();
+    expect(instruction.rows).toEqual([[{ content: [] }]]);
+  });
+
+  it('keeps a column position when its alignment is not one of the three keywords', () => {
+    const instruction = resolveRichTextNode(
+      node({
+        type: 'mdxJsxFlowElement',
+        name: 'table',
+        props: { align: ['left', 'centre', null, 'right'], tableRows },
+      }),
+      none
+    ) as any;
+    expect(instruction.align).toEqual(['left', undefined, undefined, 'right']);
+  });
+
+  it('prefers a supplied table component over the mdx fallback', () => {
+    expect(
+      resolveRichTextNode(
+        node({ type: 'mdxJsxFlowElement', name: 'table', props: {} }),
+        supplying('table')
+      )
+    ).toMatchObject({ kind: 'component', key: 'table' });
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/rich-text/resolve.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/resolve.ts
@@ -1,0 +1,280 @@
+import { sanitizeUrl } from '@tinacms/mdx/sanitize-url';
+import type {
+  RichTextChildren,
+  RichTextInstruction,
+  RichTextMark,
+  RichTextMarkKey,
+  RichTextNodeFields,
+  RichTextProps,
+  RichTextTableAlign,
+  RichTextTableCell,
+  SuppliedComponents,
+  TinaMarkdownContent,
+} from './types';
+
+const supplied = (components: SuppliedComponents, key: string): boolean =>
+  Boolean(components[key]);
+
+const PASSTHROUGH_TAGS = new Set([
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'p',
+  'ol',
+  'ul',
+  'li',
+]);
+
+const MARK_FALLBACK_TAG: Record<Exclude<RichTextMarkKey, 'text'>, string> = {
+  bold: 'strong',
+  italic: 'em',
+  underline: 'u',
+  strikethrough: 's',
+  code: 'code',
+  highlight: 'mark',
+};
+
+export function resolveRichTextNode(
+  node: TinaMarkdownContent,
+  components: SuppliedComponents
+): RichTextInstruction {
+  const fields = node as RichTextNodeFields;
+  const { children, ...props } = fields;
+  const content: RichTextChildren = { kind: 'content', content: children };
+  const noChildren: RichTextChildren = { kind: 'none' };
+
+  const componentOr = (
+    key: string,
+    fallback: { tag: string; props?: RichTextProps },
+    children: RichTextChildren
+  ): RichTextInstruction =>
+    supplied(components, key)
+      ? { kind: 'component', key, props, children }
+      : {
+          kind: 'element',
+          tag: fallback.tag,
+          props: fallback.props ?? {},
+          children,
+        };
+
+  if (PASSTHROUGH_TAGS.has(fields.type)) {
+    return componentOr(fields.type, { tag: fields.type }, content);
+  }
+
+  switch (fields.type) {
+    case 'lic': // List Item Content
+      return componentOr('lic', { tag: 'div' }, content);
+
+    case 'blockquote':
+      return componentOr(
+        supplied(components, 'blockquote') ? 'blockquote' : 'block_quote',
+        { tag: 'blockquote' },
+        content
+      );
+
+    case 'img':
+      return componentOr(
+        'img',
+        {
+          tag: 'img',
+          props: { src: sanitizeUrl(fields.url), alt: fields.alt },
+        },
+        noChildren
+      );
+
+    case 'a':
+      return componentOr(
+        'a',
+        { tag: 'a', props: { href: sanitizeUrl(fields.url) } },
+        content
+      );
+
+    case 'code_block': {
+      const value = readCodeBlockValue(fields);
+      if (supplied(components, 'code_block')) {
+        return {
+          kind: 'component',
+          key: 'code_block',
+          props: { ...props, value },
+          children: noChildren,
+        };
+      }
+      return {
+        kind: 'element',
+        tag: 'pre',
+        props: {},
+        children: {
+          kind: 'nodes',
+          nodes: [
+            {
+              kind: 'element',
+              tag: 'code',
+              props: {},
+              children: { kind: 'text', text: value },
+            },
+          ],
+        },
+      };
+    }
+
+    case 'hr':
+      return componentOr('hr', { tag: 'hr' }, noChildren);
+
+    case 'break':
+      return componentOr('break', { tag: 'br' }, noChildren);
+
+    case 'text':
+      return resolveLeaf(fields, components);
+
+    case 'mdxJsxTextElement':
+    case 'mdxJsxFlowElement': {
+      const name = fields.name ?? '';
+      if (supplied(components, name)) {
+        return {
+          kind: 'component',
+          key: name,
+          props: fields.props ?? {},
+          children: noChildren,
+        };
+      }
+      if (name === 'table') {
+        return resolveMdxTable(fields);
+      }
+      if (supplied(components, 'component_missing')) {
+        return {
+          kind: 'component',
+          key: 'component_missing',
+          props: { name },
+          children: noChildren,
+        };
+      }
+      return {
+        kind: 'element',
+        tag: 'span',
+        props: {},
+        children: { kind: 'text', text: `No component provided for ${name}` },
+      };
+    }
+
+    case 'table':
+      return resolveGfmTable(fields);
+
+    case 'maybe_mdx':
+      return { kind: 'nothing' };
+
+    case 'html':
+    case 'html_inline':
+      if (supplied(components, fields.type)) {
+        return {
+          kind: 'component',
+          key: fields.type,
+          props,
+          children: noChildren,
+        };
+      }
+      return { kind: 'text', text: fields.value ?? '' };
+
+    case 'invalid_markdown':
+      return {
+        kind: 'element',
+        tag: 'pre',
+        props: {},
+        children: { kind: 'text', text: fields.value ?? '' },
+      };
+
+    default:
+      if (typeof fields.text === 'string') {
+        return resolveLeaf(fields, components);
+      }
+      return { kind: 'nothing' };
+  }
+}
+
+function resolveLeaf(
+  fields: RichTextNodeFields,
+  components: SuppliedComponents
+): RichTextInstruction {
+  const marks: RichTextMark[] = [];
+  const mark = (
+    key: Exclude<RichTextMarkKey, 'text'>,
+    props: RichTextProps = {}
+  ) => {
+    marks.push(
+      supplied(components, key)
+        ? { kind: 'component', key, props }
+        : { kind: 'element', tag: MARK_FALLBACK_TAG[key], props }
+    );
+  };
+
+  if (fields.bold) mark('bold');
+  if (fields.italic) mark('italic');
+  if (fields.underline) mark('underline');
+  if (fields.strikethrough) mark('strikethrough');
+  if (fields.code) mark('code');
+  if (fields.highlight) mark('highlight', { color: fields.highlightColor });
+  if (supplied(components, 'text')) {
+    marks.push({ kind: 'component', key: 'text', props: {} });
+  }
+
+  return { kind: 'leaf', text: fields.text ?? '', marks };
+}
+
+function readCodeBlockValue(fields: RichTextNodeFields): string {
+  if (Array.isArray(fields.children)) {
+    return fields.children
+      .map((line) =>
+        Array.isArray(line.children)
+          ? line.children
+              .map((token) => (token as RichTextNodeFields).text ?? '')
+              .join('')
+          : ''
+      )
+      .join('\n');
+  }
+  return typeof fields.value === 'string' ? fields.value : '';
+}
+
+type MdxTableRow = { tableCells?: { value: TinaMarkdownContent }[] };
+
+const TABLE_ALIGNMENTS = new Set<string>(['left', 'right', 'center']);
+
+const columnAlignments = (
+  align: unknown
+): (RichTextTableAlign | undefined)[] =>
+  Array.isArray(align)
+    ? align.map((value) =>
+        typeof value === 'string' && TABLE_ALIGNMENTS.has(value)
+          ? (value as RichTextTableAlign)
+          : undefined
+      )
+    : [];
+
+function resolveMdxTable(fields: RichTextNodeFields): RichTextInstruction {
+  const firstRowHeader = Boolean(fields.props?.firstRowHeader);
+  const tableRows: MdxTableRow[] = fields.props?.tableRows ?? [];
+  const cellsOf = (row: MdxTableRow | undefined): RichTextTableCell[] =>
+    (row?.tableCells ?? []).map((cell) => ({ content: cell.value }));
+
+  return {
+    kind: 'table',
+    source: 'mdx',
+    align: columnAlignments(fields.props?.align),
+    header: firstRowHeader ? cellsOf(tableRows.at(0)) : null,
+    rows: (firstRowHeader ? tableRows.slice(1) : tableRows).map(cellsOf),
+  };
+}
+
+function resolveGfmTable(fields: RichTextNodeFields): RichTextInstruction {
+  return {
+    kind: 'table',
+    source: 'gfm',
+    align: columnAlignments(fields.props?.align),
+    header: null,
+    rows: (fields.children ?? []).map((row) =>
+      (row.children ?? []).map((cell) => ({ content: cell.children }))
+    ),
+  };
+}

--- a/packages/v4/@tinacms/tinacms/src/rich-text/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/rich-text/types.ts
@@ -1,0 +1,126 @@
+export type TinaMarkdownContent = {
+  type: string;
+  children?: TinaMarkdownContent[];
+};
+
+export type RichTextNodeFields = TinaMarkdownContent & {
+  text?: string;
+  value?: string;
+  url?: string;
+  alt?: string;
+  caption?: string;
+  lang?: string;
+  name?: string;
+  props?: Record<string, any>;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+  code?: boolean;
+  highlight?: boolean;
+  highlightColor?: string;
+};
+
+export type RichTextTableAlign = 'left' | 'right' | 'center';
+
+export type BaseComponents<Rendered> = {
+  h1?: { children: Rendered };
+  h2?: { children: Rendered };
+  h3?: { children: Rendered };
+  h4?: { children: Rendered };
+  h5?: { children: Rendered };
+  h6?: { children: Rendered };
+  p?: { children: Rendered };
+  a?: { url: string; children: Rendered };
+  italic?: { children: Rendered };
+  bold?: { children: Rendered };
+  strikethrough?: { children: Rendered };
+  underline?: { children: Rendered };
+  code?: { children: Rendered };
+  highlight?: { children: Rendered; color?: string };
+  text?: { children: string };
+  ul?: { children: Rendered };
+  ol?: { children: Rendered };
+  li?: { children: Rendered };
+  lic?: { children: Rendered };
+  blockquote?: { children: Rendered };
+  code_block?: { lang?: string; value: string };
+  mermaid?: { value: string };
+  img?: { url: string; caption?: string; alt?: string };
+  hr?: {};
+  break?: {};
+  maybe_mdx?: { children: Rendered };
+  html?: { value: string };
+  html_inline?: { value: string };
+  th?: { align?: RichTextTableAlign; children: Rendered };
+  td?: { align?: RichTextTableAlign; children: Rendered };
+  tr?: { children: Rendered };
+  table?:
+    | {
+        align?: RichTextTableAlign[];
+        tableRows: { tableCells: { value: TinaMarkdownContent }[] }[];
+      }
+    | { children: Rendered };
+  component_missing?: { name: string };
+};
+
+export type BaseComponentSignature<Rendered> = {
+  [BK in keyof BaseComponents<Rendered>]: (
+    props: BaseComponents<Rendered>[BK]
+  ) => Rendered;
+};
+
+export type RichTextComponents<ComponentAndProps extends object, Rendered> = {
+  [K in keyof ComponentAndProps]: (props: ComponentAndProps[K]) => Rendered;
+} & BaseComponentSignature<Rendered>;
+
+export type SuppliedComponents = Record<string, unknown>;
+
+export type RichTextProps = Record<string, unknown>;
+
+export type RichTextMarkKey =
+  | 'bold'
+  | 'italic'
+  | 'underline'
+  | 'strikethrough'
+  | 'code'
+  | 'highlight'
+  | 'text';
+
+export type RichTextMark =
+  | { kind: 'element'; tag: string; props: RichTextProps }
+  | { kind: 'component'; key: RichTextMarkKey; props: RichTextProps };
+
+export type RichTextTableCell = {
+  content: TinaMarkdownContent | TinaMarkdownContent[] | undefined;
+};
+
+export type RichTextChildren =
+  | { kind: 'none' }
+  | { kind: 'text'; text: string }
+  | { kind: 'content'; content: TinaMarkdownContent[] | undefined }
+  | { kind: 'nodes'; nodes: RichTextInstruction[] };
+
+export type RichTextInstruction =
+  | { kind: 'nothing' }
+  | { kind: 'text'; text: string }
+  | { kind: 'leaf'; text: string; marks: RichTextMark[] }
+  | {
+      kind: 'element';
+      tag: string;
+      props: RichTextProps;
+      children: RichTextChildren;
+    }
+  | {
+      kind: 'component';
+      key: string;
+      props: RichTextProps;
+      children: RichTextChildren;
+    }
+  | {
+      kind: 'table';
+      source: 'mdx' | 'gfm';
+      align: (RichTextTableAlign | undefined)[];
+      header: RichTextTableCell[] | null;
+      rows: RichTextTableCell[][];
+    };

--- a/packages/v4/examples/barebones/package.json
+++ b/packages/v4/examples/barebones/package.json
@@ -10,6 +10,7 @@
     "types": "tsc"
   },
   "dependencies": {
+    "@tinacms/rich-text": "workspace:*",
     "@tinacms/tinacms": "workspace:*",
     "@tinacms/ui": "workspace:*",
     "react": "^19.2.7",

--- a/packages/v4/examples/barebones/src/preview/post-preview.tsx
+++ b/packages/v4/examples/barebones/src/preview/post-preview.tsx
@@ -1,4 +1,8 @@
-import { tinaField, useTina } from '@tinacms/tinacms/adapters/react';
+import {
+  TinaMarkdown,
+  tinaField,
+  useTina,
+} from '@tinacms/tinacms/adapters/react';
 import { sampleDocument } from '../content';
 
 // The site side of visual editing, written as a real site would write it. useTina seeds
@@ -39,6 +43,9 @@ export function PostPreview() {
           ? 'This preview renders the document streamed from the editor. Click the title or the badge to focus its field in the sidebar.'
           : 'Standalone preview — rendering the static document.'}
       </p>
+      <div {...tinaField('body')}>
+        <TinaMarkdown content={post.body} />
+      </div>
     </article>
   );
 }

--- a/packages/v4/examples/barebones/tina/admin.css
+++ b/packages/v4/examples/barebones/tina/admin.css
@@ -4,3 +4,4 @@
    so name the package sources here. These lines go when the dist build lands. */
 @source "../node_modules/@tinacms/tinacms/src";
 @source "../node_modules/@tinacms/ui/src";
+@source "../node_modules/@tinacms/rich-text/src";

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -21,6 +21,7 @@ export const postCollection = {
     t.boolean({ name: 'featured', label: 'Featured' }),
     // The custom field of this project. tina/rating-field.tsx is the whole plugin.
     rating({ name: 'stars', label: 'Stars' }),
+    t.richText({ name: 'body', label: 'Body', isBody: true }),
   ],
 } satisfies CollectionSchema;
 

--- a/packages/v4/examples/barebones/tina/tina-lock.json
+++ b/packages/v4/examples/barebones/tina/tina-lock.json
@@ -23,6 +23,12 @@
             "name": "stars",
             "label": "Stars",
             "type": "rating"
+          },
+          {
+            "name": "body",
+            "label": "Body",
+            "isBody": true,
+            "type": "rich-text"
           }
         ]
       }
@@ -37,6 +43,7 @@
   "primitives": {
     "boolean": 1,
     "rating": 1,
+    "rich-text": 1,
     "string": 1
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ catalogs:
     '@graphql-tools/utils':
       specifier: ^10.8.1
       version: 10.11.0
+    '@headlessui/react':
+      specifier: 2.1.8
+      version: 2.1.8
     '@iarna/toml':
       specifier: ^2.2.5
       version: 2.2.5
@@ -2589,6 +2592,157 @@ importers:
         specifier: ^22.13.1
         version: 22.19.3
 
+  packages/v4/@tinacms/rich-text:
+    dependencies:
+      '@ariakit/react':
+        specifier: 'catalog:'
+        version: 0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@headlessui/react':
+        specifier: 'catalog:'
+        version: 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dialog':
+        specifier: 'catalog:'
+        version: 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu':
+        specifier: 'catalog:'
+        version: 2.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover':
+        specifier: 'catalog:'
+        version: 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator':
+        specifier: 'catalog:'
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot':
+        specifier: 'catalog:'
+        version: 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-toolbar':
+        specifier: 'catalog:'
+        version: 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip':
+        specifier: 'catalog:'
+        version: 1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tinacms/mdx':
+        specifier: workspace:*
+        version: link:../../../@tinacms/mdx
+      '@tinacms/schema-tools':
+        specifier: workspace:*
+        version: link:../../../@tinacms/schema-tools
+      '@tinacms/ui':
+        specifier: workspace:*
+        version: link:../ui
+      '@udecode/cn':
+        specifier: 'catalog:'
+        version: 48.0.3(@types/react@19.2.17)(class-variance-authority@0.7.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwind-merge@3.6.0)
+      '@udecode/plate':
+        specifier: 'catalog:'
+        version: 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-autoformat':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-basic-marks':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-block-quote':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-break':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-code-block':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-combobox':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-dnd':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17))(@types/node@25.1.0)(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-floating':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-heading':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-highlight':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-horizontal-rule':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-indent-list':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-link':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-list':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-node-id':
+        specifier: 'catalog:'
+        version: 48.0.6(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-reset-node':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-resizable':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-selection':
+        specifier: 'catalog:'
+        version: 48.0.5(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-slash-command':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-table':
+        specifier: 'catalog:'
+        version: 48.0.6(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-trailing-block':
+        specifier: 'catalog:'
+        version: 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      class-variance-authority:
+        specifier: 'catalog:'
+        version: 0.7.1
+      cmdk:
+        specifier: 'catalog:'
+        version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      color-string:
+        specifier: 'catalog:'
+        version: 1.9.1
+      is-hotkey:
+        specifier: 'catalog:'
+        version: 0.2.0
+      lowlight:
+        specifier: 'catalog:'
+        version: 3.3.0
+      lucide-react:
+        specifier: 'catalog:'
+        version: 0.424.0(react@19.2.7)
+      mermaid:
+        specifier: 'catalog:'
+        version: 11.12.2
+    devDependencies:
+      '@tinacms/scripts':
+        specifier: workspace:*
+        version: link:../../../@tinacms/scripts
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+      typescript:
+        specifier: ^5.7.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.9
+        version: 2.1.9(@types/node@25.1.0)(happy-dom@15.10.2)(jsdom@15.2.1(bufferutil@4.1.0))(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)
+
   packages/v4/@tinacms/tinacms:
     dependencies:
       '@tanstack/react-query':
@@ -2600,6 +2754,9 @@ importers:
       '@tinacms/mdx':
         specifier: workspace:*
         version: link:../../../@tinacms/mdx
+      '@tinacms/rich-text':
+        specifier: workspace:*
+        version: link:../rich-text
       '@tinacms/ui':
         specifier: workspace:*
         version: link:../ui
@@ -2719,6 +2876,9 @@ importers:
 
   packages/v4/examples/barebones:
     dependencies:
+      '@tinacms/rich-text':
+        specifier: workspace:*
+        version: link:../../@tinacms/rich-text
       '@tinacms/tinacms':
         specifier: workspace:*
         version: link:../../@tinacms/tinacms
@@ -6287,34 +6447,8 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-arrow@1.1.7':
-    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-collection@1.1.11':
     resolution: {integrity: sha512-djW9+zeg137KQdlPtmE8xnaD+K2rcXXMWFrSg0hsmYZ6HRbdTA7tDHFgpaW9+huWVEu0RCabL+985T4TA0BE7g==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-collection@1.1.7':
-    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6388,15 +6522,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-direction@1.1.1':
-    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-direction@1.1.2':
     resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
     peerDependencies:
@@ -6421,19 +6546,6 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.14':
     resolution: {integrity: sha512-4lUhWTWAjbDIqFrAPWJ3WqBOpO5YchVZ88X3nh6H9Lu5AFi5nCUeTPj3D8FSDmabmFeRe9ME0BDA4MwKTha5GQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-dropdown-menu@2.1.16':
-    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6520,19 +6632,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-menu@2.1.16':
-    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-menu@2.1.19':
     resolution: {integrity: sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==}
     peerDependencies:
@@ -6548,19 +6647,6 @@ packages:
 
   '@radix-ui/react-popover@1.1.18':
     resolution: {integrity: sha512-qdXDes+eHlnMUGlBAAAe5EG7oOQvqsXuq4mq585diMudg80iB+jHbsSeG3+Q4eWNsogNyhqU2p/3i+Y0iEepqg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popper@1.2.8':
-    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6665,19 +6751,6 @@ packages:
 
   '@radix-ui/react-primitive@2.1.7':
     resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-roving-focus@1.1.11':
-    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6807,19 +6880,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -6910,26 +6970,8 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-use-rect@1.1.1':
-    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-use-rect@1.1.2':
     resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-size@1.1.1':
-    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -6944,19 +6986,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-visually-hidden@1.2.3':
-    resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-visually-hidden@1.2.4':
@@ -6984,9 +7013,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  '@radix-ui/rect@1.1.1':
-    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@radix-ui/rect@1.1.2':
     resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
@@ -16492,11 +16518,25 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
 
+  '@ariakit/react-core@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@ariakit/core': 0.4.17
+      '@floating-ui/dom': 1.7.4
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
+
   '@ariakit/react@0.4.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@ariakit/react-core': 0.4.20(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@ariakit/react@0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@ariakit/react-core': 0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@5.9.3)':
     dependencies:
@@ -19774,6 +19814,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@floating-ui/react-dom@2.1.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/dom': 1.7.4
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@floating-ui/react-dom@2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/dom': 1.8.0
@@ -19802,12 +19848,28 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       tabbable: 6.3.0
 
+  '@floating-ui/react@0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tabbable: 6.3.0
+
   '@floating-ui/react@0.27.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@floating-ui/utils': 0.2.10
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      tabbable: 6.3.0
+
+  '@floating-ui/react@0.27.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.10
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       tabbable: 6.3.0
 
   '@floating-ui/utils@0.2.10': {}
@@ -19818,9 +19880,9 @@ snapshots:
     dependencies:
       '@graphiql/toolkit': 0.8.4(@types/node@25.1.0)(graphql@15.8.0)
       '@headlessui/react': 1.7.19(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-dropdown-menu': 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dialog': 1.1.18(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu': 2.1.19(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.2.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-visually-hidden': 1.2.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/codemirror': 5.60.17
       clsx: 1.2.1
@@ -20016,6 +20078,15 @@ snapshots:
       '@tanstack/react-virtual': 3.13.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@headlessui/react@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/focus': 3.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/interactions': 3.25.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual': 3.13.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -21209,14 +21280,14 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-arrow@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-collection@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21230,17 +21301,17 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-collection@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21248,11 +21319,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-compose-refs@1.1.3(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-context@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21260,11 +21343,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-context@1.1.4(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-dialog@1.1.15(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21288,6 +21383,28 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-dialog@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -21310,17 +21427,39 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-direction@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+  '@radix-ui/react-dialog@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      react: 18.3.1
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-direction@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21335,6 +21474,19 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -21348,20 +21500,18 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-dropdown-menu@2.1.19(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21378,17 +21528,44 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-dropdown-menu@2.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-focus-guards@1.1.3(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-focus-guards@1.1.4(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-focus-scope@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21401,6 +21578,17 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-focus-scope@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
@@ -21412,12 +21600,30 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-id@1.1.1(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-id@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21426,31 +21632,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      aria-hidden: 1.2.6
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-remove-scroll: 2.7.2(@types/react@18.3.27)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
 
   '@radix-ui/react-menu@2.1.19(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21478,6 +21665,32 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-menu@2.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-popover@1.1.18(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -21501,23 +21714,28 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/rect': 1.1.1
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-popper@1.3.2(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21537,6 +21755,24 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-popper@1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.9(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-portal@1.1.13(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -21546,6 +21782,16 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-portal@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21557,6 +21803,16 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-presence@1.1.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
@@ -21567,6 +21823,16 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-presence@1.1.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@18.3.27)(react@18.3.1)
@@ -21575,6 +21841,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-primitive@2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21585,6 +21860,15 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@18.3.27)(react@18.3.1)
@@ -21593,6 +21877,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-primitive@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21603,22 +21896,14 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-roving-focus@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21636,6 +21921,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-roving-focus@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-select@2.3.2(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21676,12 +21978,28 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-separator@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-slot@1.2.3(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-slot@1.2.4(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21690,12 +22008,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-slot@1.3.0(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-toggle-group@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21712,6 +22044,21 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
+  '@radix-ui/react-toggle-group@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-toggle@1.1.13(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -21722,6 +22069,17 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-toggle@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-toolbar@1.1.14(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21737,6 +22095,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
+
+  '@radix-ui/react-toolbar@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-tooltip@1.2.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21758,25 +22131,25 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-tooltip@1.2.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-context': 1.1.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-id': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.27)(react@18.3.1)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21784,11 +22157,23 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-callback-ref@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-controllable-state@1.2.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21798,6 +22183,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-controllable-state@1.2.3(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@18.3.27)(react@18.3.1)
@@ -21806,12 +22199,27 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-effect-event@0.0.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21820,6 +22228,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.27)(react@18.3.1)
@@ -21827,11 +22242,24 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-layout-effect@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21839,15 +22267,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-previous@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
-      react: 18.3.1
-    optionalDependencies:
-      '@types/react': 18.3.27
-
-  '@radix-ui/react-use-rect@1.1.1(@types/react@18.3.27)(react@18.3.1)':
-    dependencies:
-      '@radix-ui/rect': 1.1.1
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.27
@@ -21859,12 +22286,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
-  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.27)(react@18.3.1)':
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.27)(react@18.3.1)
-      react: 18.3.1
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.3.27
+      '@types/react': 19.2.17
 
   '@radix-ui/react-use-size@1.1.2(@types/react@18.3.27)(react@18.3.1)':
     dependencies:
@@ -21873,14 +22300,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
-  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
     optionalDependencies:
-      '@types/react': 18.3.27
-      '@types/react-dom': 18.3.7(@types/react@18.3.27)
+      '@types/react': 19.2.17
 
   '@radix-ui/react-visually-hidden@1.2.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21900,7 +22325,14 @@ snapshots:
       '@types/react': 18.3.27
       '@types/react-dom': 18.3.7(@types/react@18.3.27)
 
-  '@radix-ui/rect@1.1.1': {}
+  '@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
   '@radix-ui/rect@1.1.2': {}
 
@@ -21914,6 +22346,16 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@react-aria/focus@3.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@react-aria/interactions': 3.25.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/utils': 3.31.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-types/shared': 3.32.1(react@19.2.7)
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@react-aria/interactions@3.25.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@react-aria/ssr': 3.9.10(react@18.3.1)
@@ -21924,10 +22366,25 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@react-aria/interactions@3.25.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@react-aria/ssr': 3.9.10(react@19.2.7)
+      '@react-aria/utils': 3.31.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-stately/flags': 3.1.2
+      '@react-types/shared': 3.32.1(react@19.2.7)
+      '@swc/helpers': 0.5.17
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@react-aria/ssr@3.9.10(react@18.3.1)':
     dependencies:
       '@swc/helpers': 0.5.17
       react: 18.3.1
+
+  '@react-aria/ssr@3.9.10(react@19.2.7)':
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 19.2.7
 
   '@react-aria/utils@3.31.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -21939,6 +22396,17 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@react-aria/utils@3.31.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@react-aria/ssr': 3.9.10(react@19.2.7)
+      '@react-stately/flags': 3.1.2
+      '@react-stately/utils': 3.10.8(react@19.2.7)
+      '@react-types/shared': 3.32.1(react@19.2.7)
+      '@swc/helpers': 0.5.17
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@react-dnd/asap@5.0.2': {}
 
@@ -21980,9 +22448,18 @@ snapshots:
       '@swc/helpers': 0.5.17
       react: 18.3.1
 
+  '@react-stately/utils@3.10.8(react@19.2.7)':
+    dependencies:
+      '@swc/helpers': 0.5.17
+      react: 19.2.7
+
   '@react-types/shared@3.32.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
+
+  '@react-types/shared@3.32.1(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
 
   '@remix-run/router@1.23.2': {}
 
@@ -22840,6 +23317,12 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@tanstack/react-virtual@3.13.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.13
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@tanstack/table-core@8.21.3': {}
 
   '@tanstack/virtual-core@3.13.13': {}
@@ -23202,6 +23685,12 @@ snapshots:
   '@types/hoist-non-react-statics@3.3.7(@types/react@18.3.27)':
     dependencies:
       '@types/react': 18.3.27
+      hoist-non-react-statics: 3.3.2
+    optional: true
+
+  '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
       hoist-non-react-statics: 3.3.2
     optional: true
 
@@ -23576,6 +24065,16 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
+  '@udecode/cn@48.0.3(@types/react@19.2.17)(class-variance-authority@0.7.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwind-merge@3.6.0)':
+    dependencies:
+      '@udecode/react-utils': 47.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      class-variance-authority: 0.7.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tailwind-merge: 3.6.0
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@udecode/plate-autoformat@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -23583,11 +24082,24 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-autoformat@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-basic-marks@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-basic-marks@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-block-quote@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23595,11 +24107,23 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-block-quote@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-break@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-break@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-code-block@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23607,11 +24131,23 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-code-block@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-combobox@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-combobox@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-core@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))':
     dependencies:
@@ -23644,6 +24180,37 @@ snapshots:
       - slate-dom
       - use-sync-external-store
 
+  '@udecode/plate-core@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))':
+    dependencies:
+      '@udecode/react-hotkeys': 37.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/react-utils': 47.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/slate': 48.0.1
+      '@udecode/utils': 47.2.7
+      clsx: 2.1.1
+      html-entities: 2.6.0
+      is-hotkey: 0.2.0
+      jotai: 2.8.4(@types/react@19.2.17)(react@19.2.7)
+      jotai-optics: 0.4.0(jotai@2.8.4(@types/react@19.2.17)(react@19.2.7))(optics-ts@2.4.1)
+      jotai-x: 2.3.2(@types/react@19.2.17)(jotai@2.8.4(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)
+      lodash: 4.17.21
+      nanoid: 5.1.6
+      optics-ts: 2.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      slate-hyperscript: 0.100.0(slate@0.114.0)
+      slate-react: 0.114.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)
+      use-deep-compare: 1.3.0(react@19.2.7)
+      zustand: 5.0.9(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      zustand-x: 6.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(zustand@5.0.9(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react-native
+      - scheduler
+      - slate
+      - slate-dom
+      - use-sync-external-store
+
   '@udecode/plate-dnd@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.27))(@types/node@22.19.3)(@types/react@18.3.27)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -23654,6 +24221,16 @@ snapshots:
       react-dnd-html5-backend: 16.0.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-dnd@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17))(@types/node@25.1.0)(@types/react@19.2.17)(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      lodash: 4.17.21
+      raf: 3.4.1
+      react: 19.2.7
+      react-dnd: 16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17))(@types/node@25.1.0)(@types/react@19.2.17)(react@19.2.7)
+      react-dnd-html5-backend: 16.0.1
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-floating@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/core': 1.7.3
@@ -23662,11 +24239,25 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-floating@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/core': 1.7.3
+      '@floating-ui/react': 0.27.16(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-heading@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-heading@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-highlight@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23674,11 +24265,23 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-highlight@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-horizontal-rule@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-horizontal-rule@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-indent-list@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23689,11 +24292,26 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-indent-list@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-indent': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-list': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-indent@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-indent@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-link@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23703,6 +24321,14 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-link@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-floating': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-normalizers': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-list@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -23711,12 +24337,27 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-list@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-reset-node': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-node-id@48.0.6(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-node-id@48.0.6(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-normalizers@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23725,17 +24366,36 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-normalizers@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-reset-node@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-reset-node@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-resizable@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-resizable@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-selection@48.0.5(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23744,12 +24404,26 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-selection@48.0.5(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      copy-to-clipboard: 3.3.3
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-slash-command@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       '@udecode/plate-combobox': 48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-slash-command@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-combobox': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-table@48.0.6(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23760,11 +24434,26 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@udecode/plate-table@48.0.6(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-node-id': 48.0.6(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/plate-resizable': 48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+
   '@udecode/plate-trailing-block@48.0.0(@udecode/plate@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@udecode/plate': 48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/plate-trailing-block@48.0.0(@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7)))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@udecode/plate': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/plate-utils@48.0.5(@types/react@18.3.27)(immer@10.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@18.3.1))':
     dependencies:
@@ -23776,6 +24465,25 @@ snapshots:
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react-native
+      - scheduler
+      - slate
+      - slate-dom
+      - use-sync-external-store
+
+  '@udecode/plate-utils@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))':
+    dependencies:
+      '@udecode/plate-core': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/react-utils': 47.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/slate': 48.0.1
+      '@udecode/utils': 47.2.7
+      clsx: 2.1.1
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -23804,10 +24512,34 @@ snapshots:
       - slate-dom
       - use-sync-external-store
 
+  '@udecode/plate@48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))':
+    dependencies:
+      '@udecode/plate-core': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/plate-utils': 48.0.5(@types/react@19.2.17)(immer@10.2.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@udecode/react-hotkeys': 37.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/react-utils': 47.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@udecode/slate': 48.0.1
+      '@udecode/utils': 47.2.7
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - react-native
+      - scheduler
+      - slate
+      - slate-dom
+      - use-sync-external-store
+
   '@udecode/react-hotkeys@37.0.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+
+  '@udecode/react-hotkeys@37.0.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
 
   '@udecode/react-utils@47.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -23816,6 +24548,16 @@ snapshots:
       clsx: 2.1.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
+  '@udecode/react-utils@47.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@udecode/utils': 47.2.7
+      clsx: 2.1.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -25139,6 +25881,18 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - '@types/react-dom'
+
+  cmdk@1.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
@@ -28553,6 +29307,11 @@ snapshots:
       jotai: 2.8.4(@types/react@18.3.27)(react@18.3.1)
       optics-ts: 2.4.1
 
+  jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.2.17)(react@19.2.7))(optics-ts@2.4.1):
+    dependencies:
+      jotai: 2.8.4(@types/react@19.2.17)(react@19.2.7)
+      optics-ts: 2.4.1
+
   jotai-x@2.3.2(@types/react@18.3.27)(jotai@2.8.4(@types/react@18.3.27)(react@18.3.1))(react@18.3.1):
     dependencies:
       jotai: 2.8.4(@types/react@18.3.27)(react@18.3.1)
@@ -28560,10 +29319,22 @@ snapshots:
       '@types/react': 18.3.27
       react: 18.3.1
 
+  jotai-x@2.3.2(@types/react@19.2.17)(jotai@2.8.4(@types/react@19.2.17)(react@19.2.7))(react@19.2.7):
+    dependencies:
+      jotai: 2.8.4(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
+
   jotai@2.8.4(@types/react@18.3.27)(react@18.3.1):
     optionalDependencies:
       '@types/react': 18.3.27
       react: 18.3.1
+
+  jotai@2.8.4(@types/react@19.2.17)(react@19.2.7):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      react: 19.2.7
 
   joycon@3.1.1: {}
 
@@ -31225,6 +31996,19 @@ snapshots:
       '@types/node': 22.19.3
       '@types/react': 18.3.27
 
+  react-dnd@16.0.1(@types/hoist-non-react-statics@3.3.7(@types/react@19.2.17))(@types/node@25.1.0)(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@react-dnd/invariant': 4.0.2
+      '@react-dnd/shallowequal': 4.0.2
+      dnd-core: 16.0.1
+      fast-deep-equal: 3.1.3
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.7
+    optionalDependencies:
+      '@types/hoist-non-react-statics': 3.3.7(@types/react@19.2.17)
+      '@types/node': 25.1.0
+      '@types/react': 19.2.17
+
   react-dom@18.3.1(react@18.3.1):
     dependencies:
       loose-envify: 1.4.0
@@ -31285,6 +32069,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   react-remove-scroll@2.7.2(@types/react@18.3.27)(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -31295,6 +32087,17 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@18.3.27)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.27
+
+  react-remove-scroll@2.7.2(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.17)(react@19.2.7)
+      react-style-singleton: 2.2.3(@types/react@19.2.17)(react@19.2.7)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.17)(react@19.2.7)
+      use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   react-router-dom@6.30.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -31328,6 +32131,14 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   react-tracked@1.7.14(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0):
     dependencies:
       proxy-compare: 2.6.0
@@ -31336,6 +32147,15 @@ snapshots:
       use-context-selector: 1.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0)
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
+
+  react-tracked@1.7.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0):
+    dependencies:
+      proxy-compare: 2.6.0
+      react: 19.2.7
+      scheduler: 0.27.0
+      use-context-selector: 1.4.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
 
   react-universal-interface@0.6.2(react@18.3.1)(tslib@2.8.1):
     dependencies:
@@ -32209,6 +33029,20 @@ snapshots:
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+      scroll-into-view-if-needed: 3.1.0
+      slate: 0.114.0
+      slate-dom: 0.114.0(slate@0.114.0)
+      tiny-invariant: 1.3.1
+
+  slate-react@0.114.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0):
+    dependencies:
+      '@juggle/resize-observer': 3.4.0
+      direction: 1.0.4
+      is-hotkey: 0.2.0
+      is-plain-object: 5.0.0
+      lodash: 4.17.21
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
       scroll-into-view-if-needed: 3.1.0
       slate: 0.114.0
       slate-dom: 0.114.0(slate@0.114.0)
@@ -33361,6 +34195,13 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  use-callback-ref@1.3.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   use-context-selector@1.4.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(scheduler@0.27.0):
     dependencies:
       react: 18.3.1
@@ -33368,10 +34209,22 @@ snapshots:
     optionalDependencies:
       react-dom: 18.3.1(react@18.3.1)
 
+  use-context-selector@1.4.4(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+    optionalDependencies:
+      react-dom: 19.2.7(react@19.2.7)
+
   use-deep-compare@1.3.0(react@18.3.1):
     dependencies:
       dequal: 2.0.3
       react: 18.3.1
+
+  use-deep-compare@1.3.0(react@19.2.7):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.7
 
   use-sidecar@1.1.3(@types/react@18.3.27)(react@18.3.1):
     dependencies:
@@ -33381,9 +34234,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.27
 
+  use-sidecar@1.1.3(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.7
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   use-sync-external-store@1.4.0(react@18.3.1):
     dependencies:
       react: 18.3.1
+
+  use-sync-external-store@1.4.0(react@19.2.7):
+    dependencies:
+      react: 19.2.7
 
   use-sync-external-store@1.6.0(react@18.3.1):
     dependencies:
@@ -34295,6 +35160,20 @@ snapshots:
       - react-native
       - scheduler
 
+  zustand-x@6.1.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)(zustand@5.0.9(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))):
+    dependencies:
+      immer: 10.2.0
+      lodash.mapvalues: 4.6.0
+      mutative: 1.1.0
+      react-tracked: 1.7.14(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(scheduler@0.27.0)
+      use-sync-external-store: 1.4.0(react@19.2.7)
+      zustand: 5.0.9(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    transitivePeerDependencies:
+      - react
+      - react-dom
+      - react-native
+      - scheduler
+
   zustand@5.0.14(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
     optionalDependencies:
       '@types/react': 19.2.17
@@ -34308,6 +35187,13 @@ snapshots:
       immer: 10.2.0
       react: 18.3.1
       use-sync-external-store: 1.6.0(react@18.3.1)
+
+  zustand@5.0.9(@types/react@19.2.17)(immer@10.2.0)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      immer: 10.2.0
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)
 
   zwitch@1.0.5: {}
 


### PR DESCRIPTION
tl;dr: the rich-text half of v4, stacked on #7395, and the combined tree matches the tip of the original stack.

What's in it:

- **The renderer:** framework-free `src/rich-text`, with `TinaMarkdown` as its React binding
- **`@tinacms/rich-text`:** the Plate editor extracted into its own v4 package
- **The field plugin:** `t.richText`, per-document markdown/MDX codecs, and the field UI
- **Restores the body field** in the playground and barebones example, plus the Tailwind `@source` lines

To test: `pnpm types && pnpm test` in `packages/v4/@tinacms/tinacms`, or `pnpm dev` and edit a post body in the playground.
