### PR TITLE
🐛 Stop writing a hard break markdown cannot represent (#5426)

### DIFF
--- a/.changeset/drop-dangling-hard-breaks.md
+++ b/.changeset/drop-dangling-hard-breaks.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/mdx": patch
+---
+
+Stop writing a hard break where markdown cannot represent one. `one\` with nothing after it, or a break before raw HTML or an inline template, came back as a literal backslash the author never typed. Fixes #5426. Part of #7415.

--- a/packages/@tinacms/mdx/src/break-neighbours.test.ts
+++ b/packages/@tinacms/mdx/src/break-neighbours.test.ts
@@ -1,0 +1,178 @@
+import type { RichTextField } from '@tinacms/schema-tools';
+import { describe, expect, it } from 'vitest';
+import { parseMDX } from './parse';
+import { serializeMDX } from './stringify';
+
+/**
+ * A hard break puts whatever follows it at the start of a line, and three kinds
+ * of neighbour read differently there. Each of these corrupted content on
+ * `main` before this stack, silently and with no editor involvement.
+ */
+
+const passthrough = (value: string) => value;
+
+const mdxField: RichTextField = { name: 'body', type: 'rich-text' };
+
+const markdownField: RichTextField = {
+  name: 'body',
+  type: 'rich-text',
+  parser: { type: 'markdown' },
+};
+
+const templateField = {
+  name: 'body',
+  type: 'rich-text',
+  templates: [
+    {
+      name: 'DateTime',
+      label: 'DateTime',
+      inline: true,
+      fields: [{ name: 'format', type: 'string' }],
+    },
+  ],
+} as unknown as RichTextField;
+
+const emptyText = { type: 'text', text: '' };
+const breakNode = { type: 'break', children: [emptyText] };
+const text = (value: string) => ({ type: 'text', text: value });
+
+const paragraph = (children: unknown[]) =>
+  ({ type: 'root', children: [{ type: 'p', children }] }) as never;
+
+const write = (tree: never, field: RichTextField) =>
+  serializeMDX(tree, field, passthrough) as string;
+
+const rewrite = (markdown: string, field: RichTextField) =>
+  serializeMDX(parseMDX(markdown, field, passthrough), field, passthrough);
+
+describe('a break next to a line-start-sensitive neighbour', () => {
+  const html = {
+    type: 'html_inline',
+    value: '<em>x</em>',
+    children: [emptyText],
+  };
+
+  it('keeps the word separation in front of raw html', () => {
+    const written = write(paragraph([text('one'), breakNode, html]), mdxField);
+
+    expect(written).toBe('one <em>x</em>\n');
+    expect(written).not.toContain('\\');
+  });
+
+  it('does not promote an inline template out of its paragraph', () => {
+    const embed = {
+      type: 'mdxJsxTextElement',
+      name: 'DateTime',
+      props: { format: 'local' },
+      children: [emptyText],
+    };
+
+    const written = write(
+      paragraph([text('one'), breakNode, embed]),
+      templateField
+    );
+
+    expect(written).not.toContain('\\');
+    expect(parseMDX(written, templateField, passthrough).children).toHaveLength(
+      1
+    );
+  });
+
+  /**
+   * A `mark` becomes an inline element with no matching template on a markdown
+   * field, so it writes nothing — and the break in front of it became a
+   * dangling `\` only at write time, after the trim had already run.
+   */
+  it('leaves no dangling backslash when the neighbour writes nothing', () => {
+    const highlighted = { type: 'text', text: 'two', highlight: true };
+
+    const written = write(
+      paragraph([text('one'), breakNode, emptyText, highlighted]),
+      markdownField
+    );
+
+    expect(written).toBe('one\n');
+  });
+
+  it.each([
+    ['mdx', mdxField],
+    ['markdown', markdownField],
+  ])('reaches a fixed point on a %s field', (_name, field) => {
+    const written = write(paragraph([text('one'), breakNode, html]), field);
+
+    expect(rewrite(written, field)).toBe(written);
+  });
+
+  it('reaches a break nested inside a link', () => {
+    const written = write(
+      paragraph([
+        { type: 'a', url: '/x', children: [text('one'), breakNode, html] },
+      ]),
+      mdxField
+    );
+
+    expect(written).toBe('[one <em>x</em>](/x)\n');
+    expect(written).not.toContain('\\');
+  });
+
+  it('still writes a real break between two pieces of text', () => {
+    expect(
+      write(paragraph([text('one'), breakNode, text('two')]), mdxField)
+    ).toBe('one\\\ntwo\n');
+  });
+
+  it('leaves a neighbour with no break in front of it alone', () => {
+    expect(write(paragraph([text('one '), html]), mdxField)).toBe(
+      'one <em>x</em>\n'
+    );
+  });
+});
+
+/**
+ * Verbatim `editor.children` after pressing shift+Enter with the cursor just
+ * before inline html. Slate leaves a spacer between the break and the
+ * neighbour, so a hand-built `[text, break, html]` is not the shape that
+ * reaches the serializer.
+ */
+const AFTER_SHIFT_ENTER_BEFORE_HTML = [
+  {
+    type: 'p',
+    children: [
+      { text: 'one ' },
+      { type: 'break', children: [{ text: '' }] },
+      { type: 'text', text: '' },
+      { type: 'html_inline', value: '<em>x</em>', children: [{ text: '' }] },
+      { text: '' },
+    ],
+  },
+];
+
+describe('the shape the editor really produces', () => {
+  it.each([
+    ['mdx', mdxField],
+    ['markdown', markdownField],
+  ])('writes no backslash on a %s field', (_name, field) => {
+    const written = write(
+      {
+        type: 'root',
+        children: structuredClone(AFTER_SHIFT_ENTER_BEFORE_HTML),
+      } as never,
+      field
+    );
+
+    expect(written).toBe('one <em>x</em>\n');
+    expect(rewrite(written, field)).toBe(written);
+  });
+});
+
+describe('opening and re-saving a file nobody edited', () => {
+  it.each([
+    ['a hard break before inline html', 'one\\\n<em>x</em>\n'],
+    ['two spaces before inline html', 'one  \n<em>x</em>\n'],
+  ])('does not inject a backslash into %s', (_name, source) => {
+    const written = rewrite(source, mdxField) as string;
+
+    expect(written).not.toContain('\\');
+    expect(rewrite(written, mdxField)).toBe(written);
+  });
+});

--- a/packages/@tinacms/mdx/src/break-representability/markdown.md
+++ b/packages/@tinacms/mdx/src/break-representability/markdown.md
@@ -1,44 +1,44 @@
 container                   position            written                                                                                                                    blocks  breaks  ok
 p                           mid                 "one\\\ntwo\n"                                                                                                             1       1       parses
-p                           final               "one two\\\n"                                                                                                              1       0       parses UNSTABLE
-p                           final-editor        "one two\\\n"                                                                                                              1       0       parses UNSTABLE
-p                           final-editor-twice  "one two\\\n\\\n"                                                                                                          1       1       parses UNSTABLE
+p                           final               "one two\n"                                                                                                                1       0       parses
+p                           final-editor        "one two\n"                                                                                                                1       0       parses
+p                           final-editor-twice  "one two\n"                                                                                                                1       0       parses
 h1                          mid                 "one\\\ntwo\n===\n"                                                                                                        1       1       parses
-h1                          final               "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h1                          final-editor        "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h1                          final-editor-twice  "one two\\\n\\\n\n"                                                                                                        1       1       parses UNSTABLE
+h1                          final               "# one two\n"                                                                                                              1       0       parses
+h1                          final-editor        "# one two\n"                                                                                                              1       0       parses
+h1                          final-editor-twice  "# one two\n"                                                                                                              1       0       parses
 h2                          mid                 "one\\\ntwo\n---\n"                                                                                                        1       1       parses
-h2                          final               "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h2                          final-editor        "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h2                          final-editor-twice  "one two\\\n\\\n\n"                                                                                                        1       1       parses UNSTABLE
+h2                          final               "## one two\n"                                                                                                             1       0       parses
+h2                          final-editor        "## one two\n"                                                                                                             1       0       parses
+h2                          final-editor-twice  "## one two\n"                                                                                                             1       0       parses
 h3                          mid                 "### one two\n"                                                                                                            1       0       parses
-h3                          final               "### one two \n"                                                                                                           1       0       parses UNSTABLE
-h3                          final-editor        "### one two \n"                                                                                                           1       0       parses UNSTABLE
-h3                          final-editor-twice  "### one two  \n"                                                                                                          1       0       parses UNSTABLE
+h3                          final               "### one two\n"                                                                                                            1       0       parses
+h3                          final-editor        "### one two\n"                                                                                                            1       0       parses
+h3                          final-editor-twice  "### one two\n"                                                                                                            1       0       parses
 h4                          mid                 "#### one two\n"                                                                                                           1       0       parses
-h4                          final               "#### one two \n"                                                                                                          1       0       parses UNSTABLE
-h4                          final-editor        "#### one two \n"                                                                                                          1       0       parses UNSTABLE
-h4                          final-editor-twice  "#### one two  \n"                                                                                                         1       0       parses UNSTABLE
+h4                          final               "#### one two\n"                                                                                                           1       0       parses
+h4                          final-editor        "#### one two\n"                                                                                                           1       0       parses
+h4                          final-editor-twice  "#### one two\n"                                                                                                           1       0       parses
 h5                          mid                 "##### one two\n"                                                                                                          1       0       parses
-h5                          final               "##### one two \n"                                                                                                         1       0       parses UNSTABLE
-h5                          final-editor        "##### one two \n"                                                                                                         1       0       parses UNSTABLE
-h5                          final-editor-twice  "##### one two  \n"                                                                                                        1       0       parses UNSTABLE
+h5                          final               "##### one two\n"                                                                                                          1       0       parses
+h5                          final-editor        "##### one two\n"                                                                                                          1       0       parses
+h5                          final-editor-twice  "##### one two\n"                                                                                                          1       0       parses
 h6                          mid                 "###### one two\n"                                                                                                         1       0       parses
-h6                          final               "###### one two \n"                                                                                                        1       0       parses UNSTABLE
-h6                          final-editor        "###### one two \n"                                                                                                        1       0       parses UNSTABLE
-h6                          final-editor-twice  "###### one two  \n"                                                                                                       1       0       parses UNSTABLE
+h6                          final               "###### one two\n"                                                                                                         1       0       parses
+h6                          final-editor        "###### one two\n"                                                                                                         1       0       parses
+h6                          final-editor-twice  "###### one two\n"                                                                                                         1       0       parses
 blockquote                  mid                 "> one\\\n> two\n"                                                                                                         1       1       parses
-blockquote                  final               "> one two\\\n>\n"                                                                                                         1       0       parses UNSTABLE
-blockquote                  final-editor        "> one two\\\n>\n"                                                                                                         1       0       parses UNSTABLE
-blockquote                  final-editor-twice  "> one two\\\n> \\\n>\n"                                                                                                   1       1       parses UNSTABLE
+blockquote                  final               "> one two\n"                                                                                                              1       0       parses
+blockquote                  final-editor        "> one two\n"                                                                                                              1       0       parses
+blockquote                  final-editor-twice  "> one two\n"                                                                                                              1       0       parses
 li                          mid                 "* one\\\n  two\n"                                                                                                         1       1       parses
-li                          final               "* one two\\\n"                                                                                                            1       0       parses UNSTABLE
-li                          final-editor        "* one two\\\n"                                                                                                            1       0       parses UNSTABLE
-li                          final-editor-twice  "* one two\\\n  \\\n"                                                                                                      1       1       parses UNSTABLE
+li                          final               "* one two\n"                                                                                                              1       0       parses
+li                          final-editor        "* one two\n"                                                                                                              1       0       parses
+li                          final-editor-twice  "* one two\n"                                                                                                              1       0       parses
 td                          mid                 "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
-td                          final               "| h        |\n| -------- |\n| one two  |\n"                                                                               1       0       parses UNSTABLE
-td                          final-editor        "| h        |\n| -------- |\n| one two  |\n"                                                                               1       0       parses UNSTABLE
-td                          final-editor-twice  "| h         |\n| --------- |\n| one two   |\n"                                                                            1       0       parses UNSTABLE
+td                          final               "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
+td                          final-editor        "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
+td                          final-editor-twice  "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
 code_block                  -                   skipped: wants a literal newline, not a break                                                                              -       -       -
 hr                          -                   skipped: void                                                                                                              -       -       -
 html                        -                   skipped: carries a raw value, no inline children                                                                           -       -       -
@@ -50,24 +50,24 @@ ul                          -                   skipped: holds list items       
 table                       -                   skipped: holds rows                                                                                                        -       -       -
 tr                          -                   skipped: holds cells                                                                                                       -       -       -
 a (inline)                  mid                 "[one\\\ntwo](/x)\n"                                                                                                       1       1       parses
-a (inline)                  final               "[one two\\\n](/x)\n"                                                                                                      1       1       parses
-a (inline)                  final-editor        "[one two\\\n](/x)\n"                                                                                                      1       1       parses
-a (inline)                  final-editor-twice  "[one two\\\n\\\n](/x)\n"                                                                                                  1       2       parses
+a (inline)                  final               "[one two](/x)\n"                                                                                                          1       0       parses
+a (inline)                  final-editor        "[one two](/x)\n"                                                                                                          1       0       parses
+a (inline)                  final-editor-twice  "[one two](/x)\n"                                                                                                          1       0       parses
 text (inline)               -                   skipped: the injection site of every block row above                                                                       -       -       -
 img (inline)                -                   skipped: void                                                                                                              -       -       -
 html_inline (inline)        -                   skipped: carries a raw value, no inline children                                                                           -       -       -
 mdxJsxTextElement (inline)  -                   skipped: children live in props                                                                                            -       -       -
 a in h3                     mid                 "### [one two](/x)\n"                                                                                                      1       0       parses
-a in h3                     final               "### [one two ](/x)\n"                                                                                                     1       0       parses
-a in h3                     final-editor        "### [one two ](/x)\n"                                                                                                     1       0       parses
-a in h3                     final-editor-twice  "### [one two  ](/x)\n"                                                                                                    1       0       parses
+a in h3                     final               "### [one two](/x)\n"                                                                                                      1       0       parses
+a in h3                     final-editor        "### [one two](/x)\n"                                                                                                      1       0       parses
+a in h3                     final-editor-twice  "### [one two](/x)\n"                                                                                                      1       0       parses
 a in li                     mid                 "* [one\\\n  two](/x)\n"                                                                                                   1       1       parses
-a in li                     final               "* [one two\\\n  ](/x)\n"                                                                                                  1       1       parses
-a in li                     final-editor        "* [one two\\\n  ](/x)\n"                                                                                                  1       1       parses
-a in li                     final-editor-twice  "* [one two\\\n  \\\n  ](/x)\n"                                                                                            1       2       parses
+a in li                     final               "* [one two](/x)\n"                                                                                                        1       0       parses
+a in li                     final-editor        "* [one two](/x)\n"                                                                                                        1       0       parses
+a in li                     final-editor-twice  "* [one two](/x)\n"                                                                                                        1       0       parses
 a in blockquote             mid                 "> [one\\\n> two](/x)\n"                                                                                                   1       1       parses
-a in blockquote             final               "> [one two\\\n> ](/x)\n"                                                                                                  1       1       parses
-a in blockquote             final-editor        "> [one two\\\n> ](/x)\n"                                                                                                  1       1       parses
-a in blockquote             final-editor-twice  "> [one two\\\n> \\\n> ](/x)\n"                                                                                            1       2       parses
-html after                  before-neighbour    "one two \\ <em>x</em>\n"                                                                                                  1       0       parses
+a in blockquote             final               "> [one two](/x)\n"                                                                                                        1       0       parses
+a in blockquote             final-editor        "> [one two](/x)\n"                                                                                                        1       0       parses
+a in blockquote             final-editor-twice  "> [one two](/x)\n"                                                                                                        1       0       parses
+html after                  before-neighbour    "one two <em>x</em>\n"                                                                                                     1       0       parses
 inline template after       -                   skipped: needs a field carrying templates, which this matrix has none of — covered end to end in break-neighbours.test.ts  -       -       -

--- a/packages/@tinacms/mdx/src/break-representability/mdx.md
+++ b/packages/@tinacms/mdx/src/break-representability/mdx.md
@@ -1,44 +1,44 @@
 container                   position            written                                                                                                                    blocks  breaks  ok
 p                           mid                 "one\\\ntwo\n"                                                                                                             1       1       parses
-p                           final               "one two\\\n"                                                                                                              1       0       parses UNSTABLE
-p                           final-editor        "one two\\\n"                                                                                                              1       0       parses UNSTABLE
-p                           final-editor-twice  "one two\\\n\\\n"                                                                                                          1       1       parses UNSTABLE
+p                           final               "one two\n"                                                                                                                1       0       parses
+p                           final-editor        "one two\n"                                                                                                                1       0       parses
+p                           final-editor-twice  "one two\n"                                                                                                                1       0       parses
 h1                          mid                 "one\\\ntwo\n===\n"                                                                                                        1       1       parses
-h1                          final               "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h1                          final-editor        "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h1                          final-editor-twice  "one two\\\n\\\n\n"                                                                                                        1       1       parses UNSTABLE
+h1                          final               "# one two\n"                                                                                                              1       0       parses
+h1                          final-editor        "# one two\n"                                                                                                              1       0       parses
+h1                          final-editor-twice  "# one two\n"                                                                                                              1       0       parses
 h2                          mid                 "one\\\ntwo\n---\n"                                                                                                        1       1       parses
-h2                          final               "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h2                          final-editor        "one two\\\n\n"                                                                                                            1       0       parses UNSTABLE
-h2                          final-editor-twice  "one two\\\n\\\n\n"                                                                                                        1       1       parses UNSTABLE
+h2                          final               "## one two\n"                                                                                                             1       0       parses
+h2                          final-editor        "## one two\n"                                                                                                             1       0       parses
+h2                          final-editor-twice  "## one two\n"                                                                                                             1       0       parses
 h3                          mid                 "### one two\n"                                                                                                            1       0       parses
-h3                          final               "### one two \n"                                                                                                           1       0       parses UNSTABLE
-h3                          final-editor        "### one two \n"                                                                                                           1       0       parses UNSTABLE
-h3                          final-editor-twice  "### one two  \n"                                                                                                          1       0       parses UNSTABLE
+h3                          final               "### one two\n"                                                                                                            1       0       parses
+h3                          final-editor        "### one two\n"                                                                                                            1       0       parses
+h3                          final-editor-twice  "### one two\n"                                                                                                            1       0       parses
 h4                          mid                 "#### one two\n"                                                                                                           1       0       parses
-h4                          final               "#### one two \n"                                                                                                          1       0       parses UNSTABLE
-h4                          final-editor        "#### one two \n"                                                                                                          1       0       parses UNSTABLE
-h4                          final-editor-twice  "#### one two  \n"                                                                                                         1       0       parses UNSTABLE
+h4                          final               "#### one two\n"                                                                                                           1       0       parses
+h4                          final-editor        "#### one two\n"                                                                                                           1       0       parses
+h4                          final-editor-twice  "#### one two\n"                                                                                                           1       0       parses
 h5                          mid                 "##### one two\n"                                                                                                          1       0       parses
-h5                          final               "##### one two \n"                                                                                                         1       0       parses UNSTABLE
-h5                          final-editor        "##### one two \n"                                                                                                         1       0       parses UNSTABLE
-h5                          final-editor-twice  "##### one two  \n"                                                                                                        1       0       parses UNSTABLE
+h5                          final               "##### one two\n"                                                                                                          1       0       parses
+h5                          final-editor        "##### one two\n"                                                                                                          1       0       parses
+h5                          final-editor-twice  "##### one two\n"                                                                                                          1       0       parses
 h6                          mid                 "###### one two\n"                                                                                                         1       0       parses
-h6                          final               "###### one two \n"                                                                                                        1       0       parses UNSTABLE
-h6                          final-editor        "###### one two \n"                                                                                                        1       0       parses UNSTABLE
-h6                          final-editor-twice  "###### one two  \n"                                                                                                       1       0       parses UNSTABLE
+h6                          final               "###### one two\n"                                                                                                         1       0       parses
+h6                          final-editor        "###### one two\n"                                                                                                         1       0       parses
+h6                          final-editor-twice  "###### one two\n"                                                                                                         1       0       parses
 blockquote                  mid                 "> one\\\n> two\n"                                                                                                         1       1       parses
-blockquote                  final               "> one two\\\n>\n"                                                                                                         1       0       parses UNSTABLE
-blockquote                  final-editor        "> one two\\\n>\n"                                                                                                         1       0       parses UNSTABLE
-blockquote                  final-editor-twice  "> one two\\\n> \\\n>\n"                                                                                                   1       1       parses UNSTABLE
+blockquote                  final               "> one two\n"                                                                                                              1       0       parses
+blockquote                  final-editor        "> one two\n"                                                                                                              1       0       parses
+blockquote                  final-editor-twice  "> one two\n"                                                                                                              1       0       parses
 li                          mid                 "* one\\\n  two\n"                                                                                                         1       1       parses
-li                          final               "* one two\\\n"                                                                                                            1       0       parses UNSTABLE
-li                          final-editor        "* one two\\\n"                                                                                                            1       0       parses UNSTABLE
-li                          final-editor-twice  "* one two\\\n  \\\n"                                                                                                      1       1       parses UNSTABLE
+li                          final               "* one two\n"                                                                                                              1       0       parses
+li                          final-editor        "* one two\n"                                                                                                              1       0       parses
+li                          final-editor-twice  "* one two\n"                                                                                                              1       0       parses
 td                          mid                 "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
-td                          final               "| h        |\n| -------- |\n| one two  |\n"                                                                               1       0       parses UNSTABLE
-td                          final-editor        "| h        |\n| -------- |\n| one two  |\n"                                                                               1       0       parses UNSTABLE
-td                          final-editor-twice  "| h         |\n| --------- |\n| one two   |\n"                                                                            1       0       parses UNSTABLE
+td                          final               "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
+td                          final-editor        "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
+td                          final-editor-twice  "| h       |\n| ------- |\n| one two |\n"                                                                                  1       0       parses
 code_block                  -                   skipped: wants a literal newline, not a break                                                                              -       -       -
 hr                          -                   skipped: void                                                                                                              -       -       -
 html                        -                   skipped: carries a raw value, no inline children                                                                           -       -       -
@@ -50,24 +50,24 @@ ul                          -                   skipped: holds list items       
 table                       -                   skipped: holds rows                                                                                                        -       -       -
 tr                          -                   skipped: holds cells                                                                                                       -       -       -
 a (inline)                  mid                 "[one\\\ntwo](/x)\n"                                                                                                       1       1       parses
-a (inline)                  final               "[one two\\\n](/x)\n"                                                                                                      1       1       parses
-a (inline)                  final-editor        "[one two\\\n](/x)\n"                                                                                                      1       1       parses
-a (inline)                  final-editor-twice  "[one two\\\n\\\n](/x)\n"                                                                                                  1       2       parses
+a (inline)                  final               "[one two](/x)\n"                                                                                                          1       0       parses
+a (inline)                  final-editor        "[one two](/x)\n"                                                                                                          1       0       parses
+a (inline)                  final-editor-twice  "[one two](/x)\n"                                                                                                          1       0       parses
 text (inline)               -                   skipped: the injection site of every block row above                                                                       -       -       -
 img (inline)                -                   skipped: void                                                                                                              -       -       -
 html_inline (inline)        -                   skipped: carries a raw value, no inline children                                                                           -       -       -
 mdxJsxTextElement (inline)  -                   skipped: children live in props                                                                                            -       -       -
 a in h3                     mid                 "### [one two](/x)\n"                                                                                                      1       0       parses
-a in h3                     final               "### [one two ](/x)\n"                                                                                                     1       0       parses
-a in h3                     final-editor        "### [one two ](/x)\n"                                                                                                     1       0       parses
-a in h3                     final-editor-twice  "### [one two  ](/x)\n"                                                                                                    1       0       parses
+a in h3                     final               "### [one two](/x)\n"                                                                                                      1       0       parses
+a in h3                     final-editor        "### [one two](/x)\n"                                                                                                      1       0       parses
+a in h3                     final-editor-twice  "### [one two](/x)\n"                                                                                                      1       0       parses
 a in li                     mid                 "* [one\\\n  two](/x)\n"                                                                                                   1       1       parses
-a in li                     final               "* [one two\\\n  ](/x)\n"                                                                                                  1       1       parses
-a in li                     final-editor        "* [one two\\\n  ](/x)\n"                                                                                                  1       1       parses
-a in li                     final-editor-twice  "* [one two\\\n  \\\n  ](/x)\n"                                                                                            1       2       parses
+a in li                     final               "* [one two](/x)\n"                                                                                                        1       0       parses
+a in li                     final-editor        "* [one two](/x)\n"                                                                                                        1       0       parses
+a in li                     final-editor-twice  "* [one two](/x)\n"                                                                                                        1       0       parses
 a in blockquote             mid                 "> [one\\\n> two](/x)\n"                                                                                                   1       1       parses
-a in blockquote             final               "> [one two\\\n> ](/x)\n"                                                                                                  1       1       parses
-a in blockquote             final-editor        "> [one two\\\n> ](/x)\n"                                                                                                  1       1       parses
-a in blockquote             final-editor-twice  "> [one two\\\n> \\\n> ](/x)\n"                                                                                            1       2       parses
-html after                  before-neighbour    "one two \\ <em>x</em>\n"                                                                                                  1       0       parses
+a in blockquote             final               "> [one two](/x)\n"                                                                                                        1       0       parses
+a in blockquote             final-editor        "> [one two](/x)\n"                                                                                                        1       0       parses
+a in blockquote             final-editor-twice  "> [one two](/x)\n"                                                                                                        1       0       parses
+html after                  before-neighbour    "one two <em>x</em>\n"                                                                                                     1       0       parses
 inline template after       -                   skipped: needs a field carrying templates, which this matrix has none of — covered end to end in break-neighbours.test.ts  -       -       -

--- a/packages/@tinacms/mdx/src/dangling-breaks.test.ts
+++ b/packages/@tinacms/mdx/src/dangling-breaks.test.ts
@@ -1,0 +1,139 @@
+import type * as Md from 'mdast';
+import { describe, expect, it } from 'vitest';
+import { dropDanglingBreaks } from './dangling-breaks';
+
+const paragraph = (children: unknown[]): Md.Root =>
+  ({ type: 'root', children: [{ type: 'paragraph', children }] }) as Md.Root;
+
+const text = (value: string) => ({ type: 'text', value });
+const brk = { type: 'break' };
+
+const countBreaks = (tree: Md.Root) =>
+  JSON.stringify(tree).split('"break"').length - 1;
+
+const typesIn = (tree: Md.Root) =>
+  JSON.stringify(tree, (key, value) => (key === 'value' ? undefined : value));
+
+describe('dropDanglingBreaks', () => {
+  it('drops a break with nothing after it', () => {
+    const tree = paragraph([text('one'), brk]);
+    expect(dropDanglingBreaks(tree).children[0]).toMatchObject({
+      children: [{ type: 'text' }],
+    });
+  });
+
+  it('keeps a break with something after it', () => {
+    const tree = paragraph([text('one'), brk, text('two')]);
+    expect(typesIn(dropDanglingBreaks(tree))).toBe(
+      typesIn(paragraph([text('one'), brk, text('two')]))
+    );
+  });
+
+  it('drops a break trailing inside the last mark of a block', () => {
+    const tree = paragraph([{ type: 'strong', children: [text('one'), brk] }]);
+    expect(dropDanglingBreaks(tree).children[0]).toMatchObject({
+      children: [{ type: 'strong', children: [{ type: 'text' }] }],
+    });
+  });
+
+  it('keeps a break inside a mark when the block continues after it', () => {
+    const nested = () => [
+      { type: 'strong', children: [text('one'), brk] },
+      text(' two'),
+    ];
+    expect(typesIn(dropDanglingBreaks(paragraph(nested())))).toBe(
+      typesIn(paragraph(nested()))
+    );
+  });
+
+  /**
+   * The shape the editor produces: Slate keeps a text node after a trailing
+   * inline void, so the break is never literally the last child.
+   */
+  it('drops a break followed only by an empty text node', () => {
+    const tree = paragraph([text('one'), brk, { type: 'text', value: '' }]);
+    expect(dropDanglingBreaks(tree).children[0]).toMatchObject({
+      children: [{ type: 'text' }, { type: 'text' }],
+    });
+    expect(countBreaks(tree)).toBe(0);
+  });
+
+  it('keeps an empty text node that is not trailing a break', () => {
+    const tree = paragraph([{ type: 'text', value: '' }]);
+    expect(typesIn(dropDanglingBreaks(tree))).toBe(
+      typesIn(paragraph([{ type: 'text', value: '' }]))
+    );
+  });
+
+  it('drops every break of a repeated shift+Enter, not just the last', () => {
+    const tree = paragraph([
+      text('one'),
+      brk,
+      { type: 'text', value: '' },
+      brk,
+      { type: 'text', value: '' },
+    ]);
+    expect(countBreaks(dropDanglingBreaks(tree))).toBe(0);
+  });
+
+  it('descends into the last child that writes something, not the spacer', () => {
+    const tree = paragraph([
+      {
+        type: 'link',
+        url: '/x',
+        children: [text('one'), brk, { type: 'text', value: '' }],
+      },
+      { type: 'text', value: '' },
+    ]);
+    expect(countBreaks(dropDanglingBreaks(tree))).toBe(0);
+  });
+
+  it('replaces a break before raw html with a space', () => {
+    const tree = paragraph([
+      text('one'),
+      brk,
+      { type: 'html', value: '<em>x</em>' },
+    ]);
+    expect(dropDanglingBreaks(tree).children[0]).toMatchObject({
+      children: [{ type: 'text' }, { type: 'text' }, { type: 'html' }],
+    });
+    expect(countBreaks(tree)).toBe(0);
+  });
+
+  it('adds no second space when the text already ends in one', () => {
+    const tree = paragraph([
+      text('one '),
+      brk,
+      { type: 'html', value: '<em>x</em>' },
+    ]);
+    expect(dropDanglingBreaks(tree).children[0]).toMatchObject({
+      children: [{ type: 'text', value: 'one ' }, { type: 'html' }],
+    });
+  });
+
+  it('drops a break before an inline mdx element', () => {
+    const tree = paragraph([
+      text('one'),
+      brk,
+      { type: 'mdxJsxTextElement', name: 'DateTime', children: [] },
+    ]);
+    expect(countBreaks(dropDanglingBreaks(tree))).toBe(0);
+  });
+
+  it('leaves a break alone when the html is not what follows it', () => {
+    const tree = paragraph([
+      { type: 'html', value: '<em>x</em>' },
+      text('one'),
+      brk,
+      text('two'),
+    ]);
+    expect(countBreaks(dropDanglingBreaks(tree))).toBe(1);
+  });
+
+  it('leaves a break at the start of a block alone', () => {
+    const tree = paragraph([brk, text('one')]);
+    expect(typesIn(dropDanglingBreaks(tree))).toBe(
+      typesIn(paragraph([brk, text('one')]))
+    );
+  });
+});

--- a/packages/@tinacms/mdx/src/dangling-breaks.ts
+++ b/packages/@tinacms/mdx/src/dangling-breaks.ts
@@ -1,0 +1,116 @@
+import type * as Md from 'mdast';
+
+/**
+ * A trailing backslash is a hard break in CommonMark only when another line
+ * follows it in the same block. With nothing after it, `one\` reads back as a
+ * literal backslash, so the break is lost and a character the author never
+ * typed enters the content as data (#5426). Reshapes in place.
+ */
+export const dropDanglingBreaks = <T extends Md.Root>(tree: T): T => {
+  walk(tree);
+  return tree;
+};
+
+/** Blockquotes and list items hold paragraphs, which the walk reaches anyway. */
+const BLOCKS = new Set(['paragraph', 'heading', 'tableCell']);
+
+type Parent = { type?: string; children: unknown[] };
+
+const isParent = (node: unknown): node is Parent =>
+  Array.isArray((node as Parent | undefined)?.children);
+
+const walk = (node: Parent) => {
+  // What sits after a break is a local question, so it holds at any inline
+  // depth. Only "trailing" needs the block gate — `**one\** two` is not dangling.
+  dropBreaksBeforeLineStartSensitive(node.children);
+  if (BLOCKS.has(node.type ?? '')) {
+    trimTrailingBreaks(node);
+  }
+  for (const child of node.children) {
+    if (isParent(child)) {
+      walk(child);
+    }
+  }
+};
+
+/**
+ * A break puts whatever follows it at the start of a line, and these two read
+ * differently there:
+ *
+ * - raw HTML — `toMarkdown` will not let `<` open a line, so it rewrites the
+ *   break to `\` plus a space, which reads back as a literal backslash;
+ * - an inline MDX element — at line start it parses as flow, so the element is
+ *   promoted out of the paragraph, or writes nothing at all when no template
+ *   matches it, leaving the `\` dangling.
+ *
+ * Either way the break has no representable form in front of one, so drop it
+ * rather than write a character the author never typed.
+ */
+const dropBreaksBeforeLineStartSensitive = (children: unknown[]) => {
+  for (let index = children.length - 1; index >= 0; index--) {
+    if (!isBreak(children[index])) {
+      continue;
+    }
+    const next = children
+      .slice(index + 1)
+      .find((sibling) => !writesNothing(sibling));
+    const type = (next as Parent | undefined)?.type;
+    if (type === 'html') {
+      // Raw HTML always writes, so keep the word separation the break gave —
+      // unless what precedes it already ends in whitespace, where a second
+      // space would only churn the author's file.
+      const before = children[index - 1] as Md.Text | undefined;
+      const spaced = before?.type === 'text' && /[ \t]$/.test(before.value);
+      children.splice(
+        index,
+        1,
+        ...(spaced ? [] : [{ type: 'text', value: ' ' }])
+      );
+    } else if (type === 'mdxJsxTextElement') {
+      // An inline element with no matching template writes nothing at all, so a
+      // space here would just be trailing whitespace.
+      children.splice(index, 1);
+    }
+  }
+};
+
+/** Slate keeps one of these after a trailing inline void, and it writes nothing. */
+const writesNothing = (node: unknown) =>
+  (node as Md.Text | undefined)?.type === 'text' &&
+  (node as Md.Text).value === '';
+
+const isBreak = (node: unknown) =>
+  (node as { type?: string } | undefined)?.type === 'break';
+
+/**
+ * Walks back over breaks and the empty text nodes between them, in any order:
+ * two shift+Enters leave `[break, text(''), break, text('')]`, so a single pass
+ * of each would strip one break and leave the other dangling.
+ *
+ * Descends through the last child that writes something — the spacer after it
+ * is not it — so `**one\**` and `[one\](/x)` are both dangling, while
+ * `**one\** two` is not.
+ */
+const trimTrailingBreaks = ({ children }: Parent) => {
+  let index = children.length;
+  const trailing: number[] = [];
+  while (index > 0) {
+    const child = children[index - 1];
+    if (isBreak(child)) {
+      trailing.push(index - 1);
+    } else if (!writesNothing(child)) {
+      break;
+    }
+    index--;
+  }
+  // Descending indices, so each splice leaves the rest addressable. Only the
+  // breaks go; a lone empty text node is a deliberate spacer.
+  for (const at of trailing) {
+    children.splice(at, 1);
+  }
+
+  const last = children[index - 1];
+  if (isParent(last)) {
+    trimTrailingBreaks(last);
+  }
+};

--- a/packages/@tinacms/mdx/src/next/stringify/to-markdown.ts
+++ b/packages/@tinacms/mdx/src/next/stringify/to-markdown.ts
@@ -3,6 +3,7 @@ import type * as Md from 'mdast';
 import { gfmToMarkdown } from 'mdast-util-gfm';
 import { Handlers, toMarkdown } from 'mdast-util-to-markdown';
 import { text } from 'mdast-util-to-markdown/lib/handle/text';
+import { dropDanglingBreaks } from '../../dangling-breaks';
 import { Pattern } from '../shortcodes';
 import { mdxJsxToMarkdown } from '../shortcodes/mdast';
 import { getFieldPatterns } from '../util';
@@ -58,7 +59,7 @@ export const toTinaMarkdown = (tree: Md.Root, field: RichTextField) => {
     }
     return text(node, parent, context, safeOptions);
   };
-  return toMarkdown(tree, {
+  return toMarkdown(dropDanglingBreaks(tree), {
     extensions: [mdxJsxToMarkdown({ patterns }), gfmToMarkdown()],
     listItemIndent: 'one',
     handlers,

--- a/packages/@tinacms/mdx/src/stringify/index.ts
+++ b/packages/@tinacms/mdx/src/stringify/index.ts
@@ -8,6 +8,7 @@ import {
 } from 'mdast-util-mdx-jsx';
 import { Handlers, toMarkdown } from 'mdast-util-to-markdown';
 import { text } from 'mdast-util-to-markdown/lib/handle/text';
+import { dropDanglingBreaks } from '../dangling-breaks';
 import { directiveToMarkdown } from '../extensions/tina-shortcodes/to-markdown';
 import { stringifyMDX as stringifyMDXNext } from '../next';
 import type * as Plate from '../parse/plate';
@@ -137,7 +138,7 @@ export const toTinaMarkdown = (tree: Md.Root, field: RichTextType) => {
     }
     return text(node, parent, context, safeOptions);
   };
-  return toMarkdown(tree, {
+  return toMarkdown(dropDanglingBreaks(tree), {
     extensions: [
       directiveToMarkdown(patterns),
       mdxJsxToMarkdown(),


### PR DESCRIPTION
Part 3 of 5 against #7415, and the fix for #5426 (open since January 2025). Stacked on #7449.

## What breaks

Every row here writes a character the author never typed.

| Do this in the editor | Saves as | Next save |
|---|---|---|
| Shift+Enter at the end of a paragraph | `one\` | `one\\` — backslash is now content |
| Shift+Enter twice at the end | `one\` | `one\\` |
| Shift+Enter at the end of a blockquote or list item | `> one\` / `* one\` | same |
| Shift+Enter with the cursor just before inline HTML | `one\ <em>x</em>` — literal backslash | stable at the corrupted form |
| Shift+Enter just before an inline template | `one\`⏎`<DateTime />` — embed promoted to its own block, paragraph torn in two | `one\\` |
| **Open and save a file containing** `one\`⏎`<em>x</em>` **— no edit at all** | `one\ <em>x</em>` | stable at the corrupted form |

That last row is the one that needs no keystroke.

## The fix

Two positions have no representable form.

**Nothing after it.** A trailing backslash is a hard break in CommonMark only when another line follows it in the same block. With nothing after it, `one\` reads back as a literal backslash — the break is lost and the backslash enters the content as data.

**A line-start-sensitive neighbour after it.** A break puts its neighbour at the start of a line. `toMarkdown` will not let `<` open a line, so it rewrote the break as `\` plus a space; and an inline element at line start parses as flow, so it is promoted out of the paragraph — or writes nothing at all when no template matches it, leaving the `\` dangling.

Both are handled by a walk over the mdast tree before `toMarkdown`, called by the `markdown` and `mdx` serializers alike. Representability here is *positional*, not type-based, which is why no list of container types could express it. A break before raw HTML becomes a **space** (HTML always writes, so the word separation is worth keeping); before an inline element it is **dropped** (an element that writes nothing would leave only trailing whitespace).

Three shapes the walk has to get right, each of which was wrong in an earlier revision and each of which is now a test: the break is never the last child (Slate keeps a spacer); a repeated Shift+Enter emits two; the recursive descent must skip the spacer to reach a break at the end of a link.

**Trade-off worth naming:** in the HTML case the author's line break becomes a space. That is a downgrade, chosen over a literal backslash in their prose. Preserving it means patching upstream's `unsafe` table to let `<` open a line, which risks `<` starting lines everywhere else.

## Testing

`pnpm --filter @tinacms/mdx test` — 228 passing. `break-neighbours.test.ts` asserts on verbatim `editor.children`, not hand-built trees. Use `pnpm test`, not `npx vitest` (this package pins vitest `^0.32.4`, its siblings `^2.1.9`).
