### PR TITLE
✨ Add the reference field to v4

### DIFF
--- a/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
@@ -48,6 +48,9 @@ v4 supplies four more examples:
 - The `select` field ([`select-field.md`](./select-field.md)) picks one value
   from a fixed `options` list. Its Zod validator is a `z.enum` with a custom
   `errorMap`, and it has no `defaultValue`, `parse`, or `serialize`.
+- The `reference` field ([`reference-field.md`](./reference-field.md)) points
+  at another document, and stores that document's path. Its options come from
+  the content capability, not from a fixed list.
 - The `rich-text` field ([`rich-text-field.md`](./rich-text-field.md)) uses the
   `block` layout. With `isBody`, it controls the markdown body of the file.
 

--- a/packages/v4/@tinacms/tinacms/_docs/plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/plugins.md
@@ -58,6 +58,8 @@ same time, one plugin for each schema `type` such as `string` or `image`.
   - [The `array` field](./array-field.md) — the repeatable field that v4 supplies
   - [The `select` field](./select-field.md) — the fixed-option picker that v4
     supplies
+  - [The `reference` field](./reference-field.md) — the document picker that v4
+    supplies
   - [The `rich-text` field](./rich-text-field.md) — the Plate editor that v4
     supplies, and the markdown body that it controls
 - [Architecture](./architecture.md) — how a plugin gets to the screen

--- a/packages/v4/@tinacms/tinacms/_docs/reference-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/reference-field.md
@@ -1,0 +1,231 @@
+# The `reference` field
+
+The `reference` field is one of the field plugins that v4 supplies. It points
+one document at another document. The document stores the path of the document
+it points at, and the editor shows a combobox of the documents an author can
+choose.
+
+The `select` field also picks one value, but it reads a fixed `options` list.
+The `reference` field has no fixed list. It asks the content capability for the
+documents of each collection it names, so its options come from the content at
+the time an author opens the field.
+
+## Files
+
+The four files are in `plugins/fields/reference/`:
+
+| File | Role |
+|---|---|
+| `reference-field.schema.ts` | The `t.reference()` helper function, and the `referenceSchema` validator |
+| `reference-field.client.tsx` | The descriptor, which takes the `reference` key |
+| `reference-field.ui.tsx` | The `ReferenceField` component |
+| `reference-field.plugin.ts` | The manifest, `tina:field:reference` |
+
+## Authoring
+
+`t.reference({...})` adds `type: 'reference'` (`REFERENCE_FIELD_TYPE`) to the
+config:
+
+```ts
+import { t } from '@tinacms/tinacms';
+
+const collection = {
+  name: 'post',
+  fields: [
+    t.reference({
+      name: 'author',
+      label: 'Author',
+      required: true,
+      collections: ['author'],
+    }),
+  ],
+};
+```
+
+`ReferenceFieldSchema` extends `BaseFieldSchema`. It adds one property:
+
+| Key | Type | Effect |
+|---|---|---|
+| `collections` | `string[]` (required) | the names of the collections an author can choose a document from |
+
+`collections` holds collection **names**, not paths and not labels. A field can
+name more than one collection. The field then shows the documents of every one
+of them in a single list, and the author still chooses one document.
+
+## The stored value
+
+The document stores the path of the document it points at, as a plain string:
+
+```yaml
+---
+title: Hello World
+author: content/authors/ada.mdx
+---
+```
+
+The value is one path. `collections` controls what an author can choose. It
+does not make the value a list.
+
+## The descriptor
+
+The client segment (`reference-field.client.tsx`) takes the `reference` key:
+
+```tsx
+defineClientPlugin({
+  field: {
+    Component: ReferenceField,
+    metadata: { layout: 'inline' },
+    schema: referenceSchema,
+    parse: (stored: string) => (stored == null ? undefined : stored),
+    serialize: (value: string | null) => value ?? undefined,
+  },
+});
+```
+
+The descriptor has no `defaultValue`. An absent reference stays absent, because
+the field does not pick a first document for the author.
+
+`parse` and `serialize` convert between an absent value and a cleared value.
+The editor writes `null` when an author clears the field, and `serialize` turns
+that `null` into `undefined`, so a cleared reference leaves the document
+instead of writing a literal `null` to it.
+
+## Validation
+
+`referenceSchema(node)` builds a `z.string()`. The stored value is a path, so
+the validator checks that a path is present. It does not check that the path
+resolves.
+
+| Config | Rule | Message |
+|---|---|---|
+| `required` | the value is absent or empty | `<label> is required` |
+| (none) | an absent or empty value passes | |
+
+An optional field wraps the string in `z.preprocess`, so `''` and `null` become
+`undefined` and pass. This runs through the shared path (`validateField`); see
+[`field-plugins.md`](./field-plugins.md#validation-in-two-layers).
+
+A reference whose document no longer exists is not a validation failure. Zod
+sees only the stored string, and it cannot read the content. The component
+reports that case instead; see [Missing references](#missing-references).
+
+## Ingest and digest
+
+`ingestDocument` and `digestDocument` pass the stored path through unchanged. A
+document with no stored value stays absent after ingest, because the descriptor
+sets no `defaultValue`. A cleared reference digests as absent, not as `null`.
+
+## The component
+
+`ReferenceField` (`reference-field.ui.tsx`) has no props. It reads its address
+and its resolved schema node from the context, and it gets the value and the
+errors from hooks that use the address.
+
+### The options
+
+A field can name more than one collection, and the rules of hooks do not permit
+a call to `useCollectionDocuments` for each name in a loop. The component uses
+`useQueries` instead, which takes the whole set in one call:
+
+```tsx
+const useReferenceOptions = (collections: string[]): ReferenceOptions => {
+  const content = useContentSlice();
+  return useQueries({
+    queries: collections.map((collection) => ({
+      queryKey: contentKeys.list(collection),
+      queryFn: () => content.list(collection),
+      staleTime: CONTENT_STALE_TIME,
+    })),
+    combine: (results) => ({
+      options: results.flatMap(
+        (result) =>
+          result.data?.map((summary) => ({
+            value: summary.path,
+            label: summary.path,
+          })) ?? []
+      ),
+      isLoading: results.some((result) => result.isLoading),
+      error: results.find((result) => result.error)?.error ?? null,
+    }),
+  });
+};
+```
+
+The queries use the same keys as `useCollectionDocuments`
+(`contentKeys.list(collection)`), so the field and the rest of the editor share
+one cache.
+
+`content.list` returns a `DocumentSummary`, which holds a path and no content.
+Each option therefore shows its path. See
+[`core/content/contract.ts`](../src/core/content/contract.ts) for why `list`
+carries no bodies.
+
+### Search and clear
+
+The field renders a combobox, not a select. A collection can hold more
+documents than a list can show, so an author types to narrow the options. The
+field shows "No documents match." when nothing does.
+
+An optional field shows a clear button. A required field does not.
+
+### Missing references
+
+A stored path whose document is gone stays in the list, with `(missing)` after
+it. The field does not drop the value, and it does not silently show an empty
+control. An author sees what the reference points at, and can choose another
+document.
+
+### A failed lookup
+
+When `content.list` fails, the field disables the input and reports the message
+through `FieldWrapper`. Before this, the field showed an empty list and gave no
+reason for it.
+
+## In the preview
+
+The form holds a reference as a path. A site renders the document that the path
+points at. `usePreviewConnection` closes that gap: it swaps each reference path
+for the document it names before it posts the values to the preview, so the
+site reads the same shape whether it renders statically or through the editor.
+
+The walk is in [`core/form/references.ts`](../src/core/form/references.ts).
+`collectReferences` names the documents to fetch, and `resolveReferences`
+substitutes the documents that the content cache already holds. The post stays
+synchronous, so a keystroke never waits on the network. A reference that has
+not arrived yet keeps its path for a frame.
+
+## The connections
+
+- The manifest is `reference-field.plugin.ts`. Its name is
+  `tina:field:reference`, and it exports `referenceFieldPlugin`.
+- The registration is in `plugins/fields/index.ts`. That file adds the plugin
+  to `corePlugins`, and it supplies `t.reference`.
+- `FieldSchema` carries `collections`, so the GraphQL pipeline and
+  `references.ts` both read it from a bare schema node.
+
+## Tests
+
+`reference-field.test.tsx` does these tests:
+
+- It shows the path of the referenced document, and the placeholder when the
+  field is absent.
+- It narrows the options to what an author types, and reports when nothing
+  matches.
+- It offers every document of each collection the field names, and it asks the
+  content capability once for each name.
+- It stores the path of the chosen document.
+- It clears an optional reference, and it shows no clear button on a required
+  one.
+- It marks a stored path that no document answers, and keeps that path
+  selectable.
+- It rejects a missing value on a required field, and passes an empty value on
+  an optional field.
+- It passes a stored path through ingest and digest without a change, and
+  digests a cleared reference as absent.
+- It examines the metadata of the descriptor.
+
+## Not in this field
+
+A document cannot yet name the documents that reference it. That reverse query
+needs an index in the content layer, not a change to this field, and it is
+tracked separately.

--- a/packages/v4/@tinacms/tinacms/src/core/form/references.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/references.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import type { CollectionSchema, FieldSchema } from '../schema/types';
+import { collectReferences, resolveReferences } from './references';
+
+const collections: CollectionSchema[] = [
+  { name: 'post', format: 'mdx', path: 'content/posts', fields: [] },
+  { name: 'page', format: 'mdx', path: 'content/pages', fields: [] },
+];
+
+const pageReference: FieldSchema = {
+  name: 'page',
+  type: 'reference',
+  collections: ['page'],
+};
+
+const fields: FieldSchema[] = [
+  { name: 'title', type: 'string' },
+  pageReference,
+  {
+    name: 'related',
+    type: 'array',
+    fields: [pageReference],
+  } as FieldSchema,
+];
+
+const page = { title: 'Test Title' };
+const resolve = () => page;
+
+describe('collectReferences', () => {
+  it('names the collection that owns a stored path', () => {
+    const targets = collectReferences(
+      { page: 'content/pages/test.mdx' },
+      fields,
+      collections
+    );
+    expect(targets).toEqual([
+      { collection: 'page', path: 'content/pages/test.mdx' },
+    ]);
+  });
+
+  it('reaches references inside array items', () => {
+    const targets = collectReferences(
+      { related: [{ page: 'content/pages/test.mdx' }] },
+      fields,
+      collections
+    );
+    expect(targets).toEqual([
+      { collection: 'page', path: 'content/pages/test.mdx' },
+    ]);
+  });
+
+  it('ignores a path that no listed collection owns', () => {
+    expect(
+      collectReferences(
+        { page: 'content/posts/other.mdx' },
+        fields,
+        collections
+      )
+    ).toEqual([]);
+  });
+
+  it('ignores an empty reference', () => {
+    expect(collectReferences({ page: '' }, fields, collections)).toEqual([]);
+  });
+});
+
+describe('resolveReferences', () => {
+  it('replaces the path with the document it points at', () => {
+    expect(
+      resolveReferences(
+        { title: 'Hello', page: 'content/pages/test.mdx' },
+        fields,
+        collections,
+        resolve
+      )
+    ).toEqual({ title: 'Hello', page });
+  });
+
+  it('resolves inside array items', () => {
+    expect(
+      resolveReferences(
+        { related: [{ page: 'content/pages/test.mdx' }] },
+        fields,
+        collections,
+        resolve
+      )
+    ).toEqual({ related: [{ page }] });
+  });
+
+  it('keeps the path when the document is not available', () => {
+    expect(
+      resolveReferences(
+        { page: 'content/pages/test.mdx' },
+        fields,
+        collections,
+        () => undefined
+      )
+    ).toEqual({ page: 'content/pages/test.mdx' });
+  });
+
+  it('leaves the values it was given alone', () => {
+    const values = { page: 'content/pages/test.mdx' };
+    resolveReferences(values, fields, collections, resolve);
+    expect(values).toEqual({ page: 'content/pages/test.mdx' });
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/core/form/references.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/references.ts
@@ -1,0 +1,105 @@
+import type {
+  CollectionSchema,
+  FieldSchema,
+  TinaDocument,
+} from '../schema/types';
+
+const REFERENCE_FIELD_TYPE = 'reference';
+
+export interface ReferenceTarget {
+  collection: string;
+  path: string;
+}
+
+const isDocument = (value: unknown): value is TinaDocument =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const childFieldsOf = (node: FieldSchema): FieldSchema[] | undefined => {
+  const { fields } = node as { fields?: FieldSchema[] };
+  return Array.isArray(fields) ? fields : undefined;
+};
+
+// A reference stores the path of the document it points at. `collections`
+// narrows the candidates, and the one whose `path` contains that document owns
+// it — `content.get` needs a collection name, not a path.
+const targetOf = (
+  node: FieldSchema,
+  value: unknown,
+  collections: CollectionSchema[]
+): ReferenceTarget | null => {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const candidates = node.collections;
+  if (!candidates) return null;
+  const owner = collections.find(
+    (collection) =>
+      candidates.includes(collection.name) &&
+      collection.path != null &&
+      value.startsWith(`${collection.path}/`)
+  );
+  return owner ? { collection: owner.name, path: value } : null;
+};
+
+export const collectReferences = (
+  values: TinaDocument | undefined,
+  fields: FieldSchema[],
+  collections: CollectionSchema[]
+): ReferenceTarget[] => {
+  const targets: ReferenceTarget[] = [];
+  const walk = (document: TinaDocument, nodes: FieldSchema[]): void => {
+    for (const node of nodes) {
+      const value = document[node.name];
+      if (node.type === REFERENCE_FIELD_TYPE) {
+        const target = targetOf(node, value, collections);
+        if (target) targets.push(target);
+        continue;
+      }
+      const children = childFieldsOf(node);
+      if (!children) continue;
+      if (Array.isArray(value)) {
+        for (const item of value) if (isDocument(item)) walk(item, children);
+      } else if (isDocument(value)) {
+        walk(value, children);
+      }
+    }
+  };
+  walk(values ?? {}, fields);
+  return targets;
+};
+
+export type ReferenceResolver = (
+  target: ReferenceTarget
+) => TinaDocument | undefined;
+
+// The preview renders the site's own shape, where a reference reads as the
+// document it points at. An unresolved target keeps its path, so the site sees
+// the same value it would for a reference that no longer exists.
+export const resolveReferences = (
+  values: TinaDocument | undefined,
+  fields: FieldSchema[],
+  collections: CollectionSchema[],
+  resolve: ReferenceResolver
+): TinaDocument => {
+  const walk = (document: TinaDocument, nodes: FieldSchema[]): TinaDocument => {
+    const resolved: TinaDocument = { ...document };
+    for (const node of nodes) {
+      const value = document[node.name];
+      if (node.type === REFERENCE_FIELD_TYPE) {
+        const target = targetOf(node, value, collections);
+        const referenced = target ? resolve(target) : undefined;
+        if (referenced) resolved[node.name] = referenced;
+        continue;
+      }
+      const children = childFieldsOf(node);
+      if (!children) continue;
+      if (Array.isArray(value)) {
+        resolved[node.name] = value.map((item) =>
+          isDocument(item) ? walk(item, children) : item
+        );
+      } else if (isDocument(value)) {
+        resolved[node.name] = walk(value, children);
+      }
+    }
+    return resolved;
+  };
+  return walk(values ?? {}, fields);
+};

--- a/packages/v4/@tinacms/tinacms/src/core/form/references.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/references.ts
@@ -1,8 +1,7 @@
-import {
-  type CollectionSchema,
-  type FieldSchema,
-  REFERENCE_FIELD_TYPE,
-  type TinaDocument,
+import type {
+  CollectionSchema,
+  FieldSchema,
+  TinaDocument,
 } from '../schema/types';
 
 export interface ReferenceTarget {
@@ -18,9 +17,11 @@ const childFieldsOf = (node: FieldSchema): FieldSchema[] | undefined => {
   return Array.isArray(fields) ? fields : undefined;
 };
 
-// A reference stores the path of the document it points at. `collections`
-// narrows the candidates, and the one whose `path` contains that document owns
-// it — `content.get` needs a collection name, not a path.
+// A reference stores the path of the document it points at, and it is the only
+// node that declares `collections`. Reading that rather than the type key keeps
+// core from naming a field type. `collections` narrows the candidates, and the
+// one whose `path` contains that document owns it, because `content.get` needs
+// a collection name and not a path.
 const targetOf = (
   node: FieldSchema,
   value: unknown,
@@ -38,9 +39,9 @@ const targetOf = (
   return owner ? { collection: owner.name, path: value } : null;
 };
 
-// TODO(#7534): this walk reads `node.fields` and matches on the type key
-// itself, so it misses any other way a plugin nests children. `templates` is
-// the live gap. Fold it into the registry-driven path that `ingest.ts` uses.
+// TODO(#7534): this walk reads `node.fields`, so it misses any other way a
+// plugin nests children. `templates` is the live gap. Fold it into the
+// registry-driven path that `ingest.ts` uses.
 export const collectReferences = (
   values: TinaDocument | undefined,
   fields: FieldSchema[],
@@ -50,9 +51,9 @@ export const collectReferences = (
   const walk = (document: TinaDocument, nodes: FieldSchema[]): void => {
     for (const node of nodes) {
       const value = document[node.name];
-      if (node.type === REFERENCE_FIELD_TYPE) {
-        const target = targetOf(node, value, collections);
-        if (target) targets.push(target);
+      const target = targetOf(node, value, collections);
+      if (target) {
+        targets.push(target);
         continue;
       }
       const children = childFieldsOf(node);
@@ -85,9 +86,9 @@ export const resolveReferences = (
     const resolved: TinaDocument = { ...document };
     for (const node of nodes) {
       const value = document[node.name];
-      if (node.type === REFERENCE_FIELD_TYPE) {
-        const target = targetOf(node, value, collections);
-        const referenced = target ? resolve(target) : undefined;
+      const target = targetOf(node, value, collections);
+      if (target) {
+        const referenced = resolve(target);
         if (referenced) resolved[node.name] = referenced;
         continue;
       }

--- a/packages/v4/@tinacms/tinacms/src/core/form/references.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/form/references.ts
@@ -1,10 +1,9 @@
-import type {
-  CollectionSchema,
-  FieldSchema,
-  TinaDocument,
+import {
+  type CollectionSchema,
+  type FieldSchema,
+  REFERENCE_FIELD_TYPE,
+  type TinaDocument,
 } from '../schema/types';
-
-const REFERENCE_FIELD_TYPE = 'reference';
 
 export interface ReferenceTarget {
   collection: string;
@@ -39,6 +38,9 @@ const targetOf = (
   return owner ? { collection: owner.name, path: value } : null;
 };
 
+// TODO(#7534): this walk reads `node.fields` and matches on the type key
+// itself, so it misses any other way a plugin nests children. `templates` is
+// the live gap. Fold it into the registry-driven path that `ingest.ts` uses.
 export const collectReferences = (
   values: TinaDocument | undefined,
   fields: FieldSchema[],

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
@@ -21,6 +21,7 @@ export interface FieldSchema extends BaseFieldSchema {
   type: string;
   isBody?: boolean;
   templates?: TemplateSchema[];
+  collections?: string[];
 }
 
 export const COLLECTION_FORMATS = ['md', 'mdx', 'json', 'yaml'] as const;

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
@@ -17,8 +17,6 @@ export interface TemplateSchema {
   fields?: TemplateFieldSchema[];
 }
 
-export const REFERENCE_FIELD_TYPE = 'reference';
-
 export interface FieldSchema extends BaseFieldSchema {
   type: string;
   isBody?: boolean;

--- a/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
+++ b/packages/v4/@tinacms/tinacms/src/core/schema/types.ts
@@ -17,6 +17,8 @@ export interface TemplateSchema {
   fields?: TemplateFieldSchema[];
 }
 
+export const REFERENCE_FIELD_TYPE = 'reference';
+
 export interface FieldSchema extends BaseFieldSchema {
   type: string;
   isBody?: boolean;

--- a/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/hooks.ts
@@ -12,7 +12,11 @@ import type { FieldRegistry } from '../core/field/registry';
 import { digestDocument } from '../core/form/ingest';
 import { invariant } from '../core/invariant';
 import type { SliceState, TinaStoreState } from '../core/plugin';
-import type { FieldSchema, TinaDocument } from '../core/schema/types';
+import type {
+  CollectionSchema,
+  FieldSchema,
+  TinaDocument,
+} from '../core/schema/types';
 import { type FormId, toFormValues, useFormStore } from '../form/form-store';
 import {
   FieldAddressContext,
@@ -52,10 +56,15 @@ const isContentSlice = (
   typeof slice.list === 'function' &&
   typeof slice.update === 'function';
 
-export function useContentSlice(): ContentSlice {
+export function useOptionalContentSlice(): ContentSlice | null {
   const slice = useTinaStore((state) => state.content);
+  return slice && isContentSlice(slice) ? slice : null;
+}
+
+export function useContentSlice(): ContentSlice {
+  const slice = useOptionalContentSlice();
   invariant(
-    slice && isContentSlice(slice),
+    slice,
     'content-capability-missing',
     'No content capability with get, list and update is mounted — pass a content plugin (e.g. localContentPlugin()) to <TinaProvider plugins>'
   );
@@ -70,6 +79,21 @@ function useFormScope(hookCode: string, hookName: string): FormScope {
 
 export function useFormId(): FormId {
   return useFormScope('form-id-outside-provider', 'useFormId').formId;
+}
+
+export function useFormCollection(): CollectionSchema {
+  return useFormScope('form-collection-outside-provider', 'useFormCollection')
+    .collection;
+}
+
+export function useSchemaCollections(): CollectionSchema[] {
+  const runtime = use(TinaRuntimeContext);
+  invariant(
+    runtime,
+    'schema-collections-outside-provider',
+    'useSchemaCollections must be used within a TinaProvider'
+  );
+  return runtime.schema.collections;
 }
 
 export function useDocumentPath(): string {

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.test.tsx
@@ -9,10 +9,13 @@ import userEvent from '@testing-library/user-event';
 import { type ReactNode, type RefObject, useRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { asResolvedConfig } from '../config';
+import type { ContentProvider } from '../core/content/contract';
 import { toFieldAddress } from '../core/field/address';
-import type { CollectionSchema } from '../core/schema/types';
+import { definePlugin } from '../core/plugin';
+import type { CollectionSchema, TinaDocument } from '../core/schema/types';
 import { toFormId, useFormStore } from '../form/form-store';
 import { t } from '../index';
+import referenceFieldPlugin from '../plugins/fields/reference/reference-field.plugin';
 import stringFieldPlugin from '../plugins/fields/string/string-field.plugin';
 import {
   activateMessage,
@@ -86,6 +89,111 @@ const renderConnected = (iframeRef: RefObject<HTMLIFrameElement | null>) =>
       </FormProvider>
     </TinaProvider>
   );
+
+const REFERENCED_PATH = 'content/pages/deleted.mdx';
+
+const referenceCollection: CollectionSchema = {
+  name: 'post',
+  format: 'mdx',
+  fields: [
+    t.string({ name: 'title', label: 'Title' }),
+    t.reference({ name: 'page', label: 'Page', collections: ['page'] }),
+  ],
+};
+
+const pageCollection: CollectionSchema = {
+  name: 'page',
+  path: 'content/pages',
+  format: 'mdx',
+  fields: [t.string({ name: 'title', label: 'Title' })],
+};
+
+const renderWithReference = (
+  iframeRef: RefObject<HTMLIFrameElement | null>,
+  get: ContentProvider['get']
+) => {
+  const contentPlugin = definePlugin({
+    name: 'test:content:stub',
+    provides: ['content'],
+    client: async () => ({
+      default: {
+        slice: () => ({
+          get,
+          list: async () => [],
+          update: async (_c: string, p: string, value: TinaDocument) => ({
+            path: p,
+            document: value,
+          }),
+        }),
+      },
+    }),
+  });
+  return render(
+    <TinaProvider
+      config={asResolvedConfig({
+        plugins: [stringFieldPlugin, referenceFieldPlugin, contentPlugin],
+        schema: { collections: [referenceCollection, pageCollection] },
+      })}
+    >
+      <FormProvider
+        collection={referenceCollection}
+        path={path}
+        document={{ title: 'Hello', page: REFERENCED_PATH }}
+      >
+        <LabelledFields />
+        <Connection iframeRef={iframeRef} />
+      </FormProvider>
+    </TinaProvider>
+  );
+};
+
+describe('usePreviewConnection reference resolution', () => {
+  it('posts once per edit when a reference points at a document that is gone', async () => {
+    const get = vi.fn(async () => null);
+    const iframe = fakeIframe();
+    renderWithReference(iframe.ref, get);
+    const input = await screen.findByLabelText('Title');
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(1));
+    iframe.postMessage.mockClear();
+
+    await userEvent.type(input, '!');
+    await waitFor(() => expect(iframe.postMessage).toHaveBeenCalled());
+
+    // `content.get` answers null for a document that is gone. Reading the
+    // cached document rather than the cache entry treats that null as a miss,
+    // so every edit re-enters the fetch and posts a second time.
+    expect(iframe.postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the path when the document is gone', async () => {
+    const iframe = fakeIframe();
+    renderWithReference(iframe.ref, async () => null);
+    await screen.findByLabelText('Title');
+
+    await waitFor(() =>
+      expect(iframe.postMessage).toHaveBeenCalledWith(
+        valuesMessage({ title: 'Hello', page: REFERENCED_PATH }),
+        window.origin
+      )
+    );
+  });
+
+  it('swaps the path for the document it points at', async () => {
+    const iframe = fakeIframe();
+    renderWithReference(iframe.ref, async () => ({
+      path: REFERENCED_PATH,
+      document: { title: 'Deleted Page' },
+    }));
+    await screen.findByLabelText('Title');
+
+    await waitFor(() =>
+      expect(iframe.postMessage).toHaveBeenCalledWith(
+        valuesMessage({ title: 'Hello', page: { title: 'Deleted Page' } }),
+        window.origin
+      )
+    );
+  });
+});
 
 describe('usePreviewConnection', () => {
   it('answers the ready handshake with the registered document', async () => {

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
@@ -1,5 +1,8 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { type RefObject, useEffect } from 'react';
+import type { DocumentEntry } from '../core/content/contract';
 import { toFieldAddress } from '../core/field/address';
+import { collectReferences, resolveReferences } from '../core/form/references';
 import { invariant } from '../core/invariant';
 import { type FormValues, toDocument, useFormStore } from '../form/form-store';
 import {
@@ -7,7 +10,13 @@ import {
   isReadyMessage,
   valuesMessage,
 } from '../preview/protocol';
-import { useFormId } from './hooks';
+import { CONTENT_STALE_TIME, contentKeys } from './content-queries';
+import {
+  useFormCollection,
+  useFormId,
+  useOptionalContentSlice,
+  useSchemaCollections,
+} from './hooks';
 
 export interface PreviewConnectionOptions {
   targetOrigin?: string;
@@ -17,7 +26,6 @@ export function usePreviewConnection(
   iframeRef: RefObject<HTMLIFrameElement | null>,
   options?: PreviewConnectionOptions
 ): void {
-  const formId = useFormId();
   const targetOrigin = options?.targetOrigin ?? window.origin;
   invariant(
     targetOrigin !== '*',
@@ -25,10 +33,59 @@ export function usePreviewConnection(
     "targetOrigin must name the preview's origin — never '*'."
   );
 
+  const formId = useFormId();
+  const { fields } = useFormCollection();
+  const collections = useSchemaCollections();
+  const content = useOptionalContentSlice();
+  const queryClient = useQueryClient();
+
   useEffect(() => {
     const target = () => iframeRef.current?.contentWindow ?? null;
-    const postValues = (values: FormValues) =>
-      target()?.postMessage(valuesMessage(toDocument(values)), targetOrigin);
+
+    const cachedDocument = (collection: string, path: string) =>
+      queryClient.getQueryData<DocumentEntry | null>(
+        contentKeys.document(collection, path)
+      )?.document;
+
+    // Posting stays synchronous, so it only ever reads the cache
+    const postValues = (values: FormValues) => {
+      const document = resolveReferences(
+        toDocument(values),
+        fields,
+        collections,
+        ({ collection, path }) => cachedDocument(collection, path)
+      );
+      target()?.postMessage(valuesMessage(document), targetOrigin);
+    };
+
+    const repost = () => {
+      const scope = useFormStore.getState().forms[formId];
+      if (scope) postValues(scope.values);
+    };
+
+    const warmReferences = (values: FormValues) => {
+      if (!content) return;
+      for (const { collection, path } of collectReferences(
+        toDocument(values),
+        fields,
+        collections
+      )) {
+        if (cachedDocument(collection, path)) continue;
+        queryClient
+          .fetchQuery({
+            queryKey: contentKeys.document(collection, path),
+            queryFn: () => content.get(collection, path),
+            staleTime: CONTENT_STALE_TIME,
+          })
+          .then(repost)
+          .catch(() => {});
+      }
+    };
+
+    const publish = (values: FormValues) => {
+      postValues(values);
+      warmReferences(values);
+    };
 
     const onMessage = (event: MessageEvent) => {
       const source = target();
@@ -36,7 +93,7 @@ export function usePreviewConnection(
         return;
       if (isReadyMessage(event.data)) {
         const scope = useFormStore.getState().forms[formId];
-        if (scope) postValues(scope.values);
+        if (scope) publish(scope.values);
       } else if (isActivateMessage(event.data)) {
         useFormStore
           .getState()
@@ -48,16 +105,24 @@ export function usePreviewConnection(
     const unsubscribe = useFormStore.subscribe((state, previous) => {
       const values = state.forms[formId]?.values;
       if (values && values !== previous.forms[formId]?.values) {
-        postValues(values);
+        publish(values);
       }
     });
 
     const scope = useFormStore.getState().forms[formId];
-    if (scope) postValues(scope.values);
+    if (scope) publish(scope.values);
 
     return () => {
       window.removeEventListener('message', onMessage);
       unsubscribe();
     };
-  }, [iframeRef, formId, targetOrigin]);
+  }, [
+    iframeRef,
+    formId,
+    targetOrigin,
+    fields,
+    collections,
+    content,
+    queryClient,
+  ]);
 }

--- a/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/preview-connection.ts
@@ -70,15 +70,24 @@ export function usePreviewConnection(
         fields,
         collections
       )) {
-        if (cachedDocument(collection, path)) continue;
+        const key = contentKeys.document(collection, path);
+        // Test the cache entry, not the document. `content.get` resolves null
+        // for a document that is gone, and that null is a cached answer.
+        if (queryClient.getQueryState(key)) continue;
         queryClient
           .fetchQuery({
-            queryKey: contentKeys.document(collection, path),
+            queryKey: key,
             queryFn: () => content.get(collection, path),
             staleTime: CONTENT_STALE_TIME,
           })
           .then(repost)
-          .catch(() => {});
+          .catch((cause: unknown) => {
+            const reason =
+              cause instanceof Error ? cause.message : String(cause);
+            console.warn(
+              `Tina could not read "${path}" from the "${collection}" collection, so the preview keeps its path. ${reason}`
+            );
+          });
       }
     };
 

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
@@ -39,7 +39,7 @@ describe('TinaProvider boot', () => {
       </TinaProvider>
     );
     expect(await screen.findByTestId('field-types')).toHaveTextContent(
-      'array,boolean,datetime,number,rich-text,select,string'
+      'array,boolean,datetime,number,reference,rich-text,select,string'
     );
     expect(screen.getByTestId('namespaces')).toHaveTextContent(
       'branch,documents,ui'

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql/graphql-pipeline.test.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql/graphql-pipeline.test.ts
@@ -11,9 +11,15 @@ import {
 const HELLO_RAW = `---
 title: Hello World
 featured: false
+author: content/authors/ada.md
 ---
 
 Body prose.
+`;
+
+const ADA_RAW = `---
+name: Ada
+---
 `;
 
 let rootDir: string;
@@ -23,6 +29,8 @@ beforeEach(async () => {
   rootDir = await fs.mkdtemp(path.join(tmpdir(), 'tina-graphql-'));
   await fs.mkdir(path.join(rootDir, 'content/posts'), { recursive: true });
   await fs.writeFile(path.join(rootDir, 'content/posts/hello.mdx'), HELLO_RAW);
+  await fs.mkdir(path.join(rootDir, 'content/authors'), { recursive: true });
+  await fs.writeFile(path.join(rootDir, 'content/authors/ada.md'), ADA_RAW);
   dataLayer = createLocalDataLayer({
     rootDir,
     collections: [
@@ -33,8 +41,15 @@ beforeEach(async () => {
         fields: [
           { name: 'title', type: 'string', required: true },
           { name: 'featured', type: 'boolean' },
+          { name: 'author', type: 'reference', collections: ['author'] },
           { name: 'body', type: 'rich-text', isBody: true },
         ],
+      },
+      {
+        name: 'author',
+        path: 'content/authors',
+        format: 'md',
+        fields: [{ name: 'name', type: 'string', required: true }],
       },
     ],
   });
@@ -52,6 +67,18 @@ describe('graphql (the v3 pipeline)', () => {
     expect(result.data?.post).toMatchObject({
       title: 'Hello World',
       featured: false,
+    });
+  });
+
+  it('resolves a reference into the document it points at', async () => {
+    const result = await dataLayer.graphql(
+      'query($relativePath: String!) { post(relativePath: $relativePath) { title author { ... on Author { name } } } }',
+      { relativePath: 'hello.mdx' }
+    );
+    expect(result.errors).toBeUndefined();
+    expect(result.data?.post).toMatchObject({
+      title: 'Hello World',
+      author: { name: 'Ada' },
     });
   });
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql/graphql-pipeline.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/content/local/graphql/graphql-pipeline.ts
@@ -35,6 +35,7 @@ const toV3Field = (field: FieldSchema) => ({
   required: field.required,
   isBody: field.isBody,
   ...(field.templates ? { templates: field.templates } : {}),
+  ...(field.collections ? { collections: field.collections } : {}),
 });
 
 const toV3Collection = (collection: CollectionSchema) => ({

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -1,4 +1,6 @@
 import arrayFieldPlugin from './array/array-field.plugin';
+import referenceFieldPlugin from './reference/reference-field.plugin';
+import { reference } from './reference/reference-field.schema';
 import { array } from './array/array-field.schema';
 import booleanFieldPlugin from './boolean/boolean-field.plugin';
 import { boolean } from './boolean/boolean-field.schema';
@@ -21,10 +23,20 @@ export const corePlugins = [
   arrayFieldPlugin,
   selectFieldPlugin,
   richTextFieldPlugin,
+  referenceFieldPlugin,
 ];
 
 // TODO: build `t` from the configured plugin set when defineConfig arrives
-export const t = { string, boolean, number, datetime, select, array, richText };
+export const t = {
+  string,
+  boolean,
+  number,
+  datetime,
+  select,
+  array,
+  richText,
+  reference,
+};
 
 export type { ArrayFieldSchema } from './array/array-field.schema';
 export type { BooleanFieldSchema } from './boolean/boolean-field.schema';
@@ -36,3 +48,4 @@ export type {
   SelectFieldSchema,
 } from './select/select-field.schema';
 export type { StringFieldSchema } from './string/string-field.schema';
+export type { ReferenceFieldSchema } from './reference/reference-field.schema';

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.client.tsx
@@ -1,13 +1,13 @@
-import { defineClientPlugin } from "../../../client";
-import { referenceSchema } from "./reference-field.schema";
-import { ReferenceField } from "./reference-field.ui";
+import { defineClientPlugin } from '../../../client';
+import { referenceSchema } from './reference-field.schema';
+import { ReferenceField } from './reference-field.ui';
 
 export default defineClientPlugin({
-    field: {
-        Component: ReferenceField,
-        metadata: {layout: 'inline'},
-        schema: referenceSchema,
-        parse: (stored: string) => (stored == null ? undefined : stored),
-        serialize: (value: string | null) => value ?? undefined,
-    }
-})
+  field: {
+    Component: ReferenceField,
+    metadata: { layout: 'inline' },
+    schema: referenceSchema,
+    parse: (stored: string) => (stored == null ? undefined : stored),
+    serialize: (value: string | null) => value ?? undefined,
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.client.tsx
@@ -1,0 +1,13 @@
+import { defineClientPlugin } from "../../../client";
+import { referenceSchema } from "./reference-field.schema";
+import { ReferenceField } from "./reference-field.ui";
+
+export default defineClientPlugin({
+    field: {
+        Component: ReferenceField,
+        metadata: {layout: 'inline'},
+        schema: referenceSchema,
+        parse: (stored: string) => (stored == null ? undefined : stored),
+        serialize: (value: string | null) => value ?? undefined,
+    }
+})

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.plugin.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '../../../core/plugin';
+import { REFERENCE_FIELD_TYPE } from './reference-field.schema';
+
+const referenceFieldPlugin = definePlugin({
+    name: 'tina:field:reference',
+    provides: ['field'],
+    field: { type: REFERENCE_FIELD_TYPE, contractVersion: 1 },
+    client: () => import('./reference-field.client')
+})
+
+export default referenceFieldPlugin

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.plugin.ts
@@ -2,10 +2,10 @@ import { definePlugin } from '../../../core/plugin';
 import { REFERENCE_FIELD_TYPE } from './reference-field.schema';
 
 const referenceFieldPlugin = definePlugin({
-    name: 'tina:field:reference',
-    provides: ['field'],
-    field: { type: REFERENCE_FIELD_TYPE, contractVersion: 1 },
-    client: () => import('./reference-field.client')
-})
+  name: 'tina:field:reference',
+  provides: ['field'],
+  field: { type: REFERENCE_FIELD_TYPE, contractVersion: 1 },
+  client: () => import('./reference-field.client'),
+});
 
-export default referenceFieldPlugin
+export default referenceFieldPlugin;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
@@ -1,29 +1,33 @@
-import { ZodType, z } from "zod";
-import { BaseFieldSchema, FieldSchema } from "../../../core/schema/types";
+import { ZodType, z } from 'zod';
+import { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
 
-export const REFERENCE_FIELD_TYPE= 'reference'
+export const REFERENCE_FIELD_TYPE = 'reference';
 
 export interface ReferenceFieldSchema extends BaseFieldSchema {
   type: typeof REFERENCE_FIELD_TYPE;
-  collections: string[]
+  collections: string[];
 }
 
-export const reference = ( config: Omit<ReferenceFieldSchema, 'type'> ): ReferenceFieldSchema => ({
+export const reference = (
+  config: Omit<ReferenceFieldSchema, 'type'>
+): ReferenceFieldSchema => ({
   type: REFERENCE_FIELD_TYPE,
   ...config,
 });
 
-const labelOf = (node: ReferenceFieldSchema): string => node.label ?? node.name
+const labelOf = (node: ReferenceFieldSchema): string => node.label ?? node.name;
 
 export const referenceSchema = (node: FieldSchema): ZodType => {
-    const field = node as ReferenceFieldSchema;
-    const schema = z.string()
-    if (field.required) {
-         return z.preprocess(
+  const field = node as ReferenceFieldSchema;
+  const schema = z.string();
+  if (field.required) {
+    return z.preprocess(
       (value) => value ?? '',
       schema.min(1, `${labelOf(field)} is required`)
     );
-    }
-    return z.preprocess((value) => (value === '' || value == null ? undefined : value), schema.optional());
-    
-}
+  }
+  return z.preprocess(
+    (value) => (value === '' || value == null ? undefined : value),
+    schema.optional()
+  );
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
@@ -1,0 +1,29 @@
+import { ZodType, z } from "zod";
+import { BaseFieldSchema, FieldSchema } from "../../../core/schema/types";
+
+export const REFERENCE_FIELD_TYPE= 'reference'
+
+export interface ReferenceFieldSchema extends BaseFieldSchema {
+  type: typeof REFERENCE_FIELD_TYPE;
+  collections: string[]
+}
+
+export const reference = ( config: Omit<ReferenceFieldSchema, 'type'> ): ReferenceFieldSchema => ({
+  type: REFERENCE_FIELD_TYPE,
+  ...config,
+});
+
+const labelOf = (node: ReferenceFieldSchema): string => node.label ?? node.name
+
+export const referenceSchema = (node: FieldSchema): ZodType => {
+    const field = node as ReferenceFieldSchema;
+    const schema = z.string()
+    if (field.required) {
+         return z.preprocess(
+      (value) => value ?? '',
+      schema.min(1, `${labelOf(field)} is required`)
+    );
+    }
+    return z.preprocess((value) => (value === '' || value == null ? undefined : value), schema.optional());
+    
+}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
@@ -1,14 +1,7 @@
 import { ZodType, z } from 'zod';
-import {
-  type BaseFieldSchema,
-  type FieldSchema,
-  REFERENCE_FIELD_TYPE,
-} from '../../../core/schema/types';
+import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
 
-// The key lives in core, which reads it to resolve references for the
-// preview. Re-exported so this file stays the plugin's schema surface, as
-// every other field's does.
-export { REFERENCE_FIELD_TYPE };
+export const REFERENCE_FIELD_TYPE = 'reference';
 
 export interface ReferenceFieldSchema extends BaseFieldSchema {
   type: typeof REFERENCE_FIELD_TYPE;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.schema.ts
@@ -1,7 +1,14 @@
 import { ZodType, z } from 'zod';
-import { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
+import {
+  type BaseFieldSchema,
+  type FieldSchema,
+  REFERENCE_FIELD_TYPE,
+} from '../../../core/schema/types';
 
-export const REFERENCE_FIELD_TYPE = 'reference';
+// The key lives in core, which reads it to resolve references for the
+// preview. Re-exported so this file stays the plugin's schema surface, as
+// every other field's does.
+export { REFERENCE_FIELD_TYPE };
 
 export interface ReferenceFieldSchema extends BaseFieldSchema {
   type: typeof REFERENCE_FIELD_TYPE;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.test.tsx
@@ -169,21 +169,19 @@ describe('ReferenceField value updates', () => {
   });
 
   it('clears an optional reference through the clear button', async () => {
-    const { container } = renderField({ page: ABOUT });
+    renderField({ page: ABOUT });
     const input = await screen.findByLabelText('Page');
-    const clear = container.querySelector('[data-slot="combobox-clear"]');
-    expect(clear).not.toBeNull();
-    await userEvent.click(clear as Element);
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
     expect(valueOf('page')).toBeNull();
     expect(input).toHaveValue('');
   });
 
   it('offers no clear button on a required reference', async () => {
-    const { container } = renderField({ author: ADA });
+    renderField({ author: ADA });
     await screen.findByLabelText('Author');
     expect(
-      container.querySelectorAll('[data-slot="combobox-clear"]')
-    ).toHaveLength(0);
+      screen.queryByRole('button', { name: 'Clear' })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.test.tsx
@@ -1,0 +1,264 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { asResolvedConfig } from '../../../config';
+import type {
+  ContentProvider,
+  DocumentSummary,
+} from '../../../core/content/contract';
+import { toFieldAddress } from '../../../core/field/address';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import { type PluginManifest, definePlugin } from '../../../core/plugin';
+import type {
+  CollectionSchema,
+  TinaDocument,
+} from '../../../core/schema/types';
+import { validateField } from '../../../core/validation';
+import { FormProvider, TinaProvider } from '../../../editor';
+import { toFormId, useFormStore } from '../../../form/form-store';
+import { t } from '../../../index';
+import { LabelledFields } from '../../../test/labelled-fields';
+import referenceFieldPlugin from './reference-field.plugin';
+
+const DOCUMENT_PATH = 'content/posts/featured.mdx';
+const ABOUT = 'content/pages/about.mdx';
+const CONTACT = 'content/pages/contact.mdx';
+const ADA = 'content/authors/ada.mdx';
+
+const SUMMARIES: Record<string, DocumentSummary[]> = {
+  page: [{ path: ABOUT }, { path: CONTACT }],
+  author: [{ path: ADA }],
+};
+
+const valueOf = (name: string) =>
+  useFormStore.getState().forms[toFormId(DOCUMENT_PATH)]?.values[
+    toFieldAddress(name)
+  ];
+
+const collection: CollectionSchema = {
+  name: 'post',
+  label: 'Posts',
+  format: 'mdx',
+  fields: [
+    t.reference({
+      name: 'author',
+      label: 'Author',
+      required: true,
+      collections: ['author'],
+    }),
+    t.reference({ name: 'page', label: 'Page', collections: ['page'] }),
+    t.reference({
+      name: 'related',
+      label: 'Related',
+      collections: ['page', 'author'],
+    }),
+  ],
+};
+
+const [authorNode, pageNode] = collection.fields;
+
+const contentPlugin = (
+  overrides: Partial<ContentProvider> = {}
+): PluginManifest => {
+  const provider: ContentProvider = {
+    list: vi.fn(async (name: string) => SUMMARIES[name] ?? []),
+    get: vi.fn(async () => null),
+    update: vi.fn(async (_collection, path, value) => ({
+      path,
+      document: value,
+    })),
+    ...overrides,
+  };
+  return definePlugin({
+    name: 'test:content:stub',
+    provides: ['content'],
+    client: async () => ({ default: { slice: () => ({ ...provider }) } }),
+  });
+};
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins([referenceFieldPlugin]);
+
+const renderField = (document?: TinaDocument, content = contentPlugin()) =>
+  render(
+    <TinaProvider
+      config={asResolvedConfig({
+        plugins: [referenceFieldPlugin, content],
+        schema: { collections: [collection] },
+      })}
+    >
+      <FormProvider
+        collection={collection}
+        path={DOCUMENT_PATH}
+        document={document}
+      >
+        <LabelledFields />
+      </FormProvider>
+    </TinaProvider>
+  );
+
+describe('ReferenceField rendering', () => {
+  it('shows the path of the referenced document', async () => {
+    renderField({ page: ABOUT });
+    expect(await screen.findByLabelText('Page')).toHaveValue(ABOUT);
+  });
+
+  it('shows the placeholder when the field is absent', async () => {
+    renderField();
+    expect(await screen.findByLabelText('Page')).toHaveAttribute(
+      'placeholder',
+      'Search documents…'
+    );
+  });
+});
+
+describe('ReferenceField searching', () => {
+  it('narrows the options to what was typed', async () => {
+    renderField();
+    await userEvent.type(await screen.findByLabelText('Page'), 'contact');
+    expect(await screen.findByRole('option', { name: CONTACT })).toBeVisible();
+    expect(
+      screen.queryByRole('option', { name: ABOUT })
+    ).not.toBeInTheDocument();
+  });
+
+  it('says so when nothing matches', async () => {
+    renderField();
+    await userEvent.type(await screen.findByLabelText('Page'), 'nothing');
+    expect(await screen.findByText('No documents match.')).toBeVisible();
+  });
+});
+
+describe('ReferenceField lookup', () => {
+  it('offers every document of the collection it names', async () => {
+    renderField();
+    await userEvent.click(await screen.findByLabelText('Page'));
+    expect(await screen.findByRole('option', { name: ABOUT })).toBeVisible();
+    expect(await screen.findByRole('option', { name: CONTACT })).toBeVisible();
+  });
+
+  it('draws candidates from every collection a field names', async () => {
+    renderField();
+    await userEvent.click(await screen.findByLabelText('Related'));
+    expect(await screen.findByRole('option', { name: ABOUT })).toBeVisible();
+    expect(await screen.findByRole('option', { name: ADA })).toBeVisible();
+  });
+
+  it('asks the content capability for each collection a field names', async () => {
+    const list = vi.fn(async (name: string) => SUMMARIES[name] ?? []);
+    renderField(undefined, contentPlugin({ list }));
+    await userEvent.click(await screen.findByLabelText('Related'));
+    await screen.findByRole('option', { name: ADA });
+    expect(list.mock.calls.map(([name]) => name).sort()).toEqual([
+      'author',
+      'page',
+    ]);
+  });
+});
+
+describe('ReferenceField value updates', () => {
+  it('stores the path of the chosen document', async () => {
+    renderField();
+    await userEvent.click(await screen.findByLabelText('Page'));
+    await userEvent.click(await screen.findByRole('option', { name: ABOUT }));
+    expect(valueOf('page')).toBe(ABOUT);
+  });
+
+  it('clears an optional reference through the clear button', async () => {
+    const { container } = renderField({ page: ABOUT });
+    const input = await screen.findByLabelText('Page');
+    const clear = container.querySelector('[data-slot="combobox-clear"]');
+    expect(clear).not.toBeNull();
+    await userEvent.click(clear as Element);
+    expect(valueOf('page')).toBeNull();
+    expect(input).toHaveValue('');
+  });
+
+  it('offers no clear button on a required reference', async () => {
+    const { container } = renderField({ author: ADA });
+    await screen.findByLabelText('Author');
+    expect(
+      container.querySelectorAll('[data-slot="combobox-clear"]')
+    ).toHaveLength(0);
+  });
+});
+
+describe('ReferenceField missing references', () => {
+  it('marks a stored path that no document answers', async () => {
+    renderField({ page: 'content/pages/deleted.mdx' });
+    expect(await screen.findByLabelText('Page')).toHaveValue(
+      'content/pages/deleted.mdx (missing)'
+    );
+  });
+
+  it('keeps a missing reference selectable so it is not silently dropped', async () => {
+    renderField({ page: 'content/pages/deleted.mdx' });
+    await userEvent.click(await screen.findByLabelText('Page'));
+    expect(
+      await screen.findByRole('option', {
+        name: 'content/pages/deleted.mdx (missing)',
+      })
+    ).toBeVisible();
+    expect(valueOf('page')).toBe('content/pages/deleted.mdx');
+  });
+});
+
+describe('ReferenceField validation', () => {
+  it('requires a reference to be chosen', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('reference');
+    expect(validateField(authorNode, descriptor, ADA)).toEqual([]);
+    expect(validateField(authorNode, descriptor, undefined)).toEqual([
+      'Author is required',
+    ]);
+    expect(validateField(authorNode, descriptor, '')).toEqual([
+      'Author is required',
+    ]);
+  });
+
+  it('passes an optional reference left empty', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('reference');
+    expect(validateField(pageNode, descriptor, '')).toEqual([]);
+    expect(validateField(pageNode, descriptor, undefined)).toEqual([]);
+    expect(validateField(pageNode, descriptor, null)).toEqual([]);
+  });
+});
+
+describe('ReferenceField ingest and digest', () => {
+  it('round-trips a stored path unchanged', async () => {
+    const registry = await resolveRegistry();
+    const stored = { author: ADA, page: ABOUT };
+    const ingested = ingestDocument(stored, collection.fields, { registry });
+    expect(ingested).toEqual(stored);
+    expect(digestDocument(ingested, collection.fields, { registry })).toEqual(
+      stored
+    );
+  });
+
+  it('leaves an absent reference absent', async () => {
+    const registry = await resolveRegistry();
+    expect(ingestDocument({}, collection.fields, { registry })).toEqual({});
+    expect(digestDocument({}, collection.fields, { registry })).toEqual({});
+  });
+
+  it('digests a cleared reference as absent, not literal null', async () => {
+    const registry = await resolveRegistry();
+    expect(
+      digestDocument({ page: null }, collection.fields, { registry })
+    ).toEqual({});
+  });
+});
+
+describe('ReferenceField metadata wrapping', () => {
+  it('registers the reference descriptor with its declared metadata', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('reference');
+    expect(descriptor?.metadata).toEqual({ layout: 'inline' });
+    expect(descriptor?.defaultValue).toBeUndefined();
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
@@ -1,0 +1,111 @@
+import { useQueries } from '@tanstack/react-query';
+import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@tinacms/ui/components/select';
+import { useRef } from 'react';
+import {
+  CONTENT_STALE_TIME,
+  contentKeys,
+  useContentSlice,
+  useFieldActivation,
+  useFieldAddress,
+  useFieldErrors,
+  useFieldSchema,
+  useFieldValue,
+} from '../../../editor';
+import type { ReferenceFieldSchema } from './reference-field.schema';
+
+interface ReferenceOption {
+  value: string;
+  label: string;
+}
+
+interface ReferenceOptions {
+  options: ReferenceOption[];
+  isLoading: boolean;
+  error: Error | null;
+}
+
+// `useCollectionDocuments` reads one collection, and a reference field can name
+// several. The hook order stays stable because `useQueries` takes the whole set
+// in one call.
+const useReferenceOptions = (collections: string[]): ReferenceOptions => {
+  const content = useContentSlice();
+  return useQueries({
+    queries: collections.map((collection) => ({
+      queryKey: contentKeys.list(collection),
+      queryFn: () => content.list(collection),
+      staleTime: CONTENT_STALE_TIME,
+    })),
+    combine: (results) => ({
+      options: results.flatMap(
+        (result) =>
+          result.data?.map((summary) => ({
+            value: summary.path,
+            label: summary.path,
+          })) ?? []
+      ),
+      isLoading: results.some((result) => result.isLoading),
+      error: results.find((result) => result.error)?.error ?? null,
+    }),
+  });
+};
+
+const placeholderFor = ({ isLoading, error }: ReferenceOptions): string => {
+  if (isLoading) return 'Loading…';
+  if (error) return 'Could not load documents';
+  return 'Select…';
+};
+
+export function ReferenceField() {
+  const address = useFieldAddress();
+  const field = useFieldSchema<ReferenceFieldSchema>();
+  const [value, setValue] = useFieldValue<string | null>(address);
+  const errors = useFieldErrors(address);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+
+  useFieldActivation(() => triggerRef.current?.focus());
+
+  const lookup = useReferenceOptions(field.collections);
+  const { options, isLoading, error } = lookup;
+
+  const noneItem = { value: '', label: 'None' };
+  const missingItem =
+    value && !isLoading && !error && !options.some((o) => o.value === value)
+      ? { value, label: `${value} (missing)` }
+      : null;
+
+  const items = [
+    ...(field.required ? [] : [noneItem]),
+    ...(missingItem ? [missingItem] : []),
+    ...options,
+  ];
+
+  return (
+    <FieldWrapper errors={errors}>
+      <Select
+        items={items}
+        value={value ?? null}
+        onValueChange={(newValue) =>
+          setValue(newValue === '' ? null : newValue)
+        }
+      >
+        <SelectTrigger ref={triggerRef} id={address} disabled={isLoading}>
+          <SelectValue placeholder={placeholderFor(lookup)} />
+        </SelectTrigger>
+        <SelectContent>
+          {items.map((item) => (
+            <SelectItem key={item.value} value={item.value}>
+              {item.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </FieldWrapper>
+  );
+}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
@@ -73,7 +73,7 @@ export function ReferenceField() {
 
   const lookup = useReferenceOptions(field.collections);
   console.log('field.collections', field.collections);
-  console.log('lookup' , lookup);
+  console.log('lookup', lookup);
   const { options, isLoading, error } = lookup;
 
   const noneItem = { value: '', label: 'None' };
@@ -97,7 +97,11 @@ export function ReferenceField() {
           setValue(newValue === '' ? null : newValue)
         }
       >
-        <SelectTrigger ref={triggerRef} id={address} disabled={isLoading || !!error}>
+        <SelectTrigger
+          ref={triggerRef}
+          id={address}
+          disabled={isLoading || !!error}
+        >
           <SelectValue placeholder={placeholderFor(lookup)} />
         </SelectTrigger>
         <SelectContent>

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
@@ -1,12 +1,13 @@
 import { useQueries } from '@tanstack/react-query';
-import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@tinacms/ui/components/select';
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList,
+} from '@tinacms/ui/components/combobox';
+import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
 import { useRef } from 'react';
 import {
   CONTENT_STALE_TIME,
@@ -32,8 +33,8 @@ interface ReferenceOptions {
 }
 
 // `useCollectionDocuments` reads one collection, and a reference field can name
-// several. The hook order stays stable because `useQueries` takes the whole set
-// in one call.
+// several. `useQueries` takes the whole set in one call, so the hook order
+// stays stable.
 const useReferenceOptions = (collections: string[]): ReferenceOptions => {
   const content = useContentSlice();
   return useQueries({
@@ -59,7 +60,7 @@ const useReferenceOptions = (collections: string[]): ReferenceOptions => {
 const placeholderFor = ({ isLoading, error }: ReferenceOptions): string => {
   if (isLoading) return 'Loading…';
   if (error) return 'Could not load documents';
-  return 'Select…';
+  return 'Search documents…';
 };
 
 export function ReferenceField() {
@@ -67,51 +68,51 @@ export function ReferenceField() {
   const field = useFieldSchema<ReferenceFieldSchema>();
   const [value, setValue] = useFieldValue<string | null>(address);
   const errors = useFieldErrors(address);
-  const triggerRef = useRef<HTMLButtonElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  useFieldActivation(() => triggerRef.current?.focus());
+  useFieldActivation(() => inputRef.current?.focus());
 
   const lookup = useReferenceOptions(field.collections);
-  console.log('field.collections', field.collections);
-  console.log('lookup', lookup);
   const { options, isLoading, error } = lookup;
 
-  const noneItem = { value: '', label: 'None' };
-  const missingItem =
+  // A stored path whose document is gone stays selectable, so opening the
+  // field does not silently drop the reference.
+  const missing =
     value && !isLoading && !error && !options.some((o) => o.value === value)
       ? { value, label: `${value} (missing)` }
       : null;
 
-  const items = [
-    ...(field.required ? [] : [noneItem]),
-    ...(missingItem ? [missingItem] : []),
-    ...options,
-  ];
+  const items = missing ? [missing, ...options] : options;
+  const selected = items.find((item) => item.value === value) ?? null;
+  const unusable = isLoading || error !== null;
 
   return (
-    <FieldWrapper errors={errors}>
-      <Select
+    <FieldWrapper errors={error ? [...errors, error.message] : errors}>
+      <Combobox
         items={items}
-        value={value ?? null}
-        onValueChange={(newValue) =>
-          setValue(newValue === '' ? null : newValue)
+        value={selected}
+        onValueChange={(next: ReferenceOption | null) =>
+          setValue(next?.value ?? null)
         }
       >
-        <SelectTrigger
-          ref={triggerRef}
+        <ComboboxInput
+          ref={inputRef}
           id={address}
-          disabled={isLoading || !!error}
-        >
-          <SelectValue placeholder={placeholderFor(lookup)} />
-        </SelectTrigger>
-        <SelectContent>
-          {items.map((item) => (
-            <SelectItem key={item.value} value={item.value}>
-              {item.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
+          disabled={unusable}
+          showClear={!field.required}
+          placeholder={placeholderFor(lookup)}
+        />
+        <ComboboxContent>
+          <ComboboxEmpty>No documents match.</ComboboxEmpty>
+          <ComboboxList>
+            {(item: ReferenceOption) => (
+              <ComboboxItem key={item.value} value={item}>
+                {item.label}
+              </ComboboxItem>
+            )}
+          </ComboboxList>
+        </ComboboxContent>
+      </Combobox>
     </FieldWrapper>
   );
 }

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/reference/reference-field.ui.tsx
@@ -72,6 +72,8 @@ export function ReferenceField() {
   useFieldActivation(() => triggerRef.current?.focus());
 
   const lookup = useReferenceOptions(field.collections);
+  console.log('field.collections', field.collections);
+  console.log('lookup' , lookup);
   const { options, isLoading, error } = lookup;
 
   const noneItem = { value: '', label: 'None' };
@@ -95,7 +97,7 @@ export function ReferenceField() {
           setValue(newValue === '' ? null : newValue)
         }
       >
-        <SelectTrigger ref={triggerRef} id={address} disabled={isLoading}>
+        <SelectTrigger ref={triggerRef} id={address} disabled={isLoading || !!error}>
           <SelectValue placeholder={placeholderFor(lookup)} />
         </SelectTrigger>
         <SelectContent>

--- a/packages/v4/@tinacms/ui/src/components/combobox.tsx
+++ b/packages/v4/@tinacms/ui/src/components/combobox.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+import { Combobox as ComboboxPrimitive } from '@base-ui/react';
+import { cn } from '@tinacms/ui/lib/utils';
+import * as React from 'react';
+
+import { Button } from '@tinacms/ui/components/button';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@tinacms/ui/components/input-group';
+import { CheckIcon, ChevronDownIcon, XIcon } from 'lucide-react';
+
+const Combobox = ComboboxPrimitive.Root;
+
+function ComboboxValue({ ...props }: ComboboxPrimitive.Value.Props) {
+  return <ComboboxPrimitive.Value data-slot='combobox-value' {...props} />;
+}
+
+function ComboboxTrigger({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Trigger.Props) {
+  return (
+    <ComboboxPrimitive.Trigger
+      data-slot='combobox-trigger'
+      className={cn("[&_svg:not([class*='size-'])]:size-4", className)}
+      {...props}
+    >
+      {children}
+      <ChevronDownIcon className='pointer-events-none size-4 text-muted-foreground' />
+    </ComboboxPrimitive.Trigger>
+  );
+}
+
+function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
+  return (
+    <ComboboxPrimitive.Clear
+      data-slot='combobox-clear'
+      render={<InputGroupButton variant='ghost' size='icon-xs' />}
+      className={cn(className)}
+      {...props}
+    >
+      <XIcon className='pointer-events-none' />
+    </ComboboxPrimitive.Clear>
+  );
+}
+
+function ComboboxInput({
+  className,
+  children,
+  disabled = false,
+  showTrigger = true,
+  showClear = false,
+  ...props
+}: ComboboxPrimitive.Input.Props & {
+  showTrigger?: boolean;
+  showClear?: boolean;
+}) {
+  return (
+    <InputGroup className={cn('w-auto', className)}>
+      <ComboboxPrimitive.Input
+        render={<InputGroupInput disabled={disabled} />}
+        {...props}
+      />
+      <InputGroupAddon align='inline-end'>
+        {showTrigger && (
+          <InputGroupButton
+            size='icon-xs'
+            variant='ghost'
+            render={<ComboboxTrigger />}
+            data-slot='input-group-button'
+            className='group-has-data-[slot=combobox-clear]/input-group:hidden data-pressed:bg-transparent'
+            disabled={disabled}
+          />
+        )}
+        {showClear && <ComboboxClear disabled={disabled} />}
+      </InputGroupAddon>
+      {children}
+    </InputGroup>
+  );
+}
+
+function ComboboxContent({
+  className,
+  side = 'bottom',
+  sideOffset = 6,
+  align = 'start',
+  alignOffset = 0,
+  anchor,
+  ...props
+}: ComboboxPrimitive.Popup.Props &
+  Pick<
+    ComboboxPrimitive.Positioner.Props,
+    'side' | 'align' | 'sideOffset' | 'alignOffset' | 'anchor'
+  >) {
+  return (
+    <ComboboxPrimitive.Portal>
+      <ComboboxPrimitive.Positioner
+        side={side}
+        sideOffset={sideOffset}
+        align={align}
+        alignOffset={alignOffset}
+        anchor={anchor}
+        className='isolate z-50'
+      >
+        <ComboboxPrimitive.Popup
+          data-slot='combobox-content'
+          data-chips={!!anchor}
+          className={cn(
+            'group/combobox-content relative max-h-(--available-height) w-(--anchor-width) max-w-(--available-width) min-w-[calc(var(--anchor-width)+--spacing(7))] origin-(--transform-origin) overflow-hidden rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[chips=true]:min-w-(--anchor-width) data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 *:data-[slot=input-group]:m-1 *:data-[slot=input-group]:mb-0 *:data-[slot=input-group]:h-8 *:data-[slot=input-group]:border-input/30 *:data-[slot=input-group]:bg-input/30 *:data-[slot=input-group]:shadow-none data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+            className
+          )}
+          {...props}
+        />
+      </ComboboxPrimitive.Positioner>
+    </ComboboxPrimitive.Portal>
+  );
+}
+
+function ComboboxList({ className, ...props }: ComboboxPrimitive.List.Props) {
+  return (
+    <ComboboxPrimitive.List
+      data-slot='combobox-list'
+      className={cn(
+        'no-scrollbar max-h-[min(calc(--spacing(72)---spacing(9)),calc(var(--available-height)---spacing(9)))] scroll-py-1 overflow-y-auto overscroll-contain p-1 data-empty:p-0',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxItem({
+  className,
+  children,
+  ...props
+}: ComboboxPrimitive.Item.Props) {
+  return (
+    <ComboboxPrimitive.Item
+      data-slot='combobox-item'
+      className={cn(
+        "relative flex w-full cursor-default items-center gap-2 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none data-highlighted:bg-accent data-highlighted:text-accent-foreground not-data-[variant=destructive]:data-highlighted:**:text-accent-foreground data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ComboboxPrimitive.ItemIndicator
+        render={
+          <span className='pointer-events-none absolute right-2 flex size-4 items-center justify-center' />
+        }
+      >
+        <CheckIcon className='pointer-events-none' />
+      </ComboboxPrimitive.ItemIndicator>
+    </ComboboxPrimitive.Item>
+  );
+}
+
+function ComboboxGroup({ className, ...props }: ComboboxPrimitive.Group.Props) {
+  return (
+    <ComboboxPrimitive.Group
+      data-slot='combobox-group'
+      className={cn(className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxLabel({
+  className,
+  ...props
+}: ComboboxPrimitive.GroupLabel.Props) {
+  return (
+    <ComboboxPrimitive.GroupLabel
+      data-slot='combobox-label'
+      className={cn('px-2 py-1.5 text-xs text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxCollection({ ...props }: ComboboxPrimitive.Collection.Props) {
+  return (
+    <ComboboxPrimitive.Collection data-slot='combobox-collection' {...props} />
+  );
+}
+
+function ComboboxEmpty({ className, ...props }: ComboboxPrimitive.Empty.Props) {
+  return (
+    <ComboboxPrimitive.Empty
+      data-slot='combobox-empty'
+      className={cn(
+        'hidden w-full justify-center py-2 text-center text-sm text-muted-foreground group-data-empty/combobox-content:flex',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxSeparator({
+  className,
+  ...props
+}: ComboboxPrimitive.Separator.Props) {
+  return (
+    <ComboboxPrimitive.Separator
+      data-slot='combobox-separator'
+      className={cn('-mx-1 my-1 h-px bg-border', className)}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChips({
+  className,
+  ...props
+}: React.ComponentPropsWithRef<typeof ComboboxPrimitive.Chips> &
+  ComboboxPrimitive.Chips.Props) {
+  return (
+    <ComboboxPrimitive.Chips
+      data-slot='combobox-chips'
+      className={cn(
+        'flex min-h-8 flex-wrap items-center gap-1 rounded-lg border border-input bg-transparent bg-clip-padding px-2.5 py-1 text-sm transition-colors focus-within:border-ring focus-within:ring-3 focus-within:ring-ring/50 has-aria-invalid:border-destructive has-aria-invalid:ring-3 has-aria-invalid:ring-destructive/20 has-data-[slot=combobox-chip]:px-1 dark:bg-input/30 dark:has-aria-invalid:border-destructive/50 dark:has-aria-invalid:ring-destructive/40',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function ComboboxChip({
+  className,
+  children,
+  showRemove = true,
+  ...props
+}: ComboboxPrimitive.Chip.Props & {
+  showRemove?: boolean;
+}) {
+  return (
+    <ComboboxPrimitive.Chip
+      data-slot='combobox-chip'
+      className={cn(
+        'flex h-[calc(--spacing(5.25))] w-fit items-center justify-center gap-1 rounded-sm bg-muted px-1.5 text-xs font-medium whitespace-nowrap text-foreground has-disabled:pointer-events-none has-disabled:cursor-not-allowed has-disabled:opacity-50 has-data-[slot=combobox-chip-remove]:pr-0',
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showRemove && (
+        <ComboboxPrimitive.ChipRemove
+          render={<Button variant='ghost' size='icon-xs' />}
+          className='-ml-1 opacity-50 hover:opacity-100'
+          data-slot='combobox-chip-remove'
+        >
+          <XIcon className='pointer-events-none' />
+        </ComboboxPrimitive.ChipRemove>
+      )}
+    </ComboboxPrimitive.Chip>
+  );
+}
+
+function ComboboxChipsInput({
+  className,
+  ...props
+}: ComboboxPrimitive.Input.Props) {
+  return (
+    <ComboboxPrimitive.Input
+      data-slot='combobox-chip-input'
+      className={cn('min-w-16 flex-1 outline-none', className)}
+      {...props}
+    />
+  );
+}
+
+function useComboboxAnchor() {
+  return React.useRef<HTMLDivElement | null>(null);
+}
+
+export {
+  Combobox,
+  ComboboxInput,
+  ComboboxContent,
+  ComboboxList,
+  ComboboxItem,
+  ComboboxGroup,
+  ComboboxLabel,
+  ComboboxCollection,
+  ComboboxEmpty,
+  ComboboxSeparator,
+  ComboboxChips,
+  ComboboxChip,
+  ComboboxChipsInput,
+  ComboboxTrigger,
+  ComboboxValue,
+  useComboboxAnchor,
+};

--- a/packages/v4/@tinacms/ui/src/components/combobox.tsx
+++ b/packages/v4/@tinacms/ui/src/components/combobox.tsx
@@ -40,11 +40,12 @@ function ComboboxClear({ className, ...props }: ComboboxPrimitive.Clear.Props) {
   return (
     <ComboboxPrimitive.Clear
       data-slot='combobox-clear'
+      aria-label='Clear'
       render={<InputGroupButton variant='ghost' size='icon-xs' />}
       className={cn(className)}
       {...props}
     >
-      <XIcon className='pointer-events-none' />
+      <XIcon aria-hidden='true' className='pointer-events-none' />
     </ComboboxPrimitive.Clear>
   );
 }

--- a/packages/v4/@tinacms/ui/src/components/input-group.tsx
+++ b/packages/v4/@tinacms/ui/src/components/input-group.tsx
@@ -1,0 +1,156 @@
+import { cn } from '@tinacms/ui/lib/utils';
+import { type VariantProps, cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { Button } from '@tinacms/ui/components/button';
+import { Input } from '@tinacms/ui/components/input';
+import { Textarea } from '@tinacms/ui/components/textarea';
+
+function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot='input-group'
+      role='group'
+      className={cn(
+        'group/input-group relative flex h-8 w-full min-w-0 items-center rounded-lg border border-input transition-colors outline-none in-data-[slot=combobox-content]:focus-within:border-inherit in-data-[slot=combobox-content]:focus-within:ring-0 has-disabled:bg-input/50 has-disabled:opacity-50 has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-3 has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50 has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-3 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>textarea]:h-auto dark:bg-input/30 dark:has-disabled:bg-input/80 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40 has-[>[data-align=block-end]]:[&>input]:pt-3 has-[>[data-align=block-start]]:[&>input]:pb-3 has-[>[data-align=inline-end]]:[&>input]:pr-1.5 has-[>[data-align=inline-start]]:[&>input]:pl-1.5',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        'inline-start':
+          'order-first pl-2 has-[>button]:ml-[-0.3rem] has-[>kbd]:ml-[-0.15rem]',
+        'inline-end':
+          'order-last pr-2 has-[>button]:mr-[-0.3rem] has-[>kbd]:mr-[-0.15rem]',
+        'block-start':
+          'order-first w-full justify-start px-2.5 pt-2 group-has-[>input]/input-group:pt-2 [.border-b]:pb-2',
+        'block-end':
+          'order-last w-full justify-start px-2.5 pb-2 group-has-[>input]/input-group:pb-2 [.border-t]:pt-2',
+      },
+    },
+    defaultVariants: {
+      align: 'inline-start',
+    },
+  }
+);
+
+function InputGroupAddon({
+  className,
+  align = 'inline-start',
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role='group'
+      data-slot='input-group-addon'
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest('button')) {
+          return;
+        }
+        e.currentTarget.parentElement?.querySelector('input')?.focus();
+      }}
+      {...props}
+    />
+  );
+}
+
+const inputGroupButtonVariants = cva(
+  'flex items-center gap-2 text-sm shadow-none',
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-3px)] px-1.5 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: '',
+        'icon-xs':
+          'size-6 rounded-[calc(var(--radius)-3px)] p-0 has-[>svg]:p-0',
+        'icon-sm': 'size-8 p-0 has-[>svg]:p-0',
+      },
+    },
+    defaultVariants: {
+      size: 'xs',
+    },
+  }
+);
+
+function InputGroupButton({
+  className,
+  type = 'button',
+  variant = 'ghost',
+  size = 'xs',
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, 'size' | 'type'> &
+  VariantProps<typeof inputGroupButtonVariants> & {
+    type?: 'button' | 'submit' | 'reset';
+  }) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  );
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<'span'>) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<'input'>) {
+  return (
+    <Input
+      data-slot='input-group-control'
+      className={cn(
+        'flex-1 rounded-none border-0 bg-transparent shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<'textarea'>) {
+  return (
+    <Textarea
+      data-slot='input-group-control'
+      className={cn(
+        'flex-1 resize-none rounded-none border-0 bg-transparent py-2 shadow-none ring-0 focus-visible:ring-0 disabled:bg-transparent aria-invalid:ring-0 dark:bg-transparent dark:disabled:bg-transparent',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+};

--- a/packages/v4/@tinacms/ui/src/components/textarea.tsx
+++ b/packages/v4/@tinacms/ui/src/components/textarea.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@tinacms/ui/lib/utils';
+import * as React from 'react';
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot='textarea'
+      className={cn(
+        'flex field-sizing-content min-h-16 w-full rounded-lg border border-input bg-transparent px-2.5 py-2 text-base transition-colors outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:bg-input/50 disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:disabled:bg-input/80 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40',
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/packages/v4/examples/barebones/content/pages/test.mdx
+++ b/packages/v4/examples/barebones/content/pages/test.mdx
@@ -1,0 +1,5 @@
+---
+title: sonme title
+featured: true
+---
+

--- a/packages/v4/examples/barebones/content/pages/test.mdx
+++ b/packages/v4/examples/barebones/content/pages/test.mdx
@@ -1,5 +1,5 @@
 ---
-title: sonme title
+title: Test Title
 featured: true
 ---
 

--- a/packages/v4/examples/barebones/content/posts/hello-world.mdx
+++ b/packages/v4/examples/barebones/content/posts/hello-world.mdx
@@ -7,6 +7,7 @@ authors:
   - name: Ivan
   - name: Brook
 status: draft
+pages: content/pages/test.mdx
 ---
 
 This is the barebones v4 example. Edit this prose in the admin, and the save

--- a/packages/v4/examples/barebones/src/content.ts
+++ b/packages/v4/examples/barebones/src/content.ts
@@ -23,4 +23,8 @@ export const sampleDocument = {
       },
     ],
   },
+  pages: {
+    title: 'Test Title',
+    featured: true,
+  },
 } satisfies TinaDocument;

--- a/packages/v4/examples/barebones/src/preview/post-preview.tsx
+++ b/packages/v4/examples/barebones/src/preview/post-preview.tsx
@@ -54,6 +54,10 @@ export function PostPreview() {
           {author.name}
         </p>
       ))}
+      <div style={{ backgroundColor: '#33333330', padding: '1rem' }}>
+        <p>Pages Reference: </p>
+        <span {...tinaField('pages')}>Title of File: {post?.pages?.title}</span>
+      </div>
     </article>
   );
 }

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -27,7 +27,11 @@ export const postCollection = {
       label: 'Authors',
       fields: [t.string({ name: 'name', label: 'Name' })],
     }),
-    t.reference({ collections: ['page'], name: 'pages', label: 'Pages Reference' }),
+    t.reference({
+      collections: ['page'],
+      name: 'pages',
+      label: 'Pages Reference',
+    }),
     t.select({
       name: 'status',
       label: 'Status',
@@ -38,7 +42,6 @@ export const postCollection = {
     }),
   ],
 } satisfies CollectionSchema;
-
 
 export const pageCollection = {
   name: 'page',

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -27,6 +27,7 @@ export const postCollection = {
       label: 'Authors',
       fields: [t.string({ name: 'name', label: 'Name' })],
     }),
+    t.reference({ collections: ['page'], name: 'pages', label: 'Pages Reference' }),
     t.select({
       name: 'status',
       label: 'Status',
@@ -38,7 +39,20 @@ export const postCollection = {
   ],
 } satisfies CollectionSchema;
 
+
+export const pageCollection = {
+  name: 'page',
+  label: 'Pages',
+  path: 'content/pages',
+  format: 'mdx',
+  fields: [
+    t.string({ name: 'title', label: 'Title', required: true }),
+    t.boolean({ name: 'featured', label: 'Featured' }),
+    // The custom field of this project. tina/rating-field.tsx is the whole plugin.
+  ],
+} satisfies CollectionSchema;
+
 export default defineConfig({
   plugins: [localContentPlugin(), ratingFieldPlugin],
-  schema: { collections: [postCollection] },
+  schema: { collections: [postCollection, pageCollection] },
 });

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -51,7 +51,6 @@ export const pageCollection = {
   fields: [
     t.string({ name: 'title', label: 'Title', required: true }),
     t.boolean({ name: 'featured', label: 'Featured' }),
-    // The custom field of this project. tina/rating-field.tsx is the whole plugin.
   ],
 } satisfies CollectionSchema;
 

--- a/packages/v4/examples/barebones/tina/tina-lock.json
+++ b/packages/v4/examples/barebones/tina/tina-lock.json
@@ -45,7 +45,7 @@
           {
             "type": "reference",
             "collections": [
-              "pages"
+              "page"
             ],
             "name": "pages",
             "label": "Pages Reference"

--- a/packages/v4/examples/barebones/tina/tina-lock.json
+++ b/packages/v4/examples/barebones/tina/tina-lock.json
@@ -41,8 +41,16 @@
               }
             ],
             "type": "array"
-		  },
-		  {
+          },
+          {
+            "type": "reference",
+            "collections": [
+              "pages"
+            ],
+            "name": "pages",
+            "label": "Pages Reference"
+          },
+          {
             "name": "status",
             "label": "Status",
             "options": [
@@ -58,6 +66,25 @@
             "type": "select"
           }
         ]
+      },
+      {
+        "name": "page",
+        "label": "Pages",
+        "path": "content/pages",
+        "format": "mdx",
+        "fields": [
+          {
+            "name": "title",
+            "label": "Title",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "featured",
+            "label": "Featured",
+            "type": "boolean"
+          }
+        ]
       }
     ],
     "version": {
@@ -71,6 +98,7 @@
     "array": 1,
     "boolean": 1,
     "rating": 1,
+    "reference": 1,
     "rich-text": 1,
     "select": 1,
     "string": 1


### PR DESCRIPTION
cc: —
Related PBI: https://github.com/tinacms/tinacms/issues/6921

## TL;DR

v4 had no `reference` field, so a document could not point at another document. This adds `ReferenceField` as a field plugin, and it resolves the reference for the preview so a site reads `post.author.title` while editing, not the raw path string.

**Files to review (23, +1562 / -16):**

| File | Why |
|---|---|
| `plugins/fields/reference/*` *(start here)* | The plugin: schema helper, validator, descriptor, combobox UI, 18 tests. |
| `core/form/references.ts` | Walks the schema against form values and swaps reference paths for documents. Pure, no React. |
| `editor/preview-connection.ts` | Resolves on the way out, warms the cache separately so posting stays synchronous. |
| `editor/hooks.ts` | Three accessors: the form's collection, the schema's collections, and a nullable content slice. |
| `graphql/graphql-pipeline.ts` | One line: `collections` now survives the map into v3 schema shape. |
| `@tinacms/ui/components/combobox.tsx` | shadcn combobox, plus the input-group and textarea it depends on. |

## Why

A reference stores a path (`author: content/authors/ada.md`), but a site renders the document that path names. v3 got this for free because its admin re-ran the site's GraphQL query on every edit and substituted resolved documents before streaming ([`graphql-reducer.ts:353`](https://github.com/tinacms/tinacms/blob/main/packages/%40tinacms/app/src/lib/graphql-reducer.ts)).

v4's preview posts raw form values instead, so without this the site sees two different shapes:

| | Page load | Editing |
|---|---|---|
| Before | `{ title: 'Test Title' }` | `'content/pages/test.mdx'` |
| After | `{ title: 'Test Title' }` | `{ title: 'Test Title' }` |

## How

The field itself is an ordinary plugin. The preview half is the part worth reading:

```mermaid
graph LR
    A[form values] --> B{resolveReferences}
    B -->|reads| C[react-query cache]
    B --> D[postMessage]
    A --> E[collectReferences]
    E -->|fetches what is missing| C
    C -.->|re-post on arrival| D
```

Posting reads the cache only, so a keystroke never waits on the network. A reference that has not arrived keeps its path for a frame, which the site already handles as the missing case.

## Reviewer notes

- **Options come from content, not config.** `collections` names collections; the documents come from `content.list()` at open time. A field naming several collections needs `useQueries`, since hooks cannot loop.
- **Content slice is now nullable.** `useOptionalContentSlice` exists so a preview with no content plugin degrades to bare paths instead of throwing.
- **Options are labelled by path.** `DocumentSummary` deliberately carries no content, so there is no title to show. This is where v3's `ui.optionComponent` would go.
- **shadcn generated a bad import.** `add combobox` wrote `import { cn } from "cn"` in all three files and added a junk `cn` package. Repointed at `@tinacms/ui/lib/utils`, dep removed.
- **A referenced document is not ingested.** `resolveReferences` substitutes the raw stored document, so a referenced rich-text body would arrive as markdown source, not the AST. Fine for scalars; a gap if someone renders a referenced body.

## Tests

`reference-field.test.tsx` (18) covers rendering, search, lookup across multiple collections, select, clear, missing references, validation, and the ingest/digest round trip, reading through a stub content capability.

`references.test.ts` (8) covers the walk, including references nested in array items.

`graphql-pipeline.test.ts` gains a reference resolution query. It fails with `Cannot read properties of undefined (reading 'includes')` if the `collections` passthrough is removed.

776 tests pass; typecheck clean.

<img width="1536" height="996" alt="Screenshot 2026-09-11 at 9 27 39 am" src="https://github.com/user-attachments/assets/a574678f-014f-4675-9027-af92781ba6c9" />

**Figure: UI**

---
Changes made by Claude Opus 5 (1M context) via Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
