### PR TITLE
Reject malformed URLs that name a scheme, instead of returning them unchecked

### DIFF
--- a/.changeset/sanitize-url-fail-closed.md
+++ b/.changeset/sanitize-url-fail-closed.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/mdx': patch
+---
+
+`sanitizeUrl` no longer returns the value it was given when `new URL()` cannot parse it. A value that still names a scheme, including one disguised with a null byte or a zero-width character, now returns an empty string. Relative URLs name no scheme and are kept as they were.

--- a/packages/@tinacms/mdx/src/sanitize-url.test.ts
+++ b/packages/@tinacms/mdx/src/sanitize-url.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { sanitizeUrl } from './sanitize-url';
+
+describe('sanitizeUrl', () => {
+  it('keeps the schemes on the allow list', () => {
+    expect(sanitizeUrl('https://example.com/a/b')).toBe(
+      'https://example.com/a/b'
+    );
+    expect(sanitizeUrl('http://example.com')).toBe('http://example.com');
+    expect(sanitizeUrl('mailto:hi@example.com')).toBe('mailto:hi@example.com');
+    expect(sanitizeUrl('tel:+61000')).toBe('tel:+61000');
+  });
+
+  it('keeps a relative url, which names no scheme', () => {
+    expect(sanitizeUrl('/blog/post')).toBe('/blog/post');
+    expect(sanitizeUrl('./sibling')).toBe('./sibling');
+    expect(sanitizeUrl('../parent')).toBe('../parent');
+    expect(sanitizeUrl('image.png')).toBe('image.png');
+    expect(sanitizeUrl('#anchor')).toBe('#anchor');
+    expect(sanitizeUrl('?q=1')).toBe('?q=1');
+  });
+
+  it('returns an empty string for no url', () => {
+    expect(sanitizeUrl(undefined)).toBe('');
+    expect(sanitizeUrl('')).toBe('');
+  });
+
+  it('drops a scheme that is not on the allow list', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(sanitizeUrl('javascript:alert(1)')).toBe('');
+    expect(sanitizeUrl('JaVaScRiPt:alert(1)')).toBe('');
+    expect(sanitizeUrl('data:text/html,<script>alert(1)</script>')).toBe('');
+    expect(sanitizeUrl('vbscript:msgbox(1)')).toBe('');
+  });
+
+  // A value that names a scheme but does not parse used to be returned as it
+  // was. These are the shapes that reach that branch, written as escapes so the
+  // invisible characters stay visible in review.
+  const NUL = '\u0000';
+  const ZWSP = '\u200b';
+  const ZWJ = '\u200d';
+  const BOM = '\ufeff';
+
+  it.each([
+    ['a null byte in the scheme', `java${NUL}script:alert(1)`],
+    ['a zero-width space in the scheme', `java${ZWSP}script:alert(1)`],
+    ['a zero-width space at the front', `j${ZWSP}avascript:alert(1)`],
+    ['a zero-width joiner', `java${ZWJ}script:alert(1)`],
+    ['a byte order mark', `java${BOM}script:alert(1)`],
+  ])('drops a malformed url that still names a scheme (%s)', (_label, url) => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(sanitizeUrl(url)).toBe('');
+  });
+
+  it('keeps the query and hash on a bare origin', () => {
+    expect(sanitizeUrl('https://example.com?q=1')).toBe(
+      'https://example.com?q=1'
+    );
+    expect(sanitizeUrl('https://example.com#top')).toBe(
+      'https://example.com#top'
+    );
+    expect(sanitizeUrl('https://example.com/')).toBe('https://example.com/');
+  });
+});

--- a/packages/@tinacms/mdx/src/sanitize-url.test.ts
+++ b/packages/@tinacms/mdx/src/sanitize-url.test.ts
@@ -36,16 +36,28 @@ describe('sanitizeUrl', () => {
   // A value that names a scheme but does not parse used to be returned as it
   // was. These are the shapes that reach that branch, written as escapes so the
   // invisible characters stay visible in review.
+  // Cc (control)
   const NUL = '\u0000';
+  const TAB = '\u0009';
+  const DEL = '\u007f';
+  // Cf (format) — these render as nothing, so they hide a scheme from a reader
+  const SOFT_HYPHEN = '\u00ad';
   const ZWSP = '\u200b';
   const ZWJ = '\u200d';
+  const LRM = '\u200e';
+  const WORD_JOINER = '\u2060';
   const BOM = '\ufeff';
 
   it.each([
     ['a null byte in the scheme', `java${NUL}script:alert(1)`],
+    ['a delete character', `java${DEL}script:alert(1)`],
+    ['a tab in the scheme', `java${TAB}script:alert(1)`],
+    ['a soft hyphen', `java${SOFT_HYPHEN}script:alert(1)`],
     ['a zero-width space in the scheme', `java${ZWSP}script:alert(1)`],
     ['a zero-width space at the front', `j${ZWSP}avascript:alert(1)`],
     ['a zero-width joiner', `java${ZWJ}script:alert(1)`],
+    ['a left-to-right mark', `java${LRM}script:alert(1)`],
+    ['a word joiner', `java${WORD_JOINER}script:alert(1)`],
     ['a byte order mark', `java${BOM}script:alert(1)`],
   ])('drops a malformed url that still names a scheme (%s)', (_label, url) => {
     vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/packages/@tinacms/mdx/src/sanitize-url.ts
+++ b/packages/@tinacms/mdx/src/sanitize-url.ts
@@ -6,6 +6,19 @@
  * `tinacms`'s rich-text renderer) don't have to pull in the full remark/mdast/micromark
  * markdown-parsing toolchain that the rest of `@tinacms/mdx` bundles.
  */
+
+/**
+ * Characters that carry no meaning inside a scheme, so they cannot be used to
+ * disguise one. Stripped before looking for a scheme, never from the URL itself.
+ */
+const IGNORED_IN_SCHEME = /[\u0000-\u001f\u007f\u200b-\u200d\ufeff]/g;
+
+/** A scheme, per RFC 3986: a letter, then letters, digits, `+`, `-` or `.`. */
+const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.\-]*:/;
+
+const namesAScheme = (url: string) =>
+  SCHEME_PREFIX.test(url.replace(IGNORED_IN_SCHEME, '').trim());
+
 export const sanitizeUrl = (url: string | undefined) => {
   const allowedSchemes = ['http', 'https', 'mailto', 'tel', 'xref'];
   if (!url) return '';
@@ -15,6 +28,16 @@ export const sanitizeUrl = (url: string | undefined) => {
   try {
     parsedUrl = new URL(url);
   } catch (error) {
+    /**
+     * A URL that does not parse is either relative, which carries no scheme and
+     * stays as it is, or malformed while still naming one. Returning the raw
+     * value for the second case would hand back the input unchecked, so only the
+     * first is kept.
+     */
+    if (namesAScheme(url)) {
+      console.warn(`Invalid URL scheme detected ${url}`);
+      return '';
+    }
     return url;
   }
 

--- a/packages/@tinacms/mdx/src/sanitize-url.ts
+++ b/packages/@tinacms/mdx/src/sanitize-url.ts
@@ -8,12 +8,23 @@
  */
 
 /**
- * Characters that carry no meaning inside a scheme, so they cannot be used to
- * disguise one. Stripped before looking for a scheme, never from the URL itself.
+ * Removed before the value is tested for a scheme, so a disguised one is still
+ * found. Never removed from the URL itself.
+ *
+ * `Cc` (control) matters because the URL parser strips ASCII tab and newline
+ * from anywhere in its input, so `java<TAB>script:` reaches a browser as
+ * `javascript:`. `Cf` (format) — soft hyphen, zero-width joiners, byte order
+ * mark — render as nothing, so they hide a scheme from whoever reads the link.
+ *
+ * Categories: https://www.unicode.org/reports/tr44/#General_Category_Values
+ * Tab and newline removal: https://url.spec.whatwg.org/#url-parsing
  */
-const IGNORED_IN_SCHEME = /[\u0000-\u001f\u007f\u200b-\u200d\ufeff]/g;
+const IGNORED_IN_SCHEME = /[\p{Cc}\p{Cf}]/gu;
 
-/** A scheme, per RFC 3986: a letter, then letters, digits, `+`, `-` or `.`. */
+/**
+ * A scheme is one letter, then letters, digits, `+`, `-` or `.`.
+ * RFC 3986 3.1: https://datatracker.ietf.org/doc/html/rfc3986#section-3.1
+ */
 const SCHEME_PREFIX = /^[a-zA-Z][a-zA-Z0-9+.\-]*:/;
 
 const namesAScheme = (url: string) =>


### PR DESCRIPTION
## What

`sanitizeUrl` returned the value it was given when `new URL()` threw:

```ts
try {
  parsedUrl = new URL(url);
} catch (error) {
  return url;
}
```

That branch exists for relative URLs. They have no scheme, so `new URL()` cannot parse them alone. But the branch also returned any other value that failed to parse, with no check.

The function now tells the two cases apart. When it looks for a scheme, it ignores characters that a scheme cannot contain. If the value names a scheme, the function returns an empty string. If the value names no scheme, it is relative, and the function returns it unchanged.

## Scope

- A value that names a scheme and **parses** was already rejected by the allow list. That is unchanged.
- A value that names a scheme and does **not** parse was returned unchanged. That is what this fixes.
- Relative URLs (`/blog/post`, `./x`, `#a`, `?q=1`) do not change. Tests cover them.

## Tests

This helper had no tests, although six renderers depend on it. This PR adds 10. They cover the allow list, relative URLs, empty input, disallowed schemes, and malformed values that name a scheme. The full `@tinacms/mdx` suite (251 tests) and `tinacms` suite (766 tests) pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
