### PR TITLE
fix(deps): move @tinacms/cli off the vulnerable js-yaml 4.1.1

### DIFF
--- a/packages/@tinacms/cli/package.json
+++ b/packages/@tinacms/cli/package.json
@@ -91,7 +91,7 @@
         "esbuild": "catalog:",
         "fs-extra": "catalog:",
         "graphql": "15.8.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.1",
         "many-level": "catalog:",
         "memory-level": "catalog:",
         "minimatch": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1438,8 +1438,8 @@ importers:
         specifier: 15.8.0
         version: 15.8.0
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.1
+        specifier: ^4.3.1
+        version: 4.3.1
       many-level:
         specifier: 'catalog:'
         version: 2.0.0
@@ -12172,6 +12172,10 @@ packages:
 
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsbn@0.1.1:
@@ -29393,6 +29397,10 @@ snapshots:
       esprima: 4.0.1
 
   js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
+
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
Closes #7446

**TL;DR** `@tinacms/cli` currently ships a vulnerable js-yaml. One specifier change moves it to the patch on its own major line.

**Pain:** GHSA-5p4m-2wfm-xmqj (high) covers both major lines, `>= 3.0.0 < 3.15.1` patched by 3.15.1 and `>= 4.0.0 < 4.3.1` patched by 4.3.1. #7425 closed the 3.x side by moving `@tinacms/graphql` to 3.15.1, which makes the repo look addressed, but `@tinacms/cli` was left on 4.1.1, inside the vulnerable 4.x range. js-yaml is a runtime `dependencies` entry there and the package is published, so `npm install @tinacms/cli` pulls a vulnerable copy today. Neither CI nor `dependency-review` flagged it, since the 4.x version was already present on `main` rather than introduced by a diff.

**Solution:** Sets the specifier to `^4.3.1`, resolving 4.3.1. Afterwards no workspace package sits on a vulnerable js-yaml. A transitive 4.1.1 remains via `astro`, `cosmiconfig` and `eslint`, which is upstream of this repo and out of scope here.