### PR TITLE
fix(tinacms): stop the type-check failing depending on how pnpm hoists Plate

### DIFF
--- a/.changeset/tinacms-plate-plugin-type-portability.md
+++ b/.changeset/tinacms-plate-plugin-type-portability.md
@@ -1,0 +1,7 @@
+---
+"tinacms": patch
+---
+
+Give the exported Plate plugin arrays (`plugins`, `viewPlugins`, `createEditorPlugins`) an explicit type, so their emitted declarations no longer carry a `.pnpm/` store path.
+
+The Plate satellite packages take `@udecode/plate` as a peer and never depend on `@udecode/plate-core` directly, so pnpm resolves it through the hoisted store. Once `@tinacms/rich-text` brought in a React 19 copy, the hoisted pick could land on a variant that nothing in `tinacms` is able to name, and `tsc` then failed with TS2742 rather than emit a declaration. Which copy wins varies per install, so the failure came and went.

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/core/formatting.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/core/formatting.tsx
@@ -32,7 +32,7 @@ const resetBlockTypesCommonRule = {
   defaultType: ParagraphPlugin.key,
 };
 
-export const plugins = [
+export const plugins: any[] = [
   TrailingBlockPlugin,
   AutoformatPlugin.configure({
     options: {

--- a/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/editor-plugins.tsx
+++ b/packages/tinacms/src/toolkit/fields/plugins/mdx-field-plugin/plate/plugins/editor-plugins.tsx
@@ -89,7 +89,7 @@ const resetBlockTypesCodeBlockRule = {
 };
 
 // View Plugins: Basic nodes and marks
-export const viewPlugins = [
+export const viewPlugins: any[] = [
   BasicMarksPlugin,
   UnderlinePlugin,
   HighlightPlugin,
@@ -150,7 +150,7 @@ export interface CreateEditorPluginsOptions {
 // participate in markdown autoformat shortcuts.
 export const createEditorPlugins = ({
   headingLevels,
-}: CreateEditorPluginsOptions = {}) => [
+}: CreateEditorPluginsOptions = {}): any[] => [
   createMdxBlockPlugin,
   createMdxInlinePlugin,
   createImgPlugin,


### PR DESCRIPTION

<img width="1776" height="1662" alt="CleanShot 2026-08-11 at 12 14 43@2x" src="https://github.com/user-attachments/assets/e5425a76-acb4-4d82-9f24-ee8629663111" />

## What breaks

`pnpm types` can fail on `packages/tinacms` with six `TS2742` errors:

```
plate/plugins/core/formatting.tsx(35,14): error TS2742: The inferred type of 'plugins'
cannot be named without a reference to '.pnpm/@udecode+plate-core@48.0.5_.../@udecode/plate-core'.
This is likely not portable. A type annotation is necessary.
```

`viewPlugins` and `createEditorPlugins` in `editor-plugins.tsx` fail the same way, once for the package root and once for the `/react` subpath.

## Why

The Plate satellite packages (`plate-basic-marks`, `plate-list`, `plate-link`, and the rest) take `@udecode/plate` as a peer and declare no direct dependency on `@udecode/plate-core`. pnpm therefore resolves it through the hoisted store rather than their own store directory.

Since `packages/v4/@tinacms/rich-text` landed in #7396 pinning React 19, two `plate-core` peer variants exist. The hoisted link can point at the React 19 copy. No bare specifier from `packages/tinacms` reaches that copy, because its own `@udecode/plate` resolves `plate-core` to the React 18 one. With `declaration: true`, tsc finds no portable name for the inferred type, falls back to the `.pnpm/…` realpath, and raises TS2742.

## Why fix it while CI is green

CI passes today, because a fresh install happens to hoist the React 18 copy. On run `31444276522` the only failing step is the macOS `Test`, not `Build Types`.

The pick can change per install. A future lockfile change can turn CI red, and if that happens a `.pnpm/` path lands in published declarations.

## The change

Annotate the three exports as `any[]`, matching the identical exports in `packages/v4/@tinacms/rich-text`, which hit this first and resolved it the same way. Downstream loses no type information: `useCreateEditor` already declares `plugins: any[]`, and nothing consumes `formattingPlugins` beyond re-exporting it.

## Left for later

The structural cure is a pnpm `packageExtensions` entry giving the satellites a real `plate-core` dependency. That means lockfile churn and a reinstall, so it belongs in its own change.

## Checking it

`pnpm turbo run types --filter=tinacms` passes. Emitted declarations read `export declare const viewPlugins: any[];`, and no `.pnpm/` path appears in `packages/tinacms/dist/**/*.d.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)