### PR TITLE
fix: reject templates with empty fields arrays (#7490)

### DIFF
--- a/.changeset/bump-headlessui-react-19.md
+++ b/.changeset/bump-headlessui-react-19.md
@@ -1,0 +1,5 @@
+---
+'@tinacms/rich-text': patch
+---
+
+Bump `@headlessui/react` from `2.1.8` to `2.2.10`. The pinned `2.1.8` release only declares a React 18 peer dependency, which produces `ERESOLVE overriding peer dependency` npm warnings for any project using React 19. `2.2.10` declares `react`/`react-dom` `^18 || ^19` and is otherwise API-compatible with the `Popover`/`PopoverButton`/`PopoverPanel`/`Transition` components already in use.

--- a/packages/@tinacms/schema-tools/src/validate/fields.ts
+++ b/packages/@tinacms/schema-tools/src/validate/fields.ts
@@ -149,7 +149,9 @@ export const TinaFieldZod: z.ZodType<TinaFieldType> = z.lazy(() => {
     .object({
       label: z.string().optional(),
       name,
-      fields: z.array(TinaFieldZod),
+      fields: z
+        .array(TinaFieldZod)
+        .min(1, 'Property `fields` cannot be empty.'),
       match: z
         .object({
           start: z.string(),

--- a/packages/@tinacms/schema-tools/src/validate/index.spec.ts
+++ b/packages/@tinacms/schema-tools/src/validate/index.spec.ts
@@ -345,6 +345,42 @@ const schemaWithEmptyTemplates: Schema = {
     },
   ],
 };
+const schemaWithEmptyTemplateFields: Schema = {
+  collections: [
+    {
+      name: 'foo',
+      path: 'foo/bar',
+      templates: [
+        {
+          name: 'bar',
+          label: 'Bar',
+          fields: [],
+        },
+      ],
+    },
+  ],
+};
+const schemaWithEmptyRichTextTemplateFields: Schema = {
+  collections: [
+    {
+      name: 'foo',
+      path: 'foo/bar',
+      fields: [
+        {
+          name: 'body',
+          type: 'rich-text',
+          templates: [
+            {
+              name: 'bar',
+              label: 'Bar',
+              fields: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const schemaWithInvalidFiledNesterUnderRichText = {
   collections: [
     {
@@ -466,6 +502,14 @@ describe('validateSchema', () => {
     expect(() => {
       validateSchema({ schema: schemaWithEmptyTemplates });
     }).toThrow();
+  });
+  it.each([
+    ['collection', schemaWithEmptyTemplateFields],
+    ['rich-text', schemaWithEmptyRichTextTemplateFields],
+  ])('fails when %s template fields is empty', (_templateType, schema) => {
+    expect(() => {
+      validateSchema({ schema });
+    }).toThrow('Property `fields` cannot be empty.');
   });
   it('fails when a deeply nested field under a template is invalid', () => {
     expect(() => {

--- a/packages/@tinacms/schema-tools/src/validate/schema.ts
+++ b/packages/@tinacms/schema-tools/src/validate/schema.ts
@@ -17,7 +17,7 @@ const Template = z
       required_error: 'Missing `label` property. Property `label` is required.',
     }),
     name: name,
-    fields: z.array(TinaFieldZod),
+    fields: z.array(TinaFieldZod).min(1, 'Property `fields` cannot be empty.'),
   })
   .superRefine((val, ctx) => {
     const dups = findDuplicates(val.fields?.map((x) => x.name));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ catalogs:
       specifier: ^10.8.1
       version: 10.11.0
     '@headlessui/react':
-      specifier: 2.1.8
-      version: 2.1.8
+      specifier: 2.2.10
+      version: 2.2.10
     '@iarna/toml':
       specifier: ^2.2.5
       version: 2.2.5
@@ -2585,7 +2585,7 @@ importers:
         version: 0.4.20(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@headlessui/react':
         specifier: 'catalog:'
-        version: 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog':
         specifier: 'catalog:'
         version: 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -19660,15 +19660,6 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@headlessui/react@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@floating-ui/react': 0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/focus': 3.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@react-aria/interactions': 3.25.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@tanstack/react-virtual': 3.13.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-
   '@headlessui/react@2.2.10(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@floating-ui/react': 0.26.28(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -19678,6 +19669,16 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       use-sync-external-store: 1.6.0(react@18.3.1)
+
+  '@headlessui/react@2.2.10(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react': 0.26.28(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/focus': 3.21.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@react-aria/interactions': 3.25.6(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@tanstack/react-virtual': 3.13.13(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.7)
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,7 +57,7 @@ catalog:
     "@graphql-tools/graphql-file-loader": ^7.5.17
     "@graphql-tools/load": ^7.8.14
     "@graphql-tools/utils": ^10.8.1
-    "@headlessui/react": 2.1.8
+    "@headlessui/react": 2.2.10
     "@iarna/toml": ^2.2.5
     "@monaco-editor/loader": ^1.7.0
     "@octokit/rest": ^22.0.1


### PR DESCRIPTION
Fixes #7490.

A template with `fields: []` passes schema validation today but generates a zero-field GraphQL input filter type, which is invalid per the GraphQL spec ("Input Object type ...Filter must define one or more fields"). On TinaCloud that breaks every content API request for the project.

The sibling case - `templates: []` on a collection - already got a `.min(1, 'Property \`templates\` cannot be empty.')` guard for the same reason (#3089). Added the equivalent guard to `Template.fields` in `schema.ts`, and found it needed a second copy in `fields.ts`'s `TemplateTemp` too - rich-text/object-field templates validate through that separate lazy schema, not through `schema.ts`'s `Template`, so `schema.ts`'s guard alone didn't cover them.

One related thing the issue flags but this doesn't close: a template whose fields are *all* `displayOnly` or `password` type hits the same zero-field-filter wall, since `_buildFieldFilter` excludes those types when building the filter. A plain `.min(1)` on the array length doesn't catch that (array length 1, still zero-field filter). Duplicating `_buildFieldFilter`'s exact exclusion list into this validation layer felt like the wrong tradeoff - it's private policy that lives in the GraphQL builder, and a copy here would just be another thing to keep in sync. Left as a known gap rather than reaching for a fix that's more architecture change than the issue's own acceptance criteria ask for.

Added test cases for both the collection-template and rich-text-template empty-`fields` rejection, plus confirmed the existing "at least one real field" cases still pass.
