### PR TITLE
fix(mdx): keep carriage returns out of parsed text, and keep task-list state

### DIFF
--- a/.changeset/mdx-line-endings-and-task-lists.md
+++ b/.changeset/mdx-line-endings-and-task-lists.md
@@ -1,0 +1,7 @@
+---
+"@tinacms/mdx": patch
+---
+
+`parseMDX` now normalizes CRLF to LF before parsing. A carriage return used to survive micromark into the value of a text node, so a document authored on Windows carried `\r` into the editor.
+
+GFM task list items now keep their checked state through a round trip. `parseMDX` reads `checked` onto the `li` node, and both stringifiers write it back. A ticked checkbox previously came back unticked on save. `ListItemElement` gains an optional `checked?: boolean` — set only on task list items.

--- a/packages/@tinacms/mdx/src/line-endings.test.ts
+++ b/packages/@tinacms/mdx/src/line-endings.test.ts
@@ -1,0 +1,37 @@
+import type { RichTextField } from '@tinacms/schema-tools';
+import { describe, expect, it } from 'vitest';
+import { parseMDX } from './parse';
+
+const passthrough = (value: string) => value;
+
+const markdownField: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+  parser: { type: 'markdown' },
+};
+
+const mdxField: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+};
+
+const textOf = (tree: { children: unknown[] }): unknown =>
+  (tree.children[0] as { children: { text: string }[] }).children[0]?.text;
+
+describe('a carriage return never reaches a text node', () => {
+  it('drops it from a soft break in markdown', () => {
+    expect(textOf(parseMDX('a\r\nb\r\n', markdownField, passthrough))).toBe(
+      'a\nb'
+    );
+  });
+
+  it('drops it from a soft break in mdx', () => {
+    expect(textOf(parseMDX('a\r\nb\r\n', mdxField, passthrough))).toBe('a\nb');
+  });
+
+  it('reads a CRLF document as the same tree as an LF document', () => {
+    expect(
+      parseMDX('# Head\r\n\r\nOne.\r\ntwo.\r\n', markdownField, passthrough)
+    ).toEqual(parseMDX('# Head\n\nOne.\ntwo.\n', markdownField, passthrough));
+  });
+});

--- a/packages/@tinacms/mdx/src/next/stringify/pre-processing.ts
+++ b/packages/@tinacms/mdx/src/next/stringify/pre-processing.ts
@@ -202,6 +202,9 @@ const listItemElement = (
     // spread is always false since we don't support block elements in list items
     // good explanation of the difference: https://stackoverflow.com/questions/43503528/extra-lines-appearing-between-list-items-in-github-markdown
     spread: false,
+    ...(typeof content.checked === 'boolean'
+      ? { checked: content.checked }
+      : {}),
     children: content.children.map((child) => {
       if (child.type === 'lic') {
         return {

--- a/packages/@tinacms/mdx/src/parse/index.ts
+++ b/packages/@tinacms/mdx/src/parse/index.ts
@@ -152,6 +152,12 @@ const sanitizeSlateTree = <T>(node: T): T => {
   return next as unknown as T;
 };
 
+/**
+ * A CRLF pair survives micromark into the value of a text node. Normalize the
+ * source so no carriage return reaches the editor.
+ */
+const toLineFeeds = (value: string): string => value.replace(/\r\n/g, '\n');
+
 export const parseMDX = (
   value: string,
   field: RichTextType,
@@ -164,14 +170,15 @@ export const parseMDX = (
   try {
     switch (field.parser?.type) {
       case 'markdown':
-        return parseMDXNext(value, field, imageCallback);
+        return parseMDXNext(toLineFeeds(value), field, imageCallback);
       case 'slatejson':
         // Assuming `value` is a JSON object
         return sanitizeSlateTree(
           value as unknown as Plate.RootElement
         ) as Plate.RootElement;
     }
-    let preprocessedString = value;
+    const source = toLineFeeds(value);
+    let preprocessedString = source;
     const templatesWithMatchers = field.templates?.filter(
       (template) => template.match
     );
@@ -187,7 +194,7 @@ export const parseMDX = (
     });
     tree = mdxToAst(preprocessedString);
     if (tree) {
-      return remarkToSlate(tree, field, imageCallback, value);
+      return remarkToSlate(tree, field, imageCallback, source);
     } else {
       return { type: 'root', children: [] };
     }

--- a/packages/@tinacms/mdx/src/parse/plate.ts
+++ b/packages/@tinacms/mdx/src/parse/plate.ts
@@ -98,6 +98,8 @@ export type ListItemChildrenElement =
  */
 export type ListItemElement = {
   type: 'li';
+  /** Set only on GFM task list items. `false` is an unticked checkbox. */
+  checked?: boolean;
   children: ListItemChildrenElement[];
 };
 /**

--- a/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
+++ b/packages/@tinacms/mdx/src/parse/remarkToPlate.ts
@@ -179,6 +179,9 @@ export const remarkToSlate = (
 
     return {
       type: 'li',
+      ...(typeof content.checked === 'boolean'
+        ? { checked: content.checked }
+        : {}),
       // @ts-ignore
       children: content.children.map((child) => {
         switch (child.type) {

--- a/packages/@tinacms/mdx/src/stringify/index.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.ts
@@ -360,6 +360,9 @@ const listItemElement = (
     // spread is always false since we don't support block elements in list items
     // good explanation of the difference: https://stackoverflow.com/questions/43503528/extra-lines-appearing-between-list-items-in-github-markdown
     spread: false,
+    ...(typeof content.checked === 'boolean'
+      ? { checked: content.checked }
+      : {}),
     children: content.children.map((child) => {
       if (child.type === 'lic') {
         return {

--- a/packages/@tinacms/mdx/src/task-list.test.ts
+++ b/packages/@tinacms/mdx/src/task-list.test.ts
@@ -1,0 +1,62 @@
+import type { RichTextField } from '@tinacms/schema-tools';
+import { describe, expect, it } from 'vitest';
+import { parseMDX } from './parse';
+import { serializeMDX } from './stringify';
+
+const passthrough = (value: string) => value;
+
+const markdownField: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+  parser: { type: 'markdown' },
+};
+
+const mdxField: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+};
+
+const TASK_LIST = '* [ ] task\n* [x] done\n';
+
+describe('GFM task list items', () => {
+  it('keeps the checked state on the parsed markdown list items', () => {
+    const tree = parseMDX(TASK_LIST, markdownField, passthrough);
+    expect(tree.children[0]).toMatchObject({
+      type: 'ul',
+      children: [
+        { type: 'li', checked: false },
+        { type: 'li', checked: true },
+      ],
+    });
+  });
+
+  it('keeps the checked state on the parsed mdx list items', () => {
+    const tree = parseMDX(TASK_LIST, mdxField, passthrough);
+    expect(tree.children[0]).toMatchObject({
+      type: 'ul',
+      children: [
+        { type: 'li', checked: false },
+        { type: 'li', checked: true },
+      ],
+    });
+  });
+
+  it('writes a markdown task list back unchanged', () => {
+    const tree = parseMDX(TASK_LIST, markdownField, passthrough);
+    expect(serializeMDX(tree, markdownField, passthrough)).toBe(TASK_LIST);
+  });
+
+  it('writes an mdx task list back unchanged', () => {
+    const tree = parseMDX(TASK_LIST, mdxField, passthrough);
+    expect(serializeMDX(tree, mdxField, passthrough)).toBe(TASK_LIST);
+  });
+
+  it('leaves a list with no checkboxes without a checked state', () => {
+    const tree = parseMDX('* one\n* two\n', markdownField, passthrough);
+    const list = tree.children[0] as { children: Record<string, unknown>[] };
+    expect(list.children.every((item) => !('checked' in item))).toBe(true);
+    expect(serializeMDX(tree, markdownField, passthrough)).toBe(
+      '* one\n* two\n'
+    );
+  });
+});


### PR DESCRIPTION
Two parser fixes in `@tinacms/mdx`, found while reviewing the v4 rich-text work. Both are v3, both ship on the v3 release train, and neither depends on v4 — so they are split out here rather than sitting behind the v4 stack.

### Carriage returns

A CRLF pair survives micromark into the `value` of a text node, so a document authored on Windows carries a `\r` into the editor. `parseMDX` now normalizes the source to line feeds before parsing, and passes the normalized source to `remarkToSlate`.

### GFM task lists

A ticked checkbox came back unticked. `parseMDX` now reads `checked` onto the `li` node, and both stringifiers (`stringify/index.ts` and `next/stringify/pre-processing.ts`) write it back. `ListItemElement` gains an optional `checked?: boolean`, set only on task-list items — additive, so no consumer breaks.

### Notes

- Changeset included: patch for `@tinacms/mdx`.
- `packages/@tinacms/mdx`: **77 test files, 119 tests passing.**
- The same two source changes also appear in #7405 (the v4 review-findings branch), because v4 tests depend on them. The files and the changeset are byte-identical, so whichever lands first, the other rebases away cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)