### PR TITLE
fix(@tinacms/app): stop a failed raw markdown editor blanking the whole admin

### DIFF
--- a/.changeset/app-raw-editor-error-boundary.md
+++ b/.changeset/app-raw-editor-error-boundary.md
@@ -1,0 +1,9 @@
+---
+"@tinacms/app": patch
+---
+
+Switching a rich-text field to raw markdown no longer risks blanking the whole admin.
+
+The raw editor arrives as a lazy chunk. `Suspense` covered the wait, but nothing caught a rejected import, so a failed fetch tore down the entire editing session: no message, no way back, and any unsaved work in the other fields gone with it. A flaky network or a stale cache after a deploy was enough to trigger it.
+
+The failure now stays inside the field it came from. You get a message saying your content is untouched, and a button back to the rich-text editor.

--- a/.changeset/app-raw-editor-error-boundary.md
+++ b/.changeset/app-raw-editor-error-boundary.md
@@ -2,8 +2,8 @@
 "@tinacms/app": patch
 ---
 
-Switching a rich-text field to raw markdown no longer risks blanking the whole admin.
+Switching a rich-text field to raw markdown no longer blanks the whole admin.
 
-The raw editor arrives as a lazy chunk. `Suspense` covered the wait, but nothing caught a rejected import, so a failed fetch tore down the entire editing session: no message, no way back, and any unsaved work in the other fields gone with it. A flaky network or a stale cache after a deploy was enough to trigger it.
+Two things could take the editing session down. The raw editor arrives as a lazy chunk, so a failed fetch after a deploy or on a flaky connection tore the page down. It also serializes the field while rendering, so content it cannot represent threw with the chunk already loaded. Applying inline code and then bolding a word inside it was enough. Either way you got a blank page: no message, no way back, and unsaved work in the other fields gone with it.
 
-The failure now stays inside the field it came from. You get a message saying your content is untouched, and a button back to the rich-text editor.
+The failure now stays inside the field it came from. You get the thrown message, which for the formatting case names what to undo, and a button back to the rich-text editor.

--- a/packages/@tinacms/app/package.json
+++ b/packages/@tinacms/app/package.json
@@ -15,6 +15,7 @@
 		"test-watch": "vitest"
 	},
 	"devDependencies": {
+		"@testing-library/react": "catalog:",
 		"@types/react": "^18.3.18",
 		"@types/react-dom": "catalog:",
 		"happy-dom": "catalog:",

--- a/packages/@tinacms/app/src/App.tsx
+++ b/packages/@tinacms/app/src/App.tsx
@@ -2,6 +2,7 @@ import React, { Suspense } from 'react';
 import TinaCMS, { TinaAdmin, useCMS, MdxFieldPluginExtendible } from 'tinacms';
 import { Preview } from './preview';
 import Playground from './Playground';
+import { RawEditorErrorBoundary } from './fields/rich-text/error-boundary';
 
 // TODO: Resolve this to local file in tsconfig.json
 // @ts-expect-error
@@ -21,9 +22,11 @@ const Editor = (props) => {
       setRawMode={setRawMode}
       {...props}
       rawEditor={
-        <Suspense fallback={<div>Loading raw editor...</div>}>
-          <RawEditor {...props} setRawMode={setRawMode} rawMode={rawMode} />
-        </Suspense>
+        <RawEditorErrorBoundary onDismiss={() => setRawMode(false)}>
+          <Suspense fallback={<div>Loading raw editor...</div>}>
+            <RawEditor {...props} setRawMode={setRawMode} rawMode={rawMode} />
+          </Suspense>
+        </RawEditorErrorBoundary>
       }
     />
   );

--- a/packages/@tinacms/app/src/fields/rich-text/error-boundary.test.tsx
+++ b/packages/@tinacms/app/src/fields/rich-text/error-boundary.test.tsx
@@ -3,8 +3,21 @@ import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { RawEditorErrorBoundary } from './error-boundary';
 
-const Boom = () => {
-  throw new Error('Failed to fetch dynamically imported module');
+const Throws = ({ message }: { message: string }) => {
+  throw new Error(message);
+};
+
+const FAILED_IMPORT = 'Failed to fetch dynamically imported module';
+const FAILED_SERIALIZE = 'Marks inside inline code are not supported';
+
+const renderWithThrow = (message: string, onDismiss = () => {}) => {
+  const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+  render(
+    <RawEditorErrorBoundary onDismiss={onDismiss}>
+      <Throws message={message} />
+    </RawEditorErrorBoundary>
+  );
+  consoleError.mockRestore();
 };
 
 describe('RawEditorErrorBoundary', () => {
@@ -18,30 +31,28 @@ describe('RawEditorErrorBoundary', () => {
   });
 
   it('keeps a failed lazy import inside the field', () => {
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
-    render(
-      <RawEditorErrorBoundary onDismiss={() => {}}>
-        <Boom />
-      </RawEditorErrorBoundary>
-    );
-    expect(screen.getByText(/couldn't be loaded/)).toBeTruthy();
-    consoleError.mockRestore();
+    renderWithThrow(FAILED_IMPORT);
+    expect(
+      screen.getByText(/Couldn't open this field in raw markdown/)
+    ).toBeTruthy();
+  });
+
+  it('keeps a failure to serialize the field inside the field', () => {
+    renderWithThrow(FAILED_SERIALIZE);
+    expect(
+      screen.getByText(/Couldn't open this field in raw markdown/)
+    ).toBeTruthy();
+  });
+
+  it('shows the underlying message so the editor knows what to undo', () => {
+    renderWithThrow(FAILED_SERIALIZE);
+    expect(screen.getByText(FAILED_SERIALIZE)).toBeTruthy();
   });
 
   it('offers a way back to the rich-text editor', () => {
-    const consoleError = vi
-      .spyOn(console, 'error')
-      .mockImplementation(() => {});
     const onDismiss = vi.fn();
-    render(
-      <RawEditorErrorBoundary onDismiss={onDismiss}>
-        <Boom />
-      </RawEditorErrorBoundary>
-    );
+    renderWithThrow(FAILED_IMPORT, onDismiss);
     fireEvent.click(screen.getByRole('button'));
     expect(onDismiss).toHaveBeenCalledOnce();
-    consoleError.mockRestore();
   });
 });

--- a/packages/@tinacms/app/src/fields/rich-text/error-boundary.test.tsx
+++ b/packages/@tinacms/app/src/fields/rich-text/error-boundary.test.tsx
@@ -1,0 +1,47 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { RawEditorErrorBoundary } from './error-boundary';
+
+const Boom = () => {
+  throw new Error('Failed to fetch dynamically imported module');
+};
+
+describe('RawEditorErrorBoundary', () => {
+  it('renders its children when nothing throws', () => {
+    render(
+      <RawEditorErrorBoundary onDismiss={() => {}}>
+        <div>raw editor</div>
+      </RawEditorErrorBoundary>
+    );
+    expect(screen.getByText('raw editor')).toBeTruthy();
+  });
+
+  it('keeps a failed lazy import inside the field', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    render(
+      <RawEditorErrorBoundary onDismiss={() => {}}>
+        <Boom />
+      </RawEditorErrorBoundary>
+    );
+    expect(screen.getByText(/couldn't be loaded/)).toBeTruthy();
+    consoleError.mockRestore();
+  });
+
+  it('offers a way back to the rich-text editor', () => {
+    const consoleError = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const onDismiss = vi.fn();
+    render(
+      <RawEditorErrorBoundary onDismiss={onDismiss}>
+        <Boom />
+      </RawEditorErrorBoundary>
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+    consoleError.mockRestore();
+  });
+});

--- a/packages/@tinacms/app/src/fields/rich-text/error-boundary.tsx
+++ b/packages/@tinacms/app/src/fields/rich-text/error-boundary.tsx
@@ -6,40 +6,51 @@ interface Props {
 }
 
 /**
- * The raw editor is a lazy chunk, so a network failure or a dev-server restart
- * makes its import reject. Without a boundary that rejection unmounts the whole
- * admin, leaving a blank page. Keep the failure inside the field and offer a
- * way back to the rich-text editor.
+ * The raw editor fails in more than one way: its chunk is loaded lazily, so the
+ * import can reject, and it serializes the field on render, so content it can't
+ * represent throws. Either one unmounts the whole admin without a boundary,
+ * leaving a blank page.
+ *
+ * The heading names the outcome rather than a cause, since the boundary cannot
+ * tell them apart. The message underneath is the one thing that lets an editor
+ * act — "Marks inside inline code are not supported" says which formatting to
+ * undo — and it is what a bug report needs verbatim.
  */
 export class RawEditorErrorBoundary extends React.Component<
   Props,
-  { hasError: boolean }
+  { message: string | null }
 > {
-  state = { hasError: false };
+  state: { message: string | null } = { message: null };
 
-  static getDerivedStateFromError() {
-    return { hasError: true };
+  static getDerivedStateFromError(error: Error) {
+    return { message: error?.message ?? '' };
   }
 
   componentDidCatch(error: Error) {
-    console.error('Raw markdown editor failed to load:', error);
+    console.error('Raw markdown editor failed to open:', error);
   }
 
   render() {
-    if (!this.state.hasError) {
+    if (this.state.message === null) {
       return this.props.children;
     }
+    // `whitespace-normal` because the field wrapper sets `nowrap`, which this
+    // would otherwise inherit and clip the message.
     return (
-      <div className='p-4 text-sm text-gray-700'>
-        <p className='mb-3'>
-          The raw markdown editor couldn't be loaded. Your content hasn't
-          changed.
+      <div className='p-4 text-sm whitespace-normal text-gray-700'>
+        <p className='mb-2'>
+          Couldn't open this field in raw markdown. Your content hasn't changed.
         </p>
+        {this.state.message ? (
+          <p className='mb-3 font-mono text-xs break-words text-gray-500'>
+            {this.state.message}
+          </p>
+        ) : null}
         <button
           type='button'
           className='rounded border border-gray-200 bg-white px-2 py-1 font-medium shadow hover:bg-blue-500 hover:text-white'
           onClick={() => {
-            this.setState({ hasError: false });
+            this.setState({ message: null });
             this.props.onDismiss();
           }}
         >

--- a/packages/@tinacms/app/src/fields/rich-text/error-boundary.tsx
+++ b/packages/@tinacms/app/src/fields/rich-text/error-boundary.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+interface Props {
+  children: React.ReactNode;
+  onDismiss: () => void;
+}
+
+/**
+ * The raw editor is a lazy chunk, so a network failure or a dev-server restart
+ * makes its import reject. Without a boundary that rejection unmounts the whole
+ * admin, leaving a blank page. Keep the failure inside the field and offer a
+ * way back to the rich-text editor.
+ */
+export class RawEditorErrorBoundary extends React.Component<
+  Props,
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error) {
+    console.error('Raw markdown editor failed to load:', error);
+  }
+
+  render() {
+    if (!this.state.hasError) {
+      return this.props.children;
+    }
+    return (
+      <div className='p-4 text-sm text-gray-700'>
+        <p className='mb-3'>
+          The raw markdown editor couldn't be loaded. Your content hasn't
+          changed.
+        </p>
+        <button
+          type='button'
+          className='rounded border border-gray-200 bg-white px-2 py-1 font-medium shadow hover:bg-blue-500 hover:text-white'
+          onClick={() => {
+            this.setState({ hasError: false });
+            this.props.onDismiss();
+          }}
+        >
+          Back to rich-text editor
+        </button>
+      </div>
+    );
+  }
+}

--- a/packages/@tinacms/app/vitest.config.ts
+++ b/packages/@tinacms/app/vitest.config.ts
@@ -5,6 +5,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'happy-dom',
-    include: ['src/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1230,6 +1230,9 @@ importers:
         specifier: 'catalog:'
         version: 3.25.76
     devDependencies:
+      '@testing-library/react':
+        specifier: 'catalog:'
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: ^18.3.18
         version: 18.3.27
@@ -1377,7 +1380,7 @@ importers:
         version: link:../search
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
+        version: 4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))
       altair-express-middleware:
         specifier: 'catalog:'
         version: 7.3.6
@@ -1473,7 +1476,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^6.4.3
-        version: 6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
+        version: 6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
       yup:
         specifier: ^1.6.1
         version: 1.7.1
@@ -3377,10 +3380,6 @@ packages:
 
   '@babel/code-frame@7.12.11':
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
-
-  '@babel/code-frame@7.27.1':
-    resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -9951,6 +9950,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
@@ -17489,12 +17489,6 @@ snapshots:
     dependencies:
       '@babel/highlight': 7.25.9
 
-  '@babel/code-frame@7.27.1':
-    dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
-      js-tokens: 4.0.0
-      picocolors: 1.1.1
-
   '@babel/code-frame@7.29.7':
     dependencies:
       '@babel/helper-validator-identifier': 7.29.7
@@ -19351,7 +19345,7 @@ snapshots:
   '@emotion/babel-plugin@11.13.5':
     dependencies:
       '@babel/helper-module-imports': 7.29.7
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/hash': 0.9.2
       '@emotion/memoize': 0.9.0
       '@emotion/serialize': 1.3.3
@@ -19388,7 +19382,7 @@ snapshots:
 
   '@emotion/react@11.10.5(@babel/core@7.29.7)(@types/react@18.3.27)(react@19.2.3)':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.10.5
       '@emotion/serialize': 1.3.3
@@ -20842,14 +20836,14 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
 
   '@manypkg/get-packages@1.1.3':
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
       '@changesets/types': 4.1.0
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
@@ -23378,8 +23372,8 @@ snapshots:
 
   '@testing-library/dom@10.4.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/runtime': 7.28.4
+      '@babel/code-frame': 7.29.7
+      '@babel/runtime': 7.29.7
       '@types/aria-query': 5.0.4
       aria-query: 5.3.0
       dom-accessibility-api: 0.5.16
@@ -23398,7 +23392,7 @@ snapshots:
 
   '@testing-library/react@16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -23408,7 +23402,7 @@ snapshots:
 
   '@testing-library/react@16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.7
       '@testing-library/dom': 10.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -24707,7 +24701,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))':
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.28.5
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.5)
@@ -24715,7 +24709,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.27
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
+      vite: 6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -32364,7 +32358,7 @@ snapshots:
 
   redux@4.2.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -32740,7 +32734,7 @@ snapshots:
 
   rtl-css-js@1.16.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.7
 
   run-parallel-limit@1.1.0:
     dependencies:
@@ -34647,7 +34641,7 @@ snapshots:
       terser: 5.46.0
       yaml: 2.8.2
 
-  vite@6.4.3(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2):
+  vite@6.4.3(@types/node@22.19.3)(jiti@1.21.7)(lightningcss@1.32.0)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -34658,7 +34652,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.3
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 1.21.7
       lightningcss: 1.32.0
       sass: 1.97.3
       terser: 5.46.0


### PR DESCRIPTION
https://youtu.be/S9WrOnLfq5M

## What breaks

Clicking the raw markdown button can blank the entire admin.

It fails two different ways, and both used to cost you the page.

**The chunk fails to fetch.** The raw editor loads lazily:

```tsx
const RawEditor = React.lazy(() => import('./fields/rich-text'));
```

`App.tsx` wrapped it in `Suspense` and nothing else. `Suspense` handles a pending promise. It does nothing for a rejected one. A stale cache after a deploy or a flaky connection is enough.

**The field fails to serialize.** `RawEditor` calls `serializeMDX` in a `useMemo` during render, so content it cannot represent throws with the chunk already loaded. Apply inline code to a phrase, bold one word inside it, click Raw Markdown:

```
Marks inside inline code are not supported
```

Reproduced in the kitchen-sink admin on `main`: `document.body.innerText` empty, zero children under the root. React unmounts the tree and the editing session is gone, taking unsaved work in the other fields with it.

## The change

A boundary around the lazy editor. The failure now stays inside the field. The rest of the form keeps working, and a button returns you to the rich-text editor through the `setRawMode(false)` already threaded through.

The message names the outcome rather than a cause, since the boundary cannot tell the two apart, and shows the thrown message underneath. For the formatting case that tells you which formatting to undo. It is also the string a bug report needs verbatim, which `CLAUDE.md` makes the first required field of one.

I scoped it to this field rather than reusing the full-screen boundary in `tina-cms.tsx`. A field that failed to open is a local problem, and taking over the screen to announce it repeats the behaviour this fixes.

One layout fix came with it: the field wrapper sets `white-space: nowrap`, which the message inherited and which clipped it mid-sentence.

## Tests

Five: children render, a failed import stays contained, a failed serialize stays contained, the thrown message reaches the screen, and the dismiss button leaves raw mode.

This is the package's first `.tsx` test, so `vitest.config.ts` picks up `src/**/*.test.tsx` and `@testing-library/react` joins devDependencies from the existing catalog entry.

## Scope

This does not fix either underlying failure. `serializeMDX` still cannot represent a mark inside inline code, which is worth its own issue. This fixes losing the admin when something in that field goes wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)