### PR TITLE
perf(mdx): ship one copy of acorn instead of three

### DIFF
--- a/.changeset/dedupe-acorn-in-mdx-bundle.md
+++ b/.changeset/dedupe-acorn-in-mdx-bundle.md
@@ -1,0 +1,6 @@
+---
+"@tinacms/scripts": patch
+"@tinacms/mdx": patch
+---
+
+Ship one copy of the `acorn` parser in `@tinacms/mdx` instead of three, cutting `dist/index.browser.js` from 1,976,421 to 1,578,764 bytes (440,787 to 356,471 gzipped) and `dist/index.js` from 2,013,419 to 1,615,828 bytes (452,063 to 367,630 gzipped). The catalog pinned `acorn` to 8.8.2 while `micromark-extension-mdxjs` pulled 8.16.0, so two 8.x copies were bundled side by side; separately, `acorn-jsx` reaches `acorn` through `require`, which acorn's export map answers with its CJS build while every other importer gets the ESM build, bundling the parser a second time. Aligning the catalog to `^8.16.0` and aliasing `acorn` to its ESM entry in the `@tinacms/mdx` esbuild config collapses all three into one. Parser and serializer output is unchanged — `parseMDX`/`serializeMDX` round-trips over the package's 64 markdown fixtures produce byte-identical results from the old and new bundles.

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { exec } from 'node:child_process';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import chalk from 'chalk';
 import chokidar from 'chokidar';
@@ -410,6 +411,20 @@ export class BuildTina {
         });
       } else if (['@tinacms/mdx'].includes(packageJSON.name)) {
         const peerDeps = packageJSON.peerDependencies;
+
+        // acorn-jsx reaches acorn with `require`, which acorn's export map
+        // answers with the CJS build, while every other importer gets the ESM
+        // build. Without this the whole parser is bundled twice.
+        const acornManifest = createRequire(
+          path.join(process.cwd(), 'package.json')
+        ).resolve('acorn/package.json');
+        const alias = {
+          acorn: path.join(
+            path.dirname(acornManifest),
+            JSON.parse(fs.readFileSync(acornManifest, 'utf8')).module
+          ),
+        };
+
         await esbuild({
           entryPoints: [path.join(process.cwd(), entry)],
           bundle: true,
@@ -418,6 +433,7 @@ export class BuildTina {
           format: 'esm',
           outfile: path.join(process.cwd(), 'dist', 'index.js'),
           external: Object.keys({ ...peerDeps }),
+          alias,
         });
 
         // The ES version is targeting the browser. This is used by the rich-text's raw mode
@@ -432,6 +448,7 @@ export class BuildTina {
           // and includes "development" export maps which actually throw errors during
           // development, which we don't want to expose our users to.
           external: Object.keys({ ...peerDeps }),
+          alias,
         });
       } else {
         await esbuild({

--- a/packages/@tinacms/scripts/src/index.ts
+++ b/packages/@tinacms/scripts/src/index.ts
@@ -1,5 +1,6 @@
 import * as fs from 'fs';
 import { exec } from 'node:child_process';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import chalk from 'chalk';
 import chokidar from 'chokidar';
@@ -424,6 +425,20 @@ export class BuildTina {
         });
       } else if (['@tinacms/mdx'].includes(packageJSON.name)) {
         const peerDeps = packageJSON.peerDependencies;
+
+        // acorn-jsx reaches acorn with `require`, which acorn's export map
+        // answers with the CJS build, while every other importer gets the ESM
+        // build. Without this the whole parser is bundled twice.
+        const acornManifest = createRequire(
+          path.join(process.cwd(), 'package.json')
+        ).resolve('acorn/package.json');
+        const alias = {
+          acorn: path.join(
+            path.dirname(acornManifest),
+            JSON.parse(fs.readFileSync(acornManifest, 'utf8')).module
+          ),
+        };
+
         await esbuild({
           entryPoints: [path.join(process.cwd(), entry)],
           bundle: true,
@@ -432,6 +447,7 @@ export class BuildTina {
           format: 'esm',
           outfile: path.join(process.cwd(), 'dist', 'index.js'),
           external: Object.keys({ ...peerDeps }),
+          alias,
         });
 
         // The ES version is targeting the browser. This is used by the rich-text's raw mode
@@ -446,6 +462,7 @@ export class BuildTina {
           // and includes "development" export maps which actually throw errors during
           // development, which we don't want to expose our users to.
           external: Object.keys({ ...peerDeps }),
+          alias,
         });
       } else {
         await esbuild({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,8 +310,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     acorn:
-      specifier: 8.8.2
-      version: 8.8.2
+      specifier: ^8.16.0
+      version: 8.16.0
     altair-express-middleware:
       specifier: ^7.3.6
       version: 7.3.6
@@ -1724,7 +1724,7 @@ importers:
         version: link:../schema-tools
       acorn:
         specifier: 'catalog:'
-        version: 8.8.2
+        version: 8.16.0
       ccount:
         specifier: 'catalog:'
         version: 2.0.1
@@ -9031,11 +9031,6 @@ packages:
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -24886,8 +24881,6 @@ snapshots:
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
-
-  acorn@8.8.2: {}
 
   adm-zip@0.5.16: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,8 +304,8 @@ catalogs:
       specifier: ^1.0.4
       version: 1.0.4
     acorn:
-      specifier: 8.8.2
-      version: 8.8.2
+      specifier: ^8.16.0
+      version: 8.16.0
     altair-express-middleware:
       specifier: ^7.3.6
       version: 7.3.6
@@ -1704,7 +1704,7 @@ importers:
         version: link:../schema-tools
       acorn:
         specifier: 'catalog:'
-        version: 8.8.2
+        version: 8.16.0
       ccount:
         specifier: 'catalog:'
         version: 2.0.1
@@ -9012,11 +9012,6 @@ packages:
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -24202,8 +24197,6 @@ snapshots:
   acorn@8.15.0: {}
 
   acorn@8.16.0: {}
-
-  acorn@8.8.2: {}
 
   adm-zip@0.5.16: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -140,7 +140,7 @@ catalog:
     "@vercel/stega": ^0.0.5
     "@vitejs/plugin-react": ^4.7.0
     abstract-level: ^1.0.4
-    acorn: 8.8.2
+    acorn: ^8.16.0
     altair-express-middleware: ^7.3.6
     async-lock: ^1.4.1
     auto-bind: ^4.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -142,7 +142,7 @@ catalog:
     "@vercel/stega": ^0.0.5
     "@vitejs/plugin-react": ^4.7.0
     abstract-level: ^1.0.4
-    acorn: 8.8.2
+    acorn: ^8.16.0
     altair-express-middleware: ^7.3.6
     auto-bind: ^4.0.0
     autoprefixer: ^10.4.20


### PR DESCRIPTION
`@tinacms/mdx` bundles the acorn parser three times. This collapses it to one, with no source change to the package and no change to emitted output.

### The two causes

1. **`pnpm-workspace.yaml` pinned `acorn: 8.8.2`** while `micromark-extension-mdxjs` pulls `^8.0.0`, resolving to 8.16.0 — two 8.x copies side by side. Aligned to `^8.16.0` (a caret, not an exact pin: `micromark-extension-mdxjs` declares a range, so an exact pin would re-split the moment a lockfile refresh moved it to 8.17.0).
2. **`acorn-jsx` reaches acorn via `require`**, which acorn's export map answers with the CJS build while every other importer gets ESM — so esbuild bundled `acorn.js` *and* `acorn.mjs`. The `@tinacms/mdx` esbuild config now aliases `acorn` to the ESM entry acorn itself declares in its `module` field.

### Measured

| Entry | raw before | raw after | Δ | gzip before | gzip after | Δ |
|---|---:|---:|---:|---:|---:|---:|
| `index.browser.js` | 1,976,421 | 1,578,764 | **−397,657 (−20.1%)** | 440,787 | 356,471 | **−84,316 (−19.1%)** |
| `index.js` | 2,013,419 | 1,615,828 | −397,591 (−19.7%) | 452,063 | 367,630 | −84,433 (−18.7%) |

Acorn versions in the browser bundle: `8.8.2` + `8.16.0` before, `8.16.0` alone after.

### Output is unchanged

All 64 `src/next/tests/*` fixtures round-tripped through `parseMDX` → `serializeMDX` from the old and new bundles produce **one identical SHA-256**, across both the node and browser entries.

That check was mutation-proved. The first mutant survived — acorn's module-level `parseExpressionAt` wrapper is never called, because `micromark-extension-mdxjs` passes `Parser.extend(acornJsx())` and reaches the **static** method (39 calls, measured). Unreachable by construction, not a hole. Mutating the entry that *is* called flipped the digest and changed 12 of 64 fixtures.

**What it does not cover:** only markdown/MDX fixtures in this repo — no `parser.type: 'slatejson'`, no consumer-side integration, and the browser bundle ran under node+jsdom rather than a real browser engine.

### Verification

`pnpm types` forced cold: 46/46. `pnpm test`: 60/60. `pnpm lint` and `pnpm format` clean. Lockfile diff is 13 lines across 4 hunks — the catalog entry, the mdx importer, and `acorn@8.8.2` dropped from both sections.

No other published package changes size: `@tinacms/graphql` and `packages/tinacms` externalise `@tinacms/mdx`, and `@tinacms/app` has no build step. `packages/v4/**` are all `private: true`.

### Left alone

A **fourth** acorn (~138 KB) is vendored inside prettier's own pre-bundled dist. esbuild cannot dedupe it — it is baked into prettier's published bundle. It goes away with the prettier replacement stacked on top of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)