### PR TITLE
fix(v4): match the v3 gray-matter engine configuration in the v4 markdown adapter

### DIFF
--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/adapters/format-adapters.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/adapters/format-adapters.test.ts
@@ -129,6 +129,18 @@ describe('markdown adapter', () => {
       ).toThrow(/Expected a string for body field/);
     }
   });
+
+  it('refuses to run code in frontmatter', () => {
+    const globals = globalThis as Record<string, unknown>;
+    for (const language of ['js', 'javascript', 'coffee', 'coffeescript']) {
+      const raw = `---${language}\n{ pwned: (globalThis.PWNED = true) }\n---\n`;
+      expect(() => adapter.parse(raw)).toThrow(/not allowed for security/);
+      expect(() => adapter.serialize({ body: raw }, undefined, 'body')).toThrow(
+        /not allowed for security/
+      );
+      expect(globals.PWNED).toBeUndefined();
+    }
+  });
 });
 
 describe('markdown adapter — documents with and without frontmatter', () => {

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/adapters/markdown.adapter.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/adapters/markdown.adapter.ts
@@ -4,7 +4,28 @@ import type { FormatAdapter } from './format-adapters';
 const dropLayoutBlankLine = (body: string): string =>
   body.startsWith('\n') ? body.slice(1) : body;
 
-const NO_MATTER_CACHE = {};
+const refuse = (language: string) => {
+  const reject = () => {
+    throw new Error(
+      `${language} execution in frontmatter is not allowed for security reasons`
+    );
+  };
+  return { parse: reject, stringify: reject };
+};
+
+/**
+ * gray-matter runs `---js` front matter through eval(). Replace the engines
+ * that execute code, so a document cannot run code when the adapter reads or
+ * writes it. An options object also turns off the gray-matter parse cache.
+ */
+const MATTER_OPTIONS = {
+  engines: {
+    js: refuse('JavaScript'),
+    javascript: refuse('JavaScript'),
+    coffee: refuse('CoffeeScript'),
+    coffeescript: refuse('CoffeeScript'),
+  },
+};
 
 const CRLF = '\r\n';
 
@@ -37,14 +58,14 @@ const mergeFrontmatter = (
 export const markdownAdapter = (extension: string): FormatAdapter => ({
   extension,
   parse: (raw, bodyField) => {
-    const { data, content } = matter(toLineFeeds(raw), NO_MATTER_CACHE);
+    const { data, content } = matter(toLineFeeds(raw), MATTER_OPTIONS);
     return bodyField
       ? { ...data, [bodyField]: dropLayoutBlankLine(content) }
       : data;
   },
   serialize: (document, previousRaw, bodyField) => {
     const crlf = previousRaw?.includes(CRLF) ?? false;
-    const previous = matter(toLineFeeds(previousRaw ?? ''), NO_MATTER_CACHE);
+    const previous = matter(toLineFeeds(previousRaw ?? ''), MATTER_OPTIONS);
     const frontmatter = mergeFrontmatter(document, previous.data);
     if (bodyField != null) {
       delete frontmatter[bodyField];
@@ -63,7 +84,10 @@ export const markdownAdapter = (extension: string): FormatAdapter => ({
     ) {
       return previousRaw;
     }
-    return toDocumentEol(matter.stringify(content, frontmatter), crlf);
+    return toDocumentEol(
+      matter.stringify(content, frontmatter, MATTER_OPTIONS),
+      crlf
+    );
   },
 });
 


### PR DESCRIPTION
Thanks to @utkusen, @hash3liZer and @eros938 for spotting this one.

The v4 markdown adapter called `gray-matter` without an `engines` option, so it used the library defaults. The v3 stack does not: it passes a replacement engine map in `packages/@tinacms/graphql/src/database/util.ts`.

This brings the v4 adapter in line with v3.

The adapter now passes the same options object to all three `gray-matter` calls: `parse`, the re-parse inside `serialize`, and `stringify`. `matter.stringify()` re-parses the string it is given, so it needs the options as well.

The options object also replaces the empty cache object the adapter passed before, which keeps the previous behaviour of not sharing the `gray-matter` parse cache between calls.

## Testing

`format-adapters.test.ts` covers the new behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


