### PR TITLE
Fix validation for templates with empty fields

### DIFF
--- a/.changeset/tidy-templates-validate.md
+++ b/.changeset/tidy-templates-validate.md
@@ -1,0 +1,5 @@
+---
+"@tinacms/schema-tools": patch
+---
+
+Reject templates with empty `fields` arrays during schema validation.

--- a/packages/@tinacms/schema-tools/src/validate/index.spec.ts
+++ b/packages/@tinacms/schema-tools/src/validate/index.spec.ts
@@ -345,6 +345,23 @@ const schemaWithEmptyTemplates: Schema = {
     },
   ],
 };
+
+const schemaWithTemplateWithEmptyFields: Schema = {
+  collections: [
+    {
+      name: 'foo',
+      label: 'Foo',
+      path: '/foo',
+      templates: [
+        {
+          name: 'bar',
+          label: 'Bar',
+          fields: [],
+        },
+      ],
+    },
+  ],
+};
 const schemaWithInvalidFiledNesterUnderRichText = {
   collections: [
     {
@@ -466,6 +483,11 @@ describe('validateSchema', () => {
     expect(() => {
       validateSchema({ schema: schemaWithEmptyTemplates });
     }).toThrow();
+  });
+  it('fails when a template has empty fields', () => {
+    expect(() => {
+      validateSchema({ schema: schemaWithTemplateWithEmptyFields });
+    }).toThrow('Property `fields` cannot be empty.');
   });
   it('fails when a deeply nested field under a template is invalid', () => {
     expect(() => {

--- a/packages/@tinacms/schema-tools/src/validate/schema.ts
+++ b/packages/@tinacms/schema-tools/src/validate/schema.ts
@@ -17,7 +17,7 @@ const Template = z
       required_error: 'Missing `label` property. Property `label` is required.',
     }),
     name: name,
-    fields: z.array(TinaFieldZod),
+    fields: z.array(TinaFieldZod).min(1, 'Property `fields` cannot be empty.'),
   })
   .superRefine((val, ctx) => {
     const dups = findDuplicates(val.fields?.map((x) => x.name));


### PR DESCRIPTION
## Problem

Templates currently accept an empty `fields` array. A rich-text block using that template can then produce an invalid GraphQL input object with no fields.

Fixes #7490.

## Fix

Apply the existing non-empty `fields` validation used by sibling schema definitions to `Template.fields`. The regression test verifies both rejection and the expected validation message.

## Tests

- `pnpm --dir packages/@tinacms/schema-tools exec jest --config jest.config.js --runInBand` — 116 passed
- `pnpm --filter @tinacms/schema-tools types` — passed
- `pnpm --filter @tinacms/schema-tools build` — passed
- `pnpm biome lint packages/@tinacms/schema-tools/src/validate/schema.ts packages/@tinacms/schema-tools/src/validate/index.spec.ts` — passed
- `pnpm biome format packages/@tinacms/schema-tools/src/validate/schema.ts packages/@tinacms/schema-tools/src/validate/index.spec.ts` — passed

The required patch changeset for `@tinacms/schema-tools` is included.
