### PR TITLE
fix: 🤖 TinaMarkdown component renders table and td elements with unnecessa...

### DIFF
--- a/packages/tinacms/src/rich-text/index.test.tsx
+++ b/packages/tinacms/src/rich-text/index.test.tsx
@@ -64,6 +64,56 @@ describe('TinaMarkdown URL sanitization', () => {
   });
 });
 
+describe('TinaMarkdown tables', () => {
+  const tableContent = (align?: (string | null)[]) =>
+    ({
+      type: 'root',
+      children: [
+        {
+          type: 'table',
+          props: { align: align || [] },
+          children: [
+            {
+              type: 'tr',
+              children: [
+                {
+                  type: 'td',
+                  children: [
+                    { type: 'p', children: [{ type: 'text', text: 'A' }] },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    }) as any;
+
+  it('renders a table without inline styles', () => {
+    const { container } = render(<TinaMarkdown content={tableContent()} />);
+
+    expect(container.querySelector('table')?.getAttribute('style')).toBeNull();
+    expect(container.querySelector('td')?.getAttribute('style')).toBeNull();
+  });
+
+  it('does not leak node props onto cell elements', () => {
+    const { container } = render(<TinaMarkdown content={tableContent()} />);
+    const cell = container.querySelector('td');
+
+    expect(cell?.getAttribute('type')).toBeNull();
+    expect(cell?.getAttribute('align')).toBeNull();
+    expect(cell?.textContent).toBe('A');
+  });
+
+  it('applies text alignment when the column declares one', () => {
+    const { container } = render(
+      <TinaMarkdown content={tableContent(['right'])} />
+    );
+
+    expect(container.querySelector('td')?.style.textAlign).toBe('right');
+  });
+});
+
 /**
  * Characterises what this renderer does with `html` / `html_inline` nodes, so
  * the behaviour is pinned while `@tinacms/astro` and `@tinacms/web-components`

--- a/packages/tinacms/src/rich-text/index.tsx
+++ b/packages/tinacms/src/rich-text/index.tsx
@@ -398,18 +398,23 @@ const Node = ({ components, child }) => {
               : child.props?.tableRows) || [];
           const header = child.props?.tableRows?.at(0);
           const TableComponent =
-            components['table'] || ((props) => <table {...props} />);
+            components['table'] ||
+            (({ children }) => <table>{children}</table>);
           const TrComponent =
-            components['tr'] || ((props) => <tr {...props} />);
+            components['tr'] || (({ children }) => <tr>{children}</tr>);
           const ThComponent =
             components['th'] ||
-            ((props) => (
-              <th style={{ textAlign: props?.align || 'auto' }} {...props} />
+            (({ align, children }) => (
+              <th style={align ? { textAlign: align } : undefined}>
+                {children}
+              </th>
             ));
           const TdComponent =
             components['td'] ||
-            ((props) => (
-              <td style={{ textAlign: props?.align || 'auto' }} {...props} />
+            (({ align, children }) => (
+              <td style={align ? { textAlign: align } : undefined}>
+                {children}
+              </td>
             ));
           const align = child.props?.align || [];
           return (
@@ -468,22 +473,13 @@ const Node = ({ components, child }) => {
     case 'table':
       const rows = child.children || [];
       const TableComponent =
-        components['table'] ||
-        ((props) => (
-          <table style={{ border: '1px solid #EDECF3' }} {...props} />
-        ));
-      const TrComponent = components['tr'] || ((props) => <tr {...props} />);
+        components['table'] || (({ children }) => <table>{children}</table>);
+      const TrComponent =
+        components['tr'] || (({ children }) => <tr>{children}</tr>);
       const TdComponent =
         components['td'] ||
-        ((props) => (
-          <td
-            style={{
-              textAlign: props?.align || 'auto',
-              border: '1px solid #EDECF3',
-              padding: '0.25rem',
-            }}
-            {...props}
-          />
+        (({ align, children }) => (
+          <td style={align ? { textAlign: align } : undefined}>{children}</td>
         ));
       const align = child.props?.align || [];
       return (

--- a/packages/tinacms/src/rich-text/static.tsx
+++ b/packages/tinacms/src/rich-text/static.tsx
@@ -312,18 +312,23 @@ const Node = ({
               : child.props?.tableRows) || [];
           const header = child.props?.tableRows?.at(0);
           const TableComponent = //@ts-ignore Same issue with TinaMarkdown
-            components['table'] || ((props) => <table {...props} />);
+            components['table'] ||
+            (({ children }) => <table>{children}</table>);
           const TrComponent =
-            components['tr'] || ((props) => <tr {...props} />);
+            components['tr'] || (({ children }) => <tr>{children}</tr>);
           const ThComponent =
             components['th'] ||
-            ((props) => (
-              <th style={{ textAlign: props?.align || 'auto' }} {...props} />
+            (({ align, children }) => (
+              <th style={align ? { textAlign: align } : undefined}>
+                {children}
+              </th>
             ));
           const TdComponent =
             components['td'] ||
-            ((props) => (
-              <td style={{ textAlign: props?.align || 'auto' }} {...props} />
+            (({ align, children }) => (
+              <td style={align ? { textAlign: align } : undefined}>
+                {children}
+              </td>
             ));
           const align = child.props?.align || [];
           return (
@@ -382,22 +387,13 @@ const Node = ({
     case 'table':
       const rows = child.children || [];
       const TableComponent =
-        components['table'] ||
-        ((
-          props //@ts-ignore Same issue with TinaMarkdown
-        ) => <table style={{ border: '1px solid #EDECF3' }} {...props} />);
-      const TrComponent = components['tr'] || ((props) => <tr {...props} />);
+        components['table'] || (({ children }) => <table>{children}</table>);
+      const TrComponent =
+        components['tr'] || (({ children }) => <tr>{children}</tr>);
       const TdComponent =
         components['td'] ||
-        ((props) => (
-          <td
-            style={{
-              textAlign: props?.align || 'auto',
-              border: '1px solid #EDECF3',
-              padding: '0.25rem',
-            }}
-            {...props}
-          />
+        (({ align, children }) => (
+          <td style={align ? { textAlign: align } : undefined}>{children}</td>
         ));
       const align = child.props?.align || [];
       return (


### PR DESCRIPTION
Fixes #5432

## Root cause

TinaMarkdown default table/td renderers hard-code inline styles and spread node props onto DOM elements

## Changes

- Default `table`/`tr`/`th`/`td` renderers in both the client and static TinaMarkdown implementations now render bare elements from `children` only: no border/padding styles, no prop spread onto the DOM, and `text-align` emitted solely when the table declares a column alignment. Added regression tests plus a changeset.