### PR TITLE
fix(tinacms): use absolute README image URLs so they render on npm

### DIFF
--- a/.changeset/npm-readme-images.md
+++ b/.changeset/npm-readme-images.md
@@ -1,0 +1,5 @@
+---
+'tinacms': patch
+---
+
+Use absolute URLs for the README images so they render on the npm package page.

--- a/packages/tinacms/README.md
+++ b/packages/tinacms/README.md
@@ -2,9 +2,9 @@
 [![npm version](https://img.shields.io/npm/v/tinacms.svg?style=flat)](https://www.npmjs.com/package/tinacms)
 [![Build, Test, Lint for Main](https://github.com/tinacms/tinacms/actions/workflows/main.yml/badge.svg?branch=main&event=push)](https://github.com/tinacms/tinacms/actions/workflows/main.yml)
 
-# [![TINA CMS](./.github/assets/tinacms-logo-small-default.svg)](https://tina.io)
+# [![TINA CMS](https://raw.githubusercontent.com/tinacms/tinacms/main/.github/assets/tinacms-logo-small-default.svg)](https://tina.io)
 
-[![Tina Demo](./.github/assets/homepage-demo-2.gif)](https://tina.io/)
+[![Tina Demo](https://raw.githubusercontent.com/tinacms/tinacms/main/.github/assets/homepage-demo-2.gif)](https://tina.io/)
 
 Tina is a headless content management system with support for **Markdown**, MDX, JSON, YAML, and more.
 


### PR DESCRIPTION
No linked issue.

**TL;DR** Swap the two README image paths from repo-relative to absolute `raw.githubusercontent.com` URLs. They render on the npm package page again, and the README is unchanged on GitHub.

**Pain:** the Tina logo and the demo GIF are broken on https://www.npmjs.com/package/tinacms, so the first thing anyone sees when they look the package up is two missing images.

**Solution:** points both images at absolute URLs, so they resolve the same way wherever the README is rendered. Includes a patch changeset, because the npm page only picks the README up on the next publish.
