### PR TITLE
feat(create-tina-app): add --yes defaults

### DIFF
--- a/.changeset/calm-lions-build.md
+++ b/.changeset/calm-lions-build.md
@@ -1,0 +1,5 @@
+---
+'create-tina-app': minor
+---
+
+Add a `--yes` flag that uses the default package manager, project name, and starter template without prompting.

--- a/packages/create-tina-app/src/index.ts
+++ b/packages/create-tina-app/src/index.ts
@@ -238,77 +238,92 @@ export async function run() {
       );
     }
 
-    const res = await prompts({
-      message: 'Which package manager would you like to use?',
-      name: 'packageManager',
-      type: 'select',
-      initial: Math.max(0, installedPkgManagers.indexOf('pnpm')),
-      choices: installedPkgManagers.map((manager) => {
-        return {
-          title: manager === 'pnpm' ? 'pnpm (recommended)' : manager,
-          value: manager,
-        };
-      }),
-    });
-    if (!Object.hasOwn(res, 'packageManager')) {
-      postHogCaptureError(
-        posthogClient,
-        userId,
-        sessionId,
-        new Error('User cancelled package manager selection'),
-        {
-          errorCode: ERROR_CODES.ERR_CANCEL_PKG_MANAGER_PROMPT,
-          errorCategory: 'user-cancellation',
-          step: TRACKING_STEPS.PKG_MANAGER_SELECT,
-          fatal: true,
-          additionalProperties: telemetryData,
-        }
-      );
-      if (posthogClient) await posthogClient.shutdown();
-      exit(1);
+    if (opts.yes) {
+      pkgManager = installedPkgManagers.includes('pnpm')
+        ? 'pnpm'
+        : installedPkgManagers[0];
+      console.log(`Using ${pkgManager} as the package manager.`);
+    } else {
+      const res = await prompts({
+        message: 'Which package manager would you like to use?',
+        name: 'packageManager',
+        type: 'select',
+        initial: Math.max(0, installedPkgManagers.indexOf('pnpm')),
+        choices: installedPkgManagers.map((manager) => {
+          return {
+            title: manager === 'pnpm' ? 'pnpm (recommended)' : manager,
+            value: manager,
+          };
+        }),
+      });
+      if (!Object.hasOwn(res, 'packageManager')) {
+        postHogCaptureError(
+          posthogClient,
+          userId,
+          sessionId,
+          new Error('User cancelled package manager selection'),
+          {
+            errorCode: ERROR_CODES.ERR_CANCEL_PKG_MANAGER_PROMPT,
+            errorCategory: 'user-cancellation',
+            step: TRACKING_STEPS.PKG_MANAGER_SELECT,
+            fatal: true,
+            additionalProperties: telemetryData,
+          }
+        );
+        if (posthogClient) await posthogClient.shutdown();
+        exit(1);
+      }
+      pkgManager = res.packageManager;
     }
-    pkgManager = res.packageManager;
   }
   telemetryData['package-manager'] = pkgManager;
 
   let projectName = opts.projectName;
   if (!projectName) {
-    const res = await prompts({
-      name: 'name',
-      type: 'text',
-      message: 'What is your project named?',
-      initial: 'my-tina-app',
-      validate: (name) => {
-        const { message, isError } = validate(
-          path.basename(path.resolve(name))
+    if (opts.yes) {
+      projectName = 'my-tina-app';
+      console.log(`Using ${projectName} as the project name.`);
+    } else {
+      const res = await prompts({
+        name: 'name',
+        type: 'text',
+        message: 'What is your project named?',
+        initial: 'my-tina-app',
+        validate: (name) => {
+          const { message, isError } = validate(
+            path.basename(path.resolve(name))
+          );
+          if (isError) return `Invalid project name: ${message}`;
+          return true;
+        },
+      });
+      if (!Object.hasOwn(res, 'name')) {
+        postHogCaptureError(
+          posthogClient,
+          userId,
+          sessionId,
+          new Error('User cancelled project name input'),
+          {
+            errorCode: ERROR_CODES.ERR_CANCEL_PROJECT_NAME_PROMPT,
+            errorCategory: 'user-cancellation',
+            step: TRACKING_STEPS.PROJECT_NAME_INPUT,
+            fatal: true,
+            additionalProperties: telemetryData,
+          }
         );
-        if (isError) return `Invalid project name: ${message}`;
-        return true;
-      },
-    });
-    if (!Object.hasOwn(res, 'name')) {
-      postHogCaptureError(
-        posthogClient,
-        userId,
-        sessionId,
-        new Error('User cancelled project name input'),
-        {
-          errorCode: ERROR_CODES.ERR_CANCEL_PROJECT_NAME_PROMPT,
-          errorCategory: 'user-cancellation',
-          step: TRACKING_STEPS.PROJECT_NAME_INPUT,
-          fatal: true,
-          additionalProperties: telemetryData,
-        }
-      );
-      if (posthogClient) await posthogClient.shutdown();
-      exit(1);
+        if (posthogClient) await posthogClient.shutdown();
+        exit(1);
+      }
+      projectName = res.name;
     }
-    projectName = res.name;
   }
 
   if (!template) {
-    if (!process.stdin.isTTY) {
+    if (opts.yes || !process.stdin.isTTY) {
       template = DEFAULT_TEMPLATE;
+      if (opts.yes) {
+        console.log(`Using ${template.title} as the starter template.`);
+      }
     } else {
       const res = await prompts({
         name: 'template',

--- a/packages/create-tina-app/src/util/options.ts
+++ b/packages/create-tina-app/src/util/options.ts
@@ -11,6 +11,7 @@ export interface CreateOptions {
   noTelemetry: boolean;
   projectName: string;
   verbose: boolean;
+  yes: boolean;
   theme?: string;
 }
 
@@ -34,6 +35,10 @@ export function extractOptions(args: string[]): CreateOptions {
       'Choose which directory to run this script from.'
     )
     .option('-v, --verbose', 'Enable verbose output.')
+    .option(
+      '-y, --yes',
+      'Use the default package manager, project name, and starter template.'
+    )
     .option('--noTelemetry', 'Disable anonymous telemetry that is collected.')
     .option(
       '--theme <theme>',


### PR DESCRIPTION
Closes #7330.

`create-tina-app --yes` now skips the package manager, project name, and starter template prompts. It prefers pnpm when available, falls back to the first installed supported manager, and reports each selected default in the output.

The existing interactive flow and explicit command line options keep their current behavior. A minor changeset is included for `create-tina-app`.

Validation:

* Bundled `packages/create-tina-app/src/index.ts` successfully with esbuild for Node ESM
* `git diff --check`

The full pnpm install could not complete locally because this Windows checkout is on a UNC backed drive and pnpm stalled while linking the workspace. CI should cover the repository build and type checks.

AI assistance disclosure: Codex assisted with the implementation and verification. I reviewed the final diff and take responsibility for the contribution. The commit is authored by ASVLCII, and I will complete the repository CLA check if prompted.
