### PR TITLE
fix(deps): override qs to ^6.15.2 to clear three advisories

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -656,6 +656,7 @@ catalogs:
       version: 3.25.76
 
 overrides:
+  qs: ^6.15.2
   '@clerk/clerk-js>react': 19.2.3
   '@clerk/clerk-js>react-dom': 19.2.3
   '@clerk/backend>react': 19.2.3
@@ -14043,16 +14044,8 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
-  qs@6.11.0:
-    resolution: {integrity: sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==}
-    engines: {node: '>=0.6'}
-
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
-    engines: {node: '>=0.6'}
-
-  qs@6.5.3:
-    resolution: {integrity: sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -14704,6 +14697,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -14714,6 +14711,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -19183,7 +19184,7 @@ snapshots:
       core-js: 3.26.1
       dequal: 2.0.3
       qrcode.react: 3.1.0(react@19.2.3)
-      qs: 6.11.0
+      qs: 6.15.3
       react: 19.2.3
       regenerator-runtime: 0.13.11
     transitivePeerDependencies:
@@ -25609,7 +25610,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.4.24
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.15.3
       raw-body: 2.5.3
       type-is: 1.6.18
       unpipe: 1.0.0
@@ -27386,7 +27387,7 @@ snapshots:
       parseurl: 1.3.3
       path-to-regexp: 0.1.12
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
       send: 0.19.2
@@ -31958,16 +31959,10 @@ snapshots:
     dependencies:
       react: 19.2.3
 
-  qs@6.11.0:
+  qs@6.15.3:
     dependencies:
-      side-channel: 1.1.0
-
-  qs@6.14.0:
-    dependencies:
-      side-channel: 1.1.0
-
-  qs@6.5.3:
-    optional: true
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
 
   quansync@0.2.11: {}
 
@@ -32547,7 +32542,7 @@ snapshots:
       mime-types: 2.1.35
       oauth-sign: 0.9.0
       performance-now: 2.1.0
-      qs: 6.5.3
+      qs: 6.15.3
       safe-buffer: 5.2.1
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
@@ -32980,6 +32975,11 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
 
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
   side-channel-map@1.0.1:
     dependencies:
       call-bound: 1.0.4
@@ -33000,6 +33000,14 @@ snapshots:
       es-errors: 1.3.0
       object-inspect: 1.13.4
       side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ minimumReleaseAgeExclude:
     - create-tina-app
     - next-tinacms-*
 overrides:
+    qs: ^6.15.2
     "@clerk/clerk-js>react": 19.2.3
     "@clerk/clerk-js>react-dom": 19.2.3
     "@clerk/backend>react": 19.2.3


### PR DESCRIPTION
Closes #7441

**TL;DR** One line in `pnpm-workspace.yaml` collapses four vulnerable `qs` copies into one patched version, and unblocks three Dependabot PRs as a side effect.

**Pain:** The lockfile carried four separate `qs` copies (6.5.3, 6.5.5, 6.11.0, 6.14.0), every one below the 6.14.1 patch line for GHSA-6rw7-vpxm-498p, with two further advisories applying up to 6.15.2. `main` looked green only because `dependency-review` reports what a diff introduces rather than what is already present, so the problem stayed invisible until Dependabot regenerated some lockfiles and pulled qs 6.5.3 up to 6.5.5. Three unrelated PRs (#7425, #7421, #7321) then failed the same check for a vulnerability that had been on `main` all along. The tempting fix, pinning qs back to 6.5.3, would turn the check green while fixing nothing, because 6.5.3 is equally affected.

**Solution:** Added `qs: ^6.15.2` to the existing `overrides:` block, which collapses all four copies to a single 6.15.3, past the patch line for all three open advisories. The affected chain is test-only (`vitest@0.32.4` to `jsdom@15.2.1` to `request-promise-native` to `request` to `qs`), so nothing user-facing changes. Retiring `vitest@0.32.4` and the deprecated `request` chain is the real fix and is tracked separately on #7441.