### PR TITLE
chore: add missing changeset for the js-yaml 4.3.1 bump

### DIFF
--- a/.changeset/bump-js-yaml-cli-4-3-1.md
+++ b/.changeset/bump-js-yaml-cli-4-3-1.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+Bump `js-yaml` to 4.3.1, picking up an upstream security fix (GHSA-5p4m-2wfm-xmqj)


### PR DESCRIPTION
Closes #7453

**TL;DR** #7447 fixed the vulnerable js-yaml but merged without a changeset, so the fix is sitting on `main` unreleased. This adds one.

**Pain:** `@tinacms/cli` is published and not in the changesets `ignore` list, so a dependency change there needs a changeset to produce a version bump and a release. #7447 moved it from the vulnerable js-yaml 4.1.1 to 4.3.1, closing GHSA-5p4m-2wfm-xmqj on `main`, but with no changeset there is no release. The published package keeps resolving 4.1.1, so `npm install @tinacms/cli` still pulls the vulnerable copy and the advisory stays open for users.

**Solution:** Adds a changeset marking `@tinacms/cli` `patch` and naming the js-yaml bump with its advisory. Version Packages #7443 is still open, so this is picked up in the current release rather than the one after.