### PR TITLE
fix: reject templates with empty fields arrays (#7490)

### DIFF
--- a/packages/@tinacms/mdx/src/next/tests/mdx-basic-nested-objects-3/field.ts
+++ b/packages/@tinacms/mdx/src/next/tests/mdx-basic-nested-objects-3/field.ts
@@ -21,7 +21,15 @@ export const field: RichTextField = {
                 {
                   name: 'content',
                   type: 'rich-text',
-                  templates: [{ name: 'World', fields: [] }],
+                  templates: [
+                    {
+                      name: 'World',
+                      // A schema-valid template needs at least one field even
+                      // though this element is used with none in this fixture's
+                      // markdown (a bare self-closing `<World />`).
+                      fields: [{ name: 'label', type: 'string' }],
+                    },
+                  ],
                 },
               ],
             },

--- a/packages/@tinacms/schema-tools/src/validate/fields.ts
+++ b/packages/@tinacms/schema-tools/src/validate/fields.ts
@@ -149,7 +149,9 @@ export const TinaFieldZod: z.ZodType<TinaFieldType> = z.lazy(() => {
     .object({
       label: z.string().optional(),
       name,
-      fields: z.array(TinaFieldZod),
+      fields: z
+        .array(TinaFieldZod)
+        .min(1, 'Property `fields` cannot be empty.'),
       match: z
         .object({
           start: z.string(),
@@ -199,20 +201,6 @@ export const TinaFieldZod: z.ZodType<TinaFieldType> = z.lazy(() => {
             message: duplicateTemplateErrorMessage(dups),
           });
         }
-        // An object field's templates each get their own generated GraphQL
-        // filter type (_buildTemplateFilter), which is invalid GraphQL when
-        // it has no fields. Rich-text embed templates don't have this
-        // problem (their containing rich-text field always gets one fixed
-        // generic filter regardless of embed shape), so this check is
-        // scoped to ObjectField's templates only, not RichTextField's.
-        val?.forEach((template) => {
-          if (template.fields.length === 0) {
-            ctx.addIssue({
-              code: z.ZodIssueCode.custom,
-              message: 'Property `fields` cannot be empty.',
-            });
-          }
-        });
       }),
   });
 

--- a/packages/@tinacms/schema-tools/src/validate/fields.ts
+++ b/packages/@tinacms/schema-tools/src/validate/fields.ts
@@ -199,6 +199,20 @@ export const TinaFieldZod: z.ZodType<TinaFieldType> = z.lazy(() => {
             message: duplicateTemplateErrorMessage(dups),
           });
         }
+        // An object field's templates each get their own generated GraphQL
+        // filter type (_buildTemplateFilter), which is invalid GraphQL when
+        // it has no fields. Rich-text embed templates don't have this
+        // problem (their containing rich-text field always gets one fixed
+        // generic filter regardless of embed shape), so this check is
+        // scoped to ObjectField's templates only, not RichTextField's.
+        val?.forEach((template) => {
+          if (template.fields.length === 0) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Property `fields` cannot be empty.',
+            });
+          }
+        });
       }),
   });
 

--- a/packages/@tinacms/schema-tools/src/validate/index.spec.ts
+++ b/packages/@tinacms/schema-tools/src/validate/index.spec.ts
@@ -345,6 +345,68 @@ const schemaWithEmptyTemplates: Schema = {
     },
   ],
 };
+const schemaWithEmptyTemplateFields: Schema = {
+  collections: [
+    {
+      name: 'foo',
+      path: 'foo/bar',
+      templates: [
+        {
+          name: 'bar',
+          label: 'Bar',
+          fields: [],
+        },
+      ],
+    },
+  ],
+};
+const schemaWithEmptyObjectFieldTemplateFields: Schema = {
+  collections: [
+    {
+      name: 'foo',
+      path: 'foo/bar',
+      fields: [
+        {
+          name: 'items',
+          type: 'object',
+          templates: [
+            {
+              name: 'bar',
+              label: 'Bar',
+              fields: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+// A rich-text embed template with no fields is a legitimate, intentionally
+// supported shape (a prop-less self-closing element, e.g. `<Divider />`) -
+// unlike an object field's templates, a rich-text field's own GraphQL filter
+// type doesn't depend on its embed templates' field counts, so this must
+// keep validating successfully.
+const schemaWithEmptyRichTextTemplateFields: Schema = {
+  collections: [
+    {
+      name: 'foo',
+      path: 'foo/bar',
+      fields: [
+        {
+          name: 'body',
+          type: 'rich-text',
+          templates: [
+            {
+              name: 'bar',
+              label: 'Bar',
+              fields: [],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
 const schemaWithInvalidFiledNesterUnderRichText = {
   collections: [
     {
@@ -466,6 +528,21 @@ describe('validateSchema', () => {
     expect(() => {
       validateSchema({ schema: schemaWithEmptyTemplates });
     }).toThrow();
+  });
+  it('fails when a collection template fields is empty', () => {
+    expect(() => {
+      validateSchema({ schema: schemaWithEmptyTemplateFields });
+    }).toThrow('Property `fields` cannot be empty.');
+  });
+  it('fails when an object field template fields is empty', () => {
+    expect(() => {
+      validateSchema({ schema: schemaWithEmptyObjectFieldTemplateFields });
+    }).toThrow('Property `fields` cannot be empty.');
+  });
+  it('passes when a rich-text embed template fields is empty', () => {
+    expect(() => {
+      validateSchema({ schema: schemaWithEmptyRichTextTemplateFields });
+    }).not.toThrow();
   });
   it('fails when a deeply nested field under a template is invalid', () => {
     expect(() => {

--- a/packages/@tinacms/schema-tools/src/validate/index.spec.ts
+++ b/packages/@tinacms/schema-tools/src/validate/index.spec.ts
@@ -2,8 +2,8 @@
 
 */
 
-import type { Schema } from '../types';
 import { validateSchema } from '.';
+import type { Schema } from '../types';
 
 let consoleErrMock: any;
 beforeEach(() => {
@@ -381,11 +381,11 @@ const schemaWithEmptyObjectFieldTemplateFields: Schema = {
     },
   ],
 };
-// A rich-text embed template with no fields is a legitimate, intentionally
-// supported shape (a prop-less self-closing element, e.g. `<Divider />`) -
-// unlike an object field's templates, a rich-text field's own GraphQL filter
-// type doesn't depend on its embed templates' field counts, so this must
-// keep validating successfully.
+// A rich-text field WITH templates goes through the same
+// _filterCollectionDocumentType/_buildTemplateFilter path an object field's
+// templates do (confirmed by tracing packages/@tinacms/graphql's builder),
+// so an empty-fields embed template is just as invalid here as it is for an
+// object field.
 const schemaWithEmptyRichTextTemplateFields: Schema = {
   collections: [
     {
@@ -539,10 +539,10 @@ describe('validateSchema', () => {
       validateSchema({ schema: schemaWithEmptyObjectFieldTemplateFields });
     }).toThrow('Property `fields` cannot be empty.');
   });
-  it('passes when a rich-text embed template fields is empty', () => {
+  it('fails when a rich-text embed template fields is empty', () => {
     expect(() => {
       validateSchema({ schema: schemaWithEmptyRichTextTemplateFields });
-    }).not.toThrow();
+    }).toThrow('Property `fields` cannot be empty.');
   });
   it('fails when a deeply nested field under a template is invalid', () => {
     expect(() => {

--- a/packages/@tinacms/schema-tools/src/validate/schema.ts
+++ b/packages/@tinacms/schema-tools/src/validate/schema.ts
@@ -17,7 +17,7 @@ const Template = z
       required_error: 'Missing `label` property. Property `label` is required.',
     }),
     name: name,
-    fields: z.array(TinaFieldZod),
+    fields: z.array(TinaFieldZod).min(1, 'Property `fields` cannot be empty.'),
   })
   .superRefine((val, ctx) => {
     const dups = findDuplicates(val.fields?.map((x) => x.name));


### PR DESCRIPTION
Fixes #7490. Replaces #7547 (closed - that branch accidentally carried an unrelated commit from another local branch).

A collection template with `fields: []` passes schema validation today but generates a zero-field GraphQL input filter type via `_buildTemplateFilter`, which is invalid per the GraphQL spec and breaks every content API request for the project on TinaCloud.

The sibling case - `templates: []` on a collection - already got a `.min(1, 'Property \`templates\` cannot be empty.')` guard for the same reason (#3089). Added the equivalent guard to `Template.fields` in `schema.ts`, and to the shared `TemplateTemp` schema in `fields.ts` (used by both `ObjectField.templates` and `RichTextField.templates`) - both go through the same `_buildTemplateFilter` path once a field actually has templates, traced via `_filterCollectionDocumentType`/`TinaSchema.getTemplatesForCollectable` in `@tinacms/graphql`'s builder.

(Earlier revisions of this PR tried to scope the fix to only `ObjectField`, reasoning a rich-text field's own filter type is fixed regardless of its embed templates - that's only true when the field has no templates at all; once it has any, it falls through to the identical code path `object` fields use. A reviewer caught this. `PageBodySponsorshipTiersFilter` from the issue's own repro decodes as collection `page` + field `body` + template `SponsorshipTiers`, confirming the originally reported bug is exactly this rich-text-embed case.)

Also fixed `@tinacms/mdx`'s `mdx-basic-nested-objects-3` test fixture, which modeled a rich-text embed template with `fields: []` (a prop-less self-closing element) - an actual instance of this same bug that its own test never caught, since that test only round-trips MDX parsing and never calls `validateSchema`.

A separate related gap the issue also flags - a template whose fields are all `displayOnly`/`password` type also produces a zero-field filter, since `_buildFieldFilter` excludes those types - isn't closed by this fix. Duplicating that exclusion list into schema-tools to catch it would risk drifting out of sync with the actual GraphQL filter builder, so it's left as a known limitation rather than folded into this narrower, spec-matching fix.

Tests cover: a collection template with empty fields, an object field's template with empty fields, and a rich-text embed template with empty fields - all rejected.