### PR TITLE
Stop printing the build summary as raw JSON in CI

### DIFF
--- a/.changeset/build-summary-in-ci.md
+++ b/.changeset/build-summary-in-ci.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/cli': patch
+---
+
+`tinacms build` and `tinacms dev` print the same boxed summary in CI as they do locally. Before this change, any environment that set `CI` (GitHub Actions, most other CI providers) got the summary as a raw JSON object instead.

--- a/packages/@tinacms/cli/src/logger/index.test.ts
+++ b/packages/@tinacms/cli/src/logger/index.test.ts
@@ -1,0 +1,53 @@
+jest.mock('chalk', () => {
+  const identity = (s: string) => s;
+  return {
+    __esModule: true,
+    default: {
+      gray: identity,
+      green: identity,
+      cyan: identity,
+      white: identity,
+      reset: identity,
+    },
+  };
+});
+
+import { summary } from './index';
+
+describe('summary', () => {
+  let out: string;
+  let write: jest.SpyInstance;
+  const ci = process.env.CI;
+
+  beforeEach(() => {
+    out = '';
+    write = jest
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        out += chunk.toString();
+        return true;
+      });
+  });
+
+  afterEach(() => {
+    write.mockRestore();
+    process.env.CI = ci;
+  });
+
+  it('prints the boxed summary when CI is set', () => {
+    process.env.CI = 'true';
+    summary({
+      heading: 'Tina build complete',
+      items: [
+        {
+          emoji: '🦙',
+          heading: 'Tina Config',
+          subItems: [{ key: 'API url', value: 'http://localhost:4001' }],
+        },
+      ],
+    });
+    expect(out).toContain('Tina build complete');
+    expect(out).toContain('API url:');
+    expect(out).not.toContain('"subItems"');
+  });
+});

--- a/packages/@tinacms/cli/src/logger/index.ts
+++ b/packages/@tinacms/cli/src/logger/index.ts
@@ -132,11 +132,7 @@ export const summary = (content: {
     outString.push(``);
   });
 
-  if (process.env.CI) {
-    logger.info(JSON.stringify(content, null, 2));
-  } else {
-    note(outString.join('\n'), content.heading);
-  }
+  note(outString.join('\n'), content.heading);
 };
 
 const unicode = isUnicodeSupported();


### PR DESCRIPTION
## What was wrong

Any environment that sets `CI` (GitHub Actions does by default) got the end-of-build summary as a raw JSON object instead of the boxed summary a local run prints. The logger had a branch that switched to JSON when `CI` was set. It was added in 2023 (653522ae6) with no recorded reason, and nothing in the repo reads that JSON.

## Change

- Remove the `CI` branch in `packages/@tinacms/cli/src/logger/index.ts`. The summary now prints the same way everywhere.
- Add `packages/@tinacms/cli/src/logger/index.test.ts`. It sets `CI=true` and checks the output is the box, not JSON. The test fails on `main` and passes here.
- Changeset: patch for `@tinacms/cli`.

`tinacms dev` uses the same logger, so its summary changes the same way.

## Before and after

Both captured with `CI=true` and the same summary payload.

**Before**

```
{
  "heading": "Tina build complete",
  "items": [
    {
      "emoji": "🦙",
      "heading": "Tina Config",
      "subItems": [
        {
          "key": "API url",
          "value": "https://content.tinajs.io/2.4/content/<client-id>/github/redesign"
        }
      ]
    },
    ...
  ]
}
```

**After**

```
│
○  Tina build complete ───────────────────────────────────────────────╮
│                                                                     │
│  🦙 Tina Config                                                     │
│     API url:            https://content.tinajs.io/2.4/content/...   │
│                                                                     │
│  🤖 Auto-generated files                                            │
│     GraphQL Client:     tina/__generated__/client.ts                │
│     Typescript Types:   tina/__generated__/types.ts                 │
│     Static HTML file:   public/admin/index.html                     │
│                                                                     │
├─────────────────────────────────────────────────────────────────────╯
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LssiV88a13d9btvmuDGDbK
