### PR TITLE
🐛 Support soft returns in the standard markdown editor

### DIFF
--- a/.changeset/soft-returns-standard-markdown.md
+++ b/.changeset/soft-returns-standard-markdown.md
@@ -1,0 +1,19 @@
+---
+"tinacms": patch
+---
+
+Fix soft returns (`shift+Enter`) being dropped outside blockquotes in the rich-text editor.
+
+Plate's `SoftBreakPlugin` inserts a literal `\n` into the text node. In markdown a bare newline inside a paragraph is a soft wrap, so serialization re-flowed it into a space and the line break vanished on save. Blockquotes were unaffected because a separate plugin already inserted a `break` element there — hence the inconsistency.
+
+`shift+Enter` now inserts the same `break` element everywhere, which serializes to a `\` hard break and round-trips as a `<br>`:
+
+```md
+123 Abc Street\
+Town Central, CA\
+90210
+```
+
+Two places keep the old behaviour: code blocks (which want a real newline) and GFM table cells (which cannot represent a hard break — put a literal `<br>` in the cell instead).
+
+`mod+Enter` / `mod+shift+enter` inside a blockquote also work again; the blockquote handler used to swallow them before `ExitBreakPlugin` could exit the quote.

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/create-html-block/index.test.ts
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/create-html-block/index.test.ts
@@ -1,0 +1,134 @@
+import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import { TablePlugin } from '@udecode/plate-table/react';
+import { createPlateEditor } from '@udecode/plate/react';
+import { describe, expect, it } from 'vitest';
+import {
+  ELEMENT_BREAK,
+  createBreakPlugin,
+  createSoftBreakPlugin,
+} from './index';
+
+const pressEnter = (
+  value: any[],
+  path: number[],
+  modifiers: { shiftKey?: boolean; metaKey?: boolean } = {}
+) => {
+  const editor = createPlateEditor({
+    plugins: [
+      BlockquotePlugin,
+      CodeBlockPlugin,
+      TablePlugin,
+      createBreakPlugin,
+      createSoftBreakPlugin,
+    ],
+    value,
+  });
+  const point = { path, offset: 3 };
+  editor.tf.select({ anchor: point, focus: point });
+
+  let defaultPrevented = false;
+  const event = {
+    key: 'Enter',
+    shiftKey: false,
+    metaKey: false,
+    ctrlKey: false,
+    ...modifiers,
+    preventDefault: () => {
+      defaultPrevented = true;
+    },
+  };
+  createSoftBreakPlugin.handlers.onKeyDown({ editor, event } as any);
+
+  return { defaultPrevented, value: editor.children };
+};
+
+const hasBreak = (node: any): boolean =>
+  node.type === ELEMENT_BREAK ||
+  (Array.isArray(node.children) && node.children.some(hasBreak));
+
+const paragraph = [{ type: 'p', children: [{ text: 'one two' }] }];
+
+describe('createSoftBreakPlugin', () => {
+  it('inserts a break element on shift+Enter in a paragraph', () => {
+    const { defaultPrevented, value } = pressEnter(paragraph, [0, 0], {
+      shiftKey: true,
+    });
+    expect(defaultPrevented).toBe(true);
+    expect(value.some(hasBreak)).toBe(true);
+  });
+
+  it('leaves a plain Enter in a paragraph alone', () => {
+    const { defaultPrevented, value } = pressEnter(paragraph, [0, 0]);
+    expect(defaultPrevented).toBe(false);
+    expect(value.some(hasBreak)).toBe(false);
+  });
+
+  it('still inserts a break on plain Enter inside a blockquote', () => {
+    const { defaultPrevented, value } = pressEnter(
+      [
+        {
+          type: BlockquotePlugin.key,
+          children: [{ type: 'p', children: [{ text: 'quoted' }] }],
+        },
+      ],
+      [0, 0, 0]
+    );
+    expect(defaultPrevented).toBe(true);
+    expect(value.some(hasBreak)).toBe(true);
+  });
+
+  it('leaves code blocks to SoftBreakPlugin so they keep real newlines', () => {
+    const { defaultPrevented, value } = pressEnter(
+      [
+        {
+          type: CodeBlockPlugin.key,
+          children: [{ type: 'code_line', children: [{ text: 'const x' }] }],
+        },
+      ],
+      [0, 0, 0],
+      { shiftKey: true }
+    );
+    expect(defaultPrevented).toBe(false);
+    expect(value.some(hasBreak)).toBe(false);
+  });
+
+  it('leaves table cells alone — GFM cells cannot hold a hard break', () => {
+    const { defaultPrevented, value } = pressEnter(
+      [
+        {
+          type: TablePlugin.key,
+          children: [
+            {
+              type: 'tr',
+              children: [
+                {
+                  type: 'td',
+                  children: [{ type: 'p', children: [{ text: 'cell' }] }],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+      [0, 0, 0, 0, 0],
+      { shiftKey: true }
+    );
+    expect(defaultPrevented).toBe(false);
+    expect(value.some(hasBreak)).toBe(false);
+  });
+
+  it('leaves mod+Enter to ExitBreakPlugin inside a blockquote', () => {
+    const { defaultPrevented } = pressEnter(
+      [
+        {
+          type: BlockquotePlugin.key,
+          children: [{ type: 'p', children: [{ text: 'quoted' }] }],
+        },
+      ],
+      [0, 0, 0],
+      { metaKey: true }
+    );
+    expect(defaultPrevented).toBe(false);
+  });
+});

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/create-html-block/index.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/create-html-block/index.tsx
@@ -1,4 +1,9 @@
 import { BlockquotePlugin } from '@udecode/plate-block-quote/react';
+import { CodeBlockPlugin } from '@udecode/plate-code-block/react';
+import {
+  TableCellHeaderPlugin,
+  TableCellPlugin,
+} from '@udecode/plate-table/react';
 import { createPlatePlugin } from '@udecode/plate/react';
 import React from 'react';
 
@@ -20,27 +25,43 @@ export const createHTMLInlinePlugin = createPlatePlugin({
   },
 });
 
-export const KEY_BLOCKQUOTE_ENTER_BREAK = 'blockquote-enter-break';
+export const KEY_SOFT_BREAK = 'tina-soft-break';
 
-// Custom Plate plugin to handle Enter key inside blockquotes.
-// Our parsing logic expects a soft break with type 'break' to be inserted for proper handling within blockquotes.
-// This plugin inserts a 'break' element and a new paragraph when Enter is pressed inside a blockquote.
-export const createBlockquoteEnterBreakPlugin = createPlatePlugin({
-  key: KEY_BLOCKQUOTE_ENTER_BREAK,
+// Plate's SoftBreakPlugin inserts a literal "\n", which markdown re-flows into a
+// space when serialized, so the line break is silently lost. Our parser and
+// serializer round-trip a `break` element (a `\` hard break) instead, so insert
+// that for shift+Enter, and for a plain Enter inside a blockquote where a new
+// paragraph would end the quote.
+//
+// Code blocks and table cells are left to SoftBreakPlugin: code blocks want a
+// real newline, and GFM table cells cannot hold a hard break at all.
+const NO_HARD_BREAK = [
+  CodeBlockPlugin.key,
+  TableCellPlugin.key,
+  TableCellHeaderPlugin.key,
+];
+
+export const createSoftBreakPlugin = createPlatePlugin({
+  key: KEY_SOFT_BREAK,
 
   handlers: {
     onKeyDown: ({ editor, event }) => {
-      if (event.key !== 'Enter') return;
-      const blockquoteEntry = editor.api.above({
+      // mod+enter / mod+shift+enter belong to ExitBreakPlugin.
+      if (event.key !== 'Enter' || event.metaKey || event.ctrlKey) return;
+
+      const inBlockquote = editor.api.above({
         match: { type: BlockquotePlugin.key },
       });
+      if (!event.shiftKey && !inBlockquote) return;
 
-      if (!blockquoteEntry) return;
+      if (editor.api.some({ match: { type: NO_HARD_BREAK } })) return;
 
-      event.preventDefault();
-      // Log the entire editor value BEFORE insertion
+      if (editor.api.isExpanded()) editor.tf.delete();
+
       const cursorPosition = editor.selection?.focus;
       if (!cursorPosition) return;
+
+      event.preventDefault();
 
       editor.tf.insertNodes(
         [

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/editor-plugins.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/editor-plugins.tsx
@@ -59,9 +59,9 @@ import { autoformatLists } from './core/autoformat/autoformat-lists';
 import { autoformatMarks } from './core/autoformat/autoformat-marks';
 import type { HeadingLevel } from '@tinacms/schema-tools';
 import {
-  createBlockquoteEnterBreakPlugin,
   createBreakPlugin,
   createHTMLInlinePlugin,
+  createSoftBreakPlugin,
 } from './create-html-block';
 import { createHTMLBlockPlugin } from './create-html-block';
 
@@ -156,7 +156,7 @@ export const createEditorPlugins = ({
   createImgPlugin,
   createHTMLBlockPlugin,
   createHTMLInlinePlugin,
-  createBlockquoteEnterBreakPlugin,
+  createSoftBreakPlugin,
   createInvalidMarkdownPlugin,
   CorrectNodeBehaviorPlugin,
   ClearHighlightOnEnterPlugin,
@@ -260,6 +260,8 @@ export const createEditorPlugins = ({
       ],
     },
   }),
+  // Only reached where `createSoftBreakPlugin` bails (code blocks, table
+  // cells) — everywhere else it has already inserted a `break` element.
   SoftBreakPlugin.configure({
     options: {
       rules: [


### PR DESCRIPTION
Closes #7408

## Investigation

Soft returns worked in blockquotes and nowhere else. Two different code paths were responsible:

- **Blockquotes** — `createBlockquoteEnterBreakPlugin` intercepted Enter and inserted a `break` element, which `@tinacms/mdx` serializes to a `\` hard break.
- **Everywhere else** — `shift+Enter` fell through to Plate's `SoftBreakPlugin`, which does `editor.tf.insertText('\n')`. Markdown treats a bare newline inside a paragraph as a soft wrap, so the break was re-flowed into a space on save.

Confirmed against the serializer:

| Editor node | Serialized markdown |
|---|---|
| text `"line one\nline two"` | `line one⏎line two` — soft wrap, renders as one line |
| `break` element | `line one\`⏎`line two` — hard break, renders as `<br>` |

So it's a functionality gap, not a docs problem. `@tinacms/mdx` already parses and stringifies `break` in plain paragraphs (`markdown-basic-break` fixture) — only the editor never produced one.

## Fix

Generalised the blockquote plugin into `createSoftBreakPlugin`: `shift+Enter` inserts a `break` element everywhere, and plain Enter inside a blockquote keeps doing what it already did. `SoftBreakPlugin`'s config is untouched — it only ever runs now where the new plugin bails.

Also stopped the handler swallowing `mod+Enter` / `mod+shift+Enter` inside blockquotes. It preventDefault'd on any Enter, and `ExitBreakPlugin` skips events that are already handled, so cmd+Enter couldn't exit a quote. Required anyway, since `mod+shift+Enter` would otherwise hit the new shift branch.

## Limitations

- **Code blocks** keep a real `\n` via `SoftBreakPlugin` — a hard break there would be wrong.
- **Table cells** are skipped. GFM cells can't hold a hard break: a `break` element serializes away to a space, and the current `\n` at least survives as `&#xA;`. A literal `<br>` in the cell is the workaround. Unchanged from today's behaviour either way.

## Tests

`create-html-block/index.test.ts` drives the handler headlessly over six cases. Verified the two new assertions fail against `main`:

```
× inserts a break element on shift+Enter in a paragraph
× leaves mod+Enter to ExitBreakPlugin inside a blockquote
```

The other four (plain Enter in a paragraph, plain Enter in a blockquote, code blocks, table cells) pass before and after — they're there to pin the behaviour that shouldn't move.

Note: `src/rich-text/index.test.tsx` fails on this branch and on a clean `main` alike — it needs `@tinacms/mdx` built first. Unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XQ3RmyQZZeuaQFqBXPQm5m