### PR TITLE
feat(v4): add object field

### DIFF
--- a/packages/v4/@tinacms/tinacms/_docs/array-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/array-field.md
@@ -148,24 +148,11 @@ The registry is necessary: `invariant` throws `array-field-no-registry` if
 already-installed tool for exactly this job, with stable item keys so React
 does not misalign inputs across a reorder.
 
-For each item, for each item field, it renders a row — a `<label>` pointing at
-the item field's own nested address (unless that field's descriptor sets
-`labelable: false` too), then `<FieldNode address node>`:
-
-```tsx
-function ItemFieldRow({ address, node }: { address: string; node: FieldSchema }) {
-  const labelable =
-    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
-  return (
-    <div>
-      <Label id={`${address}-label`} htmlFor={labelable ? address : undefined}>
-        {node.label ?? node.name}
-      </Label>
-      <FieldNode address={toFieldAddress(address)} node={node} />
-    </div>
-  );
-}
-```
+For each item, for each item field, it renders `<NestedFieldRow address node>`
+(`editor/field.tsx`) — a `<Label>` pointing at the item field's own nested
+address (unless that field's descriptor sets `labelable: false` too), then
+`<FieldNode address node>`. `object` renders the same row, so the row is
+shared, not copied per field.
 
 `<FieldNode>` (`editor/field.tsx`) is the part of `<Field>` that resolves a
 descriptor and supplies `FieldAddressContext`/`FieldSchemaContext` — it does

--- a/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
@@ -45,6 +45,9 @@ v4 supplies four more examples:
   of item fields. Its items reuse the ordinary field contract through
   `<FieldNode>` and `validateField` — see
   [Compound fields](#compound-fields) below.
+- The `object` field ([`object-field.md`](./object-field.md)) groups a fixed
+  set of nested fields under one name. It is the `array` field without the
+  repetition, and it uses the same compound-field mechanism.
 - The `select` field ([`select-field.md`](./select-field.md)) picks one value
   from a fixed `options` list. Its Zod validator is a `z.enum` with a custom
   `errorMap`, and it has no `defaultValue`, `parse`, or `serialize`.

--- a/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/field-plugins.md
@@ -254,9 +254,11 @@ need three extra pieces. Each one has a plain, ordinary counterpart; refer to
 
 - **Rendering** — `<FieldNode address node>` (`editor/field.tsx`) renders one
   resolved node at an address, the same way `<Field>` does after it resolves a
-  node by name. A compound field's component calls `<FieldNode>` directly,
-  once for each item field, with a nested address such as `items.0.title`.
-  Export it from your own component the same way `array-field.ui.tsx` does.
+  node by name. A compound field's component renders one child field per row
+  with `<NestedFieldRow address node>` (`editor/field.tsx`) — the label and
+  `<FieldNode>` pair, with a nested address such as `items.0.title`. `array`
+  and `object` both use it; a new compound field imports it, it does not copy
+  it.
 - **Parse and serialize** — `context.registry` (`FieldTransformContext`,
   `core/field/contract.ts`) carries the registry into `parse` and `serialize`.
   A compound field's `parse`/`serialize` calls `ingestDocument`/

--- a/packages/v4/@tinacms/tinacms/_docs/object-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/object-field.md
@@ -1,0 +1,173 @@
+# The `object` field
+
+The `object` field is one of the field plugins that v4 supplies. It groups a
+fixed set of nested fields under one name. It is a compound field — see
+[field-plugins.md](./field-plugins.md#compound-fields) for the shared
+mechanism it uses.
+
+The `object` field is the `array` field without the repetition. It holds one
+group, not a list of groups, so it has no add, remove, or reorder.
+
+## Files
+
+The four files are in `plugins/fields/object/`:
+
+| File | Role |
+|---|---|
+| `object-field.schema.ts` | The `t.object()` helper function, and the `objectSchema` validator |
+| `object-field.client.tsx` | The descriptor, which takes the `object` key |
+| `object-field.ui.tsx` | The `ObjectField` component, and its field row |
+| `object-field.plugin.ts` | The manifest, `tina:field:object` |
+
+## Authoring
+
+`t.object({...})` adds `type: 'object'` (`OBJECT_FIELD_TYPE`) to the config. Its
+`fields` property is an ordinary array of `FieldSchema` nodes, the same shape a
+collection uses for its own `fields`:
+
+```ts
+import { t } from '@tinacms/tinacms';
+
+const collection = {
+  name: 'page',
+  fields: [
+    t.object({
+      name: 'seo',
+      label: 'SEO',
+      fields: [
+        t.string({ name: 'title', label: 'Title', required: true }),
+        t.string({ name: 'description', label: 'Description' }),
+      ],
+    }),
+  ],
+};
+```
+
+`ObjectFieldSchema` extends `BaseFieldSchema`. It adds one property:
+
+| Key | Type | Effect |
+|---|---|---|
+| `fields` | `FieldSchema[]` (required) | the nested fields, keyed by each field's own `name` |
+
+The stored value is a plain object, keyed by each nested field's own `name`.
+
+## The descriptor
+
+The client segment (`object-field.client.tsx`) takes the `object` key:
+
+```tsx
+defineClientPlugin({
+  field: {
+    Component: ObjectField,
+    // No defaultValue — an absent field stays absent, same as array.
+    metadata: { layout: 'block', labelable: false },
+    schema: objectSchema,
+    parse, serialize,       // recurse into nested fields — see below
+    validateChildren,       // recurse into nested fields, at any depth — see below
+  },
+});
+```
+
+`metadata.labelable: false` because the field has no single input for a row's
+`htmlFor` to reach. The component carries its own accessible name with
+`aria-labelledby` instead — see
+[Accessibility](../../../CLAUDE.md#accessibility) in the v4 CLAUDE.md.
+
+## Validation
+
+`objectSchema(node)` checks the value's own shape only — it must be an object.
+`required` adds a floor: the object must hold at least one key.
+
+| Config | Rule | Message |
+|---|---|---|
+| `required` | an empty or absent object | `<label> is required` |
+
+Each nested field's own rules run through `validateChildren(value, node,
+address, registry)`, which calls `validateFieldTree(subfield, descriptor,
+value[subfield.name], \`${address}.${subfield.name}\`, registry)`
+(`core/validation.ts`) for every nested field, and merges what it returns. It
+builds each nested address from its own `address` parameter, not `node.name` —
+an object nested inside another object is not addressed by its bare name
+(`social`), only by where it actually sits (`seo.social`).
+
+`validateFieldTree` runs `validateField` for the nested field, then — because a
+nested field can itself be an `object` or an `array` — calls that field's own
+`validateChildren` too, passing its own nested address down. So an object
+nested in an object, or an array of objects, validates at any depth without
+either field's code knowing the other exists. Refer to
+[field-plugins.md](./field-plugins.md#compound-fields).
+
+A nested field's message also reaches the object's own address through
+`useFieldErrors` (`editor/hooks.ts`), the same way it does for the `array`
+field.
+
+## Ingest and digest
+
+`parse` and `serialize` recurse: `parse` calls `ingestDocument(stored,
+field.fields, context)` (`core/form/ingest.ts`); `serialize` calls
+`digestDocument(value, field.fields, context)`. Both read the registry from
+`context.registry` (`FieldTransformContext`, `core/field/contract.ts`), which
+the form provider and the save path set. Thus a nested field with its own
+`parse`/`serialize` — a nested `number` field, for example — converts the same
+way it would at the top level.
+
+`parse` reads a `null` stored value as an empty object, the same way the
+`array` field reads `null` as an empty list.
+
+## The component
+
+`ObjectField` (`object-field.ui.tsx`) renders every nested field, always. An
+absent stored value does not hide the nested fields — each nested field
+resolves its own absent value and shows an empty control.
+
+For each nested field, it renders a row — a `<label>` pointing at the nested
+field's own address (unless that field's descriptor sets `labelable: false`
+too), then `<FieldNode address node>`:
+
+```tsx
+function ObjectFieldRow({ address, node }: { address: string; node: FieldSchema }) {
+  const labelable =
+    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
+  return (
+    <div>
+      <Label id={`${address}-label`} htmlFor={labelable ? address : undefined}>
+        {node.label ?? node.name}
+      </Label>
+      <FieldNode address={toFieldAddress(address)} node={node} />
+    </div>
+  );
+}
+```
+
+`<FieldNode>` (`editor/field.tsx`) is the part of `<Field>` that resolves a
+descriptor and supplies `FieldAddressContext`/`FieldSchemaContext`. It does not
+look the node up by name, so it accepts a node that lives outside the
+collection schema. A nested field's own `useFieldActivation` works for visual
+editing for the same reason.
+
+## The connections
+
+- The manifest is `object-field.plugin.ts`. Its name is `tina:field:object`,
+  and it exports `objectFieldPlugin`.
+- The registration is in `plugins/fields/index.ts`. That file adds the plugin
+  to `corePlugins`, and it supplies `t.object`.
+
+## Tests
+
+`object-field.test.tsx` does these tests:
+
+- It renders each nested field with its own label and value.
+- It writes an edit to a nested field back through the store at its nested
+  address.
+- It rejects an empty value on a required object field.
+- It rejects an invalid nested field value, with the message at the nested
+  field's own address.
+- It recurses into an object nested inside an object, with the message at the
+  doubly-nested address, via a direct `validateChildren` call.
+- It rolls a nested field's error up onto the object's own address.
+- It goes dirty on a nested edit, then back to clean once the edit is undone.
+- It round-trips the object through ingest and digest, including a nested field
+  with its own `parse`/`serialize`.
+- It reads a `null` stored value as an empty object.
+- It refuses stored content that is not an object.
+- It examines the metadata of the descriptor.

--- a/packages/v4/@tinacms/tinacms/_docs/object-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/object-field.md
@@ -150,6 +150,9 @@ editing for the same reason.
   field's own address.
 - It recurses into an object nested inside an object, with the message at the
   doubly-nested address, via a direct `validateChildren` call.
+- It composes with the `array` field both ways: it round-trips an object
+  nested in an array, and an array nested in an object, through ingest and
+  digest, and it recurses validation through an array nested in an object.
 - It rolls a nested field's error up onto the object's own address.
 - It goes dirty on a nested edit, then back to clean once the edit is undone.
 - It round-trips the object through ingest and digest, including a nested field

--- a/packages/v4/@tinacms/tinacms/_docs/object-field.md
+++ b/packages/v4/@tinacms/tinacms/_docs/object-field.md
@@ -120,24 +120,10 @@ way it would at the top level.
 absent stored value does not hide the nested fields — each nested field
 resolves its own absent value and shows an empty control.
 
-For each nested field, it renders a row — a `<label>` pointing at the nested
-field's own address (unless that field's descriptor sets `labelable: false`
-too), then `<FieldNode address node>`:
-
-```tsx
-function ObjectFieldRow({ address, node }: { address: string; node: FieldSchema }) {
-  const labelable =
-    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
-  return (
-    <div>
-      <Label id={`${address}-label`} htmlFor={labelable ? address : undefined}>
-        {node.label ?? node.name}
-      </Label>
-      <FieldNode address={toFieldAddress(address)} node={node} />
-    </div>
-  );
-}
-```
+For each nested field, it renders `<NestedFieldRow address node>`
+(`editor/field.tsx`) — the shared row that `array` also uses: a `<Label>`
+pointing at the nested field's own address (unless that field's descriptor
+sets `labelable: false` too), then `<FieldNode address node>`.
 
 `<FieldNode>` (`editor/field.tsx`) is the part of `<Field>` that resolves a
 descriptor and supplies `FieldAddressContext`/`FieldSchemaContext`. It does not

--- a/packages/v4/@tinacms/tinacms/_docs/plugins.md
+++ b/packages/v4/@tinacms/tinacms/_docs/plugins.md
@@ -56,6 +56,7 @@ same time, one plugin for each schema `type` such as `string` or `image`.
   - [The `datetime` field](./datetime-field.md) — the datetime-local input that
     v4 supplies
   - [The `array` field](./array-field.md) — the repeatable field that v4 supplies
+  - [The `object` field](./object-field.md) — the field group that v4 supplies
   - [The `select` field](./select-field.md) — the fixed-option picker that v4
     supplies
   - [The `rich-text` field](./rich-text-field.md) — the Plate editor that v4

--- a/packages/v4/@tinacms/tinacms/src/editor/field.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/field.tsx
@@ -1,3 +1,4 @@
+import { Label } from '@tinacms/ui/components/label';
 import { use } from 'react';
 import type { FieldAddress } from '../core/field/address';
 import { toFieldAddress } from '../core/field/address';
@@ -49,6 +50,33 @@ export function FieldNode({ address, node }: FieldNodeProps) {
         </div>
       </FieldSchemaContext>
     </FieldAddressContext>
+  );
+}
+
+export interface NestedFieldRowProps {
+  address: string;
+  node: FieldSchema;
+}
+
+// The label + <FieldNode> pair a compound field (array, object) renders for
+// each of its child fields. A child whose descriptor sets `labelable: false`
+// gets no `htmlFor` — its widget reads the row's label id through
+// `aria-labelledby` instead.
+export function NestedFieldRow({ address, node }: NestedFieldRowProps) {
+  const runtime = use(TinaRuntimeContext);
+  const labelable =
+    runtime?.registry.get(node.type)?.metadata?.labelable !== false;
+  return (
+    <div className='mb-3 min-w-0 last:mb-0'>
+      <Label
+        className='mb-1'
+        id={`${address}-label`}
+        htmlFor={labelable ? address : undefined}
+      >
+        {node.label ?? node.name}
+      </Label>
+      <FieldNode address={toFieldAddress(address)} node={node} />
+    </div>
   );
 }
 

--- a/packages/v4/@tinacms/tinacms/src/editor/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/editor/index.ts
@@ -16,6 +16,8 @@ export {
   FieldNode,
   type FieldNodeProps,
   type FieldProps,
+  NestedFieldRow,
+  type NestedFieldRowProps,
 } from './field';
 export {
   FormProvider,

--- a/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/editor/provider.test.tsx
@@ -39,7 +39,7 @@ describe('TinaProvider boot', () => {
       </TinaProvider>
     );
     expect(await screen.findByTestId('field-types')).toHaveTextContent(
-      'array,boolean,datetime,number,rich-text,select,string'
+      'array,boolean,datetime,number,object,rich-text,select,string'
     );
     expect(screen.getByTestId('namespaces')).toHaveTextContent(
       'branch,documents,ui'

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/array/array-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/array/array-field.ui.tsx
@@ -1,12 +1,10 @@
 import { Button } from '@tinacms/ui/components/button';
 import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
-import { Label } from '@tinacms/ui/components/label';
 import { useFieldArray, useFormContext } from 'react-hook-form';
-import { toFieldAddress } from '../../../core/field/address';
 import { ingestDocument } from '../../../core/form/ingest';
-import type { FieldSchema, TinaDocument } from '../../../core/schema/types';
+import type { TinaDocument } from '../../../core/schema/types';
 import {
-  FieldNode,
+  NestedFieldRow,
   useDocumentPath,
   useFieldAddress,
   useFieldErrors,
@@ -14,29 +12,6 @@ import {
   useFieldSchema,
 } from '../../../editor';
 import { asArrayFieldSchema } from './array-field.schema';
-
-function ItemFieldRow({
-  address,
-  node,
-}: {
-  address: string;
-  node: FieldSchema;
-}) {
-  const labelable =
-    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
-  return (
-    <div className='mb-3 min-w-0 last:mb-0'>
-      <Label
-        className='mb-1'
-        id={`${address}-label`}
-        htmlFor={labelable ? address : undefined}
-      >
-        {node.label ?? node.name}
-      </Label>
-      <FieldNode address={toFieldAddress(address)} node={node} />
-    </div>
-  );
-}
 
 export function ArrayField() {
   const address = useFieldAddress();
@@ -103,7 +78,7 @@ export function ArrayField() {
               </div>
             </div>
             {field.fields.map((subfield) => (
-              <ItemFieldRow
+              <NestedFieldRow
                 key={subfield.name}
                 address={`${address}.${index}.${subfield.name}`}
                 node={subfield}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/index.ts
@@ -6,6 +6,8 @@ import datetimeFieldPlugin from './datetime/datetime-field.plugin';
 import { datetime } from './datetime/datetime-field.schema';
 import numberFieldPlugin from './number/number-field.plugin';
 import { number } from './number/number-field.schema';
+import objectFieldPlugin from './object/object-field.plugin';
+import { object } from './object/object-field.schema';
 import richTextFieldPlugin from './rich-text/rich-text-field.plugin';
 import { richText } from './rich-text/rich-text-field.schema';
 import selectFieldPlugin from './select/select-field.plugin';
@@ -19,17 +21,28 @@ export const corePlugins = [
   numberFieldPlugin,
   datetimeFieldPlugin,
   arrayFieldPlugin,
+  objectFieldPlugin,
   selectFieldPlugin,
   richTextFieldPlugin,
 ];
 
 // TODO: build `t` from the configured plugin set when defineConfig arrives
-export const t = { string, boolean, number, datetime, select, array, richText };
+export const t = {
+  string,
+  boolean,
+  number,
+  datetime,
+  select,
+  array,
+  object,
+  richText,
+};
 
 export type { ArrayFieldSchema } from './array/array-field.schema';
 export type { BooleanFieldSchema } from './boolean/boolean-field.schema';
 export type { DatetimeFieldSchema } from './datetime/datetime-field.schema';
 export type { NumberFieldSchema } from './number/number-field.schema';
+export type { ObjectFieldSchema } from './object/object-field.schema';
 export type { RichTextFieldSchema } from './rich-text/rich-text-field.schema';
 export type {
   SelectFieldOption,

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.client.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.client.tsx
@@ -1,0 +1,61 @@
+import { defineClientPlugin } from '../../../client';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import { invariant } from '../../../core/invariant';
+import type { TinaDocument } from '../../../core/schema/types';
+import { validateFieldTree } from '../../../core/validation';
+import { asObjectFieldSchema, objectSchema } from './object-field.schema';
+import { ObjectField } from './object-field.ui';
+
+const isPlainObject = (value: unknown): value is TinaDocument =>
+  value != null && typeof value === 'object' && !Array.isArray(value);
+
+// Refuse content that is not an object. Coercing it to `{}` here means the next
+// save writes that `{}` back over whatever the file held.
+const asObjectValue = (stored: unknown, name: string): TinaDocument => {
+  if (stored == null) return {};
+  invariant(
+    isPlainObject(stored),
+    'object-field-content-invalid',
+    `The object field "${name}" expected an object in the stored content.`
+  );
+  return stored;
+};
+
+export default defineClientPlugin({
+  field: {
+    Component: ObjectField,
+    metadata: { layout: 'block', labelable: false },
+    schema: objectSchema,
+    parse: (stored: unknown, node, context) => {
+      const field = asObjectFieldSchema(node);
+      return ingestDocument(
+        asObjectValue(stored, node.name),
+        field.fields,
+        context
+      );
+    },
+    serialize: (value: TinaDocument, node, context) => {
+      const field = asObjectFieldSchema(node);
+      return digestDocument(value, field.fields, context);
+    },
+    validateChildren: (value: TinaDocument, node, address, registry) => {
+      const field = asObjectFieldSchema(node);
+      const object = isPlainObject(value) ? value : {};
+      const errors: Record<string, string[]> = {};
+      for (const subfield of field.fields) {
+        const descriptor = registry.get(subfield.type);
+        Object.assign(
+          errors,
+          validateFieldTree(
+            subfield,
+            descriptor,
+            object[subfield.name],
+            `${address}.${subfield.name}`,
+            registry
+          )
+        );
+      }
+      return errors;
+    },
+  },
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.plugin.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.plugin.ts
@@ -1,0 +1,11 @@
+import { definePlugin } from '../../../core/plugin';
+import { OBJECT_FIELD_TYPE } from './object-field.schema';
+
+export const objectFieldPlugin = definePlugin({
+  name: 'tina:field:object',
+  provides: ['field'],
+  field: { type: OBJECT_FIELD_TYPE, contractVersion: 1 },
+  client: () => import('./object-field.client'),
+});
+
+export default objectFieldPlugin;

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.schema.ts
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.schema.ts
@@ -1,0 +1,42 @@
+import { type ZodType, z } from 'zod';
+import { invariant } from '../../../core/invariant';
+import type { BaseFieldSchema, FieldSchema } from '../../../core/schema/types';
+
+export const OBJECT_FIELD_TYPE = 'object';
+
+export interface ObjectFieldSchema extends BaseFieldSchema {
+  type: typeof OBJECT_FIELD_TYPE;
+  fields: FieldSchema[];
+}
+
+export const object = (
+  config: Omit<ObjectFieldSchema, 'type'>
+): ObjectFieldSchema => ({ ...config, type: OBJECT_FIELD_TYPE });
+
+// A raw config or codegen output reaches the descriptor as a bare `FieldSchema`.
+// Narrow it here so a node with no `fields` fails loudly, not later on `.map`.
+export const asObjectFieldSchema = (node: FieldSchema): ObjectFieldSchema => {
+  invariant(
+    node.type === OBJECT_FIELD_TYPE &&
+      Array.isArray((node as ObjectFieldSchema).fields),
+    'object-field-schema-invalid',
+    `The object field "${node.name}" needs a "fields" array.`
+  );
+  return node as ObjectFieldSchema;
+};
+
+const labelOf = (node: ObjectFieldSchema): string => node.label ?? node.name;
+
+export const objectSchema = (node: FieldSchema): ZodType => {
+  const field = asObjectFieldSchema(node);
+  const base = z.record(z.string(), z.unknown());
+  if (field.required) {
+    return z.preprocess(
+      (value) => value ?? {},
+      base.refine((value) => Object.keys(value).length > 0, {
+        message: `${labelOf(field)} is required`,
+      })
+    );
+  }
+  return z.preprocess((value) => value ?? {}, base);
+};

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.test.tsx
@@ -1,0 +1,238 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it } from 'vitest';
+import { asResolvedConfig } from '../../../config';
+import { toFieldAddress } from '../../../core/field/address';
+import {
+  type FieldRegistry,
+  resolveFieldPlugins,
+} from '../../../core/field/registry';
+import { digestDocument, ingestDocument } from '../../../core/form/ingest';
+import type {
+  CollectionSchema,
+  FieldSchema,
+  TinaDocument,
+} from '../../../core/schema/types';
+import { validateField } from '../../../core/validation';
+import { FormProvider, TinaProvider } from '../../../editor';
+import { formStatus, toFormId, useFormStore } from '../../../form/form-store';
+import { t } from '../../../index';
+import { LabelledFields } from '../../../test/labelled-fields';
+import numberFieldPlugin from '../number/number-field.plugin';
+import stringFieldPlugin from '../string/string-field.plugin';
+import objectFieldPlugin from './object-field.plugin';
+import { asObjectFieldSchema } from './object-field.schema';
+
+const NO_COLLECTIONS = { collections: [] };
+const DOCUMENT_PATH = 'content/pages/home.mdx';
+const PLUGINS = [objectFieldPlugin, stringFieldPlugin, numberFieldPlugin];
+
+const valueOf = (name: string) =>
+  useFormStore.getState().forms[toFormId(DOCUMENT_PATH)]?.values[
+    toFieldAddress(name)
+  ];
+
+const status = () =>
+  formStatus(useFormStore.getState().forms[toFormId(DOCUMENT_PATH)]);
+
+const collection: CollectionSchema = {
+  name: 'page',
+  label: 'Pages',
+  format: 'mdx',
+  fields: [
+    t.object({
+      name: 'seo',
+      label: 'SEO',
+      required: true,
+      fields: [
+        t.string({ name: 'title', label: 'Title', required: true }),
+        t.number({ name: 'views', label: 'Views' }),
+      ],
+    }),
+    t.object({
+      name: 'meta',
+      label: 'Meta',
+      fields: [
+        t.object({
+          name: 'social',
+          label: 'Social',
+          fields: [
+            t.string({ name: 'handle', label: 'Handle', required: true }),
+          ],
+        }),
+      ],
+    }),
+  ],
+};
+
+const [seoNode, metaNode] = collection.fields;
+
+const resolveRegistry = (): Promise<FieldRegistry> =>
+  resolveFieldPlugins(PLUGINS);
+
+const renderField = (document?: TinaDocument) =>
+  render(
+    <TinaProvider
+      config={asResolvedConfig({ plugins: PLUGINS, schema: NO_COLLECTIONS })}
+    >
+      <FormProvider
+        collection={collection}
+        path={DOCUMENT_PATH}
+        document={document}
+      >
+        <LabelledFields />
+      </FormProvider>
+    </TinaProvider>
+  );
+
+describe('ObjectField rendering', () => {
+  it('renders each nested field with its own label and value', async () => {
+    renderField({ seo: { title: 'Home', views: 10 } });
+    const title = (await screen.findByLabelText('Title')) as HTMLInputElement;
+    const views = (await screen.findByLabelText('Views')) as HTMLInputElement;
+    expect(title.value).toBe('Home');
+    expect(views.value).toBe('10');
+  });
+
+  it('renders the nested fields even when the object is absent', async () => {
+    renderField();
+    const title = (await screen.findByLabelText('Title')) as HTMLInputElement;
+    expect(title.value).toBe('');
+  });
+
+  it('renders an object nested inside an object', async () => {
+    renderField({ meta: { social: { handle: '@tina' } } });
+    const handle = (await screen.findByLabelText('Handle')) as HTMLInputElement;
+    expect(handle.value).toBe('@tina');
+  });
+});
+
+describe('ObjectField value updates', () => {
+  it('writes a nested field edit back through the store', async () => {
+    renderField({ seo: { title: 'Home' } });
+    const title = await screen.findByLabelText('Title');
+    await userEvent.clear(title);
+    await userEvent.type(title, 'About');
+    expect(valueOf('seo')).toEqual({ title: 'About' });
+  });
+});
+
+describe('ObjectField dirty tracking', () => {
+  it('goes dirty on a nested edit, then back to clean once it is undone', async () => {
+    renderField({ seo: { title: 'Home' } });
+    const title = await screen.findByLabelText('Title');
+    expect(status()).toBe('pristine');
+
+    await userEvent.type(title, '!');
+    expect(status()).toBe('dirty');
+
+    await userEvent.clear(title);
+    await userEvent.type(title, 'Home');
+    expect(valueOf('seo')).toEqual({ title: 'Home' });
+    expect(status()).toBe('clean');
+  });
+});
+
+describe('ObjectField validation', () => {
+  it('rejects an empty value on a required object field', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('object');
+    expect(validateField(seoNode, descriptor, { title: 'Home' })).toEqual([]);
+    expect(validateField(seoNode, descriptor, {})).toEqual(['SEO is required']);
+    expect(validateField(seoNode, descriptor, undefined)).toEqual([
+      'SEO is required',
+    ]);
+  });
+
+  it("validates each nested field and keys messages by the field's nested address", async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('object');
+    const errors = descriptor?.validateChildren?.(
+      { title: '', views: 10 },
+      seoNode,
+      'seo',
+      registry
+    );
+    expect(errors).toEqual({ 'seo.title': ['Title is required'] });
+  });
+
+  it('recurses into an object nested inside an object', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('object');
+    const errors = descriptor?.validateChildren?.(
+      { social: { handle: '' } },
+      metaNode,
+      'meta',
+      registry
+    );
+    expect(errors).toEqual({ 'meta.social.handle': ['Handle is required'] });
+  });
+
+  it('surfaces a nested field error at its own address, and rolls it up onto the object', async () => {
+    renderField({ seo: { title: 'Home' } });
+    const title = await screen.findByLabelText('Title');
+    await userEvent.clear(title);
+    await waitFor(() => expect(screen.getAllByRole('alert')).toHaveLength(2));
+    for (const alert of screen.getAllByRole('alert')) {
+      expect(alert).toHaveTextContent('Title is required');
+    }
+  });
+});
+
+describe('ObjectField ingest and digest', () => {
+  it('recurses into nested fields, including one with its own parse/serialize', async () => {
+    const registry = await resolveRegistry();
+    const stored = { seo: { title: 'Home', views: 10 } };
+    const ingested = ingestDocument(stored, collection.fields, { registry });
+    expect(ingested).toEqual({ seo: { title: 'Home', views: '10' } });
+    expect(digestDocument(ingested, collection.fields, { registry })).toEqual(
+      stored
+    );
+  });
+
+  it('leaves an absent object absent (no default seeding)', async () => {
+    const registry = await resolveRegistry();
+    expect(ingestDocument({}, collection.fields, { registry })).toEqual({});
+    expect(digestDocument({}, collection.fields, { registry })).toEqual({});
+  });
+
+  it('reads null as an empty object', async () => {
+    const registry = await resolveRegistry();
+    expect(
+      ingestDocument({ meta: null }, collection.fields, { registry })
+    ).toEqual({ meta: {} });
+  });
+
+  it('refuses stored content that is not an object', async () => {
+    const registry = await resolveRegistry();
+    for (const bad of ['oops', 42, true, ['Home']]) {
+      expect(() =>
+        ingestDocument({ seo: bad }, collection.fields, { registry })
+      ).toThrow(/expected an object/);
+    }
+  });
+});
+
+describe('asObjectFieldSchema', () => {
+  it('throws on an object node with no fields rather than passing it through', () => {
+    const node = { name: 'seo', type: 'object' } as FieldSchema;
+    expect(() => asObjectFieldSchema(node)).toThrow(/needs a "fields" array/);
+  });
+
+  it('returns the narrowed node when fields is present', () => {
+    const node = { name: 'seo', type: 'object', fields: [] } as FieldSchema;
+    expect(asObjectFieldSchema(node).fields).toEqual([]);
+  });
+});
+
+describe('ObjectField metadata', () => {
+  it('registers the object descriptor with its declared metadata', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('object');
+    expect(descriptor?.metadata).toEqual({
+      layout: 'block',
+      labelable: false,
+    });
+    expect(descriptor?.defaultValue).toBeUndefined();
+  });
+});

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.test.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.test.tsx
@@ -18,6 +18,7 @@ import { FormProvider, TinaProvider } from '../../../editor';
 import { formStatus, toFormId, useFormStore } from '../../../form/form-store';
 import { t } from '../../../index';
 import { LabelledFields } from '../../../test/labelled-fields';
+import arrayFieldPlugin from '../array/array-field.plugin';
 import numberFieldPlugin from '../number/number-field.plugin';
 import stringFieldPlugin from '../string/string-field.plugin';
 import objectFieldPlugin from './object-field.plugin';
@@ -25,7 +26,12 @@ import { asObjectFieldSchema } from './object-field.schema';
 
 const NO_COLLECTIONS = { collections: [] };
 const DOCUMENT_PATH = 'content/pages/home.mdx';
-const PLUGINS = [objectFieldPlugin, stringFieldPlugin, numberFieldPlugin];
+const PLUGINS = [
+  objectFieldPlugin,
+  arrayFieldPlugin,
+  stringFieldPlugin,
+  numberFieldPlugin,
+];
 
 const valueOf = (name: string) =>
   useFormStore.getState().forms[toFormId(DOCUMENT_PATH)]?.values[
@@ -62,10 +68,33 @@ const collection: CollectionSchema = {
         }),
       ],
     }),
+    t.array({
+      name: 'blocks',
+      label: 'Blocks',
+      fields: [
+        t.object({
+          name: 'hero',
+          label: 'Hero',
+          fields: [t.number({ name: 'height', label: 'Height' })],
+        }),
+      ],
+    }),
+    t.object({
+      name: 'layout',
+      label: 'Layout',
+      fields: [
+        t.array({
+          name: 'rows',
+          label: 'Rows',
+          fields: [t.string({ name: 'label', label: 'Label', required: true })],
+        }),
+      ],
+    }),
   ],
 };
 
 const [seoNode, metaNode] = collection.fields;
+const layoutNode = collection.fields[3];
 
 const resolveRegistry = (): Promise<FieldRegistry> =>
   resolveFieldPlugins(PLUGINS);
@@ -210,6 +239,42 @@ describe('ObjectField ingest and digest', () => {
         ingestDocument({ seo: bad }, collection.fields, { registry })
       ).toThrow(/expected an object/);
     }
+  });
+});
+
+describe('ObjectField composed with array', () => {
+  it('round-trips an object nested inside an array', async () => {
+    const registry = await resolveRegistry();
+    const stored = { blocks: [{ hero: { height: 10 } }] };
+    const ingested = ingestDocument(stored, collection.fields, { registry });
+    expect(ingested).toEqual({ blocks: [{ hero: { height: '10' } }] });
+    expect(digestDocument(ingested, collection.fields, { registry })).toEqual(
+      stored
+    );
+  });
+
+  it('round-trips an array nested inside an object', async () => {
+    const registry = await resolveRegistry();
+    const stored = {
+      layout: { rows: [{ label: 'top' }, { label: 'bottom' }] },
+    };
+    const ingested = ingestDocument(stored, collection.fields, { registry });
+    expect(ingested).toEqual(stored);
+    expect(digestDocument(ingested, collection.fields, { registry })).toEqual(
+      stored
+    );
+  });
+
+  it('recurses validation through an array nested inside an object', async () => {
+    const registry = await resolveRegistry();
+    const descriptor = registry.get('object');
+    const errors = descriptor?.validateChildren?.(
+      { rows: [{ label: 'ok' }, { label: '' }] },
+      layoutNode,
+      'layout',
+      registry
+    );
+    expect(errors).toEqual({ 'layout.rows.1.label': ['Label is required'] });
   });
 });
 

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.ui.tsx
@@ -1,38 +1,11 @@
 import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
-import { Label } from '@tinacms/ui/components/label';
-import { toFieldAddress } from '../../../core/field/address';
-import type { FieldSchema } from '../../../core/schema/types';
 import {
-  FieldNode,
+  NestedFieldRow,
   useFieldAddress,
   useFieldErrors,
-  useFieldRegistry,
   useFieldSchema,
 } from '../../../editor';
 import { asObjectFieldSchema } from './object-field.schema';
-
-function ObjectFieldRow({
-  address,
-  node,
-}: {
-  address: string;
-  node: FieldSchema;
-}) {
-  const labelable =
-    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
-  return (
-    <div className='mb-3 min-w-0 last:mb-0'>
-      <Label
-        className='mb-1'
-        id={`${address}-label`}
-        htmlFor={labelable ? address : undefined}
-      >
-        {node.label ?? node.name}
-      </Label>
-      <FieldNode address={toFieldAddress(address)} node={node} />
-    </div>
-  );
-}
 
 export function ObjectField() {
   const address = useFieldAddress();
@@ -47,7 +20,7 @@ export function ObjectField() {
         className='rounded-md border p-3'
       >
         {field.fields.map((subfield) => (
-          <ObjectFieldRow
+          <NestedFieldRow
             key={subfield.name}
             address={`${address}.${subfield.name}`}
             node={subfield}

--- a/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.ui.tsx
+++ b/packages/v4/@tinacms/tinacms/src/plugins/fields/object/object-field.ui.tsx
@@ -1,0 +1,59 @@
+import { FieldWrapper } from '@tinacms/ui/components/field-wrapper';
+import { Label } from '@tinacms/ui/components/label';
+import { toFieldAddress } from '../../../core/field/address';
+import type { FieldSchema } from '../../../core/schema/types';
+import {
+  FieldNode,
+  useFieldAddress,
+  useFieldErrors,
+  useFieldRegistry,
+  useFieldSchema,
+} from '../../../editor';
+import { asObjectFieldSchema } from './object-field.schema';
+
+function ObjectFieldRow({
+  address,
+  node,
+}: {
+  address: string;
+  node: FieldSchema;
+}) {
+  const labelable =
+    useFieldRegistry().get(node.type)?.metadata?.labelable !== false;
+  return (
+    <div className='mb-3 min-w-0 last:mb-0'>
+      <Label
+        className='mb-1'
+        id={`${address}-label`}
+        htmlFor={labelable ? address : undefined}
+      >
+        {node.label ?? node.name}
+      </Label>
+      <FieldNode address={toFieldAddress(address)} node={node} />
+    </div>
+  );
+}
+
+export function ObjectField() {
+  const address = useFieldAddress();
+  const field = asObjectFieldSchema(useFieldSchema());
+  const errors = useFieldErrors(address);
+
+  return (
+    <FieldWrapper errors={errors}>
+      <div
+        role='group'
+        aria-labelledby={`${address}-label`}
+        className='rounded-md border p-3'
+      >
+        {field.fields.map((subfield) => (
+          <ObjectFieldRow
+            key={subfield.name}
+            address={`${address}.${subfield.name}`}
+            node={subfield}
+          />
+        ))}
+      </div>
+    </FieldWrapper>
+  );
+}

--- a/packages/v4/examples/barebones/content/posts/hello-world.mdx
+++ b/packages/v4/examples/barebones/content/posts/hello-world.mdx
@@ -7,6 +7,9 @@ authors:
   - name: Ivan
   - name: Brook
 status: draft
+seo:
+  title: TinaCMS v4 Example
+  description: This is the example project for the TinaCMS v4 work
 ---
 
 This is the barebones v4 example. Edit this prose in the admin, and the save

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -35,6 +35,14 @@ export const postCollection = {
         { value: 'published', label: 'Published' },
       ],
     }),
+		t.object({
+			name: 'seo',
+			label: 'SEO',
+			fields: [
+				t.string({ name: 'title', label: 'Title', required: true }),
+				t.string({ name: 'description', label: 'Description' }),
+			],
+		}),
   ],
 } satisfies CollectionSchema;
 

--- a/packages/v4/examples/barebones/tina/config.ts
+++ b/packages/v4/examples/barebones/tina/config.ts
@@ -35,14 +35,14 @@ export const postCollection = {
         { value: 'published', label: 'Published' },
       ],
     }),
-		t.object({
-			name: 'seo',
-			label: 'SEO',
-			fields: [
-				t.string({ name: 'title', label: 'Title', required: true }),
-				t.string({ name: 'description', label: 'Description' }),
-			],
-		}),
+    t.object({
+      name: 'seo',
+      label: 'SEO',
+      fields: [
+        t.string({ name: 'title', label: 'Title', required: true }),
+        t.string({ name: 'description', label: 'Description' }),
+      ],
+    }),
   ],
 } satisfies CollectionSchema;
 

--- a/packages/v4/examples/barebones/tina/tina-lock.json
+++ b/packages/v4/examples/barebones/tina/tina-lock.json
@@ -41,8 +41,8 @@
               }
             ],
             "type": "array"
-		  },
-		  {
+          },
+          {
             "name": "status",
             "label": "Status",
             "options": [
@@ -56,6 +56,24 @@
               }
             ],
             "type": "select"
+          },
+          {
+            "name": "seo",
+            "label": "SEO",
+            "fields": [
+              {
+                "name": "title",
+                "label": "Title",
+                "required": true,
+                "type": "string"
+              },
+              {
+                "name": "description",
+                "label": "Description",
+                "type": "string"
+              }
+            ],
+            "type": "object"
           }
         ]
       }
@@ -70,6 +88,7 @@
   "primitives": {
     "array": 1,
     "boolean": 1,
+    "object": 1,
     "rating": 1,
     "rich-text": 1,
     "select": 1,


### PR DESCRIPTION
This PR adds support for `Object`.

.. code:: tsx

	const collection = {
		name: 'post',
		fields: [
			t.object({
				name: 'seo',
				label: 'SEO',
				fields: [
					t.string({ name: 'title', label: 'Title', required: true }),
					t.string({ name: 'description', label: 'Description' }),
				],
			}),

		],
	};

<img width="1496" height="1372" alt="image" src="https://github.com/user-attachments/assets/e7ce939e-a4fc-4914-a923-1c2da045aab2" />

Issue: https://github.com/tinacms/tinacms/issues/6922 Field Type Implementation - Object
Assisted-by: ClaudeCode:claude-sonnet-5
Signed-off-by: brookjeynes-ssw <brookjeynes@ssw.com.au>
