### PR TITLE
chore: add missing changeset for the multer 2.2.0 bump

### DIFF
--- a/.changeset/bump-multer-off-eol-1x.md
+++ b/.changeset/bump-multer-off-eol-1x.md
@@ -1,0 +1,6 @@
+---
+'next-tinacms-cloudinary': patch
+'next-tinacms-dos': patch
+---
+
+Bump `multer` to 2.2.0. multer 1.x is end of life; 2.x changes file-handling behaviour, so review upload paths when upgrading.


### PR DESCRIPTION
Closes #7435

**TL;DR** #7079 bumped multer 1.4.5-lts.1 to 2.2.0 without a changeset. This adds one, so both affected packages record the change.

**Pain:** multer is consumed via `catalog:` by `next-tinacms-cloudinary` and `next-tinacms-dos`, both published, and neither is in the changesets `ignore` list. #7079 landed the bump with no changeset, and nothing in CI requires one. As it stands, `next-tinacms-cloudinary` will ship the multer 1.x to 2.x major on the back of an unrelated patch entry (`cloudinary-escape-search-expression`), so the changelog describes a search-expression fix while a breaking runtime dependency change rides along. `next-tinacms-dos` gets no release at all, leaving its published dependency on multer 1.4.5-lts.1 while `main` says 2.2.0.

**Solution:** Added a changeset marking both packages `patch` and naming the actual change, including that multer 1.x is end of life and 2.x alters file-handling behaviour. Version Packages #7287 is still open, so this is picked up in the current release rather than the one after.