### PR TITLE
chore: add missing changesets for two merged dependency fixes

### DIFF
--- a/.changeset/bump-js-yaml-graphql-3-15-1.md
+++ b/.changeset/bump-js-yaml-graphql-3-15-1.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/graphql': patch
+---
+
+Bump `js-yaml` to 3.15.1, picking up an upstream security fix (GHSA-5p4m-2wfm-xmqj)

--- a/.changeset/bump-next-auth-4-24-15.md
+++ b/.changeset/bump-next-auth-4-24-15.md
@@ -1,0 +1,5 @@
+---
+'tinacms-authjs': patch
+---
+
+Bump `next-auth` to 4.24.15


### PR DESCRIPTION
Closes #7455

**TL;DR** #7425 and #7321 merged without changesets, so both fixes are stranded on `main`. This adds them.

**Pain:** `@tinacms/graphql` and `tinacms-authjs` are both published and neither is in the changesets `ignore` list, so a dependency change in either needs a changeset to produce a version bump and a release. #7425 moved `@tinacms/graphql` to js-yaml 3.15.1 and #7321 moved `tinacms-authjs` to next-auth 4.24.15, both without one. The js-yaml case matters most: it closed GHSA-5p4m-2wfm-xmqj on the 3.x line, and `@tinacms/graphql` is the package that parses content YAML, so the published package still resolves the vulnerable 3.14.2 until a release ships.

**Solution:** Adds a changeset for each, both `patch`, naming the bump and its advisory where there is one. Version Packages #7443 is still open, so these are picked up in the current release rather than the one after.