### PR TITLE
fix(admin): prevent long filenames from overflowing the collection table

### DIFF
--- a/packages/tinacms/src/admin/pages/CollectionListPage.tsx
+++ b/packages/tinacms/src/admin/pages/CollectionListPage.tsx
@@ -937,7 +937,7 @@ const CollectionListPage = () => {
                                                   </a>
                                                 </td>
                                                 <td
-                                                  className='px-3 py-3'
+                                                  className='pl-5 pr-3 py-3 break-all'
                                                   colSpan={4}
                                                 >
                                                   <span className='leading-5 block text-sm font-medium text-gray-400 truncate'>
@@ -976,7 +976,7 @@ const CollectionListPage = () => {
                                               key={`document-${document.node._sys.relativePath}`}
                                             >
                                               <td
-                                                className='pl-5 pr-3 py-3'
+                                                className='pl-5 pr-3 py-3 break-all'
                                                 colSpan={hasTitle ? 1 : 2}
                                               >
                                                 <a
@@ -1027,7 +1027,7 @@ const CollectionListPage = () => {
                                                 </a>
                                               </td>
                                               {hasTitle && (
-                                                <td className='px-3 py-3'>
+                                                <td className='px-3 py-3 break-all'>
                                                   <span className='leading-5 block text-sm font-medium text-gray-900 truncate'>
                                                     {!folderView &&
                                                       subfolders && (


### PR DESCRIPTION
## Description

When documents have long filenames without spaces (e.g., legacy imported slugs like `a-really-long-legacy-slug-path-with-no-spaces.mdx`), the collection table columns expand beyond the viewport. This pushes the pagination buttons off-screen, making them unreachable.

## Fix

Added `break-all` (Tailwind's `word-break: break-all`) to:
1. The folder path cell (showing path segments)
2. The title/filename cell (showing document title or filename)
3. The filename cell (shown when a document has a title)

This ensures long unbroken strings wrap at character boundaries, keeping the table within its scrollable container.

## Before

The table expands beyond the viewport, and pagination buttons become unreachable.

## After

Long filenames wrap at character boundaries, and the table stays within the viewport.

Fixes #7399